### PR TITLE
Ip quest limit

### DIFF
--- a/Source/ACE.Database/Models/World/QuestIpTracking.cs
+++ b/Source/ACE.Database/Models/World/QuestIpTracking.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace ACE.Database.Models.World
+{
+    public class QuestIpTracking
+    {
+        public uint QuestId { get; set; }
+        public string IpAddress { get; set; }
+        public int SolvesCount { get; set; }
+        public DateTime? LastSolveTime { get; set; }
+
+        public Quest Quest { get; set; }
+    }
+
+
+}

--- a/Source/ACE.Database/Models/World/WorldDbContext.cs
+++ b/Source/ACE.Database/Models/World/WorldDbContext.cs
@@ -25,6 +25,7 @@ namespace ACE.Database.Models.World
         public virtual DbSet<LandblockInstanceLink> LandblockInstanceLink { get; set; }
         public virtual DbSet<PointsOfInterest> PointsOfInterest { get; set; }
         public virtual DbSet<Quest> Quest { get; set; }
+        public virtual DbSet<QuestIpTracking> QuestIpTracking { get; set; }
         public virtual DbSet<Recipe> Recipe { get; set; }
         public virtual DbSet<RecipeMod> RecipeMod { get; set; }
         public virtual DbSet<RecipeModsBool> RecipeModsBool { get; set; }
@@ -391,6 +392,14 @@ namespace ACE.Database.Models.World
                     .HasColumnName("max_Solves")
                     .HasComment("Maximum number of times Quest can be completed");
 
+                entity.Property(e => e.IpLootLimit)
+                    .HasColumnName("ip_loot_limit") // Ensure correct casing
+                    .HasComment("Maximum number of times Quest can be completed per IP");
+
+                entity.Property(e => e.IsIpRestricted)
+                    .HasColumnName("is_ip_restricted") // Ensure correct casing
+                    .HasComment("Indicates if the quest is IP restricted");
+
                 entity.Property(e => e.Message)
                     .HasColumnType("text")
                     .HasColumnName("message")
@@ -404,6 +413,35 @@ namespace ACE.Database.Models.World
                     .IsRequired()
                     .HasColumnName("name")
                     .HasComment("Unique Name of Quest");
+            });
+
+            modelBuilder.Entity<QuestIpTracking>(entity =>
+            {
+                entity.ToTable("quest_ip_tracking");
+
+                entity.HasKey(e => new { e.QuestId, e.IpAddress });
+
+                entity.Property(e => e.QuestId)
+                      .HasColumnName("quest_id")
+                      .IsRequired();
+
+                entity.Property(e => e.IpAddress)
+                      .HasColumnName("ip_address")
+                      .HasMaxLength(45)
+                      .IsRequired();
+
+                entity.Property(e => e.SolvesCount)
+                      .HasColumnName("solves_count")
+                      .IsRequired()
+                      .HasDefaultValue(0);
+
+                entity.Property(e => e.LastSolveTime)
+                      .HasColumnName("last_solve_time");
+
+                entity.HasOne(e => e.Quest)
+                      .WithMany(q => q.QuestIpTrackings)
+                      .HasForeignKey(e => e.QuestId)
+                      .HasConstraintName("quest_ip_tracking_ibfk_1"); // Ensure the foreign key name matches
             });
 
             modelBuilder.Entity<Recipe>(entity =>

--- a/Source/ACE.Entity/Enum/Properties/PropertyString.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyString.cs
@@ -88,12 +88,23 @@ namespace ACE.Entity.Enum.Properties
         PCAPRecordedServerName          = 8031,
         PCAPRecordedCharacterName       = 8032,
 
-        AllegianceMotd = 9001,
-        AllegianceMotdSetBy = 9002,
-        AllegianceSpeakerTitle = 9003,
-        AllegianceSeneschalTitle = 9004,
-        AllegianceCastellanTitle = 9005,
-        GodState = 9006,
-        TinkerLog = 9007,
+        /* custom */
+        AllegianceMotd                  = 9001,
+        AllegianceMotdSetBy             = 9002,
+        AllegianceSpeakerTitle          = 9003,
+        AllegianceSeneschalTitle        = 9004,
+        AllegianceCastellanTitle        = 9005,
+        GodState                        = 9006,
+        TinkerLog                       = 9007,
+        IPQuest                         = 9008,
+    }
+
+    public static class PropertyStringExtensions
+    {
+        public static string GetDescription(this PropertyString prop)
+        {
+            var description = prop.GetAttributeOfType<DescriptionAttribute>();
+            return description?.Description ?? prop.ToString();
+        }
     }
 }

--- a/Source/ACE.Server/Managers/QuestManager.cs
+++ b/Source/ACE.Server/Managers/QuestManager.cs
@@ -398,7 +398,6 @@ namespace ACE.Server.Managers
 
             return true;
         }
-
         /// <summary>
         /// Returns the time remaining until the player can solve this quest again
         /// </summary>
@@ -626,7 +625,7 @@ namespace ACE.Server.Managers
             player.Session.Network.EnqueueSend(error);
         }
 
-        public void HandlePortalQuestError(string questName)
+        public void HandlePortalQuestError(string questName, string customMessage = null)
         {
             var player = Creature as Player;
 
@@ -641,6 +640,12 @@ namespace ACE.Server.Managers
                 var error = new GameEventWeenieError(player.Session, WeenieError.QuestSolvedTooLongAgo);
                 var text = new GameMessageSystemChat("You completed the quest this portal requires too long ago!", ChatMessageType.Magic); // This msg wasn't sent in retail PCAP, leading to a completely silent fail when using the portal with an expired flag.
                 player.Session.Network.EnqueueSend(text, error);
+            }
+            else if (!string.IsNullOrEmpty(customMessage))
+            {
+                // Custom error message for IPQuest restriction
+                var error = new GameMessageSystemChat(customMessage, ChatMessageType.Broadcast);
+                player.Session.Network.EnqueueSend(error);
             }
         }
 

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading;
+using System.Net;
 
 using ACE.Database;
 using ACE.DatLoader;
@@ -934,6 +935,62 @@ namespace ACE.Server.WorldObjects
             return true;
         }
 
+        private bool HandleIPQuestItem(WorldObject item, Container itemRootOwner, Container containerRootOwner, uint itemGuid)
+        {
+            // Fetch the IPQuest property
+            var ipQuestName = item.GetProperty(PropertyString.IPQuest);
+            if (string.IsNullOrEmpty(ipQuestName))
+                return true; // If not an IPQuest item, allow normal processing
+
+            // Fetch the player's IP address
+            string playerIp = new IPAddress(Session.Player.Account.LastLoginIP).ToString();
+            //Console.WriteLine($"Player IP: {playerIp}");
+
+            // Fetch the quest object
+            var quest = DatabaseManager.World.GetCachedQuest(ipQuestName);
+            if (quest == null)
+            {
+                //Console.WriteLine($"Quest '{ipQuestName}' not found.");
+                Session.Player.SendMessage("Quest data is invalid or missing.", ChatMessageType.Broadcast);
+                return false;
+            }
+
+            // Check if the player is allowed to loot the item
+            var (success, message) = DatabaseManager.World.IncrementAndCheckIPQuestAttempts(
+                questId: quest.Id,
+                playerIp: playerIp,
+                characterId: Session.Player.Character.Id,
+                maxAttempts: (int)quest.IpLootLimit
+            );
+
+            if (!success)
+            {
+                //Console.WriteLine($"Loot blocked for quest: {ipQuestName}, playerIp: {playerIp}, characterId: {Session.Player.Character.Id}. Reason: {message}");
+                Session.Player.SendMessage(message, ChatMessageType.Broadcast);
+                Session.Network.EnqueueSend(new GameEventInventoryServerSaveFailed(Session, item.Guid.Full, WeenieError.YouHaveSolvedThisQuestTooRecently));
+                return false;
+            }
+
+            //Console.WriteLine($"Loot allowed for quest: {ipQuestName}, playerIp: {playerIp}, characterId: {Session.Player.Character.Id}");
+
+            // Update player's quest progress
+            bool stampedNew, stampedCompletion;
+            Session.Player.QuestManager.UpdatePlayerQuestCompletions(Session.Player, ipQuestName, out stampedNew, out stampedCompletion);
+
+            // Provide feedback to the player if quest progress is updated
+            if (stampedNew)
+            {
+                Session.Player.SendMessage($"You've stamped {ipQuestName}!", ChatMessageType.Advancement);
+            }
+            else if (stampedCompletion)
+            {
+                Session.Player.SendMessage($"You've completed {ipQuestName}!", ChatMessageType.Advancement);
+            }
+
+            // Proceed with looting logic
+            return true;
+        }
+
         // =========================================
         // Game Action Handlers - Inventory Movement 
         // =========================================
@@ -955,6 +1012,27 @@ namespace ACE.Server.WorldObjects
                 out Container itemRootOwner, out WorldObject item, out Container containerRootOwner, out Container container, out bool itemWasEquipped))
             {
                 return;
+            }
+
+            // Determine if movement is between the player and the world (i.e., picking up or dropping the item)
+            bool isWorldInteraction = (itemRootOwner != this && containerRootOwner == this) || (itemRootOwner == this && containerRootOwner != this);
+
+            if (isWorldInteraction && itemRootOwner != this) // Picking up from the world
+            {
+                // Handle IPQuest items specifically
+                var ipQuestName = item.GetProperty(PropertyString.IPQuest);
+                if (!string.IsNullOrEmpty(ipQuestName))
+                {
+                    if (!HandleIPQuestItem(item, itemRootOwner, containerRootOwner, itemGuid))
+                    {
+                        //Console.WriteLine($"IPQuest logic blocked the item pick-up: {ipQuestName}");
+                        return; // IP logic blocked the action
+                    }
+                }
+                else
+                {
+                    //Console.WriteLine($"Skipping IPQuest logic: Item does not have PropertyString.IPQuest.");
+                }
             }
 
             if ((itemRootOwner == this && containerRootOwner != this) || (itemRootOwner != this && containerRootOwner == this)) // Movement is between the player and the world


### PR DESCRIPTION
New IPQuest string property 9008 that can be applied to items or portals to limit the IP interactions with them. Can set the desired ip loot limit in the desired quest.sql file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added IP-based quest tracking and restrictions
	- Implemented quest attempt limits based on player IP addresses
	- Enhanced portal and item looting mechanics with IP-based checks

- **Bug Fixes**
	- Improved quest management and cooldown tracking

- **Chores**
	- Updated database models and context to support new IP quest tracking functionality
	- Added new methods for managing quest-related operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->