### PR TITLE
Handle null CurrentMotionState in Monster_Tick

### DIFF
--- a/Source/ACE.Server/WorldObjects/Monster_Tick.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Tick.cs
@@ -76,6 +76,11 @@ namespace ACE.Server.WorldObjects
 
             if (firstUpdate)
             {
+                if (CurrentMotionState == null)
+                {
+                    log.Warn($"[Monster_Tick] 0x{Guid} {Name} has a null CurrentMotionState setting to NonCombat");
+                    CurrentMotionState = new ACE.Server.Entity.Motion(MotionStance.NonCombat, MotionCommand.Ready);
+                }
                 if (CurrentMotionState.Stance == MotionStance.NonCombat)
                     DoAttackStance();
 


### PR DESCRIPTION
Set it back to default value and throw a console warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced monster behavior stability during updates by ensuring a default state is applied when conditions are not met. This improvement minimizes interruptions and supports smoother interactions in the game.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->