### PR TITLE
QOL and QB checks

### DIFF
--- a/Source/ACE.Entity/Enum/EmoteType.cs
+++ b/Source/ACE.Entity/Enum/EmoteType.cs
@@ -137,6 +137,7 @@ namespace ACE.Entity.Enum
         SetEnvironment                = 128, //Custom
         DecrementInt64Stat            = 129, //Custom
         IncrementInt64Stat            = 130, //Custom
+        QuestCompletionCount          = 131, //Custom
 
         // Unknown Id Emotes & Custom Emotes
         Enlightenment                 = 9001

--- a/Source/ACE.Entity/Enum/PortalRequirement.cs
+++ b/Source/ACE.Entity/Enum/PortalRequirement.cs
@@ -6,6 +6,19 @@ namespace ACE.Entity.Enum
          CreatureAug = 1,
          ItemAug     = 2,
          LifeAug     = 3,
-         Enlighten   = 4
+         Enlighten   = 4,
+         QuestBonus  = 5,
+           
      }
- }
+
+    public enum PortalRequirement2
+    {
+        None = 0,
+        CreatureAug = 1,
+        ItemAug = 2,
+        LifeAug = 3,
+        Enlighten = 4,
+        QuestBonus = 5,
+
+    }
+}

--- a/Source/ACE.Entity/Enum/Properties/PropertyInt.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyInt.cs
@@ -642,6 +642,12 @@ namespace ACE.Entity.Enum.Properties
         PortalReqValue                          = 9020,
         [ServerOnly]
         PortalReqMaxValue                       = 9021,
+        [ServerOnly]
+        PortalReqType2                          = 9022,
+        [ServerOnly]
+        PortalReqValue2                         = 9023,
+        [ServerOnly]
+        PortalReqMaxValue2                      = 9024,
 
     }
 

--- a/Source/ACE.Server/WorldObjects/Creature_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Death.cs
@@ -771,5 +771,15 @@ namespace ACE.Server.WorldObjects
             0x5965,     // Gauntlet Arena Two (Radiant Blood)
             0x596B,     // Gauntlet Staging Area (All Societies)
         };
+
+        public bool IsInMarketplace => Location != null ? Marketplace_Landblocks.Contains(Location.LandblockId.Landblock) : false;
+
+        /// <summary>
+        /// landblock required for using /clap command
+        /// </summary>
+        public static HashSet<ushort> Marketplace_Landblocks = new HashSet<ushort>()
+        {
+            0x016C,     // Marketplace
+        };
     }
 }

--- a/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
@@ -448,6 +448,26 @@ namespace ACE.Server.WorldObjects.Managers
                     }
                     break;
 
+                /* inq questbonus amount */
+                case EmoteType.QuestCompletionCount:
+
+                    if (targetObject != null)
+                    {
+                        var QB = targetObject.GetProperty((PropertyInt64)emote.Stat);
+
+                        if (QB == null && HasValidTestNoQuality(emote.Message))
+                        {
+                            ExecuteEmoteSet(EmoteCategory.TestNoQuality, emote.Message, targetObject, true);
+                        }
+                        else
+                        {
+                            QB ??= 0;
+                            success = QB != null && QB >= (emote.Min64 ?? long.MinValue) && QB <= (emote.Max64 ?? long.MaxValue);
+                            ExecuteEmoteSet(success ? EmoteCategory.TestSuccess : EmoteCategory.TestFailure, emote.Message, targetObject, true);
+                        }
+                    }
+                    break;
+
                 case EmoteType.IncrementMyQuest:
                 case EmoteType.IncrementQuest:
 

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -2515,6 +2515,24 @@ namespace ACE.Server.WorldObjects
             set { if (!value.HasValue) RemoveProperty(PropertyInt.PortalReqMaxValue); else SetProperty(PropertyInt.PortalReqMaxValue, value.Value); }
         }
 
+        public PortalRequirement2 PortalReqType2
+        {
+            get => (PortalRequirement2)(GetProperty(PropertyInt.PortalReqType2) ?? 0);
+            set { if (value == PortalRequirement2.None) RemoveProperty(PropertyInt.PortalReqType2); else SetProperty(PropertyInt.PortalReqType2, (int)value); }
+        }
+
+        public int? PortalReqValue2
+        {
+            get => GetProperty(PropertyInt.PortalReqValue2);
+            set { if (!value.HasValue) RemoveProperty(PropertyInt.PortalReqValue2); else SetProperty(PropertyInt.PortalReqValue2, value.Value); }
+        }
+
+        public int? PortalReqMaxValue2
+        {
+            get => GetProperty(PropertyInt.PortalReqMaxValue2);
+            set { if (!value.HasValue) RemoveProperty(PropertyInt.PortalReqMaxValue2); else SetProperty(PropertyInt.PortalReqMaxValue2, value.Value); }
+        }
+
         public uint? CreatedByAccountId
         {
             get => GetProperty(PropertyDataId.CreatedByAccountId);


### PR DESCRIPTION
QOL upgrade for auto crafting enl coins faster with /clap command. Also added in a secondary portal requires property to allow multiple checks to enter a portal. Added in a QB check for portals and made a emote to inq players questbonus.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Added new emote type for quest completion counts.
	- Introduced a new command for depositing Enlightened Coins in the marketplace.
	- Enhanced portal requirement checks with new validation methods.
	- Added properties for additional portal requirement configurations.

- **Improvements**
	- Improved logic for determining if a creature is in the marketplace.
	- Streamlined portal requirement checks for better readability and maintainability. 

These updates enhance user experience by expanding functionalities and improving existing systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->