### PR TITLE
Dynamic quest updates

### DIFF
--- a/Source/ACE.Server/Managers/QuestManager.cs
+++ b/Source/ACE.Server/Managers/QuestManager.cs
@@ -723,7 +723,10 @@ namespace ACE.Server.Managers
             {
                 return;
             }
-            session.Player.QuestManager.Erase(DynamicQuestFlagName);
+            if (session.Player != null)
+            {
+                session.Player.QuestManager.Erase(DynamicQuestFlagName);
+            }
 
 
             bool created = false;


### PR DESCRIPTION
Use a generic quest flag to prevent a player from handing a Parchment to multiple NPCs in the same day
Don't add a Dynamic Quest to an NPC who already has one