### PR TITLE
corrected wording of broadcasted messages

### DIFF
--- a/Source/ACE.Server/Command/Handlers/PlayerCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/PlayerCommands.cs
@@ -164,7 +164,7 @@ namespace ACE.Server.Command.Handlers
         {
             if (session.Player.IsBusy)
             {
-                session.Network.EnqueueSend(new GameMessageSystemChat($"You are to busy to complete this deposit!", ChatMessageType.System));
+                session.Network.EnqueueSend(new GameMessageSystemChat($"Cannot deposit while teleporting or busy. Complete your movement and try again!", ChatMessageType.System));
                 return;
             }
 

--- a/Source/ACE.Server/Command/Handlers/PlayerCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/PlayerCommands.cs
@@ -162,12 +162,6 @@ namespace ACE.Server.Command.Handlers
         [CommandHandler("bank", AccessLevel.Player, CommandHandlerFlag.None, "Handles Banking Operations", "")]
         public static void HandleBank(Session session, params string[] parameters)
         {
-            if (session.Player.IsBusy)
-            {
-                session.Network.EnqueueSend(new GameMessageSystemChat($"Cannot deposit while teleporting or busy. Complete your movement and try again!", ChatMessageType.System));
-                return;
-            }
-
             if (session.Player == null)
                 return;
             if (session.Player.IsOlthoiPlayer)
@@ -269,6 +263,13 @@ namespace ACE.Server.Command.Handlers
 
             if (parameters[0] == "deposit" || parameters[0] == "d")
             {
+
+                if (session.Player.IsBusy)
+                {
+                    session.Network.EnqueueSend(new GameMessageSystemChat($"Cannot deposit while teleporting or busy. Complete your movement and try again!", ChatMessageType.System));
+                    return;
+                }
+
                 //deposit
                 if (parameters.Count() == 1) //only means all
                 {

--- a/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
@@ -2236,7 +2236,7 @@ namespace ACE.Server.WorldObjects.Managers
                                         }
                                         player.LuminanceAugmentMeleeCount = meleeAugs10 + 10;
                                         player.TryConsumeFromInventoryWithNetworking(81000133, 1);
-                                        player.Session.Network.EnqueueSend(new GameMessageSystemChat($"You have succesfully increased your {emote.Message} damage by 10.", ChatMessageType.Broadcast));
+                                        player.Session.Network.EnqueueSend(new GameMessageSystemChat($"You have succesfully increased your Melee damage by 10.", ChatMessageType.Broadcast));
                                     }), $"You are about to spend {curVal17:N0} luminance to add 10 points to all of your melee damage. Are you sure?");
                                 }
                                 break;
@@ -2277,7 +2277,7 @@ namespace ACE.Server.WorldObjects.Managers
                                         }
                                         player.LuminanceAugmentMissileCount = missileAugs10 + 10;
                                         player.TryConsumeFromInventoryWithNetworking(81000134, 1);
-                                        player.Session.Network.EnqueueSend(new GameMessageSystemChat($"You have succesfully increased your {emote.Message} damage by 10.", ChatMessageType.Broadcast));
+                                        player.Session.Network.EnqueueSend(new GameMessageSystemChat($"You have succesfully increased your Missile damage by 10.", ChatMessageType.Broadcast));
                                     }), $"You are about to spend {curVal18:N0} luminance to add 10 points to all of your missile damage. Are you sure?");
                                 }
                                 break;


### PR DESCRIPTION
corrected wording of broadcasted messages during banking and using 10x melee/missile augs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Updated bank deposit message for clarity: "Cannot deposit while teleporting or busy. Complete your movement and try again!"
	- Enhanced emote messaging to specify "Melee damage" and "Missile damage" for clearer player feedback.

- **Bug Fixes**
	- Improved clarity in messaging for player actions to enhance user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->