### PR TITLE
Make Discord Connection Optional

### DIFF
--- a/Source/ACE.Common/ChatConfiguration.cs
+++ b/Source/ACE.Common/ChatConfiguration.cs
@@ -1,3 +1,4 @@
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,6 +9,9 @@ namespace ACE.Common
 {
     public class ChatConfiguration
     {
+        [System.ComponentModel.DefaultValue(false)]
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
+        public bool EnableDiscordConnection { get; set; }
         public string DiscordToken { get; set; }
         public long GeneralChannelId { get; set; }
         public long TradeChannelId { get; set; }

--- a/Source/ACE.Server/Managers/DiscordChatManager.cs
+++ b/Source/ACE.Server/Managers/DiscordChatManager.cs
@@ -19,13 +19,16 @@ namespace ACE.Server.Managers
 
         public static void SendDiscordMessage(string player, string message, long channelId)
         {
-            try
+            if (ConfigManager.Config.Chat.EnableDiscordConnection)
             {
-                _discordSocketClient.GetGuild((ulong)ConfigManager.Config.Chat.ServerId).GetTextChannel((ulong)channelId).SendMessageAsync(player + " : " + message);
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine("Error sending discord message, " + ex.Message);
+                try
+                {
+                    _discordSocketClient.GetGuild((ulong)ConfigManager.Config.Chat.ServerId).GetTextChannel((ulong)channelId).SendMessageAsync(player + " : " + message);
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine("Error sending discord message, " + ex.Message);
+                }
             }
             
         }

--- a/Source/ACE.Server/Program.cs
+++ b/Source/ACE.Server/Program.cs
@@ -252,7 +252,7 @@ namespace ACE.Server
             GuidManager.Initialize();
 
             
-            if (!string.IsNullOrEmpty(ConfigManager.Config.Chat.DiscordToken))
+            if (ConfigManager.Config.Chat.EnableDiscordConnection && !string.IsNullOrEmpty(ConfigManager.Config.Chat.DiscordToken))
             {
                 log.Info("Attempting to start Discord Client...");
                 DiscordChatManager.Initialize();


### PR DESCRIPTION
Added a flag to the config file (defaulting to false) to enable the Discord connection. This is needed for local testing to avoid error messages every time SendDiscordMessage is called. For production please add "EnableDiscordConnection": true to the Chat section in config.js.