### PR TITLE
configurable modifier for crit damage

### DIFF
--- a/Source/ACE.Server/Entity/DamageEvent.cs
+++ b/Source/ACE.Server/Entity/DamageEvent.cs
@@ -270,6 +270,21 @@ namespace ACE.Server.Entity
             if (playerDefender != null && (playerDefender.IsLoggingOut || playerDefender.PKLogout))
                 CriticalChance = 1.0f;
 
+            // Define a configurable parameter for critical damage adjustment
+            float luminanceAugmentCritDamageMultiplier = (float)PropertyManager.GetDouble("melee/missile_aug_crit_modifier").Item;
+
+            float luminanceAugmentBonus = 0;
+            if (attacker.LuminanceAugmentMissileCount > 0)
+            {
+                luminanceAugmentBonus += attacker.LuminanceAugmentMissileCount.Value * luminanceAugmentCritDamageMultiplier;
+            }
+            if (attacker.LuminanceAugmentMeleeCount > 0)
+            {
+                luminanceAugmentBonus += attacker.LuminanceAugmentMeleeCount.Value * luminanceAugmentCritDamageMultiplier;
+            }
+
+            // Inside the critical hit check
+
             if (CriticalChance > ThreadSafeRandom.Next(0.0f, 1.0f))
             {
                 if (playerDefender != null && playerDefender.AugmentationCriticalDefense > 0)
@@ -285,13 +300,12 @@ namespace ACE.Server.Entity
                 {
                     IsCritical = true;
 
-                    // verify: CriticalMultiplier only applied to the additional crit damage,
-                    // whereas CD/CDR applied to the total damage (base damage + additional crit damage)
-                    CriticalDamageMod = 1.0f + WorldObject.GetWeaponCritDamageMod(Weapon, attacker, attackSkill, defender);
+                    // Update the CriticalDamageMod to include luminance augment bonus
+                    CriticalDamageMod = 1.0f + WorldObject.GetWeaponCritDamageMod(Weapon, attacker, attackSkill, defender) + luminanceAugmentBonus;
 
                     CriticalDamageRatingMod = Creature.GetPositiveRatingMod(attacker.GetCritDamageRating());
 
-                    // recklessness excluded from crits
+                    // Recklessness excluded from crits
                     RecklessnessMod = 1.0f;
                     DamageRatingMod = Creature.AdditiveCombine(DamageRatingBaseMod, CriticalDamageRatingMod, SneakAttackMod, HeritageMod);
 

--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -673,7 +673,8 @@ namespace ACE.Server.Managers
                 ("vitae_penalty", new Property<double>(0.05, "the amount of vitae penalty a player gets per death")),
                 ("vitae_penalty_max", new Property<double>(0.40, "the maximum vitae penalty a player can have")),
                 ("void_pvp_modifier", new Property<double>(0.5, "Scales the amount of damage players take from Void Magic. Defaults to 0.5, as per retail. For earlier content where DRR isn't as readily available, this can be adjusted for balance.")),
-                ("xp_modifier", new Property<double>(1.0, "scales the amount of xp received by players"))
+                ("xp_modifier", new Property<double>(1.0, "scales the amount of xp received by players")),
+                ("melee/missile_aug_crit_modifier", new Property<double>(0.002, "the maximum crit damage bonus from melee and missile augs"))
                 );
 
         public static readonly ReadOnlyDictionary<string, Property<string>> DefaultStringProperties =


### PR DESCRIPTION
configurable modifier for crit damage associated with the amount of melee/missile augs you have.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced damage calculation logic to include a new critical damage modifier based on luminance augment counts.
	- Introduced a new property for critical damage bonuses from melee and missile augmentations.

- **Improvements**
	- Improved flexibility and depth of the damage calculation system, enriching gameplay dynamics related to critical hits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->