### PR TITLE
CreatedByAccountId

### DIFF
--- a/Source/ACE.Entity/Enum/Properties/PropertyDataId.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyDataId.cs
@@ -168,7 +168,9 @@ namespace ACE.Entity.Enum.Properties
         [ServerOnly]
         PCAPRecordedMaxVelocityEstimated = 8030,
         [ServerOnly]
-        PCAPPhysicsDIDDataTemplatedFrom  = 8044
+        PCAPPhysicsDIDDataTemplatedFrom  = 8044,
+        [ServerOnly]
+        CreatedByAccountId               = 9027
 
         //[ServerOnly]
         //HairTexture                = 9001,

--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -2475,6 +2475,8 @@ namespace ACE.Server.Command.Handlers
                 obj.Location = session.Player.Location.InFrontOf(5f, true);
             else
             {
+                obj.CreatedByAccountId = session.Player.Account.AccountId;
+
                 var dist = Math.Max(2, obj.UseRadius ?? 2);
 
                 obj.Location = session.Player.Location.InFrontOf(dist);

--- a/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
@@ -1941,6 +1941,15 @@ namespace ACE.Server.Command.Handlers
                 return;
             }
 
+            if (propType.Equals("PropertyDataId", StringComparison.OrdinalIgnoreCase))
+            {
+                if ((PropertyDataId)result == PropertyDataId.CreatedByAccountId)
+                {
+                    session.Network.EnqueueSend(new GameMessageSystemChat($"{prop} can not be changed in this way", ChatMessageType.Broadcast));
+                    return;
+                }
+            }
+
             if (value == "null")
             {
                 if (propType.Equals("PropertyInt", StringComparison.OrdinalIgnoreCase))

--- a/Source/ACE.Server/Command/Handlers/DeveloperContentCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperContentCommands.cs
@@ -1266,6 +1266,11 @@ namespace ACE.Server.Command.Handlers.Processors
                 return;
             }
 
+            if (wo.WeenieType != WeenieType.Creature)
+            {
+                wo.CreatedByAccountId = session.Player.Account.AccountId;
+            }
+
             var isLinkChild = parentInstance != null;
 
             if (!wo.Stuck && !isLinkChild)

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -2515,6 +2515,12 @@ namespace ACE.Server.WorldObjects
             set { if (!value.HasValue) RemoveProperty(PropertyInt.PortalReqMaxValue); else SetProperty(PropertyInt.PortalReqMaxValue, value.Value); }
         }
 
+        public uint? CreatedByAccountId
+        {
+            get => GetProperty(PropertyDataId.CreatedByAccountId);
+            set { if (!value.HasValue) RemoveProperty(PropertyDataId.CreatedByAccountId); else SetProperty(PropertyDataId.CreatedByAccountId, value.Value); }
+        }
+
         /// <summary>
         /// <para>Used to mark when EnterWorld has completed for first time for this object's instance.</para>
         /// Currently used by Generators and Players

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -2518,7 +2518,13 @@ namespace ACE.Server.WorldObjects
         public uint? CreatedByAccountId
         {
             get => GetProperty(PropertyDataId.CreatedByAccountId);
-            set { if (!value.HasValue) RemoveProperty(PropertyDataId.CreatedByAccountId); else SetProperty(PropertyDataId.CreatedByAccountId, value.Value); }
+            set {
+                if (!GetProperty(PropertyDataId.CreatedByAccountId).HasValue)
+                {
+                    if (!value.HasValue) RemoveProperty(PropertyDataId.CreatedByAccountId);
+                    else SetProperty(PropertyDataId.CreatedByAccountId, value.Value);
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Added CreatedByAccountId property (9027) to easily identify items created by an Admin command and who made them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new property `CreatedByAccountId` to track the account responsible for creating objects.
	- Enhanced logic to assign `CreatedByAccountId` based on specific conditions in object creation processes.

- **Bug Fixes**
	- Improved handling of object ownership assignment based on `WeenieType` to ensure accurate tracking.

These changes enhance the tracking and management of world objects, providing better accountability for object creation within the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->