### PR TITLE
New Command to check Server Quest Completion Counts

### DIFF
--- a/Source/ACE.Database/ShardDatabase.cs
+++ b/Source/ACE.Database/ShardDatabase.cs
@@ -129,6 +129,17 @@ namespace ACE.Database
                 return context.Biota.Count();
         }
 
+        public int GetServerQuestCompletions(string questName)
+        {
+            int retVal = 0;
+            if (!string.IsNullOrEmpty(questName))
+            {
+                using var context = new ShardDbContext();
+                retVal = context.CharacterPropertiesQuestRegistry.Where(x => x.QuestName == questName).Sum(x => x.NumTimesCompleted);
+            }
+            return retVal;
+        }
+
         [Flags]
         enum PopulatedCollectionFlags
         {

--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -1150,7 +1150,7 @@ namespace ACE.Server.Command.Handlers
                     }
                 }
                 else if (parameters.Length > 1 && parameters[1] == "name")
-                {                    
+                {
                     var playerName = "";
                     for (var i = 2; i < parameters.Length; i++)
                         playerName += $"{parameters[i]} ";
@@ -1482,7 +1482,7 @@ namespace ACE.Server.Command.Handlers
                 msg += "@adminhouse payrent off / on: sets the targeted house to not require / require normal maintenance payments.\n";
 
                 session.Player.SendMessage(msg);
-            }    
+            }
         }
 
         private static void DumpHouse(Session session, House targetHouse, WorldObject wo)
@@ -1560,7 +1560,7 @@ namespace ACE.Server.Command.Handlers
                     session.Player.SendMessage(msg, ChatMessageType.System);
                 }
 
-                session.Player.SendMessage(AppendHouseLinkDump(house), ChatMessageType.System);                
+                session.Player.SendMessage(AppendHouseLinkDump(house), ChatMessageType.System);
 
                 if (house.HouseType == HouseType.Villa || house.HouseType == HouseType.Mansion)
                 {
@@ -1780,7 +1780,7 @@ namespace ACE.Server.Command.Handlers
 
                     var names = string.Join(" ", parameters).Split(",");
 
-                    var newCharName = names[1].TrimStart(' ').TrimEnd(' ');                    
+                    var newCharName = names[1].TrimStart(' ').TrimEnd(' ');
 
                     if (newCharName.StartsWith("+"))
                         newCharName = newCharName.Substring(1);
@@ -2498,7 +2498,7 @@ namespace ACE.Server.Command.Handlers
             var obj = WorldObjectFactory.CreateNewWorldObject(weenie);
 
             //if (obj.TimeToRot == null)
-                //obj.TimeToRot = double.MaxValue;
+            //obj.TimeToRot = double.MaxValue;
 
             if (obj.WeenieType == WeenieType.Creature)
                 obj.Location = session.Player.Location.InFrontOf(5f, true);
@@ -2769,7 +2769,7 @@ namespace ACE.Server.Command.Handlers
             {
                 session.Network.EnqueueSend(new GameMessageSystemChat($"You must select a player to send them a message.", ChatMessageType.Broadcast));
                 return;
-            }    
+            }
 
             var wo = session.Player.CurrentLandblock?.GetObject(objectId);
 
@@ -2809,9 +2809,9 @@ namespace ACE.Server.Command.Handlers
                 foreach (var item in session.Player.EquippedObjects.Values)
                     item.EnchantmentManager.DispelAllEnchantments();
             }
-            
 
-            
+
+
         }
 
         // event
@@ -4882,6 +4882,21 @@ namespace ACE.Server.Command.Handlers
             DiscordChatManager.SendDiscordMessage("", msg, ConfigManager.Config.Chat.GeneralChannelId);
             DiscordChatManager.SendDiscordMessage("", msg, ConfigManager.Config.Chat.EventsChannelId);
             DiscordChatManager.SendDiscordMessage("", msg, ConfigManager.Config.Chat.RaffleChannelId);
+        }
+
+        [CommandHandler("serverquestcompletions", AccessLevel.Developer, CommandHandlerFlag.None, "Get Total Completions of a Quest for all Characters")]
+        public static void HandleServerQuestCompletions(Session session, params string[] parameters)
+        {
+            if (parameters.Length > 0)
+            {
+                var questName = parameters[0];
+                var completions = DatabaseManager.Shard.BaseDatabase.GetServerQuestCompletions(questName);
+                session.Player.SendMessage($"The quest {questName} has been completed {completions} times.");
+            }
+            else
+            {
+                session.Player.SendMessage($"You must specify a quest name.");
+            }
         }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new administrative command that lets administrators easily query and display the total number of completions for a specific quest across all characters. This update enhances tracking and monitoring capabilities by providing direct insight into quest performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->