### PR TITLE
/attr command exploit fix

### DIFF
--- a/Source/ACE.Server/Command/Handlers/PlayerCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/PlayerCommands.cs
@@ -605,6 +605,11 @@ namespace ACE.Server.Command.Handlers
                 {
                     session.Network.EnqueueSend(new GameMessageSystemChat($"[ATTR] Something isn't parsing your command correctly, check your input and try again!", ChatMessageType.Advancement));
                 }
+                if (amt > 10)
+                {
+                    session.Network.EnqueueSend(new GameMessageSystemChat($"[ATTR] You can only raise your attributes by up to 10 points at a time.", ChatMessageType.Advancement));
+                    return;
+                }
                 
             }
             switch (parameters[0])

--- a/Source/ACE.Server/WorldObjects/Player_Attributes.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Attributes.cs
@@ -21,6 +21,11 @@ namespace ACE.Server.WorldObjects
                 return false;
             }
 
+            if (amount > long.MaxValue)
+            {
+                return false;
+            }
+
             if ((long)amount > AvailableExperience)
             {
                 //log.Error($"{Name}.HandleActionRaiseAttribute({attribute}, {amount}) - amount > AvaiableExperience ({AvailableExperience})");

--- a/Source/ACE.Server/WorldObjects/Player_Attributes.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Attributes.cs
@@ -105,6 +105,19 @@ namespace ACE.Server.WorldObjects
             return true;
         }
 
+        public bool SetAttributeRank(CreatureAttribute creatureAttribute, uint rank)
+        {
+            if (rank < 0)
+            {
+                return false;
+            }
+            ulong xpCost = GetXPDeltaCostByRank(rank, 0);
+            creatureAttribute.Ranks = rank;
+            creatureAttribute.ExperienceSpent = (uint)xpCost;
+            SetExtendedAttributeExperience(creatureAttribute, xpCost);
+            return true;
+        }
+
         public void SpendAllAvailableAttributeXp(CreatureAttribute creatureAttribute, bool sendNetworkUpdate = true)
         {
             var amountRemaining = creatureAttribute.ExperienceLeft;
@@ -247,6 +260,35 @@ namespace ACE.Server.WorldObjects
                         SpentExperienceSelf = attrib.ExperienceSpent;
                     }
                     SpentExperienceSelf += amount;
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        public void SetExtendedAttributeExperience(CreatureAttribute attrib, double amount)
+        {
+            switch (attrib.Attribute)
+            {
+                case PropertyAttribute.Undef:
+                    break;
+                case PropertyAttribute.Strength:
+                    SpentExperienceStrength = amount;
+                    break;
+                case PropertyAttribute.Endurance:
+                    SpentExperienceEndurance = amount;
+                    break;
+                case PropertyAttribute.Quickness:
+                    SpentExperienceQuickness = amount;
+                    break;
+                case PropertyAttribute.Coordination:
+                    SpentExperienceCoordination = amount;
+                    break;
+                case PropertyAttribute.Focus:
+                    SpentExperienceFocus = amount;
+                    break;
+                case PropertyAttribute.Self:
+                    SpentExperienceSelf = amount;
                     break;
                 default:
                     break;


### PR DESCRIPTION
Limit /attr to raising attributes 10 points at a time
Add a check when raising attributes to avoid overflowing a signed long variable