### PR TITLE
Int64 emote/clearcache quest

### DIFF
--- a/Source/ACE.Database/SQLFormatters/World/WeenieSQLWriter.cs
+++ b/Source/ACE.Database/SQLFormatters/World/WeenieSQLWriter.cs
@@ -599,6 +599,8 @@ namespace ACE.Database.SQLFormatters.World
 
                         case EmoteType.InqInt64Stat:
                         case EmoteType.SetInt64Stat:
+                        case EmoteType.DecrementInt64Stat:
+                        case EmoteType.IncrementInt64Stat:
                             statLabel = $" /* PropertyInt64.{(PropertyInt64)input[i].Stat.Value} */";
                             break;
 

--- a/Source/ACE.Entity/Enum/EmoteType.cs
+++ b/Source/ACE.Entity/Enum/EmoteType.cs
@@ -135,6 +135,8 @@ namespace ACE.Entity.Enum
         StartDynamicBounty            = 126, //Custom
         PromptAddAugment10            = 127, //Custom
         SetEnvironment                = 128, //Custom
+        DecrementInt64Stat            = 129, //Custom
+        IncrementInt64Stat            = 130, //Custom
 
         // Unknown Id Emotes & Custom Emotes
         Enlightenment                 = 9001

--- a/Source/ACE.Server/Command/Handlers/DeveloperContentCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperContentCommands.cs
@@ -2927,6 +2927,8 @@ namespace ACE.Server.Command.Handlers.Processors
                     mode = CacheType.Weenie;
                 if (parameters[0].Contains("wield", StringComparison.OrdinalIgnoreCase))
                     mode = CacheType.WieldedTreasure;
+                if (parameters[0].Contains("quest", StringComparison.OrdinalIgnoreCase))
+                    mode = CacheType.Quests;
             }
 
             if (mode.HasFlag(CacheType.Landblock))
@@ -2959,6 +2961,12 @@ namespace ACE.Server.Command.Handlers.Processors
                 CommandHandlerHelper.WriteOutputInfo(session, "Clearing wielded treasure cache");
                 DatabaseManager.World.ClearWieldedTreasureCache();
             }
+
+            if (mode.HasFlag(CacheType.Quests))
+            {
+                CommandHandlerHelper.WriteOutputInfo(session, "Clearing quest cache");
+                DatabaseManager.World.ClearAllCachedQuests();
+            }
         }
 
         [Flags]
@@ -2970,6 +2978,7 @@ namespace ACE.Server.Command.Handlers.Processors
             Spell           = 0x4,
             Weenie          = 0x8,
             WieldedTreasure = 0x10,
+            Quests          = 0x20,
             All             = 0xFFFF
         };
 

--- a/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
@@ -301,6 +301,22 @@ namespace ACE.Server.WorldObjects.Managers
                     }
                     break;
 
+                /* decrements a PropertyInt64 stat by some amount */
+                case EmoteType.DecrementInt64Stat:
+
+                    // only used by 1 emote in 16PY - check for lower bounds?
+                    if (targetObject != null && emote.Stat != null)
+                    {
+                        var int64Property = (PropertyInt64)emote.Stat;
+                        var current = targetObject.GetProperty(int64Property) ?? 0;
+                        current -= emote.Amount64 ?? 1;
+                        targetObject.SetProperty(int64Property, current);
+
+                        if (player != null)
+                            player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt64(player, int64Property, current));
+                    }
+                    break;
+
                 case EmoteType.DecrementMyQuest:
                 case EmoteType.DecrementQuest:
 
@@ -414,6 +430,21 @@ namespace ACE.Server.WorldObjects.Managers
 
                         if (player != null)
                             player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt(player, intProperty, current));
+                    }
+                    break;
+
+                /* increments a PropertyInt64 stat by some amount */
+                case EmoteType.IncrementInt64Stat:
+
+                    if (targetObject != null && emote.Stat != null)
+                    {
+                        var int64Property = (PropertyInt64)emote.Stat;
+                        var current = targetObject.GetProperty(int64Property) ?? 0;
+                        current += emote.Amount64 ?? 1;
+                        targetObject.SetProperty(int64Property, current);
+
+                        if (player != null)
+                            player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt64(player, int64Property, current));
                     }
                     break;
 

--- a/Source/ACE.Server/WorldObjects/Managers/EnchantmentManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EnchantmentManager.cs
@@ -412,9 +412,21 @@ namespace ACE.Server.WorldObjects.Managers
                 {
                     bonus += 0.000156f;
                 }
+                else if (x < 175)
+                {
+                    bonus += 0.000078f;
+                }
+                else if (x < 200)
+                {
+                    bonus += 0.000039f;
+                }
+                else if (x < 225)
+                {
+                    bonus += 0.0000195f;
+                }
                 else
                 {
-                    bonus += 0.000100f;
+                    bonus += 0.0000100f;
                 }
             }
             return bonus;

--- a/Source/ACE.Server/WorldObjects/Player_Bank.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Bank.cs
@@ -757,13 +757,13 @@ namespace ACE.Server.WorldObjects
         }
         public long? BankedLuminance
         {
-            get => GetProperty(PropertyInt64.BankedLuminance);
+            get => GetProperty(PropertyInt64.BankedLuminance) ?? 0;
             set { if (!value.HasValue) RemoveProperty(PropertyInt64.BankedLuminance); else SetProperty(PropertyInt64.BankedLuminance, value.Value); }
         }
 
         public long? BankedPyreals
         {
-            get => GetProperty(PropertyInt64.BankedPyreals);
+            get => GetProperty(PropertyInt64.BankedPyreals) ?? 0;
             set { if (!value.HasValue) RemoveProperty(PropertyInt64.BankedPyreals); else SetProperty(PropertyInt64.BankedPyreals, value.Value); }
         }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Added functionality to increment and decrement Int64 statistics based on new emote types.
    - Introduced a new cache type for managing quests.

- **Bug Fixes**
    - Ensured `BankedLuminance` and `BankedPyreals` return a default value of `0` if they are null.

- **Enhancements**
    - Updated the `EmoteType` enum with new custom types.
    - Enhanced cache handling logic to support the new quest cache type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->