### PR TITLE
Fix Infinite Loop in Landblock.TickMultiThreadedWork()

### DIFF
--- a/Source/ACE.Server/WorldObjects/WorldObject_Tick.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Tick.cs
@@ -132,6 +132,8 @@ namespace ACE.Server.WorldObjects
 
             if (cachedRegenerationInterval > 0)
                 NextGeneratorRegenerationTime = currentUnixTime + cachedRegenerationInterval;
+            else
+                NextGeneratorRegenerationTime = double.MaxValue;
 
             //Console.WriteLine($"{Name}.NextGeneratorRegenerationTime({NextGeneratorRegenerationTime})");
         }


### PR DESCRIPTION
If a Generator doesn't have an Interval, set the NextGeneratorRegenerationTime to double.MaxValue to avoid an infinite loop in Landblock.TickMultiThreadedWork()