### PR TITLE
Prevent Admin Tracking by not sending packets about objects the player can't see.

### DIFF
--- a/Source/ACE.Server/Command/Handlers/PlayerCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/PlayerCommands.cs
@@ -1361,6 +1361,10 @@ namespace ACE.Server.Command.Handlers
 
             foreach (var item in objects)
             {
+                // Don't list objects the player can't see
+                if (item.Visibility && !session.Player.Adminvision)
+                    continue;
+
                 session.Network.EnqueueSend(new GameMessageSystemChat($"{item.Name}, {item.Guid}, {item.Location}", ChatMessageType.Broadcast));
             }
         }

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -533,7 +533,13 @@ namespace ACE.Server.WorldObjects
                 result = CurrentLandblock?.GetObject(objectGuid, true, true);
 
                 if (result != null)
+                {
+                    // Don't describe objects the player can't see
+                    if (result.Visibility && !Adminvision)
+                        return null;
+
                     return result;
+                }
             }
 
             if (searchLocations.HasFlag(SearchLocations.LastUsedContainer))
@@ -594,7 +600,13 @@ namespace ACE.Server.WorldObjects
                 result = GetKnownObjects().FirstOrDefault(o => o.Guid == objectGuid);
 
                 if (result != null)
+                {
+                    // Don't describe objects the player can't see
+                    if (result.Visibility && !Adminvision)
+                        return null;
+
                     return result;
+                }
             }
 
             if (searchLocations.HasFlag(SearchLocations.LastUsedHook))
@@ -3203,11 +3215,14 @@ namespace ACE.Server.WorldObjects
 
             if ((target.Character.CharacterOptions1 & (int)CharacterOptions1.AllowGive) != (int)CharacterOptions1.AllowGive)
             {
-                Session.Network.EnqueueSend(new GameEventWeenieErrorWithString(Session, WeenieErrorWithString._IsNotAcceptingGiftsRightNow, target.Name));
-                Session.Network.EnqueueSend(new GameEventInventoryServerSaveFailed(Session, item.Guid.Full));
-                var msg = new GameMessageSystemChat($"{Name} tries to give you {(item.StackSize > 1 ? $"{item.StackSize} " : "")}{item.GetNameWithMaterial(item.StackSize)}.", ChatMessageType.Broadcast);
-                target.Session.Network.EnqueueSend(msg);
-                return;
+                if (!IsAdmin)
+                {
+                    Session.Network.EnqueueSend(new GameEventWeenieErrorWithString(Session, WeenieErrorWithString._IsNotAcceptingGiftsRightNow, target.Name));
+                    Session.Network.EnqueueSend(new GameEventInventoryServerSaveFailed(Session, item.Guid.Full));
+                    var msg = new GameMessageSystemChat($"{Name} tries to give you {(item.StackSize > 1 ? $"{item.StackSize} " : "")}{item.GetNameWithMaterial(item.StackSize)}.", ChatMessageType.Broadcast);
+                    target.Session.Network.EnqueueSend(msg);
+                    return;
+                }
             }
 
             if (target.IsLoggingOut)

--- a/Source/ACE.Server/WorldObjects/Player_Tracking.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Tracking.cs
@@ -111,7 +111,13 @@ namespace ACE.Server.WorldObjects
                     Session.Network.EnqueueSend(new GameMessageParentEvent(wo.Wielder, wo));
             }
             else
+            {
+                // Don't tell the client to delete something it has never seen
+                if (wo.Visibility && !Adminvision)
+                    return;
+
                 Session.Network.EnqueueSend(new GameMessageDeleteObject(wo));
+            }
 
             if (wo is Creature creature)
             {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved object visibility so players only see items they’re permitted to view.
  - Adjusted gift transactions to ensure non-administrators receive proper notifications when giving items, while administrators bypass these restrictions.
  - Refined deletion alerts to avoid notifying users about objects that remain unseen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->