### PR TITLE
Durable Leg Key Bank Fix

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Bank.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Bank.cs
@@ -101,7 +101,7 @@ namespace ACE.Server.WorldObjects
                 {
                     if (this.TryConsumeFromInventoryWithNetworking(dur))
                     {
-                        BankedLegendaryKeys += 10;
+                        BankedLegendaryKeys += dur.Structure ?? 10;
                     }
                     else
                     {


### PR DESCRIPTION
Use Structure (Uses Remaining) to determine how many Leg Keys a Durable Leg Key represents.