### PR TITLE
Persist Enchantment Augs

### DIFF
--- a/Source/ACE.Database/Adapter/BiotaConverter.cs
+++ b/Source/ACE.Database/Adapter/BiotaConverter.cs
@@ -457,6 +457,7 @@ namespace ACE.Database.Adapter
                         StatModKey = record.StatModKey,
                         StatModValue = record.StatModValue,
                         SpellSetId = (EquipmentSet)record.SpellSetId,
+                        AugmentationLevelWhenCast = record.AugmentationLevelWhenCast
                     };
 
                     result.PropertiesEnchantmentRegistry.Add(newEntity);
@@ -896,7 +897,8 @@ namespace ACE.Database.Adapter
                         StatModKey = value.StatModKey,
                         StatModValue = value.StatModValue,
                         SpellSetId = (uint)value.SpellSetId,
-                    };
+                        AugmentationLevelWhenCast = value.AugmentationLevelWhenCast
+    };
 
                     result.BiotaPropertiesEnchantmentRegistry.Add(entity);
                 }

--- a/Source/ACE.Database/Adapter/BiotaUpdater.cs
+++ b/Source/ACE.Database/Adapter/BiotaUpdater.cs
@@ -679,6 +679,7 @@ namespace ACE.Database.Adapter
                     existingValue.StatModKey = value.StatModKey;
                     existingValue.StatModValue = value.StatModValue;
                     existingValue.SpellSetId = (uint)value.SpellSetId;
+                    existingValue.AugmentationLevelWhenCast = value.AugmentationLevelWhenCast;
                 }
             }
             foreach (var value in targetBiota.BiotaPropertiesEnchantmentRegistry)

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesEnchantmentRegistry.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesEnchantmentRegistry.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 #nullable disable
@@ -24,6 +24,7 @@ namespace ACE.Database.Models.Shard
         public uint StatModKey { get; set; }
         public float StatModValue { get; set; }
         public uint SpellSetId { get; set; }
+        public long? AugmentationLevelWhenCast { get; set; }
 
         public virtual Biota Object { get; set; }
     }

--- a/Source/ACE.Database/Models/Shard/ShardDbContext.cs
+++ b/Source/ACE.Database/Models/Shard/ShardDbContext.cs
@@ -752,6 +752,10 @@ namespace ACE.Database.Models.Shard
                     .HasColumnName("stat_Mod_Value")
                     .HasComment("the effect value/amount");
 
+                entity.Property(e => e.AugmentationLevelWhenCast)
+                    .HasColumnName("augmentation_Level_When_Cast")
+                    .HasComment("Player Skill Augmentation Level when Enchantment Was Cast");
+
                 entity.HasOne(d => d.Object)
                     .WithMany(p => p.BiotaPropertiesEnchantmentRegistry)
                     .HasForeignKey(d => d.ObjectId)

--- a/Source/ACE.Entity/Models/PropertiesEnchantmentRegistryExtensions.cs
+++ b/Source/ACE.Entity/Models/PropertiesEnchantmentRegistryExtensions.cs
@@ -156,7 +156,7 @@ namespace ACE.Entity.Models
                     group e by e.SpellCategory
                     into categories
                     //select categories.OrderByDescending(c => c.LayerId).First();
-                    select categories.OrderByDescending(c => c.PowerLevel)
+                    select categories.OrderByDescending(c => c.PowerLevel + c.AugmentationLevelWhenCast ?? 0)
                         .ThenByDescending(c => Level8AuraSelfSpells.Contains(c.SpellId))
                         .ThenByDescending(c => setSpells.Contains(c.SpellId) ? c.SpellId : c.StartTime).First();
 
@@ -185,7 +185,7 @@ namespace ACE.Entity.Models
                     group e by e.SpellCategory
                     into categories
                     //select categories.OrderByDescending(c => c.LayerId).First();
-                    select categories.OrderByDescending(c => c.PowerLevel)
+                    select categories.OrderByDescending(c => c.PowerLevel + c.AugmentationLevelWhenCast ?? 0)
                         .ThenByDescending(c => Level8AuraSelfSpells.Contains(c.SpellId))
                         .ThenByDescending(c => setSpells.Contains(c.SpellId) ? c.SpellId : c.StartTime).First();
 
@@ -230,7 +230,7 @@ namespace ACE.Entity.Models
                     group e by e.SpellCategory
                     into categories
                     //select categories.OrderByDescending(c => c.LayerId).First();
-                    select categories.OrderByDescending(c => c.PowerLevel)
+                    select categories.OrderByDescending(c => c.PowerLevel + c.AugmentationLevelWhenCast ?? 0)
                         .ThenByDescending(c => c.StatModValue)
                         .ThenByDescending(c => Level8AuraSelfSpells.Contains(c.SpellId))
                         .ThenByDescending(c => setSpells.Contains(c.SpellId) ? c.SpellId : c.StartTime).First();


### PR DESCRIPTION
Persist Enchantment Augmentation, and ensure we account for Augmentation when Ordering Enchantments by Power Level.

This SQL script will need to be run to add the new column to the DB

ALTER TABLE ace_shard.biota_properties_enchantment_registry
ADD augmentation_Level_When_Cast BIGINT NULL