### PR TITLE
Stop sending Luminance updates to client when earning Luminance

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Luminance.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Luminance.cs
@@ -75,7 +75,8 @@ namespace ACE.Server.WorldObjects
 
             UpdateLumAllegiance(amount);
 
-            UpdateLuminance();
+            // 20250203 - Don't spam the client with properties it doesn't use
+            //UpdateLuminance();
         }
 
         /// <summary>


### PR DESCRIPTION
Luminance is automatically banked and the client doesn't know about the bank.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Optimized the luminance update process to eliminate redundant client updates, reducing unnecessary network activity and ensuring a smoother overall experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->