### PR TITLE
Server Property for Enlighten removing Society Flags

### DIFF
--- a/Source/ACE.Server/Entity/Enlightenment.cs
+++ b/Source/ACE.Server/Entity/Enlightenment.cs
@@ -317,29 +317,33 @@ namespace ACE.Server.Entity
 
         public static void RemoveSociety(Player player)
         {
-            player.QuestManager.Erase("SocietyMember");
-            player.QuestManager.Erase("CelestialHandMember");
-            player.QuestManager.Erase("EnlightenedCelestialHandMaster");
-            player.QuestManager.Erase("EldrytchWebMember");
-            player.QuestManager.Erase("EnlightenedEldrytchWebMaster");
-            player.QuestManager.Erase("RadiantBloodMember");
-            player.QuestManager.Erase("EnlightenedRadiantBloodMaster");
+            // Leave society alone if server prop is false
+            if (PropertyManager.GetBool("enl_removes_society").Item)
+            {
+                player.QuestManager.Erase("SocietyMember");
+                player.QuestManager.Erase("CelestialHandMember");
+                player.QuestManager.Erase("EnlightenedCelestialHandMaster");
+                player.QuestManager.Erase("EldrytchWebMember");
+                player.QuestManager.Erase("EnlightenedEldrytchWebMaster");
+                player.QuestManager.Erase("RadiantBloodMember");
+                player.QuestManager.Erase("EnlightenedRadiantBloodMaster");
 
-            if (player.SocietyRankCelhan == 1001)
-                player.QuestManager.Stamp("EnlightenedCelestialHandMaster"); // after rejoining society, player can get promoted instantly to master when speaking to promotions officer
-            if (player.SocietyRankEldweb == 1001)
-                player.QuestManager.Stamp("EnlightenedEldrytchWebMaster");   // after rejoining society, player can get promoted instantly to master when speaking to promotions officer
-            if (player.SocietyRankRadblo == 1001)
-                player.QuestManager.Stamp("EnlightenedRadiantBloodMaster");  // after rejoining society, player can get promoted instantly to master when speaking to promotions officer
+                if (player.SocietyRankCelhan == 1001)
+                    player.QuestManager.Stamp("EnlightenedCelestialHandMaster"); // after rejoining society, player can get promoted instantly to master when speaking to promotions officer
+                if (player.SocietyRankEldweb == 1001)
+                    player.QuestManager.Stamp("EnlightenedEldrytchWebMaster");   // after rejoining society, player can get promoted instantly to master when speaking to promotions officer
+                if (player.SocietyRankRadblo == 1001)
+                    player.QuestManager.Stamp("EnlightenedRadiantBloodMaster");  // after rejoining society, player can get promoted instantly to master when speaking to promotions officer
 
-            player.Faction1Bits = null;
-            player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt(player, PropertyInt.Faction1Bits, 0));
-            //player.SocietyRankCelhan = null;
-            //player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt(player, PropertyInt.SocietyRankCelhan, 0));
-            //player.SocietyRankEldweb = null;
-            //player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt(player, PropertyInt.SocietyRankEldweb, 0));
-            //player.SocietyRankRadblo = null;
-            //player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt(player, PropertyInt.SocietyRankRadblo, 0));
+                player.Faction1Bits = null;
+                player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt(player, PropertyInt.Faction1Bits, 0));
+                //player.SocietyRankCelhan = null;
+                //player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt(player, PropertyInt.SocietyRankCelhan, 0));
+                //player.SocietyRankEldweb = null;
+                //player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt(player, PropertyInt.SocietyRankEldweb, 0));
+                //player.SocietyRankRadblo = null;
+                //player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt(player, PropertyInt.SocietyRankRadblo, 0));
+            }
         }
 
         public static void RemoveLevel(Player player)

--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -609,7 +609,8 @@ namespace ACE.Server.Managers
                 ("use_wield_requirements", new Property<bool>(true, "disable this to bypass wield requirements. mostly for dev debugging")),
                 ("version_info_enabled", new Property<bool>(false, "toggles the /aceversion player command")),
                 ("vendor_shop_uses_generator", new Property<bool>(false, "enables or disables vendors using generator system in addition to createlist to create artificial scarcity")),
-                ("world_closed", new Property<bool>(false, "enable this to startup world as a closed to players world"))
+                ("world_closed", new Property<bool>(false, "enable this to startup world as a closed to players world")),
+                ("enl_removes_society", new Property<bool>(true, "if true, enlightenment will remove society flags"))
                 );
 
         public static readonly ReadOnlyDictionary<string, Property<long>> DefaultLongProperties =


### PR DESCRIPTION
Added boolean server property "enl_removes_society" defaulted to true. Switch to false to stop removing Society Flags when players enlighten.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new property that allows control over whether enlightenment removes society-related quests and ranks.
  
- **Bug Fixes**
	- Modified the logic for removing society membership to be conditional, ensuring that it only occurs based on the new property setting. 

- **Documentation**
	- Updated comments to clarify the new conditional behavior in the relevant methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->