### PR TITLE
Enlightenment fixes

### DIFF
--- a/Source/ACE.Server/Entity/Enlightenment.cs
+++ b/Source/ACE.Server/Entity/Enlightenment.cs
@@ -158,7 +158,7 @@ namespace ACE.Server.Entity
 
             //todo: check for trophies that are enl level appropriate
             //first, 1 enlightenment token per enlightenment past 5.
-            if (targetEnlightenment > 5 && targetEnlightenment < 150)
+            if (targetEnlightenment > 5 && targetEnlightenment <= 150)
             {
                 var count = player.GetNumInventoryItemsOfWCID(300000); //magic number - EnlightenmentToken
                 if (count < player.Enlightenment + 1 - 5)
@@ -186,7 +186,7 @@ namespace ACE.Server.Entity
                 }
             }
 
-            if (targetEnlightenment > 50 && targetEnlightenment < 150)
+            if (targetEnlightenment > 50 && targetEnlightenment <= 150)
             {
                 var baseLumCost = PropertyManager.GetLong("enl_50_base_lum_cost").Item;
                 long reqLum = targetEnlightenment * baseLumCost;
@@ -199,17 +199,17 @@ namespace ACE.Server.Entity
 
             if (targetEnlightenment > 150)
             {
-                var count2 = player.GetNumInventoryItemsOfWCID(90000217); //magic number - EnlightenmentToken
                 var baseLumCost = PropertyManager.GetLong("enl_150_base_lum_cost").Item;
                 long reqLum150 = targetEnlightenment * baseLumCost;
-                if (count2 < player.Enlightenment + 1 - 5)
-                {
-                    player.Session.Network.EnqueueSend(new GameMessageSystemChat($"You have already been enlightened {player.Enlightenment} times. You must have {player.Enlightenment + 1 - 5} Enlightenment Medallions to continue.", ChatMessageType.Broadcast));
-                    return false;
-                }
                 if (!VerifyLuminance(player, reqLum150))
                 {
                     player.Session.Network.EnqueueSend(new GameMessageSystemChat($"You must have {reqLum150:N0} luminance to enlighten to level {targetEnlightenment}.", ChatMessageType.Broadcast));
+                    return false;
+                }
+                var count2 = player.GetNumInventoryItemsOfWCID(90000217); //magic number - EnlightenmentToken
+                if (count2 < player.Enlightenment + 1 - 5)
+                {
+                    player.Session.Network.EnqueueSend(new GameMessageSystemChat($"You have already been enlightened {player.Enlightenment} times. You must have {player.Enlightenment + 1 - 5} Enlightenment Medallions to continue.", ChatMessageType.Broadcast));
                     return false;
                 }
                 if (!VerifyParagonCompleted(player))


### PR DESCRIPTION
Adjusted to handle case where going from 149 to 150 was bypassing some requirements and consuming both tokens/medallions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the progression system so players meeting the maximum enlightenment threshold are correctly recognized during advancement.
	- Refined the order of bonus requirement checks to ensure that progression tokens are validated after key conditions, providing a smoother and more reliable advancement experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->