### PR TITLE
Melee missile augs

### DIFF
--- a/Source/ACE.Entity/Enum/Properties/PropertyInt64.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyInt64.cs
@@ -67,6 +67,10 @@ namespace ACE.Entity.Enum.Properties
         BankedEnlightenedCoins = 9020,
         [ServerOnly]
         BankedMythicalKeys     = 9021,
+        [ServerOnly]
+        LumAugMeleeCount       = 9022,
+        [ServerOnly]
+        LumAugMissileCount     = 9023,
     }
 
     public static class PropertyInt64Extensions

--- a/Source/ACE.Server/Command/Handlers/PlayerCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/PlayerCommands.cs
@@ -154,6 +154,8 @@ namespace ACE.Server.Command.Handlers
             session.Network.EnqueueSend(new GameMessageSystemChat($"Duration: {session.Player.LuminanceAugmentSpellDurationCount:N0}", ChatMessageType.Broadcast));
             session.Network.EnqueueSend(new GameMessageSystemChat($"Specialization: {session.Player.LuminanceAugmentSpecializeCount:N0}", ChatMessageType.Broadcast));
             session.Network.EnqueueSend(new GameMessageSystemChat($"Summon: {session.Player.LuminanceAugmentSummonCount:N0}", ChatMessageType.Broadcast));
+            session.Network.EnqueueSend(new GameMessageSystemChat($"Melee: {session.Player.LuminanceAugmentMeleeCount:N0}", ChatMessageType.Broadcast));
+            session.Network.EnqueueSend(new GameMessageSystemChat($"Missile: {session.Player.LuminanceAugmentMissileCount:N0}", ChatMessageType.Broadcast));
         }
 
         //custom commands

--- a/Source/ACE.Server/Entity/DamageEvent.cs
+++ b/Source/ACE.Server/Entity/DamageEvent.cs
@@ -11,6 +11,7 @@ using ACE.Entity.Models;
 using ACE.Server.Managers;
 using ACE.Server.Network.GameMessages.Messages;
 using ACE.Server.WorldObjects;
+using ACE.DatLoader.Entity;
 
 namespace ACE.Server.Entity
 {
@@ -222,6 +223,19 @@ namespace ACE.Server.Entity
             }
 
             if (GeneralFailure) return 0.0f;
+
+            var isBow = Weapon != null && Weapon.IsBow;
+            long damageBonus = 0;
+            if (isBow && attacker.LuminanceAugmentMissileCount > 0)
+            {
+                damageBonus = attacker.LuminanceAugmentMissileCount.Value;
+            }
+            else if (attacker.LuminanceAugmentMeleeCount > 0)
+            {
+                damageBonus = attacker.LuminanceAugmentMeleeCount.Value;
+            }
+
+            BaseDamage += damageBonus;
 
             // get damage modifiers
             PowerMod = attacker.GetPowerMod(Weapon);

--- a/Source/ACE.Server/WorldObjects/Creature_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Properties.cs
@@ -384,6 +384,18 @@ namespace ACE.Server.WorldObjects
             set { if (!value.HasValue) RemoveProperty(PropertyInt64.LumAugWarCount); else SetProperty(PropertyInt64.LumAugWarCount, value.Value); }
         }
 
+        public long? LuminanceAugmentMeleeCount
+        {
+            get => GetProperty(PropertyInt64.LumAugMeleeCount) ?? 0;
+            set { if (!value.HasValue) RemoveProperty(PropertyInt64.LumAugMeleeCount); else SetProperty(PropertyInt64.LumAugMeleeCount, value.Value); }
+        }
+
+        public long? LuminanceAugmentMissileCount
+        {
+            get => GetProperty(PropertyInt64.LumAugMissileCount) ?? 0;
+            set { if (!value.HasValue) RemoveProperty(PropertyInt64.LumAugMissileCount); else SetProperty(PropertyInt64.LumAugMissileCount, value.Value); }
+        }
+
         public FactionBits Society => Faction1Bits ?? FactionBits.None;
     }
 }

--- a/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
@@ -1839,6 +1839,7 @@ namespace ACE.Server.WorldObjects.Managers
                                 break;
                             default:
                                 break;
+                        
                         }
                     }
                     break;
@@ -2095,6 +2096,70 @@ namespace ACE.Server.WorldObjects.Managers
                                         player.TryConsumeFromInventoryWithNetworking(81000132, 1);
                                         player.Session.Network.EnqueueSend(new GameMessageSystemChat($"You have succesfully increased your summons damage resist rating by 30.", ChatMessageType.Broadcast));
                                     }), $"You are about to spend {curVal16:N0} luminance to add 30 points to your summons damage resist rating. Are you sure?");
+                                }
+                                break;
+                            case "Melee10":
+                                long meleeAugs10 = player.LuminanceAugmentMeleeCount ?? 0;
+                                var curVal17 = emote.Amount + (meleeAugs10 * (emote.Amount * (1 + emote.Percent))) + (emote.Amount + (meleeAugs10 + 1) * (emote.Amount * (1 + emote.Percent)))
+                                    + (emote.Amount + (meleeAugs10 + 2) * (emote.Amount * (1 + emote.Percent))) + (emote.Amount + (meleeAugs10 + 3) * (emote.Amount * (1 + emote.Percent)))
+                                    + (emote.Amount + (meleeAugs10 + 4) * (emote.Amount * (1 + emote.Percent))) + (emote.Amount + (meleeAugs10 + 5) * (emote.Amount * (1 + emote.Percent)))
+                                    + (emote.Amount + (meleeAugs10 + 6) * (emote.Amount * (1 + emote.Percent))) + (emote.Amount + (meleeAugs10 + 7) * (emote.Amount * (1 + emote.Percent)))
+                                    + (emote.Amount + (meleeAugs10 + 8) * (emote.Amount * (1 + emote.Percent))) + (emote.Amount + (meleeAugs10 + 9) * (emote.Amount * (1 + emote.Percent)));
+
+                                if (player.BankedLuminance < curVal17)
+                                {
+                                    player.Session.Network.EnqueueSend(new GameMessageSystemChat($"You do not have enough luminance to use this gem. This will require {curVal17:N0} luminance to use.", ChatMessageType.Broadcast));
+                                }
+                                else
+                                {
+                                    player.ConfirmationManager.EnqueueSend(new Confirmation_Custom(player.Guid, () =>
+                                    {
+                                        if (player.BankedLuminance < curVal17)
+                                        {
+                                            player.Session.Network.EnqueueSend(new GameMessageSystemChat($"You do not have enough luminance to use this gem. This will require {curVal17:N0} luminance to use.", ChatMessageType.Broadcast));
+                                            return;
+                                        }
+                                        if (!player.SpendLuminance((long)curVal17))
+                                        {
+                                            player.Session.Network.EnqueueSend(new GameMessageSystemChat($"Failed to spend the necessary luminance. Please try again.", ChatMessageType.Broadcast));
+                                            return;
+                                        }
+                                        player.LuminanceAugmentMeleeCount = meleeAugs10 + 10;
+                                        player.TryConsumeFromInventoryWithNetworking(81000133, 1);
+                                        player.Session.Network.EnqueueSend(new GameMessageSystemChat($"You have succesfully increased your {emote.Message} damage by 10.", ChatMessageType.Broadcast));
+                                    }), $"You are about to spend {curVal17:N0} luminance to add 10 points to all of your melee damage. Are you sure?");
+                                }
+                                break;
+                            case "Missile10":
+                                long missileAugs10 = player.LuminanceAugmentMissileCount ?? 0;
+                                var curVal18 = emote.Amount + (missileAugs10 * (emote.Amount * (1 + emote.Percent))) + (emote.Amount + (missileAugs10 + 1) * (emote.Amount * (1 + emote.Percent)))
+                                    + (emote.Amount + (missileAugs10 + 2) * (emote.Amount * (1 + emote.Percent))) + (emote.Amount + (missileAugs10 + 3) * (emote.Amount * (1 + emote.Percent)))
+                                    + (emote.Amount + (missileAugs10 + 4) * (emote.Amount * (1 + emote.Percent))) + (emote.Amount + (missileAugs10 + 5) * (emote.Amount * (1 + emote.Percent)))
+                                    + (emote.Amount + (missileAugs10 + 6) * (emote.Amount * (1 + emote.Percent))) + (emote.Amount + (missileAugs10 + 7) * (emote.Amount * (1 + emote.Percent)))
+                                    + (emote.Amount + (missileAugs10 + 8) * (emote.Amount * (1 + emote.Percent))) + (emote.Amount + (missileAugs10 + 9) * (emote.Amount * (1 + emote.Percent)));
+
+                                if (player.BankedLuminance < curVal18)
+                                {
+                                    player.Session.Network.EnqueueSend(new GameMessageSystemChat($"You do not have enough luminance to use this gem. This will require {curVal18:N0} luminance to use.", ChatMessageType.Broadcast));
+                                }
+                                else
+                                {
+                                    player.ConfirmationManager.EnqueueSend(new Confirmation_Custom(player.Guid, () =>
+                                    {
+                                        if (player.BankedLuminance < curVal18)
+                                        {
+                                            player.Session.Network.EnqueueSend(new GameMessageSystemChat($"You do not have enough luminance to use this gem. This will require {curVal18:N0} luminance to use.", ChatMessageType.Broadcast));
+                                            return;
+                                        }
+                                        if (!player.SpendLuminance((long)curVal18))
+                                        {
+                                            player.Session.Network.EnqueueSend(new GameMessageSystemChat($"Failed to spend the necessary luminance. Please try again.", ChatMessageType.Broadcast));
+                                            return;
+                                        }
+                                        player.LuminanceAugmentMissileCount = missileAugs10 + 10;
+                                        player.TryConsumeFromInventoryWithNetworking(81000134, 1);
+                                        player.Session.Network.EnqueueSend(new GameMessageSystemChat($"You have succesfully increased your {emote.Message} damage by 10.", ChatMessageType.Broadcast));
+                                    }), $"You are about to spend {curVal18:N0} luminance to add 10 points to all of your missile damage. Are you sure?");
                                 }
                                 break;
                             default:

--- a/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
@@ -1783,6 +1783,60 @@ namespace ACE.Server.WorldObjects.Managers
                                     }), $"You are about to spend {curVal8:N0} luminance to add 3 points to your summons damage resist rating. Are you sure?");
                                 }
                                 break;
+                            case "Melee":
+                                long meleeAugs = player.LuminanceAugmentMeleeCount ?? 0;
+                                var curVal9 = emote.Amount + (meleeAugs * (emote.Amount * (1 + emote.Percent)));
+                                if (player.BankedLuminance < curVal9)
+                                {
+                                    player.Session.Network.EnqueueSend(new GameMessageSystemChat($"You do not have enough luminance to use this gem. This will require {curVal9:N0} luminance to use.", ChatMessageType.Broadcast));
+                                }
+                                else
+                                {
+                                    player.ConfirmationManager.EnqueueSend(new Confirmation_Custom(player.Guid, () =>
+                                    {
+                                        if (player.BankedLuminance < curVal9)
+                                        {
+                                            player.Session.Network.EnqueueSend(new GameMessageSystemChat($"You do not have enough luminance to use this gem. This will require {curVal9:N0} luminance to use.", ChatMessageType.Broadcast));
+                                            return;
+                                        }
+                                        if (!player.SpendLuminance((long)curVal9))
+                                        {
+                                            player.Session.Network.EnqueueSend(new GameMessageSystemChat($"Failed to spend the necessary luminance. Please try again.", ChatMessageType.Broadcast));
+                                            return;
+                                        }
+                                        player.LuminanceAugmentMeleeCount = meleeAugs + 1;
+                                        player.TryConsumeFromInventoryWithNetworking(2003002, 1);
+                                        player.Session.Network.EnqueueSend(new GameMessageSystemChat($"You have succesfully increased your {emote.Message} damage by 1.", ChatMessageType.Broadcast));
+                                    }), $"You are about to spend {curVal9:N0} luminance to add 1 point to all of your melee damage. Are you sure?");
+                                }
+                                break;
+                            case "Missile":
+                                long missileAugs = player.LuminanceAugmentMissileCount ?? 0;
+                                var curVal10 = emote.Amount + (missileAugs * (emote.Amount * (1 + emote.Percent)));
+                                if (player.BankedLuminance < curVal10)
+                                {
+                                    player.Session.Network.EnqueueSend(new GameMessageSystemChat($"You do not have enough luminance to use this gem. This will require {curVal10:N0} luminance to use.", ChatMessageType.Broadcast));
+                                }
+                                else
+                                {
+                                    player.ConfirmationManager.EnqueueSend(new Confirmation_Custom(player.Guid, () =>
+                                    {
+                                        if (player.BankedLuminance < curVal10)
+                                        {
+                                            player.Session.Network.EnqueueSend(new GameMessageSystemChat($"You do not have enough luminance to use this gem. This will require {curVal10:N0} luminance to use.", ChatMessageType.Broadcast));
+                                            return;
+                                        }
+                                        if (!player.SpendLuminance((long)curVal10))
+                                        {
+                                            player.Session.Network.EnqueueSend(new GameMessageSystemChat($"Failed to spend the necessary luminance. Please try again.", ChatMessageType.Broadcast));
+                                            return;
+                                        }
+                                        player.LuminanceAugmentMissileCount = missileAugs + 1;
+                                        player.TryConsumeFromInventoryWithNetworking(2003003, 1);
+                                        player.Session.Network.EnqueueSend(new GameMessageSystemChat($"You have succesfully increased your {emote.Message} damage by 1.", ChatMessageType.Broadcast));
+                                    }), $"You are about to spend {curVal10:N0} luminance to add 1 point to all of your missile damage. Are you sure?");
+                                }
+                                break;
                             default:
                                 break;
                         }


### PR DESCRIPTION
Add code to handle base damage Augmentation for Melee and Missile. Still need to create the weenies for the applicable Aug Gems.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced two new properties for tracking `LuminanceAugmentMeleeCount` and `LuminanceAugmentMissileCount`, enhancing character statistics.
	- Added new emote cases for improved interactivity related to melee and missile damage, including options for larger damage increments.
	- Expanded augment reporting to include melee and missile statistics in player feedback.

- **Bug Fixes**
	- Enhanced damage calculation logic to include bonuses from augment counts based on weapon type, improving combat mechanics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->