### PR TITLE
Autocrafting

### DIFF
--- a/Source/ACE.Entity/Enum/Properties/PropertyInt64.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyInt64.cs
@@ -53,5 +53,6 @@ namespace ACE.Entity.Enum.Properties
         LumAugMeleeDefenseCount = 9024,
         LumAugMissileDefenseCount = 9025,
         LumAugMagicDefenseCount = 9026,
+        BankedWeaklyEnlightenedCoins = 9027,
     }
 }

--- a/Source/ACE.Server/Command/Handlers/PlayerCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/PlayerCommands.cs
@@ -21,6 +21,9 @@ using System.Xml.Linq;
 using Lifestoned.DataModel.DerethForever;
 using MySqlX.XDevAPI.Common;
 using static System.Net.Mime.MediaTypeNames;
+//using ACE.Server.Factories;
+//using Org.BouncyCastle.Ocsp;
+//using System.Diagnostics.Metrics;
 
 namespace ACE.Server.Command.Handlers
 {
@@ -176,7 +179,7 @@ namespace ACE.Server.Command.Handlers
                 session.Network.EnqueueSend(new GameMessageSystemChat($"/bank Deposit to deposit all pyreals, luminance, and keys or specify enlightened coins or pyreals or luminance or notes and an amount", ChatMessageType.System));
                 session.Network.EnqueueSend(new GameMessageSystemChat($"/bank Withdraw Pyreals 100 to withdraw 100 pyreals. Groups of 250000 will be exchanged for MMDs. /bank w p 100 will accomplish the same task.", ChatMessageType.System));
                 session.Network.EnqueueSend(new GameMessageSystemChat($"/bank Transfer to send Pyreals, Luminance, Legendary Keys and enlightened coins  to a character.", ChatMessageType.System));
-                session.Network.EnqueueSend(new GameMessageSystemChat($"/bank Balance to see balance. All bank commands and keywords can be shortened to their first letter. For example, /bank d will deposit all except enlightened coins, /bank b will show balance, etc.", ChatMessageType.System));
+                session.Network.EnqueueSend(new GameMessageSystemChat($"/bank Balance to see balance. All bank commands and keywords can be shortened to their first letter. For example, /bank d will deposit all except enlightened coins and weakly enlightened coins, /bank b will show balance, etc.", ChatMessageType.System));
 
                 return;
             }
@@ -201,6 +204,10 @@ namespace ACE.Server.Command.Handlers
             if (session.Player.BankedEnlightenedCoins < 0)
             {
                 session.Player.BankedEnlightenedCoins = 0;
+            }
+            if (session.Player.BankedWeaklyEnlightenedCoins < 0)
+            {
+                session.Player.BankedWeaklyEnlightenedCoins = 0;
             }
 
             int iType = 0;
@@ -239,6 +246,10 @@ namespace ACE.Server.Command.Handlers
                 if (parameters[1] == "Mythicalkeys" || parameters[1] == "mk")
                 {
                     iType = 7;
+                }
+                if (parameters[1] == "Weaklyenlightenedcoins" || parameters[1] == "we")
+                {
+                    iType = 8;
                 }
             }
 
@@ -329,6 +340,10 @@ namespace ACE.Server.Command.Handlers
                     case 7:
                         session.Player.DepositMythicalKeys();
                         session.Network.EnqueueSend(new GameMessageSystemChat($"Deposited all Mythical keys!", ChatMessageType.System));
+                        break;
+                    case 8:
+                        session.Player.DepositWeaklyEnlightenedCoins();
+                        session.Network.EnqueueSend(new GameMessageSystemChat($"Deposited all weakly enlightened coins!", ChatMessageType.System));
                         break;
                     default:
                         break;
@@ -426,6 +441,24 @@ namespace ACE.Server.Command.Handlers
                             break;
                         }
                         session.Player.WithdrawMythicalKeys(amount);
+                        break;
+                    case 8:
+                        if (session.Player.BankedWeaklyEnlightenedCoins != null && amount > session.Player.BankedWeaklyEnlightenedCoins)
+                        {
+                            session.Network.EnqueueSend(new GameMessageSystemChat($"You do not have enough weakly enlightened coins banked to make this withdrawl", ChatMessageType.System));
+                            break;
+                        }
+                        if (amount <= 0)
+                        {
+                            session.Network.EnqueueSend(new GameMessageSystemChat($"You need to provide a positive number to withdraw", ChatMessageType.System));
+                            break;
+                        }
+                        if (2 >= session.Player.GetFreeInventorySlots())
+                        {
+                            session.Network.EnqueueSend(new GameMessageSystemChat($"You do not have enough bag space to withdraw that many weakly enlightened coins.", ChatMessageType.System));
+                            break;
+                        }
+                        session.Player.WithdrawWeaklyEnlightenedCoins(amount);
                         break;
                     default:
                         break;
@@ -551,6 +584,28 @@ namespace ACE.Server.Command.Handlers
                             session.Network.EnqueueSend(new GameMessageSystemChat($"Not eligible or transfer failed: Mythical Keys to {transferTargetName}", ChatMessageType.System));
                         }
                         break;
+                    case 8:
+                        if (session.Player.BankedWeaklyEnlightenedCoins != null && amount >= session.Player.BankedWeaklyEnlightenedCoins)
+                        {
+                            session.Network.EnqueueSend(new GameMessageSystemChat($"You do not have enough weakly enlightened coins banked to make this transfer", ChatMessageType.System));
+                            break;
+                        }
+                        if (amount <= 0)
+                        {
+                            session.Network.EnqueueSend(new GameMessageSystemChat($"You need to provide a positive number to transfer", ChatMessageType.System));
+                            break;
+                        }
+                        if (session.Player.TransferWeaklyEnlightenedCoins(amount, transferTargetName))
+                        {
+                            session.Network.EnqueueSend(new GameMessageSystemChat($"Transferred {amount:N0} Weakly Enlightened coins to {transferTargetName}", ChatMessageType.System));
+
+                            if
+                                (session.Player.IsPlussed)
+                            {
+                                PlayerManager.BroadcastToAuditChannel(session.Player, $"Transferred {amount:N0} Weakly Enlightened coins to {transferTargetName}");
+                            }
+                        }
+                        break;
                 }
             }
             if (parameters[0] == "balance" || parameters[0] == "b")
@@ -561,10 +616,11 @@ namespace ACE.Server.Command.Handlers
                 session.Network.EnqueueSend(new GameMessageSystemChat($"[BANK] Legendary Keys: {session.Player.BankedLegendaryKeys:N0}", ChatMessageType.System));
                 session.Network.EnqueueSend(new GameMessageSystemChat($"[BANK] Mythical Keys: {session.Player.BankedMythicalKeys:N0}", ChatMessageType.System));
                 session.Network.EnqueueSend(new GameMessageSystemChat($"[BANK] Enlightened Coins: {session.Player.BankedEnlightenedCoins:N0}", ChatMessageType.System));
+                session.Network.EnqueueSend(new GameMessageSystemChat($"[BANK] Weakly Enlightened Coins: {session.Player.BankedWeaklyEnlightenedCoins:N0}", ChatMessageType.System));
             }
         }
 
-        [CommandHandler("clap", AccessLevel.Player, CommandHandlerFlag.RequiresWorld, 1, "Deposit Enlightened Coins using items", "Usage: /clap <amount>")]
+        [CommandHandler("clap", AccessLevel.Player, CommandHandlerFlag.RequiresWorld, 1, "Deposit Enlightened Coins and Weakly Enlightened Coins using items from your pack. It will take the lower of the red Aetheria/Empyrean and blue Aetheria/Falatacot and deposit that amount.", "Usage: /clap")]
         public static void HandleClap(Session session, params string[] parameters)
         {
             if (session.Player == null)
@@ -576,59 +632,80 @@ namespace ACE.Server.Command.Handlers
                 return;
             }
 
-            var Marketplace = session.Player.IsInMarketplace;
-            if (session.Player.CurrentLandblock != null && session.Player.IsInMarketplace == false)
+            int ClapCostPerUnit = 250000;
+
+            // Inventory counts for Red Coalesced Aetheria + Empyrean Trinkets
+            var redAetheriaItems = session.Player.GetInventoryItemsOfWCID(42636) // Coalesced Aetheria WCID
+                .Where(item => item.EquipmentSetId == null) // Check for Coalesced Aetheria
+                .ToList();
+
+            int redAetheriaCount = redAetheriaItems.Count;
+            int empyreanTrinketCount = session.Player.GetNumInventoryItemsOfWCID(34276); // Empyrean Trinket
+
+            // Inventory counts for Blue Coalesced Aetheria + Falatacot Trinkets
+            var blueAetheriaItems = session.Player.GetInventoryItemsOfWCID(42635) // Coalesced Aetheria WCID
+                .Where(item => item.EquipmentSetId == null) // Check for Coalesced Aetheria
+                .ToList();
+
+            int blueAetheriaCount = blueAetheriaItems.Count;
+            int falatacotTrinketCount = session.Player.GetNumInventoryItemsOfWCID(34277); // Falatacot Trinket
+
+            // Calculate the maximum amount of coins that can be crafted for each type
+            int redComboCount = Math.Min(redAetheriaCount, empyreanTrinketCount);
+            int blueComboCount = Math.Min(blueAetheriaCount, falatacotTrinketCount);
+
+            // Ensure the player has enough banked pyreals to cover the total cost
+            int totalCoinsToCraft = redComboCount + blueComboCount;
+            int totalClapCost = totalCoinsToCraft * ClapCostPerUnit;
+
+            if (session.Player.BankedPyreals < totalClapCost)
             {
-                session.Network.EnqueueSend(new GameMessageSystemChat("You must be in the Marketplace to use this command.", ChatMessageType.System));
+                session.Network.EnqueueSend(new GameMessageSystemChat($"You do not have enough banked pyreals to perform this action. Required: {totalClapCost}, Available: {session.Player.BankedPyreals}", ChatMessageType.Broadcast));
                 return;
             }
 
-            if (parameters.Length == 0 || !ushort.TryParse(parameters[0], out ushort clapAmount) || clapAmount < 1 || clapAmount > 10000)
+            // Consume items and bank coins
+            // Red Aetheria + Empyrean Trinkets
+            foreach (var item in redAetheriaItems.Take(redComboCount))
             {
-                session.Network.EnqueueSend(new GameMessageSystemChat("Invalid amount specified. Please provide a value between 1 and 10000.", ChatMessageType.System));
+                if (!session.Player.TryConsumeFromInventoryWithNetworking(item))
+                {
+                    session.Network.EnqueueSend(new GameMessageSystemChat("Failed to remove Red Coalesced Aetheria from inventory.", ChatMessageType.System));
+                    return;
+                }
+            }
+
+            if (!session.Player.TryConsumeFromInventoryWithNetworking(34276, redComboCount)) // Empyrean Trinket
+            {
+                session.Network.EnqueueSend(new GameMessageSystemChat("Failed to remove Empyrean Trinkets from inventory.", ChatMessageType.System));
                 return;
             }
 
-            int requiredAmount = clapAmount;
-            int ClapCost = requiredAmount * 250000;
+            session.Player.BankedEnlightenedCoins += redComboCount;
 
-            // Check inventory for items
-            if (session.Player.BankedPyreals < ClapCost)
+            // Blue Aetheria + Falatacot Trinkets
+            foreach (var item in blueAetheriaItems.Take(blueComboCount))
             {
-                session.Network.EnqueueSend(new GameMessageSystemChat($"You do not have enough banked pyreals to perform this action", ChatMessageType.Broadcast));
-                return;
+                if (!session.Player.TryConsumeFromInventoryWithNetworking(item))
+                {
+                    session.Network.EnqueueSend(new GameMessageSystemChat("Failed to remove Blue Coalesced Aetheria from inventory.", ChatMessageType.System));
+                    return;
+                }
             }
-            int item2Count = session.Player.GetNumInventoryItemsOfWCID(42636); //magic number - Red Aetheria
-            if (item2Count < requiredAmount)
-            {
-                session.Network.EnqueueSend(new GameMessageSystemChat($"You do not have enough Red Coalesced Aetheria to perform this action", ChatMessageType.Broadcast));
-                return;
-            }
-            int item3Count = session.Player.GetNumInventoryItemsOfWCID(34276); //magic number - Empyrean Trinket
 
-            if (item3Count < requiredAmount)
+            if (!session.Player.TryConsumeFromInventoryWithNetworking(34277, blueComboCount)) // Falatacot Trinket
             {
-                session.Network.EnqueueSend(new GameMessageSystemChat("You do not have enough Ancient Empyrean Trinkets to perform this action.", ChatMessageType.Broadcast));
+                session.Network.EnqueueSend(new GameMessageSystemChat("Failed to remove Falatacot Trinkets from inventory.", ChatMessageType.System));
                 return;
             }
 
-            // Remove items from inventory
-            if (!session.Player.TryConsumeFromInventoryWithNetworking(42636, requiredAmount) ||
-        !session.Player.TryConsumeFromInventoryWithNetworking(34276, requiredAmount))
-            {
-                session.Network.EnqueueSend(new GameMessageSystemChat("Failed to remove items from inventory.", ChatMessageType.System));
-                return;
-            }
+            session.Player.BankedWeaklyEnlightenedCoins += blueComboCount; // Replace with the actual property for Weakly Enlightened Coins
 
-            // Withdraw Pyreals
-            session.Player.BankedPyreals -= ClapCost;
-
-            // Deposit Enlightened Coins
-            var depoistamount = clapAmount;
-            session.Player.BankedEnlightenedCoins += depoistamount;
+            // Deduct ClapCost for both combinations
+            session.Player.BankedPyreals -= totalClapCost;
 
             // Notify the player
-            session.Network.EnqueueSend(new GameMessageSystemChat($"Deposited {clapAmount} Enlightened Coins!", ChatMessageType.Broadcast));
+            session.Network.EnqueueSend(new GameMessageSystemChat($"Deposited {redComboCount} Enlightened Coins and {blueComboCount} Weakly Enlightened Coins! Total cost: {totalClapCost} pyreals.", ChatMessageType.Broadcast));
         }
 
         [CommandHandler("enl", AccessLevel.Player, CommandHandlerFlag.RequiresWorld, 0, "Enlightenment Alias", "")]
@@ -1552,5 +1629,1723 @@ namespace ACE.Server.Command.Handlers
 
             session.Network.EnqueueSend(new GameMessageSystemChat(msg, ChatMessageType.AdminTell));
         }
+
+        // Solo and Fellowship Blackjack shared code
+
+        /* public static class BlackjackUtils
+         {
+             // Method to calculate the hand value
+             public static int GetHandValue(List<(int cardValue, CardSuit suit)> hand)
+             {
+                 int totalValue = 0;
+                 int aceCount = 0;
+
+                 foreach (var (cardValue, _) in hand)
+                 {
+                     if (cardValue >= 11 && cardValue <= 13) // Jack, Queen, King
+                     {
+                         totalValue += 10;
+                     }
+                     else if (cardValue == 1) // Ace
+                     {
+                         aceCount++;
+                         totalValue += 11; // Initially count ace as 11
+                     }
+                     else
+                     {
+                         totalValue += cardValue; // For 2-10, use the face value
+                     }
+                 }
+
+                 // Adjust for aces if the total value exceeds 21
+                 while (totalValue > 21 && aceCount > 0)
+                 {
+                     totalValue -= 10; // Treat ace as 1 instead of 11
+                     aceCount--;
+                 }
+
+                 return totalValue;
+             }
+
+             // Method to draw cards
+             public static List<(int cardValue, CardSuit suit)> DrawCards(int numberOfCards)
+             {
+                 List<(int cardValue, CardSuit suit)> cards = new List<(int cardValue, CardSuit suit)>();
+                 Random rand = new Random();
+
+                 for (int i = 0; i < numberOfCards; i++)
+                 {
+                     int cardValue = rand.Next(1, 14); // 1 to 13 (Ace to King)
+                     CardSuit suit = (CardSuit)rand.Next(0, 2); // Two suits: Hand or Eyes
+
+                     cards.Add((cardValue, suit));
+                 }
+
+                 return cards;
+             }
+
+             // Method to get card name
+             public static string GetCardName(int cardValue, CardSuit suit)
+             {
+                 string cardName = cardValue switch
+                 {
+                     1 => "Ace",
+                     11 => "Jack",
+                     12 => "Queen",
+                     13 => "King",
+                     _ => cardValue.ToString()
+                 };
+
+                 return $"{cardName} of {suit}";
+             }
+         }
+
+         // Enums for card suits
+         public enum CardSuit
+         {
+             Hands,
+             Eyes,
+             Jesters,
+             Balls
+         }
+
+         public static class BlackjackHelperFunctions
+         {
+             // Deal cards to dealer (solo and fellowship games)
+             public static void DealCardsToDealer(SoloBlackjackGame soloGame, int numberOfCards, Session session)
+             {
+                 var cards = BlackjackUtils.DrawCards(numberOfCards);
+                 foreach (var (cardValue, suit) in cards)
+                 {
+                     soloGame.DealerHand.Add((cardValue, suit));
+                     session.Network.EnqueueSend(new GameMessageSystemChat($"Rand was dealt a {BlackjackUtils.GetCardName(cardValue, suit)}.", ChatMessageType.Tell));
+                 }
+             }
+
+             public static void DealCardsToDealer(FellowshipBlackjackGame fellowGame, int numberOfCards)
+             {
+                 var cards = BlackjackUtils.DrawCards(numberOfCards);
+                 foreach (var (cardValue, suit) in cards)
+                 {
+                     fellowGame.DealerHand.Add((cardValue, suit));
+                     foreach (var player in fellowGame.Players)
+                     {
+                         player.Session.Network.EnqueueSend(new GameMessageSystemChat($"Rand was dealt a {BlackjackUtils.GetCardName(cardValue, suit)}.", ChatMessageType.Tell));
+                     }
+                 }
+             }
+
+             // Move to the next player in fellowship game
+             public static void MoveToNextActivePlayer(FellowshipBlackjackGame game, Session session)
+             {
+                 game.CurrentTurn = (game.CurrentTurn + 1) % game.Players.Count;
+                 var nextPlayer = game.GetCurrentPlayer();
+                 nextPlayer.Session.Network.EnqueueSend(new GameMessageSystemChat($"It's your turn! Type /fhit or /fstand.", ChatMessageType.Broadcast));
+             }
+
+             // Handle moving to next hand or next player in fellowship game
+             private static void MoveToNextPlayerWithRemainingHands(FellowshipBlackjackGame game, Session session)
+             {
+                 var player = game.GetCurrentPlayer();
+
+                 // Check if the player has more hands to play
+                 if (game.PlayerCurrentHand[player] < game.PlayerHands[player].Count - 1)
+                 {
+                     // Move to the second hand after the first hand is completed
+                     game.PlayerCurrentHand[player]++;
+
+                     // Now deal a card to the second hand if the first hand is done
+                     DealCardsToPlayer(player, game, 1); // Deal one card to the second hand
+                     var secondHandCard = game.PlayerHands[player][game.PlayerCurrentHand[player]].Last(); // Get the last card dealt
+                     session.Network.EnqueueSend(new GameMessageSystemChat($"You were dealt a {BlackjackUtils.GetCardName(secondHandCard.cardValue, secondHandCard.suit)} for your second hand.", ChatMessageType.System));
+                     session.Network.EnqueueSend(new GameMessageSystemChat($"Your second hand value is {BlackjackUtils.GetHandValue(game.PlayerHands[player][game.PlayerCurrentHand[player]])}.", ChatMessageType.System));
+
+                     // Inform the player to act on their second hand
+                     session.Network.EnqueueSend(new GameMessageSystemChat("You are now on your second hand. Type /fhit or /fstand.", ChatMessageType.System));
+                 }
+                 else
+                 {
+                     // If all hands are played, mark the turn complete and move to the next player
+                     game.PlayerTurnCompleted[player] = true;
+                     MoveToNextActivePlayer(game, session);
+                 }
+             }
+
+             // Give item to player
+             public static void GiveItemToPlayer(Player player, int itemWeenieClassId)
+             {
+                 var item = WorldObjectFactory.CreateNewWorldObject((uint)itemWeenieClassId);
+
+                 if (item != null && player.TryCreateInInventoryWithNetworking(item))
+                 {
+                     player.Session.Network.EnqueueSend(new GameMessageSystemChat($"A card representing your hand has been added to your inventory.", ChatMessageType.Tell));
+                 }
+                 else
+                 {
+                     player.Session.Network.EnqueueSend(new GameMessageSystemChat($"Error: Unable to add the card item to your inventory.", ChatMessageType.System));
+                 }
+             }
+         }
+
+         // Update existing Blackjack classes to call the missing functions correctly.
+         // Example usage in Solo and Fellowship play when hitting, standing, and dealer draws.
+
+         public static void DealCardsToPlayer(Player player, FellowshipBlackjackGame game, int numberOfCards)
+         {
+             try
+             {
+                 var currentHand = game.PlayerHands[player][game.PlayerCurrentHand[player]];
+                 var cards = BlackjackUtils.DrawCards(numberOfCards);
+
+                 foreach (var (cardValue, suit) in cards)
+                 {
+                     currentHand.Add((cardValue, suit));
+
+                     if (SoloBlackjackCommands.cardItemMap.TryGetValue((cardValue, suit), out int itemWeenieClassId))
+                     {
+                         BlackjackHelperFunctions.GiveItemToPlayer(player, itemWeenieClassId);
+                         game.PlayerItems[player][game.PlayerCurrentHand[player]].Add(itemWeenieClassId);
+                     }
+
+                     player.Session.Network.EnqueueSend(new GameMessageSystemChat($"You were dealt a {BlackjackUtils.GetCardName(cardValue, suit)}.", ChatMessageType.Tell));
+                 }
+             }
+             catch (Exception ex)
+             {
+                 Console.WriteLine($"Error while dealing cards to player {player.Name}: {ex.Message}");
+             }
+         }
+
+         // Solo Blackjack Game Code with Split and Double Commands
+         public class SoloBlackjackGame
+         {
+             public Player Player { get; set; }
+             public List<List<(int cardValue, CardSuit suit)>> PlayerHands { get; set; } // Multiple hands per player
+             public List<List<int>> PlayerItems { get; set; } // Multiple item lists per player
+             public long PlayerBet { get; set; } // Base bet for the player
+             public bool PlayerDoubledDown { get; set; } // Whether the player has doubled down
+             public int PlayerCurrentHand { get; set; } // Track which hand the player is on
+             public List<(int cardValue, CardSuit suit)> DealerHand { get; set; } // Store both card value and suit for dealer
+             public bool PlayerTurnCompleted { get; set; } // Track if player's turn is done
+             public bool GameEnded { get; set; } // Flag to prevent game end logic from running multiple times
+             public List<(int cardValue, CardSuit suit)> Deck { get; private set; }
+
+             public SoloBlackjackGame(Player player, long playerBet)
+             {
+                 Player = player;
+                 PlayerHands = new List<List<(int cardValue, CardSuit suit)>> { new List<(int cardValue, CardSuit suit)>() };
+                 PlayerItems = new List<List<int>> { new List<int>() };
+                 PlayerBet = playerBet;
+                 PlayerDoubledDown = false;
+                 PlayerCurrentHand = 0;
+                 PlayerTurnCompleted = false;
+                 DealerHand = new List<(int cardValue, CardSuit suit)>();
+                 GameEnded = false;
+
+                 InitializeDeck(); // Initialize and shuffle the deck at the start of each game
+             }
+
+             // Initialize and shuffle the deck
+             private void InitializeDeck()
+             {
+                 Deck = new List<(int cardValue, CardSuit suit)>();
+
+                 // Add all 52 cards to the deck (13 values for each of the 4 suits)
+                 for (int value = 1; value <= 13; value++)
+                 {
+                     Deck.Add((value, CardSuit.Hands));
+                     Deck.Add((value, CardSuit.Eyes));
+                     Deck.Add((value, CardSuit.Jesters));
+                     Deck.Add((value, CardSuit.Balls));
+                 }
+
+                 // Shuffle the deck
+                 Random rand = new Random();
+                 Deck = Deck.OrderBy(_ => rand.Next()).ToList();
+             }
+
+             // Method to draw a card from the deck
+             public (int cardValue, CardSuit suit) DrawCard()
+             {
+                 if (Deck.Count == 0)
+                 {
+                     throw new InvalidOperationException("The deck is empty.");
+                 }
+
+                 var card = Deck[0];
+                 Deck.RemoveAt(0); // Remove the card from the deck after drawing
+                 return card;
+             }
+         }
+
+         public static class SoloBlackjackCommands
+         {
+             public static Dictionary<ObjectGuid, SoloBlackjackGame> activeSoloBlackjackGames = new Dictionary<ObjectGuid, SoloBlackjackGame>(); // Directly use ObjectGuid
+
+             public static Dictionary<(int rank, CardSuit suit), int> cardItemMap = new Dictionary<(int rank, CardSuit suit), int>
+ {
+                 //Deck of hands
+     {( 1, CardSuit.Hands),90000219 },  // Ace
+     {( 2, CardSuit.Hands), 90000220 },  // 2
+     {( 3, CardSuit.Hands), 90000221 },  // 3
+     {( 4, CardSuit.Hands), 90000222 },  // 4
+     {( 5, CardSuit.Hands), 90000223 },  // 5
+     {( 6, CardSuit.Hands), 90000224 },  // 6
+     {( 7, CardSuit.Hands), 90000225 },  // 7
+     {( 8, CardSuit.Hands), 90000226 },  // 8
+     {( 9, CardSuit.Hands), 90000227 },  // 9
+     {( 10, CardSuit.Hands), 90000228 }, // 10
+     {( 11, CardSuit.Hands), 90000229 }, // Jack
+     {( 12, CardSuit.Hands), 90000230 }, // Queen
+     {( 13, CardSuit.Hands), 90000231 },  // King
+
+                  //Deck of eyes
+     {( 1, CardSuit.Eyes),90000232 },  // Ace
+     {( 2, CardSuit.Eyes), 90000233 },  // 2
+     {( 3, CardSuit.Eyes), 90000234 },  // 3
+     {( 4, CardSuit.Eyes), 90000235 },  // 4
+     {( 5, CardSuit.Eyes), 90000236 },  // 5
+     {( 6, CardSuit.Eyes), 90000237 },  // 6
+     {( 7, CardSuit.Eyes), 90000238 },  // 7
+     {( 8, CardSuit.Eyes), 90000239 },  // 8
+     {( 9, CardSuit.Eyes), 90000240 },  // 9
+     {( 10, CardSuit.Eyes), 90000241 }, // 10
+     {( 11, CardSuit.Eyes), 90000242 }, // Jack
+     {( 12, CardSuit.Eyes), 90000243 }, // Queen
+     {( 13, CardSuit.Eyes), 90000244 },  // King
+
+                  //Deck of jesters
+     {( 1, CardSuit.Jesters),90000245 },  // Ace
+     {( 2, CardSuit.Jesters), 90000246 },  // 2
+     {( 3, CardSuit.Jesters), 90000247 },  // 3
+     {( 4, CardSuit.Jesters), 90000248 },  // 4
+     {( 5, CardSuit.Jesters), 90000249 },  // 5
+     {( 6, CardSuit.Jesters), 90000250 },  // 6
+     {( 7, CardSuit.Jesters), 90000251 },  // 7
+     {( 8, CardSuit.Jesters), 90000252 },  // 8
+     {( 9, CardSuit.Jesters), 90000253 },  // 9
+     {( 10, CardSuit.Jesters), 90000254 }, // 10
+     {( 11, CardSuit.Jesters), 90000255 }, // Jack
+     {( 12, CardSuit.Jesters), 90000256 }, // Queen
+     {( 13, CardSuit.Jesters), 90000257 },  // King
+
+                  //Deck of crosses
+     {( 1, CardSuit.Balls),90000258 },  // Ace
+     {( 2, CardSuit.Balls), 90000259 },  // 2
+     {( 3, CardSuit.Balls), 90000260 },  // 3
+     {( 4, CardSuit.Balls), 90000261 },  // 4
+     {( 5, CardSuit.Balls), 90000262 },  // 5
+     {( 6, CardSuit.Balls), 90000263 },  // 6
+     {( 7, CardSuit.Balls), 90000264 },  // 7
+     {( 8, CardSuit.Balls), 90000265 },  // 8
+     {( 9, CardSuit.Balls), 90000266 },  // 9
+     {( 10, CardSuit.Balls), 90000267 }, // 10
+     {( 11, CardSuit.Balls), 90000268 }, // Jack
+     {( 12, CardSuit.Balls), 90000269 }, // Queen
+     {( 13, CardSuit.Balls), 90000270 }, // King
+ };
+
+             // Start the solo blackjack game
+             [CommandHandler("blackjack", AccessLevel.Player, CommandHandlerFlag.RequiresWorld, "Start a solo blackjack game", "Usage: /blackjack <bet amount>")]
+             public static void HandleSoloBlackjackCommand(Session session, params string[] parameters)
+             {
+
+                 // Check if the player already has an active game
+                 if (activeSoloBlackjackGames.ContainsKey(session.Player.Guid))
+                 {
+                     session.Network.EnqueueSend(new GameMessageSystemChat("You are already in a blackjack game. Finish your current game before starting a new one.", ChatMessageType.System));
+                     return;
+                 }
+
+                 if (parameters.Length == 0 || !long.TryParse(parameters[0], out long bet) || bet <= 0)
+                 {
+                     session.Network.EnqueueSend(new GameMessageSystemChat("You must specify a valid bet amount. Example: /blackjack 1000000", ChatMessageType.System));
+                     return;
+                 }
+
+                 if (session.Player.BankedLuminance < bet)
+                 {
+                     session.Network.EnqueueSend(new GameMessageSystemChat("You don't have enough luminance to place this bet.", ChatMessageType.System));
+                     return;
+                 }
+
+                 // Initialize the game and deduct the initial bet
+                 var game = new SoloBlackjackGame(session.Player, bet);
+                 activeSoloBlackjackGames[session.Player.Guid] = game;
+
+                 // Initial bet deduction
+                 Console.WriteLine($"[DEBUG] Initial Banked Luminance before game starts: {session.Player.BankedLuminance}");
+                 session.Player.BankedLuminance -= bet; // Deduct the player's luminance
+                 Console.WriteLine($"[DEBUG] Banked Luminance after initial bet deduction: {session.Player.BankedLuminance}");
+
+                 session.Network.EnqueueSend(new GameMessageSystemChat($"You have placed a bet of {bet:N0} luminance!", ChatMessageType.Broadcast));
+
+                 // Deal initial cards to player and dealer
+                 session.Network.EnqueueSend(new GameMessageSystemChat($"The game begins! It's your turn. Type /hit or /stand.", ChatMessageType.Broadcast));
+                 DealInitialCardsToPlayer(game, session);
+             }
+
+             // Handle hitting
+             [CommandHandler("hit", AccessLevel.Player, CommandHandlerFlag.RequiresWorld, "Hit a card in solo blackjack", "")]
+             public static void HandleHitCommand(Session session, params string[] parameters)
+             {
+                 if (!activeSoloBlackjackGames.TryGetValue(session.Player.Guid, out var game))
+                 {
+                     session.Network.EnqueueSend(new GameMessageSystemChat("You are not currently in a blackjack game.", ChatMessageType.Combat));
+                     return;
+                 }
+
+                 try
+                 {
+                     // Deal a card to the player
+                     DealCardsToSoloPlayer(game, 1, session); // Deal one card
+
+                     // Calculate the current hand value
+                     int handValue = BlackjackUtils.GetHandValue(game.PlayerHands[game.PlayerCurrentHand]);
+
+                     // Update player with new hand value after the hit
+                     session.Network.EnqueueSend(new GameMessageSystemChat($"Your hand value is now {handValue}.", ChatMessageType.System));
+
+                     if (handValue > 21)
+                     {
+                         long totalBet = game.PlayerBet;  // Total bet after doubling down
+                         session.Network.EnqueueSend(new GameMessageSystemChat($"You busted with a hand value of {handValue} You lost {totalBet:N0} luminance.", ChatMessageType.Combat));
+
+                         // Check if there's a second hand after busting the first
+                         if (game.PlayerHands.Count > 1 && game.PlayerCurrentHand == 0)
+                         {
+                             game.PlayerCurrentHand++; // Move to the second hand
+                             session.Network.EnqueueSend(new GameMessageSystemChat($"Now playing your second hand. Type /hit or /stand for your second hand.", ChatMessageType.Tell));
+                             session.Network.EnqueueSend(new GameMessageSystemChat($"Your second hand value is {BlackjackUtils.GetHandValue(game.PlayerHands[game.PlayerCurrentHand])}.", ChatMessageType.Broadcast));
+                             return;
+                         }
+                         // Only end the game if this is the last hand
+                         if (game.PlayerCurrentHand == game.PlayerHands.Count - 1)
+                         {
+                             // Reveal dealer hand only after both hands have been played or busted
+                             RevealDealerHand(game, session);
+                             ResolveDealerHand(game, session);
+
+                             // Determine the winner after all hands are completed
+                             DetermineWinner(game, session);
+                             EndSoloBlackjackGame(game, session);
+                         }
+                     }
+                     else
+                     {
+                         session.Network.EnqueueSend(new GameMessageSystemChat($"Your hand value is now {handValue}. Type /hit to draw another card or /stand to end your turn.", ChatMessageType.Broadcast));
+                     }
+                 }
+                 catch (Exception ex)
+                 {
+                     Console.WriteLine($"Error in HandleHitCommand: {ex.Message}");
+                     session.Network.EnqueueSend(new GameMessageSystemChat($"Error occurred while hitting: {ex.Message}", ChatMessageType.System));
+                 }
+             }
+
+             // Handle standing for solo blackjack
+             [CommandHandler("stand", AccessLevel.Player, CommandHandlerFlag.RequiresWorld, "Stand in blackjack", "")]
+             public static void HandleStandCommand(Session session, params string[] parameters)
+             {
+                 if (!activeSoloBlackjackGames.TryGetValue(session.Player.Guid, out var game))
+                 {
+                     session.Network.EnqueueSend(new GameMessageSystemChat("You are not currently in a blackjack game.", ChatMessageType.Combat));
+                     return;
+                 }
+
+                 try
+                 {
+                     int playerHandValue = BlackjackUtils.GetHandValue(game.PlayerHands[game.PlayerCurrentHand]);
+
+                     // Inform player of their final hand value when they stand
+                     session.Network.EnqueueSend(new GameMessageSystemChat($"Your final hand value is {playerHandValue}.", ChatMessageType.System));
+
+                     // If the player has another hand, move to that hand after completing the first one
+                     if (game.PlayerHands.Count > 1 && game.PlayerCurrentHand == 0) // If there is a second hand and we just completed the first
+                     {
+                         game.PlayerCurrentHand++; // Move to the second hand
+
+                         // Automatically deal a card to the second hand
+                         DealCardsToSoloPlayer(game, 1, session); // Auto-deal one card
+
+                         session.Network.EnqueueSend(new GameMessageSystemChat($"Now playing your second hand. Type /hit or /stand for your second hand.", ChatMessageType.Tell));
+                         session.Network.EnqueueSend(new GameMessageSystemChat($"Your second hand value is {BlackjackUtils.GetHandValue(game.PlayerHands[game.PlayerCurrentHand])}.", ChatMessageType.Broadcast));
+                         return; // Return here so that it waits for the player's input for the second hand
+                     }
+
+                     // Reveal dealer hand only after both hands have been played
+                     RevealDealerHand(game, session);
+                     ResolveDealerHand(game, session);
+
+                     // Determine the winner
+                     DetermineWinner(game, session);
+                     EndSoloBlackjackGame(game, session);
+                 }
+                 catch (Exception ex)
+                 {
+                     Console.WriteLine($"Error while standing: {ex.Message}");
+                     session.Network.EnqueueSend(new GameMessageSystemChat($"Error occurred while standing: {ex.Message}", ChatMessageType.System));
+                 }
+             }
+
+             // Handle doubling down
+             [CommandHandler("double", AccessLevel.Player, CommandHandlerFlag.RequiresWorld, "Double down in blackjack", "")]
+             public static void HandleDoubleDownCommand(Session session, params string[] parameters)
+             {
+                 if (!activeSoloBlackjackGames.TryGetValue(session.Player.Guid, out var game))
+                 {
+                     session.Network.EnqueueSend(new GameMessageSystemChat("You are not currently in a blackjack game.", ChatMessageType.Combat));
+                     return;
+                 }
+
+                 var hand = game.PlayerHands[game.PlayerCurrentHand];
+
+                 // Add a check to prevent doubling down after splitting
+                 if (game.PlayerHands.Count > 1)
+                 {
+                     session.Network.EnqueueSend(new GameMessageSystemChat("You cannot double down after splitting your hand.", ChatMessageType.Combat));
+                     return;
+                 }
+
+                 // Allow doubling down only with two cards
+                 if (hand.Count == 2)
+                 {
+                     Console.WriteLine($"[DEBUG] Player is doubling down. Original bet: {game.PlayerBet}");
+
+                     // Double the player's original bet
+                     long originalBet = game.PlayerBet;  // Capture the original bet before doubling
+                     game.PlayerBet *= 2;
+                     game.PlayerDoubledDown = true;
+
+                     Console.WriteLine($"[DEBUG] Player doubled down. New bet amount: {game.PlayerBet}");
+
+                     session.Network.EnqueueSend(new GameMessageSystemChat("You have doubled your bet! You will receive one more card, and your turn will end.", ChatMessageType.Broadcast));
+
+                     // Deal one more card to the player
+                     DealCardsToSoloPlayer(game, 1, session);
+
+                     int handValue = BlackjackUtils.GetHandValue(game.PlayerHands[game.PlayerCurrentHand]);
+                     Console.WriteLine($"[DEBUG] Player's final hand value after double down: {handValue}");
+
+                     session.Network.EnqueueSend(new GameMessageSystemChat($"Your final hand value is {handValue}.", ChatMessageType.System));
+
+                     if (handValue > 21 && game.PlayerDoubledDown == true)
+                     {
+                         long totalBet = game.PlayerBet;  // Total bet after doubling down
+                         long additionalBet = totalBet / 2; // Only deduct the additional bet
+
+                         Console.WriteLine($"[DEBUG] Player busted. Deducting additional {additionalBet} luminance.");
+
+                         // Deduct luminance for busting
+                         session.Player.BankedLuminance -= additionalBet;
+                         session.Network.EnqueueSend(new GameMessageSystemChat($"You busted with a hand value of {handValue}. You have lost your bet of {totalBet:N0} luminance.", ChatMessageType.Combat));
+
+                         EndSoloBlackjackGame(game, session);
+                         return;
+                     }
+                     else
+                     {
+                         // If the player didn’t bust, proceed to reveal dealer's hand and determine winner
+                         RevealDealerHand(game, session);
+                         ResolveDealerHand(game, session);
+                         DetermineWinner(game, session);
+                     }
+
+                     // End the game only if it hasn't been ended yet
+                     if (game.GameEnded)
+                     {
+                         EndSoloBlackjackGame(game, session);
+                     }
+                 }
+                 else
+                 {
+                     session.Network.EnqueueSend(new GameMessageSystemChat("You can only double down on your first two cards.", ChatMessageType.Combat));
+                 }
+             }
+
+             // Handle splitting the hand
+             [CommandHandler("split", AccessLevel.Player, CommandHandlerFlag.RequiresWorld, "Split your hand in blackjack", "")]
+             public static void HandleSplitCommand(Session session, params string[] parameters)
+             {
+                 if (!activeSoloBlackjackGames.TryGetValue(session.Player.Guid, out var game))
+                 {
+                     session.Network.EnqueueSend(new GameMessageSystemChat("You are not currently in a blackjack game.", ChatMessageType.Combat));
+                     return;
+                 }
+
+                 var hand = game.PlayerHands[game.PlayerCurrentHand];
+
+                 // Allow splitting only if the player has two cards of the same value
+                 if (hand.Count == 2 && hand[0].cardValue == hand[1].cardValue)
+                 {
+                     // Check if player has enough luminance for the additional bet
+                     if (session.Player.BankedLuminance < game.PlayerBet)
+                     {
+                         session.Network.EnqueueSend(new GameMessageSystemChat("You don't have enough luminance to split your hand.", ChatMessageType.Combat));
+                         return;
+                     }
+
+                     // Deduct the additional bet from player's luminance
+                     session.Player.BankedLuminance -= game.PlayerBet;
+                     Console.WriteLine($"[DEBUG] Additional bet placed for split. Player's remaining luminance: {session.Player.BankedLuminance}");
+
+                     // Create a new hand by splitting the current hand
+                     game.PlayerHands.Add(new List<(int cardValue, CardSuit suit)> { hand[1] });
+                     game.PlayerItems.Add(new List<int>()); // Initialize new hand's items list
+                     hand.RemoveAt(1); // Keep one card in the original hand
+
+                     session.Network.EnqueueSend(new GameMessageSystemChat("You have split your hand into two separate hands!", ChatMessageType.Broadcast));
+
+                     // Deal one card to each of the hands
+                     DealCardsToSoloPlayer(game, 1, session);
+
+                     // Inform the player of the next action for their first hand
+                     session.Network.EnqueueSend(new GameMessageSystemChat($"Your first hand value is {BlackjackUtils.GetHandValue(game.PlayerHands[game.PlayerCurrentHand])}. Type /hit or /stand for your first hand.", ChatMessageType.Broadcast));
+                 }
+                 else
+                 {
+                     session.Network.EnqueueSend(new GameMessageSystemChat("You can only split if you have two cards of the same value.", ChatMessageType.Combat));
+                 }
+             }
+
+             // Deal initial cards to player and dealer
+             private static void DealInitialCardsToPlayer(SoloBlackjackGame game, Session session)
+             {
+
+                 // Check if the game has already ended (e.g., due to initial Blackjack)
+                 if (game.GameEnded) return;
+
+                 try
+                 {
+                     DealCardsToSoloPlayer(game, 2, session); // Deal two cards to player
+                     if (game.GameEnded) return;
+                     int playerHandValue = BlackjackUtils.GetHandValue(game.PlayerHands[game.PlayerCurrentHand]);
+
+                     // Show player's initial hand value after two cards are dealt
+                     session.Network.EnqueueSend(new GameMessageSystemChat($"Your initial hand value is {playerHandValue}.", ChatMessageType.System));
+
+                     DealInitialCardsToDealer(game, session); // Deal two cards to the dealer (show only one)
+                 }
+                 catch (Exception ex)
+                 {
+                     Console.WriteLine($"Error while dealing initial cards: {ex.Message}");
+                     session.Network.EnqueueSend(new GameMessageSystemChat($"Error occurred while dealing initial cards: {ex.Message}", ChatMessageType.System));
+                 }
+             }
+
+             // Deal cards to the solo player
+             public static void DealCardsToSoloPlayer(SoloBlackjackGame game, int numberOfCards, Session session)
+             {
+                 try
+                 {
+                     // Ensure the player's hand is initialized
+                     if (game.PlayerHands == null || game.PlayerHands.Count == 0)
+                     {
+                         game.PlayerHands = new List<List<(int cardValue, CardSuit suit)>> { new List<(int cardValue, CardSuit suit)>() };
+                     }
+
+                     var currentHand = game.PlayerHands[game.PlayerCurrentHand];
+
+                     for (int i = 0; i < numberOfCards; i++)
+                     {
+                         var card = game.DrawCard(); // Draw a unique card from the deck
+                         currentHand.Add(card);
+
+                         if (cardItemMap.TryGetValue((card.cardValue, card.suit), out int itemWeenieClassId))
+                         {
+                             BlackjackHelperFunctions.GiveItemToPlayer(game.Player, itemWeenieClassId); // Add item to player's inventory
+                             game.PlayerItems[game.PlayerCurrentHand].Add(itemWeenieClassId);
+                         }
+
+                         session.Network.EnqueueSend(new GameMessageSystemChat($"You were dealt a {BlackjackUtils.GetCardName(card.cardValue, card.suit)}.", ChatMessageType.Tell));
+                     }
+
+                     // Check for an initial blackjack if the player has exactly two cards
+                     if (currentHand.Count == 2)
+                     {
+                         int handValue = BlackjackUtils.GetHandValue(currentHand);
+                         if (handValue == 21)
+                         {
+                             long winnings = (long)(game.PlayerBet * 1.25); // 
+                             game.Player.BankedLuminance += winnings;
+
+                             session.Network.EnqueueSend(new GameMessageSystemChat($"Blackjack! You win with a hand value of 21. You gain {winnings:N0} luminance.", ChatMessageType.Broadcast));
+
+                             EndSoloBlackjackGame(game, session); // End the game
+                             return; // Exit to prevent further actions
+                         }
+                     }
+                 }
+                 catch (Exception ex)
+                 {
+                     Console.WriteLine($"Error while dealing cards to player {game.Player.Name}: {ex.Message}");
+                 }
+             }
+
+             // Deal initial cards to the dealer (deal two but only show one)
+             private static void DealInitialCardsToDealer(SoloBlackjackGame game, Session session)
+             {
+                 if (game.DealerHand == null)
+                 {
+                     game.DealerHand = new List<(int cardValue, CardSuit suit)>(); // Ensure the dealer hand is initialized
+                 }
+
+                 try
+                 {
+                     // Draw two cards for the dealer
+                     var cards = BlackjackUtils.DrawCards(2);
+
+                     // Add both cards to the dealer's hand
+                     game.DealerHand.Add(cards[0]);
+                     game.DealerHand.Add(cards[1]);
+
+                     // Show only the first card to the player
+                     var (cardValue, suit) = cards[0];
+                     session.Network.EnqueueSend(new GameMessageSystemChat($"Rand was dealt a {BlackjackUtils.GetCardName(cardValue, suit)}.", ChatMessageType.Tell));
+
+                     // Show the dealer's current hand value after the first card is revealed
+                     int currentHandValue = BlackjackUtils.GetHandValue(game.DealerHand.Take(1).ToList());
+                     session.Network.EnqueueSend(new GameMessageSystemChat($"Rand's current hand value is {currentHandValue}.", ChatMessageType.Magic));
+                 }
+                 catch (Exception ex)
+                 {
+                     Console.WriteLine($"Error while dealing initial cards to the dealer: {ex.Message}");
+                     session.Network.EnqueueSend(new GameMessageSystemChat($"Error occurred while dealing initial cards to the dealer: {ex.Message}", ChatMessageType.System));
+                 }
+             }
+
+             // Reveal the dealer's second card and determine if game should end
+             private static void RevealDealerHand(SoloBlackjackGame game, Session session)
+             {
+                 if (game.GameEnded) return; // Prevent redundant actions
+
+                 // Reveal each of Rand's cards except the first one (already revealed)
+                 for (int i = 1; i < game.DealerHand.Count; i++)
+                 {
+                     var (cardValue, suit) = game.DealerHand[i];
+                     session.Network.EnqueueSend(new GameMessageSystemChat($"Rand reveals a {BlackjackUtils.GetCardName(cardValue, suit)}.", ChatMessageType.Tell));
+                 }
+
+                 // Calculate dealer's current hand value
+                 int dealerHandValue = BlackjackUtils.GetHandValue(game.DealerHand);
+                 int playerHandValue = BlackjackUtils.GetHandValue(game.PlayerHands[game.PlayerCurrentHand]);
+
+                 Console.WriteLine($"[DEBUG] Player hand value: {playerHandValue}, Dealer hand value after reveal: {dealerHandValue}");
+
+                 if (dealerHandValue >= 17 && dealerHandValue >= playerHandValue)
+                 {
+                     // If dealer reaches final hand, announce it
+                     session.Network.EnqueueSend(new GameMessageSystemChat($"Rand's final hand value is {dealerHandValue}.", ChatMessageType.Magic));
+
+                     // Trigger DetermineWinner to finalize the game
+                     DetermineWinner(game, session);
+
+                     // End the game to clean up state and remove cards
+                     EndSoloBlackjackGame(game, session);
+                 }
+                 else if (dealerHandValue == 17 && playerHandValue > 17 && playerHandValue <= 21)
+                 {
+                     // If dealer has 17 but the player's hand is greater, Rand should attempt to beat the player's hand
+                     session.Network.EnqueueSend(new GameMessageSystemChat($"Rand's current hand value is {dealerHandValue}, but he draws to try and beat your hand of {playerHandValue}.", ChatMessageType.Magic));
+
+                     // Proceed to ResolveDealerHand to try and beat the player's hand
+                     ResolveDealerHand(game, session);
+                 }
+                 else
+                 {
+                     // Dealer will draw again if hand is less than 17 and not beating player
+                     session.Network.EnqueueSend(new GameMessageSystemChat($"Rand's current hand value is {dealerHandValue}.", ChatMessageType.Magic));
+
+                     // Proceed to ResolveDealerHand if not ended
+                     ResolveDealerHand(game, session);
+                 }
+             }
+
+             // Handle resolving the dealer's hand if necessary
+             private static void ResolveDealerHand(SoloBlackjackGame game, Session session)
+             {
+                 if (game.GameEnded) return; // Prevent duplicate resolves if the game already ended
+
+                 int playerHandValue = BlackjackUtils.GetHandValue(game.PlayerHands[game.PlayerCurrentHand]);
+                 int dealerHandValue = BlackjackUtils.GetHandValue(game.DealerHand);
+
+                 Console.WriteLine($"[DEBUG] Initial Dealer Hand: {dealerHandValue}, Player Hand: {playerHandValue}");
+
+                 while (dealerHandValue < 17 || (dealerHandValue < playerHandValue && playerHandValue > 17 && dealerHandValue < 21))
+                 {
+                     var card = BlackjackUtils.DrawCards(1).First();
+                     game.DealerHand.Add(card);
+
+                     // Announce each card Rand draws
+                     dealerHandValue = BlackjackUtils.GetHandValue(game.DealerHand);
+                     session.Network.EnqueueSend(new GameMessageSystemChat($"Rand drew a {BlackjackUtils.GetCardName(card.cardValue, card.suit)}. Rand's hand value is now {dealerHandValue}.", ChatMessageType.System));
+                     Console.WriteLine($"[DEBUG] Rand drew a card. New Dealer Hand Value: {dealerHandValue}");
+
+                     // Check if Rand busted
+                     if (dealerHandValue > 21)
+                     {
+                         session.Network.EnqueueSend(new GameMessageSystemChat($"Rand's final hand value is {dealerHandValue}.", ChatMessageType.System));
+                         Console.WriteLine("[DEBUG] Rand busted. Calling DetermineWinner and EndSoloBlackjackGame.");
+
+                         // Call DetermineWinner without setting GameEnded prematurely
+                         DetermineWinner(game, session);
+                         EndSoloBlackjackGame(game, session); // Ensure the game ends and items are removed
+                         return;
+                     }
+
+                     // If Rand's hand value equals 17 and matches player's 17, stop for a tie
+                     if (dealerHandValue == 17 && playerHandValue == 17)
+                     {
+                         session.Network.EnqueueSend(new GameMessageSystemChat($"Rand's final hand value is {dealerHandValue}.", ChatMessageType.System));
+                         Console.WriteLine("[DEBUG] Game ended with a tie at 17.");
+                         DetermineWinner(game, session);
+                         EndSoloBlackjackGame(game, session);
+                         return;
+                     }
+
+                     // Stop if Rand's hand is at least 17 and equals or exceeds player's hand
+                     if (dealerHandValue >= 17 && dealerHandValue >= playerHandValue)
+                     {
+                         session.Network.EnqueueSend(new GameMessageSystemChat($"Rand's final hand value is {dealerHandValue}.", ChatMessageType.System));
+                         Console.WriteLine("[DEBUG] Rand's hand met ending condition; exiting loop.");
+                         DetermineWinner(game, session);
+                         EndSoloBlackjackGame(game, session);
+                         return;
+                     }
+                 }
+
+                 // Final safety check if game-ending conditions were not met in the loop
+                 if (!game.GameEnded)
+                 {
+                     Console.WriteLine("[DEBUG] Loop completed without game end; calling DetermineWinner.");
+                     DetermineWinner(game, session);
+                     EndSoloBlackjackGame(game, session); // Ensure the game properly ends
+                 }
+
+                 // Now set game.GameEnded to avoid duplicate end-game calls after all logic
+                 game.GameEnded = true;
+             }
+
+             // Clean up at end of solo game, removing cards and ensuring game end message
+             private static void EndSoloBlackjackGame(SoloBlackjackGame game, Session session)
+             {
+                 Console.WriteLine("[DEBUG] Entered EndSoloBlackjackGame");
+
+                 if (game.GameEnded)
+                 {
+                     Console.WriteLine("[DEBUG] Game has already ended, exiting EndSoloBlackjackGame");
+                     return; // Prevent multiple calls to end-game logic
+                 }
+
+                 game.GameEnded = true; // Set the flag to avoid re-triggering
+
+                 // Remove cards from player inventory
+                 RemoveCardsFromPlayerInventory(game);
+                 Console.WriteLine("[DEBUG] Cards removed from player inventory.");
+
+                 // Announce end of game
+                 session.Network.EnqueueSend(new GameMessageSystemChat("The blackjack game has ended, and the cards have been removed from your inventory.", ChatMessageType.Broadcast));
+                 Console.WriteLine("[DEBUG] Game end message sent to player.");
+
+                 // Remove game from active games list
+                 activeSoloBlackjackGames.Remove(game.Player.Guid);
+                 Console.WriteLine("[DEBUG] Game removed from activeSoloBlackjackGames.");
+             }
+
+             // Determine the winner and enforce game end
+             public static void DetermineWinner(SoloBlackjackGame game, Session session)
+             {
+                 if (game.GameEnded) return; // Avoid multiple end-game calls
+
+                 // Track total winnings across multiple hands if split
+                 long totalWinnings = 0;
+                 bool playerWon = false;
+
+                 // Loop through each hand (supporting split hands)
+                 for (int i = 0; i < game.PlayerHands.Count; i++)
+                 {
+                     int playerHandValue = BlackjackUtils.GetHandValue(game.PlayerHands[i]);
+                     int dealerHandValue = BlackjackUtils.GetHandValue(game.DealerHand);
+
+                     // Calculate base bet and double-down-specific amounts
+                     long baseBet = game.PlayerBet / (game.PlayerDoubledDown && i == 0 ? 2 : 1);
+                     long additionalBet = game.PlayerDoubledDown && i == 0 ? baseBet : 0; // Additional bet for double-down
+                     long winnings = 0;
+
+                     // Scenario 1: Player busts
+                     if (playerHandValue > 21 && game.PlayerDoubledDown == false)
+                     {
+                         session.Network.EnqueueSend(new GameMessageSystemChat(
+                             $"You busted with a hand value of {playerHandValue} on hand {i + 1}. You lost your bet of {additionalBet + baseBet:N0} luminance.",
+                             ChatMessageType.Combat));
+                         game.Player.BankedLuminance -= additionalBet; // Deduct only the additional amount if it's a double-down
+                     }
+                     // Scenario 2: Dealer busts or player has a higher hand than the dealer
+                     else if (dealerHandValue > 21 || playerHandValue > dealerHandValue)
+                     {
+                         winnings = game.PlayerDoubledDown && i == 0
+                             ? (long)(baseBet * 1.5) // Double-down winnings (150% of original bet)
+                             : (long)(baseBet * 1.25); // Normal play or split hand winnings (125% of bet)
+
+                         totalWinnings += winnings;
+                         session.Network.EnqueueSend(new GameMessageSystemChat(
+                             $"You won with a hand value of {playerHandValue} on hand {i + 1}! You gain {winnings:N0} luminance.",
+                             ChatMessageType.Broadcast));
+
+                         playerWon = true;
+                     }
+                     // Scenario 3: Tie with dealer
+                     else if (playerHandValue == dealerHandValue)
+                     {
+                         session.Network.EnqueueSend(new GameMessageSystemChat(
+                             $"You tied with Rand on hand {i + 1}. Your bet of {baseBet:N0} luminance has been returned.",
+                             ChatMessageType.Tell));
+
+                         // Return only the base bet amount without any winnings or losses
+                         game.Player.BankedLuminance += baseBet;
+                         EndSoloBlackjackGame(game, session);
+                     }
+                     // Scenario 4: Dealer wins with a higher hand value (Normal loss or double-down loss)
+                     else
+                     {
+                         if (game.PlayerDoubledDown && i == 0)
+                         {
+                             session.Network.EnqueueSend(new GameMessageSystemChat(
+                                 $"You lost with a hand value of {playerHandValue} on hand {i + 1}. You have lost your bet of {additionalBet + baseBet:N0} Luminance.",
+                                 ChatMessageType.Combat));
+                             game.Player.BankedLuminance -= additionalBet; // Deduct only the additional amount for double-down
+                         }
+                         else
+                         {
+                             session.Network.EnqueueSend(new GameMessageSystemChat(
+                                 $"You lost with a hand value of {playerHandValue} on hand {i + 1}. You have lost your bet of {baseBet:N0} Luminance.",
+                                 ChatMessageType.Combat));
+                         }
+                     }
+                 }
+
+                 // Update banked luminance only once with total winnings, if any
+                 if (playerWon)
+                 {
+                     game.Player.BankedLuminance += totalWinnings;
+                 }
+
+                 EndSoloBlackjackGame(game, session);
+             }
+
+
+             // Remove cards from the player's inventory
+             private static void RemoveCardsFromPlayerInventory(SoloBlackjackGame game)
+             {
+                 var player = game.Player;
+
+                 // Loop through each hand's item list and remove the card items from the player's inventory
+                 foreach (var handItems in game.PlayerItems)
+                 {
+                     foreach (var itemWeenieClassId in handItems.Distinct()) // Ensure distinct items are removed only once
+                     {
+                         RemoveItemFromPlayer(player, itemWeenieClassId);
+                     }
+                 }
+             }
+
+             private static void RemoveItemFromPlayer(Player player, int itemWeenieClassId)
+             {
+                 try
+                 {
+                     // Get all items in the player's inventory that match the itemWeenieClassId
+                     var items = player.GetInventoryItemsOfWCID((uint)itemWeenieClassId);
+
+                     if (items.Any())
+                     {
+                         foreach (var item in items.ToList()) // Convert to a list to avoid modifying the collection while iterating
+                         {
+                             if (player.TryRemoveFromInventoryWithNetworking(item.Guid, out var removedItem, Player.RemoveFromInventoryAction.ConsumeItem))
+                             {
+                                 //player.Session.Network.EnqueueSend(new GameMessageSystemChat($"The card item has been removed from your inventory.", ChatMessageType.System));
+                             }
+                             else
+                             {
+                                 Console.WriteLine($"Error: Failed to remove card item {itemWeenieClassId} from player {player.Name}'s inventory.");
+                             }
+                         }
+                     }
+                     else
+                     {
+                         Console.WriteLine($"Error: Card item {itemWeenieClassId} not found in player {player.Name}'s inventory.");
+                     }
+                 }
+                 catch (Exception ex)
+                 {
+                     Console.WriteLine($"Error in RemoveItemFromPlayer: {ex.Message}");
+                 }
+             }
+         }
+
+         // Fellowship Blackjack Game Code
+         public class FellowshipBlackjackGame
+         {
+             public uint FellowshipLeaderGuid { get; set; }
+             public List<Player> Players { get; set; }
+             public Dictionary<Player, List<List<(int cardValue, CardSuit suit)>>> PlayerHands { get; set; } // Multiple hands per player
+             public Dictionary<Player, List<List<int>>> PlayerItems { get; set; } // Multiple item lists per player
+             public Dictionary<Player, long> PlayerBets { get; set; } // Base bet per player
+             public Dictionary<Player, bool> PlayerDoubledDown { get; set; } // Whether the player has doubled down
+             public Dictionary<Player, int> PlayerCurrentHand { get; set; } // Track which hand the player is on
+             public List<(int cardValue, CardSuit suit)> DealerHand { get; set; } // Store both card value and suit for dealer
+             public int CurrentTurn { get; set; }
+             public Dictionary<Player, bool> PlayerTurnCompleted { get; set; } // Track if player's turn is done
+             public bool DealerHandResolved { get; set; } // Flag to prevent dealer hand resolution twice
+             public bool GameEnded { get; set; } // Flag to prevent game end logic from running multiple times
+             public List<(int cardValue, CardSuit suit)> Deck { get; private set; } // Shared deck for fellowship game
+             public HashSet<(int cardValue, CardSuit suit)> DealtCards { get; set; } = new HashSet<(int, CardSuit)>();
+             public Dictionary<Player, bool> HasNaturalBlackjack { get; set; } // Flag for initial blackjack on the first two cards
+
+
+
+             public FellowshipBlackjackGame(uint fellowshipLeaderGuid, List<Player> players, Dictionary<Player, long> playerBets)
+             {
+                 FellowshipLeaderGuid = fellowshipLeaderGuid;
+                 Players = players;
+                 PlayerHands = new Dictionary<Player, List<List<(int cardValue, CardSuit suit)>>>();
+                 PlayerItems = new Dictionary<Player, List<List<int>>>();
+                 PlayerBets = new Dictionary<Player, long>();
+                 PlayerDoubledDown = new Dictionary<Player, bool>();
+                 PlayerCurrentHand = new Dictionary<Player, int>();
+                 PlayerTurnCompleted = new Dictionary<Player, bool>();
+                 HasNaturalBlackjack = new Dictionary<Player, bool>(); // Initialize the new flag
+                 DealerHand = new List<(int cardValue, CardSuit suit)>();
+                 CurrentTurn = 0;
+                 DealerHandResolved = false; // Initialize as false
+                 GameEnded = false; // Initialize as false
+
+                 foreach (var player in players)
+                 {
+                     PlayerHands[player] = new List<List<(int cardValue, CardSuit suit)>> { new List<(int cardValue, CardSuit suit)>() };
+                     PlayerItems[player] = new List<List<int>> { new List<int>() };
+                     PlayerTurnCompleted[player] = false;
+                     HasNaturalBlackjack[player] = false; // Initialize each player as not having a natural blackjack
+                 }
+
+                 InitializeDeck(); // Initialize and shuffle the deck at the start of each game
+             }
+
+             // Initialize and shuffle the deck
+             private void InitializeDeck()
+             {
+                 Deck = new List<(int cardValue, CardSuit suit)>();
+
+                 // Add all 52 cards to the deck (13 values for each of the 4 suits)
+                 for (int value = 1; value <= 13; value++)
+                 {
+                     Deck.Add((value, CardSuit.Hands));
+                     Deck.Add((value, CardSuit.Eyes));
+                     Deck.Add((value, CardSuit.Jesters));
+                     Deck.Add((value, CardSuit.Balls));
+                 }
+
+                 // Shuffle the deck
+                 Random rand = new Random();
+                 Deck = Deck.OrderBy(_ => rand.Next()).ToList();
+             }
+
+             // Method to draw a card from the deck
+             public (int cardValue, CardSuit suit) DrawCard()
+             {
+                 if (Deck.Count == 0)
+                 {
+                     throw new InvalidOperationException("The deck is empty.");
+                 }
+
+                 var card = Deck[0];
+                 Deck.RemoveAt(0); // Remove the card from the deck after drawing
+                 return card;
+             }
+
+             public Player GetCurrentPlayer()
+             {
+                 return Players[CurrentTurn];
+             }
+
+             public void MoveToNextPlayer()
+             {
+                 CurrentTurn = (CurrentTurn + 1) % Players.Count;
+             }
+         }
+
+         public static class FellowshipBlackjackCommands
+         {
+             public static Dictionary<uint, FellowshipBlackjackGame> activeFellowshipBlackjackGames = new Dictionary<uint, FellowshipBlackjackGame>();
+
+             // Start the fellowship blackjack game
+             [CommandHandler("fblackjack", AccessLevel.Player, CommandHandlerFlag.RequiresWorld, "Start a blackjack game for your fellowship", "Usage: /fblackjack <bet amount> (Maximum bet is 100 Billion)")]
+             public static void HandleFellowshipBlackjackCommand(Session session, params string[] parameters)
+             {
+                 if (session.Player.Fellowship == null)
+                 {
+                     session.Network.EnqueueSend(new GameMessageSystemChat("You must be in a fellowship to start a multiplayer blackjack game.", ChatMessageType.Combat));
+                     return;
+                 }
+
+                 var fellowship = session.Player.Fellowship;
+                 uint fellowshipId = fellowship.FellowshipLeaderGuid;
+
+                 // Check if the game has already started (cards dealt and gameplay is ongoing)
+                 if (activeFellowshipBlackjackGames.TryGetValue(fellowshipId, out FellowshipBlackjackGame existingGame))
+                 {
+                     if (existingGame.Players.Count == fellowship.FellowshipMembers.Count)
+                     {
+                         Console.WriteLine($"[DEBUG] Game already in progress for fellowship leader: {fellowshipId}");
+                         session.Network.EnqueueSend(new GameMessageSystemChat("A blackjack game is currently in progress and cannot be joined.", ChatMessageType.System));
+                         return;
+                     }
+                 }
+
+                 if (parameters.Length == 0 || !long.TryParse(parameters[0], out long bet) || bet <= 0 || bet >= 100000000001)
+                 {
+                     session.Network.EnqueueSend(new GameMessageSystemChat("You must specify a valid bet amount. Example: /fblackjack 1000000 (Maximum bet is 100 Billion)", ChatMessageType.System));
+                     return;
+                 }
+
+                 if (session.Player.BankedLuminance < bet)
+                 {
+                     session.Network.EnqueueSend(new GameMessageSystemChat("You don't have enough luminance to place this bet.", ChatMessageType.System));
+                     return;
+                 }
+
+                 FellowshipBlackjackGame game;
+                 if (!activeFellowshipBlackjackGames.TryGetValue(fellowshipId, out game))
+                 {
+                     // Create a new game if one does not exist
+                     game = new FellowshipBlackjackGame(fellowshipId, new List<Player>(), new Dictionary<Player, long>());
+                     activeFellowshipBlackjackGames[fellowshipId] = game;
+                     Console.WriteLine($"[DEBUG] New game created for fellowship leader: {fellowshipId}");
+                 }
+
+                 if (!game.Players.Contains(session.Player))
+                 {
+                     game.Players.Add(session.Player);
+                     Console.WriteLine($"[DEBUG] {session.Player.Name} joined the game with a bet of {bet:N0}");
+
+                     game.PlayerHands[session.Player] = new List<List<(int cardValue, CardSuit suit)>> { new List<(int cardValue, CardSuit suit)>() };
+                     game.PlayerItems[session.Player] = new List<List<int>> { new List<int>() };
+                     game.PlayerCurrentHand[session.Player] = 0;
+                     game.PlayerTurnCompleted[session.Player] = false;
+                 }
+
+                 game.PlayerBets[session.Player] = bet;
+                 session.Player.BankedLuminance -= bet;
+                 Console.WriteLine($"[DEBUG] {session.Player.Name}'s luminance updated after placing bet.");
+
+                 session.Network.EnqueueSend(new GameMessageSystemChat($"You have placed a bet of {bet:N0} luminance and joined the blackjack game!", ChatMessageType.Broadcast));
+
+                 // Notify other fellowship members to place their bets
+                 foreach (var memberEntry in fellowship.FellowshipMembers)
+                 {
+                     if (memberEntry.Value.TryGetTarget(out Player memberPlayer) && memberPlayer != session.Player)
+                     {
+                         memberPlayer.Session.Network.EnqueueSend(new GameMessageSystemChat($"Your fellowship has started a blackjack game. Please place your bet using /fblackjack <bet amount>.", ChatMessageType.Broadcast));
+                     }
+                 }
+
+                 // Check if all players have placed their bets
+                 if (game.Players.Count == fellowship.FellowshipMembers.Count)
+                 {
+                     // Set the CurrentTurn to the initiating player
+                     game.CurrentTurn = game.Players.IndexOf(session.Player);
+                     Console.WriteLine($"[DEBUG] All players have placed bets. Starting game with current player: {game.GetCurrentPlayer().Name}");
+
+                     // Now the game officially starts, cards are dealt
+                     DealInitialCardsToPlayers(game, session);
+
+                     // Check for initial blackjacks and handle them once per player
+                     List<Player> playersWithBlackjack = new List<Player>();
+                     foreach (var player in game.Players)
+                     {
+                         int initialHandValue = BlackjackUtils.GetHandValue(game.PlayerHands[player][game.PlayerCurrentHand[player]]);
+                         Console.WriteLine($"[DEBUG] {player.Name} dealt initial hand value: {initialHandValue}");
+
+                         if (initialHandValue == 21)
+                         {
+                             long winnings = (long)(game.PlayerBets[player] * 1.25); // 125% of the initial bet
+                             player.BankedLuminance += winnings;
+
+                             player.Session.Network.EnqueueSend(new GameMessageSystemChat(
+                                 $"Blackjack! You win with a hand value of 21. You gain {winnings:N0} luminance.", ChatMessageType.Broadcast));
+
+                             // Mark player's turn as completed and add to blackjack winners list
+                             game.PlayerTurnCompleted[player] = true;
+                             playersWithBlackjack.Add(player);
+                             Console.WriteLine($"[DEBUG] {player.Name} hit blackjack and won {winnings:N0} luminance");
+                         }
+                     }
+
+                     // If all players have blackjack, end the game immediately
+                     if (playersWithBlackjack.Count == game.Players.Count)
+                     {
+                         Console.WriteLine("[DEBUG] All players achieved blackjack. Ending game immediately.");
+                         EndBlackjackGame(game);
+                         return;
+                     }
+
+                     // Notify players whose turns are not completed to begin the game
+                     foreach (var player in game.Players)
+                     {
+                         if (!game.PlayerTurnCompleted[player])
+                         {
+                             player.Session.Network.EnqueueSend(new GameMessageSystemChat($"All players have placed their bets. The game begins! {game.GetCurrentPlayer().Name}, it's your turn. Type /fhit or /fstand.", ChatMessageType.Tell));
+                             Console.WriteLine($"[DEBUG] {player.Name}'s turn to act.");
+                         }
+                     }
+                 }
+                 else
+                 {
+                     session.Network.EnqueueSend(new GameMessageSystemChat($"Waiting for all fellowship members to place their bets...", ChatMessageType.System));
+                     Console.WriteLine("[DEBUG] Waiting for all players to place bets.");
+                 }
+             }
+
+             // Deal initial cards to all players
+             private static void DealInitialCardsToPlayers(FellowshipBlackjackGame game, Session session)
+             {
+                 List<Player> playersWithBlackjack = new List<Player>();
+
+                 foreach (var player in game.Players)
+                 {
+                     DealCardsToPlayer(player, game, 2);
+                     int playerHandValue = BlackjackUtils.GetHandValue(game.PlayerHands[player][0]);
+                     Console.WriteLine($"[DEBUG] {player.Name} dealt initial hand value: {playerHandValue}");
+
+                     if (playerHandValue == 21 && !game.HasNaturalBlackjack[player])
+                     {
+                         long winnings = (long)(game.PlayerBets[player] * 1.25);
+                         player.BankedLuminance += winnings;
+                         Console.WriteLine($"[DEBUG] {player.Name} hit blackjack with initial hand. Winning luminance: {winnings}");
+
+                         player.Session.Network.EnqueueSend(new GameMessageSystemChat(
+                             $"Blackjack! You win with a hand value of 21. You gain {winnings:N0} luminance.", ChatMessageType.Broadcast));
+
+                         game.HasNaturalBlackjack[player] = true;
+                         game.PlayerTurnCompleted[player] = true;
+                         playersWithBlackjack.Add(player);
+                     }
+                 }
+
+                 if (playersWithBlackjack.Count == game.Players.Count)
+                 {
+                     Console.WriteLine("[DEBUG] All players achieved blackjack. Ending game immediately.");
+                     EndBlackjackGame(game);
+                     return;
+                 }
+
+                 if (!game.PlayerTurnCompleted.All(p => p.Value))
+                 {
+                     Console.WriteLine("[DEBUG] Some players still have turns. Dealing initial cards to dealer.");
+                     DealInitialCardsToDealer(game);
+                     MoveToNextActivePlayer(game, session);
+                 }
+                 else
+                 {
+                     EndBlackjackGame(game);
+                 }
+             }
+
+             // Method for dealing cards to a fellowship player using the shared deck (simplified without natural blackjack check)
+             private static void DealCardsToPlayer(Player player, FellowshipBlackjackGame game, int numberOfCards)
+             {
+                 try
+                 {
+                     var currentHand = game.PlayerHands[player][game.PlayerCurrentHand[player]];
+
+                     for (int i = 0; i < numberOfCards; i++)
+                     {
+                         // Draw a unique card and add it to the hand
+                         var card = DrawUniqueCard(game);
+                         currentHand.Add(card);
+
+                         // Check if an inventory item exists for this card and add it to the player's inventory
+                         if (SoloBlackjackCommands.cardItemMap.TryGetValue((card.cardValue, card.suit), out int itemWeenieClassId))
+                         {
+                             BlackjackHelperFunctions.GiveItemToPlayer(player, itemWeenieClassId);
+                             game.PlayerItems[player][game.PlayerCurrentHand[player]].Add(itemWeenieClassId);
+                         }
+
+                         // Inform the player about the dealt card
+                         player.Session.Network.EnqueueSend(new GameMessageSystemChat($"You were dealt a {BlackjackUtils.GetCardName(card.cardValue, card.suit)}.", ChatMessageType.Tell));
+                     }
+                 }
+                 catch (Exception ex)
+                 {
+                     Console.WriteLine($"Error while dealing cards to player {player.Name}: {ex.Message}");
+                 }
+             }
+
+             // Helper method to draw a unique card
+             private static (int cardValue, CardSuit suit) DrawUniqueCard(FellowshipBlackjackGame game)
+             {
+                 (int cardValue, CardSuit suit) card;
+
+                 // Loop to find a unique card
+                 do
+                 {
+                     card = game.DrawCard(); // Attempt to draw a card from the game's deck
+                 } while (game.DealtCards.Contains(card)); // Repeat if the card has already been dealt
+
+                 game.DealtCards.Add(card); // Track the card as dealt
+                 return card;
+             }
+
+             // Deal initial cards to the dealer (deal two but only show one)
+             private static void DealInitialCardsToDealer(FellowshipBlackjackGame game)
+             {
+                 if (game.DealerHand == null)
+                 {
+                     game.DealerHand = new List<(int cardValue, CardSuit suit)>();
+                 }
+
+                 try
+                 {
+                     var cards = BlackjackUtils.DrawCards(2);
+                     game.DealerHand.Add(cards[0]);
+                     game.DealerHand.Add(cards[1]);
+
+                     var (cardValue, suit) = cards[0];
+                     foreach (var player in game.Players)
+                     {
+                         player.Session.Network.EnqueueSend(new GameMessageSystemChat($"Rand was dealt a {BlackjackUtils.GetCardName(cardValue, suit)}.", ChatMessageType.Tell));
+                     }
+                 }
+                 catch (Exception ex)
+                 {
+                     Console.WriteLine($"Error while dealing initial cards to the dealer: {ex.Message}");
+                 }
+             }
+
+             // Moves to the next player in the fellowship
+             public static void MoveToNextActivePlayer(FellowshipBlackjackGame game, Session session)
+             {
+                 Console.WriteLine("[DEBUG] Moving to next active player...");
+
+                 if (game.GameEnded)
+                 {
+                     Console.WriteLine("[DEBUG] Game already ended, returning.");
+                     return;
+                 }
+
+                 if (AllPlayersDone(game))
+                 {
+                     Console.WriteLine("[DEBUG] All players done, resolving dealer hand...");
+
+                     if (!game.DealerHandResolved)
+                     {
+                         RevealDealerHand(game, session);
+                         ResolveDealerHand(game);
+                         Console.WriteLine("[DEBUG] Dealer hand resolved.");
+                     }
+
+                     if (!game.GameEnded)
+                     {
+                         DetermineWinners(game);
+                         EndBlackjackGame(game);
+                         Console.WriteLine("[DEBUG] Game ended successfully.");
+                     }
+                 }
+                 else
+                 {
+                     do
+                     {
+                         game.MoveToNextPlayer();
+                     }
+                     while (game.PlayerTurnCompleted[game.GetCurrentPlayer()] && !AllPlayersDone(game));
+
+                     var nextPlayer = game.GetCurrentPlayer();
+                     Console.WriteLine($"[DEBUG] Next player: {nextPlayer.Name}, Turn Completed: {game.PlayerTurnCompleted[nextPlayer]}");
+                     foreach (var player in game.Players)
+                     {
+                         player.Session.Network.EnqueueSend(new GameMessageSystemChat($"It's {nextPlayer.Name}'s turn. Type /fhit or /fstand.", ChatMessageType.Tell));
+                     }
+                 }
+             }
+
+             // Handle player hitting in fellowship blackjack
+             [CommandHandler("fhit", AccessLevel.Player, CommandHandlerFlag.RequiresWorld, "Hit a card in blackjack", "")]
+             public static void HandleFellowshipHitCommand(Session session, params string[] parameters)
+             {
+                 var game = activeFellowshipBlackjackGames[session.Player.Fellowship.FellowshipLeaderGuid];
+                 Console.WriteLine($"[DEBUG] Handling hit command for {session.Player.Name}");
+
+                 if (game.GetCurrentPlayer() != session.Player)
+                 {
+                     session.Network.EnqueueSend(new GameMessageSystemChat("It's not your turn!", ChatMessageType.Combat));
+                     Console.WriteLine($"[DEBUG] Not {session.Player.Name}'s turn to hit");
+                     return;
+                 }
+
+                 DealCardsToPlayer(session.Player, game, 1);
+                 int handValue = BlackjackUtils.GetHandValue(game.PlayerHands[session.Player][game.PlayerCurrentHand[session.Player]]);
+                 Console.WriteLine($"[DEBUG] {session.Player.Name}'s hand value after hit: {handValue}");
+
+                 if (handValue > 21)
+                 {
+                     Console.WriteLine($"[DEBUG] {session.Player.Name} busted.");
+                     session.Network.EnqueueSend(new GameMessageSystemChat("You busted and lost your bet.", ChatMessageType.Combat));
+                     game.PlayerTurnCompleted[session.Player] = true; // Mark the player's turn as completed
+                     MoveToNextActivePlayer(game, session);
+                 }
+                 else
+                 {
+                     session.Network.EnqueueSend(new GameMessageSystemChat($"Your hand value is now {handValue}. Type /fhit or /fstand.", ChatMessageType.Broadcast));
+                 }
+             }
+
+             // Handle player standing in fellowship blackjack
+             [CommandHandler("fstand", AccessLevel.Player, CommandHandlerFlag.RequiresWorld, "Stand in fellowship blackjack", "")]
+             public static void HandleFellowshipStandCommand(Session session, params string[] parameters)
+             {
+                 if (!activeFellowshipBlackjackGames.TryGetValue(session.Player.Fellowship.FellowshipLeaderGuid, out var game))
+                 {
+                     session.Network.EnqueueSend(new GameMessageSystemChat("You are not currently in a blackjack game.", ChatMessageType.Broadcast));
+                     Console.WriteLine("[DEBUG] Player not in game");
+                     return;
+                 }
+
+                 var player = game.GetCurrentPlayer();
+                 Console.WriteLine($"[DEBUG] Handling stand command for {player.Name}");
+
+                 if (player != session.Player)
+                 {
+                     session.Network.EnqueueSend(new GameMessageSystemChat("It is not your turn.", ChatMessageType.Tell));
+                     Console.WriteLine($"[DEBUG] Not {session.Player.Name}'s turn to stand");
+                     return;
+                 }
+
+                 int handValue = BlackjackUtils.GetHandValue(game.PlayerHands[session.Player][game.PlayerCurrentHand[session.Player]]);
+                 session.Network.EnqueueSend(new GameMessageSystemChat($"Your ending hand value is now {handValue}.", ChatMessageType.Broadcast));
+
+                 // Complete the turn
+                 game.PlayerTurnCompleted[player] = true;
+                 Console.WriteLine($"[DEBUG] {player.Name}'s turn marked as completed.");
+
+                 if (AllPlayersDone(game))
+                 {
+                     Console.WriteLine("[DEBUG] All players done, proceeding to dealer resolution");
+                     RevealDealerHand(game, session);
+                     ResolveDealerHand(game);
+                     DetermineWinners(game);
+                     EndBlackjackGame(game);
+                 }
+                 else
+                 {
+                     MoveToNextActivePlayer(game, session);
+                 }
+             }
+
+             // Handle doubling down in fellowship blackjack
+             [CommandHandler("fdouble", AccessLevel.Player, CommandHandlerFlag.RequiresWorld, "Double down in fellowship blackjack", "")]
+             public static void HandleFellowshipDoubleDownCommand(Session session, params string[] parameters)
+             {
+                 if (!activeFellowshipBlackjackGames.TryGetValue(session.Player.Fellowship.FellowshipLeaderGuid, out var game))
+                 {
+                     session.Network.EnqueueSend(new GameMessageSystemChat("You are not currently in a blackjack game.", ChatMessageType.Combat));
+                     return;
+                 }
+
+                 var player = game.GetCurrentPlayer();
+                 if (player != session.Player)
+                 {
+                     session.Network.EnqueueSend(new GameMessageSystemChat("It's not your turn.", ChatMessageType.Combat));
+                     return;
+                 }
+
+                 var hand = game.PlayerHands[player][game.PlayerCurrentHand[player]];
+
+                 // Check if the player can double down (only allowed after two cards)
+                 if (hand.Count == 2)
+                 {
+                     // Double the player's bet specifically for this hand
+                     long baseBet = game.PlayerBets[player];
+                     long doubleBetAmount = baseBet;
+
+                     // Check if they can afford the double down
+                     if (session.Player.BankedLuminance < doubleBetAmount)
+                     {
+                         session.Network.EnqueueSend(new GameMessageSystemChat("You do not have enough luminance to double down.", ChatMessageType.System));
+                         return;
+                     }
+
+                     // Deduct additional bet from the player's luminance
+                     session.Player.BankedLuminance -= doubleBetAmount;
+                     game.PlayerBets[player] += doubleBetAmount; // Update the bet to reflect the doubled-down amount
+                     game.PlayerDoubledDown[player] = true;
+
+                     session.Network.EnqueueSend(new GameMessageSystemChat("You have doubled your bet! You will receive one more card, and your turn will end.", ChatMessageType.Broadcast));
+
+                     // Deal one more card to the player
+                     DealCardsToPlayer(player, game, 1);
+                     session.Network.EnqueueSend(new GameMessageSystemChat($"Your hand value is now {BlackjackUtils.GetHandValue(game.PlayerHands[player][game.PlayerCurrentHand[player]])}.", ChatMessageType.Broadcast));
+
+                     // Mark the player's turn as complete
+                     game.PlayerTurnCompleted[player] = true;
+
+                     // Move to the next player
+                     MoveToNextActivePlayer(game, session); // Ensure proper transition after double down
+                 }
+                 else
+                 {
+                     session.Network.EnqueueSend(new GameMessageSystemChat("You cannot double down on this hand. You must only have two cards.", ChatMessageType.Combat));
+                 }
+             }
+
+             // Handle splitting the hand in fellowship blackjack
+             [CommandHandler("fsplit", AccessLevel.Player, CommandHandlerFlag.RequiresWorld, "Split your hand in fellowship blackjack", "")]
+             public static void HandleFellowshipSplitCommand(Session session, params string[] parameters)
+             {
+                 if (!activeFellowshipBlackjackGames.TryGetValue(session.Player.Fellowship.FellowshipLeaderGuid, out var game))
+                 {
+                     session.Network.EnqueueSend(new GameMessageSystemChat("You are not currently in a blackjack game.", ChatMessageType.Combat));
+                     return;
+                 }
+
+                 var player = game.GetCurrentPlayer();
+                 if (player != session.Player)
+                 {
+                     session.Network.EnqueueSend(new GameMessageSystemChat("It's not your turn.", ChatMessageType.Combat));
+                     return;
+                 }
+
+                 var hand = game.PlayerHands[session.Player][game.PlayerCurrentHand[session.Player]];
+
+                 // Check if the player can split (only allowed with two cards of the same value)
+                 if (hand.Count == 2 && hand[0].cardValue == hand[1].cardValue)
+                 {
+                     // Ensure the player has enough luminance to double the bet
+                     long initialBet = game.PlayerBets[session.Player];
+                     if (session.Player.BankedLuminance < initialBet)
+                     {
+                         session.Network.EnqueueSend(new GameMessageSystemChat("You do not have enough luminance to split.", ChatMessageType.System));
+                         return;
+                     }
+
+                     // Deduct additional bet from luminance and apply to the split hand
+                     session.Player.BankedLuminance -= initialBet;
+                     game.PlayerBets[session.Player] += initialBet;  // Update total bet to include the split amount
+
+                     // Create a new hand by moving one card to the second hand
+                     game.PlayerHands[session.Player].Add(new List<(int cardValue, CardSuit suit)> { hand[1] });
+                     game.PlayerItems[session.Player].Add(new List<int>());  // Initialize tracking for the new hand
+                     hand.RemoveAt(1);  // Keep one card in the original hand
+
+                     session.Network.EnqueueSend(new GameMessageSystemChat("You have split your hand into two separate hands!", ChatMessageType.Broadcast));
+
+                     // Deal one card to the first hand immediately
+                     DealCardsToPlayer(session.Player, game, 1);
+                     var firstHandCard = game.PlayerHands[session.Player][game.PlayerCurrentHand[session.Player]].Last();
+                     session.Network.EnqueueSend(new GameMessageSystemChat($"You were dealt a {BlackjackUtils.GetCardName(firstHandCard.cardValue, firstHandCard.suit)} for your first hand.", ChatMessageType.Tell));
+
+                     // Update the player on the value of their first hand
+                     int firstHandValue = BlackjackUtils.GetHandValue(game.PlayerHands[session.Player][game.PlayerCurrentHand[session.Player]]);
+                     session.Network.EnqueueSend(new GameMessageSystemChat($"Your first hand value is {firstHandValue}.", ChatMessageType.Broadcast));
+
+                     // Notify the player to continue with the first hand
+                     session.Network.EnqueueSend(new GameMessageSystemChat("You are now playing your first hand. Type /fhit or /fstand.", ChatMessageType.System));
+                 }
+                 else
+                 {
+                     session.Network.EnqueueSend(new GameMessageSystemChat("You can only split if you have two cards of the same value.", ChatMessageType.Combat));
+                 }
+             }
+
+             // Check if all players are done with their turns
+             private static bool AllPlayersDone(FellowshipBlackjackGame game)
+             {
+                 bool allDone = game.PlayerTurnCompleted.All(p => p.Value);
+                 Console.WriteLine($"[DEBUG] Checking if all players are done: {allDone}");
+                 foreach (var entry in game.PlayerTurnCompleted)
+                 {
+                     Console.WriteLine($"[DEBUG] Player: {entry.Key.Name}, Turn Completed: {entry.Value}");
+                 }
+                 return allDone;
+             }
+
+                 // Reveal the dealer's hand after players have completed their turns
+                 private static void RevealDealerHand(FellowshipBlackjackGame game, Session session)
+             {
+                 var (hiddenCardValue, hiddenSuit) = game.DealerHand[1];
+                 Console.WriteLine($"[DEBUG] Dealer reveals hidden card: {BlackjackUtils.GetCardName(hiddenCardValue, hiddenSuit)}");
+
+                 foreach (var player in game.Players)
+                 {
+                     player.Session.Network.EnqueueSend(new GameMessageSystemChat($"Rand reveals a {BlackjackUtils.GetCardName(hiddenCardValue, hiddenSuit)}.", ChatMessageType.Combat));
+                 }
+
+                 int dealerHandValue = BlackjackUtils.GetHandValue(game.DealerHand);
+                 Console.WriteLine($"[DEBUG] Dealer hand value after reveal: {dealerHandValue}");
+
+                 foreach (var player in game.Players)
+                 {
+                     player.Session.Network.EnqueueSend(new GameMessageSystemChat($"Rand's hand value is now {dealerHandValue}.", ChatMessageType.Combat));
+                 }
+             }
+
+             // Ensure final dealer hand value is sent to all players
+             private static void ResolveDealerHand(FellowshipBlackjackGame game)
+             {
+                 if (game.DealerHandResolved) // Prevent duplicate resolves
+                     return;
+
+                 while (BlackjackUtils.GetHandValue(game.DealerHand) < 17)
+                 {
+                     var card = BlackjackUtils.DrawCards(1).First();
+                     game.DealerHand.Add(card);
+
+                     foreach (var player in game.Players)
+                     {
+                         player.Session.Network.EnqueueSend(new GameMessageSystemChat($"Rand drew a {BlackjackUtils.GetCardName(card.cardValue, card.suit)}. Rand's hand value is now {BlackjackUtils.GetHandValue(game.DealerHand)}.", ChatMessageType.System));
+                     }
+                 }
+
+                 int finalDealerValue = BlackjackUtils.GetHandValue(game.DealerHand);
+
+                 // Broadcast final hand value only once
+                 foreach (var player in game.Players)
+                 {
+                     player.Session.Network.EnqueueSend(new GameMessageSystemChat($"Rand's final hand value is {finalDealerValue}.", ChatMessageType.System));
+                 }
+
+                 game.DealerHandResolved = true; // Set the flag to true once resolved
+             }
+
+             private static void DetermineWinners(FellowshipBlackjackGame game)
+             {
+                 int dealerValue = BlackjackUtils.GetHandValue(game.DealerHand);
+                 Console.WriteLine($"[DEBUG] Dealer's final hand value in DetermineWinners: {dealerValue}");
+
+                 foreach (var player in game.Players)
+                 {
+                     // Verify the player exists in all required dictionaries before proceeding
+                     if (!game.PlayerBets.ContainsKey(player))
+                     {
+                         Console.WriteLine($"[ERROR] Player {player.Name} missing from PlayerBets dictionary.");
+                         continue;
+                     }
+
+                     if (!game.PlayerHands.ContainsKey(player))
+                     {
+                         Console.WriteLine($"[ERROR] Player {player.Name} missing from PlayerHands dictionary.");
+                         continue;
+                     }
+
+                     // Skip players with natural blackjack to avoid duplicate rewards and messages
+                     if (game.HasNaturalBlackjack.TryGetValue(player, out bool hasBlackjack) && hasBlackjack)
+                     {
+                         Console.WriteLine($"[DEBUG] Skipping {player.Name} as they have a natural blackjack.");
+                         continue;
+                     }
+
+                     long totalWinnings = 0;
+                     bool playerWon = false;
+
+                     for (int i = 0; i < game.PlayerHands[player].Count; i++)
+                     {
+                         int playerHandValue = BlackjackUtils.GetHandValue(game.PlayerHands[player][i]);
+                         long baseBet = game.PlayerBets[player] / game.PlayerHands[player].Count; // Divide initial bet for each split hand
+                         long winnings = 0;
+
+                         // Scenario 1: Player busts
+                         if (playerHandValue > 21)
+                         {
+                             player.Session.Network.EnqueueSend(new GameMessageSystemChat(
+                                 $"You busted with a hand value of {playerHandValue} on hand {i + 1}. You lost your bet of {baseBet:N0} luminance.",
+                                 ChatMessageType.Combat));
+                         }
+                         // Scenario 2: Dealer busts or player has a higher hand than the dealer
+                         else if (dealerValue > 21 || playerHandValue > dealerValue)
+                         {
+                             winnings = (long)(baseBet * 1.25); // Normal play or split hand winnings (125% of bet)
+                             totalWinnings += winnings;
+
+                             player.Session.Network.EnqueueSend(new GameMessageSystemChat(
+                                 $"You won with a hand value of {playerHandValue} on hand {i + 1}! You gain {winnings:N0} luminance.",
+                                 ChatMessageType.Broadcast));
+
+                             playerWon = true;
+                         }
+                         // Scenario 3: Tie with dealer
+                         else if (playerHandValue == dealerValue)
+                         {
+                             player.Session.Network.EnqueueSend(new GameMessageSystemChat(
+                                 $"You tied with Rand on hand {i + 1}. Your bet of {baseBet:N0} luminance has been returned.",
+                                 ChatMessageType.Tell));
+                             totalWinnings += baseBet;
+                         }
+                         // Scenario 4: Dealer wins with a higher hand value
+                         else
+                         {
+                             player.Session.Network.EnqueueSend(new GameMessageSystemChat(
+                                 $"You lost with a hand value of {playerHandValue} on hand {i + 1}. You lost your bet of {baseBet:N0} luminance.",
+                                 ChatMessageType.Combat));
+                         }
+                     }
+
+                     if (playerWon)
+                     {
+                         player.BankedLuminance += totalWinnings;
+                         Console.WriteLine($"[DEBUG] {player.Name} won a total of {totalWinnings:N0} luminance.");
+                     }
+                 }
+             }
+
+             // Reset dealt cards when a game ends
+             private static void EndBlackjackGame(FellowshipBlackjackGame game)
+             {
+                 Console.WriteLine($"[DEBUG] Attempting to end game for fellowship leader: {game.FellowshipLeaderGuid}");
+                 if (game.GameEnded)
+                 {
+                     Console.WriteLine("[DEBUG] Game already marked as ended, returning.");
+                     return;
+                 }
+
+                 game.GameEnded = true;
+                 Console.WriteLine("[DEBUG] GameEnded flag set to true");
+
+                 foreach (var player in game.Players)
+                 {
+                     Console.WriteLine($"[DEBUG] Removing cards for player: {player.Name}");
+                     foreach (var handItems in game.PlayerItems[player])
+                     {
+                         foreach (var itemWeenieClassId in handItems.Distinct())
+                         {
+                             Console.WriteLine($"[DEBUG] Removing item with ID {itemWeenieClassId} from {player.Name}'s inventory");
+                             RemoveItemFromPlayer(player, itemWeenieClassId);
+                         }
+                     }
+                     player.Session.Network.EnqueueSend(new GameMessageSystemChat("The blackjack game has ended, and the cards have been removed from your inventory.", ChatMessageType.Broadcast));
+                 }
+
+                 activeFellowshipBlackjackGames.Remove(game.FellowshipLeaderGuid);
+                 game.DealtCards.Clear();
+                 Console.WriteLine("[DEBUG] Active game removed and dealt cards cleared.");
+             }
+
+             // Helper to remove items from players' inventory
+             public static void RemoveItemFromPlayer(Player player, int itemWeenieClassId)
+             {
+                 try
+                 {
+                     var items = player.GetInventoryItemsOfWCID((uint)itemWeenieClassId);
+
+                     if (items.Any())
+                     {
+                         foreach (var item in items.ToList())
+                         {
+                             player.TryRemoveFromInventoryWithNetworking(item.Guid, out _, Player.RemoveFromInventoryAction.ConsumeItem);
+                         }
+                     }
+                 }
+                 catch (Exception ex)
+                 {
+                     Console.WriteLine($"Error in RemoveItemFromPlayer for player {player.Name}: {ex.Message}");
+                 }
+             }*/
     }
 }

--- a/Source/ACE.Server/Entity/OfflinePlayer.cs
+++ b/Source/ACE.Server/Entity/OfflinePlayer.cs
@@ -318,6 +318,11 @@ namespace ACE.Server.Entity
             get => GetProperty(PropertyInt64.BankedEnlightenedCoins) ?? 0;
             set { if (!value.HasValue) RemoveProperty(PropertyInt64.BankedEnlightenedCoins); else SetProperty(PropertyInt64.BankedEnlightenedCoins, value.Value); }
         }
+        public long? BankedWeaklyEnlightenedCoins
+        {
+            get => GetProperty(PropertyInt64.BankedWeaklyEnlightenedCoins) ?? 0;
+            set { if (!value.HasValue) RemoveProperty(PropertyInt64.BankedWeaklyEnlightenedCoins); else SetProperty(PropertyInt64.BankedWeaklyEnlightenedCoins, value.Value); }
+        }
         public long? BankedMythicalKeys
         {
             get => GetProperty(PropertyInt64.BankedMythicalKeys) ?? 0;


### PR DESCRIPTION
/clap all will now look for how many reds/empyrean you have as well as blues/falatacot then take the lower of each group and deposit them, charges the same 1 MMD cost for each coin banked, and now has a check for equipmentsetid so it won't destroy revealed Aetheria. also with that being said weakly coins were added to banking since we are streamlining the crafting, I needed to add an int64 for weakly coins. Now you will be able to bank/withdraw/transfer them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for a new type of in-game currency called "Weakly Enlightened Coins"
	- Implemented banking functionality for depositing, withdrawing, and transferring these coins between players

<!-- end of auto-generated comment: release notes by coderabbit.ai -->