### PR TITLE
Add PropertyBool 9013 to prevent manual Weenie creation by Admins

### DIFF
--- a/Source/ACE.Entity/Enum/Properties/PropertyBool.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyBool.cs
@@ -186,5 +186,6 @@ namespace ACE.Entity.Enum.Properties
         FreeMasteryResetRenewed          = 9010,
         ExcludeFromLeaderboards          = 9011,
         IsVPHardcore                     = 9012,
+        DisableCreate                    = 9013
     }
 }

--- a/Source/ACE.Entity/Models/WeenieExtensions.cs
+++ b/Source/ACE.Entity/Models/WeenieExtensions.cs
@@ -172,6 +172,11 @@ namespace ACE.Entity.Models
             return weenie.GetProperty(PropertyBool.Stuck) ?? false;
         }
 
+        public static bool DisableCreate(this Weenie weenie)
+        {
+            return weenie.GetProperty(PropertyBool.DisableCreate) ?? false;
+        }
+
         public static bool RequiresBackpackSlotOrIsContainer(this Weenie weenie)
         {
             var requiresBackPackSlot = weenie.GetProperty(PropertyBool.RequiresBackpackSlot) ?? false;

--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -2361,7 +2361,7 @@ namespace ACE.Server.Command.Handlers
                 return null;
             }
 
-            if (!weenie.DisableCreate())
+            if (weenie.DisableCreate())
             {
                 session.Network.EnqueueSend(new GameMessageSystemChat($"You cannot spawn {weenie.ClassName} because it is restricted", ChatMessageType.Broadcast));
                 return null;

--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -2361,6 +2361,12 @@ namespace ACE.Server.Command.Handlers
                 return null;
             }
 
+            if (!weenie.DisableCreate())
+            {
+                session.Network.EnqueueSend(new GameMessageSystemChat($"You cannot spawn {weenie.ClassName} because it is restricted", ChatMessageType.Broadcast));
+                return null;
+            }
+
             return weenie;
         }
 


### PR DESCRIPTION
Weenie can't be created with /create, /createliveops, /ci, or /createnamed. This is for rare weenies that should only be spawned by generators.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new enumeration value, `DisableCreate`, to enhance property definitions.
	- Introduced a method to check if the creation of a `Weenie` is disabled based on its properties.
	- Implemented a validation check to restrict the creation of certain `weenies`, with notifications for administrators if the creation is blocked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->