### PR TITLE
Fellow share variation fix

### DIFF
--- a/Source/ACE.Server/Entity/Fellowship.cs
+++ b/Source/ACE.Server/Entity/Fellowship.cs
@@ -670,7 +670,7 @@ namespace ACE.Server.Entity
                 return 0.0f;
 
             // If you are both indoors but in different landblocks.
-            if (earner.Location.Indoors && fellow.Location.Indoors && earner.Location.Landblock != fellow.Location.Landblock)
+            if (earner.Location.Indoors && fellow.Location.Indoors && earner.Location.Landblock != fellow.Location.Landblock && (earner.Location.Variation ?? 0) != (fellow.Location.Variation ?? 0))
                 return 0.0f;
 
             var dist = earner.Location.Distance2D(fellow.Location);

--- a/Source/ACE.Server/Entity/Fellowship.cs
+++ b/Source/ACE.Server/Entity/Fellowship.cs
@@ -670,7 +670,7 @@ namespace ACE.Server.Entity
                 return 0.0f;
 
             // If you are both indoors but in different landblocks.
-            if (earner.Location.Indoors && fellow.Location.Indoors && earner.Location.Landblock != fellow.Location.Landblock && (earner.Location.Variation ?? 0) != (fellow.Location.Variation ?? 0))
+            if (earner.Location.Indoors && fellow.Location.Indoors && (earner.Location.Landblock != fellow.Location.Landblock || (earner.Location.Variation ?? 0) != (fellow.Location.Variation ?? 0)))
                 return 0.0f;
 
             var dist = earner.Location.Distance2D(fellow.Location);


### PR DESCRIPTION
Account for Variation when checking if players are on the same landblock for Fellow Share

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved distance calculation between players in different indoor locations to enhance gameplay accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->