### PR TITLE
Automate Fellowship Requests

### DIFF
--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionTalkDirect.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionTalkDirect.cs
@@ -43,6 +43,14 @@ namespace ACE.Server.Network.GameAction.Actions
                     return;
                 }
 
+
+                if (message.Equals("xp", System.StringComparison.OrdinalIgnoreCase) && targetPlayer.Fellowship != null && targetPlayer.Fellowship.Open)
+                {
+                    session.Network.EnqueueSend(new GameMessageSystemChat($"[FSHIP]: Attempting to add you to {targetPlayer.Name}'s fellowship.", ChatMessageType.Broadcast));
+                    targetPlayer.FellowshipRecruit(session.Player);
+                    return;
+                }
+
                 var tell = new GameEventTell(targetPlayer.Session, message, session.Player.GetNameWithSuffix(), session.Player.Guid.Full, targetPlayer.Guid.Full, ChatMessageType.Tell);
                 targetPlayer.Session.Network.EnqueueSend(tell);
             }

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionTell.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionTell.cs
@@ -49,6 +49,13 @@ namespace ACE.Server.Network.GameAction.Actions
                 //return;
             }
 
+            if (message.Equals("xp", System.StringComparison.OrdinalIgnoreCase) && targetPlayer.Fellowship != null && targetPlayer.Fellowship.Open)
+            {
+                session.Network.EnqueueSend(new GameMessageSystemChat($"[FSHIP]: Attempting to add you to {targetPlayer.Name}'s fellowship.", ChatMessageType.Broadcast));
+                targetPlayer.FellowshipRecruit(session.Player);
+                return;
+            }
+
             var tell = new GameEventTell(targetPlayer.Session, message, session.Player.GetNameWithSuffix(), session.Player.Guid.Full, targetPlayer.Guid.Full, ChatMessageType.Tell);
             targetPlayer.Session.Network.EnqueueSend(tell);
         }


### PR DESCRIPTION
Capture the /t xp message and attempt to automatically add player to fellowship to avoid VTank closing an open fellow of 9+