### PR TITLE
Add a Server Property to cap Nether Dot Damage Rating

### DIFF
--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -631,7 +631,8 @@ namespace ACE.Server.Managers
                 ("teleport_visibility_fix", new Property<long>(0, "Fixes some possible issues with invisible players and mobs. 0 = default / disabled, 1 = players only, 2 = creatures, 3 = all world objects")),
                 ("enl_50_base_lum_cost", new Property<long>(100000000, "the base luminance cost for each enlighten after 50, this will be multiplied by the target enlightenment level")),
                 ("dynamic_quest_repeat_hours", new Property<long>(20, "the number of hours before a player can do another dynamic quest")),
-                ("dynamic_quest_max_xp", new Property<long>(5000000000, "the maximum base xp rewarded from a dynamic quest"))
+                ("dynamic_quest_max_xp", new Property<long>(5000000000, "the maximum base xp rewarded from a dynamic quest")),
+                ("max_nether_dot_damage_rating", new Property<long>(50, "the maximum damage rating from Void DoTs"))
                 );
 
         public static readonly ReadOnlyDictionary<string, Property<double>> DefaultDoubleProperties =

--- a/Source/ACE.Server/WorldObjects/Managers/EnchantmentManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EnchantmentManager.cs
@@ -1385,6 +1385,9 @@ namespace ACE.Server.WorldObjects.Managers
             }
             var rating = (int)Math.Round(totalBaseDamage / 8.0f);   // thanks to Xenocide for this formula!
             //Console.WriteLine($"{WorldObject.Name}.NetherDotDamageRating: {rating}");
+            long maxVoidRating = PropertyManager.GetLong("max_nether_dot_damage_rating").Item;
+            if (rating > maxVoidRating)
+                rating = (int)maxVoidRating;
             return rating;
         }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new property, `max_nether_dot_damage_rating`, for dynamic quests with a default value of 50.

- **Bug Fixes**
  - Added a cap to the `NetherDotDamageRating` to ensure it does not exceed the specified maximum void rating.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->