### PR TITLE
Clothing mod discord upload/export support

### DIFF
--- a/Source/ACE.Common/ChatConfiguration.cs
+++ b/Source/ACE.Common/ChatConfiguration.cs
@@ -21,6 +21,10 @@ namespace ACE.Common
         public long ExportsChannelId { get; set; }
         public long WeenieUploadsChannelId { get; set; }
         public long RaffleChannelId { get; set; }
+        public long AdminChannelId { get; set; }
+        public string WebhookURL { get; set; }
+        public long ClothingModUploadChannelId { get; set; }
+        public long ClothingModExportChannelId { get; set; }
 
     }
 }

--- a/Source/ACE.Server/Command/Handlers/DeveloperContentCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperContentCommands.cs
@@ -2198,7 +2198,6 @@ namespace ACE.Server.Command.Handlers.Processors
                     return;
                 }
 
-
                 // Dynamically define the target folder path using ModManager.ModPath
                 string modDirectory = ModManager.ModPath;  // This is "c:\\ACE\\Mods\\" or wherever your mods are stored
                 string customClothingBaseDirectory = "CustomClothingBase";  // The subfolder for your mod
@@ -2206,10 +2205,6 @@ namespace ACE.Server.Command.Handlers.Processors
                 string folderPath = Path.Combine(modDirectory, customClothingBaseDirectory, jsonFolder);
 
                 // Combine folder path with the identifier to create the full file path
-
-                // Define the target folder path
-                string folderPath = "/home/tindale/ACE/Mods/CustomClothingBase/json"; // Update this to your desired folder path
-
                 string filePath = Path.Combine(folderPath, $"{identifier}.json");
 
                 // Ensure the folder exists

--- a/Source/ACE.Server/Command/Handlers/DeveloperContentCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperContentCommands.cs
@@ -2201,7 +2201,7 @@ namespace ACE.Server.Command.Handlers.Processors
                 // Dynamically define the target folder path using ModManager.ModPath
                 string modDirectory = ModManager.ModPath;  // This is "c:\\ACE\\Mods\\" or wherever your mods are stored
                 string customClothingBaseDirectory = "CustomClothingBase";  // The subfolder for your mod
-                string jsonFolder = "Json";  // The "Json" subfolder where JSON files will be stored
+                string jsonFolder = "json";  // The "Json" subfolder where JSON files will be stored
                 string folderPath = Path.Combine(modDirectory, customClothingBaseDirectory, jsonFolder);
 
                 // Combine folder path with the identifier to create the full file path

--- a/Source/ACE.Server/Command/Handlers/DeveloperContentCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperContentCommands.cs
@@ -26,6 +26,10 @@ using ACE.Server.Network.GameMessages.Messages;
 using ACE.Server.Physics.Extensions;
 using ACE.Server.WorldObjects;
 using ACE.Common;
+using ACE.DatLoader.FileTypes;
+using ACE.DatLoader;
+using Discord;
+using ACE.Server.Mods;
 
 namespace ACE.Server.Command.Handlers.Processors
 {
@@ -1288,6 +1292,7 @@ namespace ACE.Server.Command.Handlers.Processors
             wo.Location.PositionZ += 0.05f;
 
             session.Network.EnqueueSend(new GameMessageSystemChat($"Creating new landblock instance {(isLinkChild ? "child object " : "")}@ {loc.ToLOCString()}\n{wo.WeenieClassId} - {wo.Name} ({nextStaticGuid:X8})", ChatMessageType.Broadcast));
+            PlayerManager.BroadcastToAuditChannel(session.Player, $"{session.Player.Name} has created a new landblock instance {(isLinkChild ? "child object " : "")}@ {loc.ToLOCString()}\n [WeenieID]: {wo.WeenieClassId} - {wo.Name} [GUID]: ({nextStaticGuid:X8})");
 
             if (!wo.EnterWorld())
             {
@@ -1537,6 +1542,7 @@ namespace ACE.Server.Command.Handlers.Processors
             DeleteInstanceFromWorldDatabase(instance);
 
             session.Network.EnqueueSend(new GameMessageSystemChat($"Removed {(instance.IsLinkChild ? "child " : "")}{wo.WeenieClassId} - {wo.Name} (0x{guid:X8}) from landblock instances", ChatMessageType.Broadcast));
+            PlayerManager.BroadcastToAuditChannel(session.Player, $"{session.Player.Name} has removed {(instance.IsLinkChild ? "child " : "")}[WeenieID]: {wo.WeenieClassId} - {wo.Name} [GUID]: (0x{guid:X8}) from landblock instances");
         }
 
         public static void SaveInstanceToWorldDatabase(LandblockInstance instance)
@@ -2171,6 +2177,114 @@ namespace ACE.Server.Command.Handlers.Processors
             
         }
 
+        [CommandHandler("import-discord-clothing", AccessLevel.Developer, CommandHandlerFlag.None, 1, "Imports JSON content from Discord to the server folder", "<filename>")]
+        public static void HandleDiscordJsonImport(Session session, params string[] parameters)
+        {
+            try
+            {
+                string identifier = parameters[0];
+                if (string.IsNullOrEmpty(identifier))
+                {
+                    CommandHandlerHelper.WriteOutputInfo(session, "Invalid identifier");
+                    return;
+                }
+
+                // Get the JSON file content from Discord
+                string jsonContent = DiscordChatManager.GetJsonFromDiscordMessage(20, identifier);
+
+                if (string.IsNullOrEmpty(jsonContent))
+                {
+                    CommandHandlerHelper.WriteOutputInfo(session, $"Couldn't find JSON attachment for {identifier}");
+                    return;
+                }
+
+                // Dynamically define the target folder path using ModManager.ModPath
+                string modDirectory = ModManager.ModPath;  // This is "c:\\ACE\\Mods\\" or wherever your mods are stored
+                string customClothingBaseDirectory = "CustomClothingBase";  // The subfolder for your mod
+                string jsonFolder = "Json";  // The "Json" subfolder where JSON files will be stored
+                string folderPath = Path.Combine(modDirectory, customClothingBaseDirectory, jsonFolder);
+
+                // Combine folder path with the identifier to create the full file path
+                string filePath = Path.Combine(folderPath, $"{identifier}.json");
+
+                // Ensure the folder exists
+                if (!Directory.Exists(folderPath))
+                {
+                    Directory.CreateDirectory(folderPath);
+                }
+
+                // Write the JSON content to the file
+                File.WriteAllText(filePath, jsonContent);
+
+                CommandHandlerHelper.WriteOutputInfo(session, $"Successfully imported JSON file {identifier} to {filePath}");
+            }
+            catch (Exception e)
+            {
+                CommandHandlerHelper.WriteOutputInfo(session, $"Error importing JSON from Discord: {e.Message}");
+            }
+        }
+
+        private static string getFilename(uint fileId)
+        {
+            string directory = ModManager.GetModContainerByName("CustomClothingBase").FolderPath;
+            string jsonFilename = Path.Combine(directory, "json", $"{fileId:X8}.json");
+            return jsonFilename;
+        }
+
+        [CommandHandler("export-discord-clothing", AccessLevel.Developer, CommandHandlerFlag.None, 1, "Exports a ClothingBase entry to JSON and sends it to Discord.")]
+        public static void HandleExportClothingToDiscord(Session session, params string[] parameters)
+        {
+            if (parameters == null || parameters.Length < 1)
+            {
+                CommandHandlerHelper.WriteOutputInfo(session, "Usage: export-discord-clothing <id>");
+                return;
+            }
+
+            uint clothingBaseId;
+            if (!uint.TryParse(parameters[0], out clothingBaseId))
+            {
+                CommandHandlerHelper.WriteOutputInfo(session, "Invalid ClothingBase ID format.");
+                return;
+            }
+
+            if (clothingBaseId < 0x10000000 || clothingBaseId > 0x10FFFFFF)
+            {
+                CommandHandlerHelper.WriteOutputInfo(session, $"{clothingBaseId:X8} is not a valid ClothingBase between 0x10000000 and 0x10FFFFFF");
+                return;
+            }
+
+            if (!DatManager.PortalDat.AllFiles.ContainsKey(clothingBaseId))
+            {
+                CommandHandlerHelper.WriteOutputInfo(session, $"ClothingBase {clothingBaseId:X8} not found.");
+                return;
+            }
+
+            // Export logic - Create JSON and send directly to Discord without saving to a file
+            var cbToExport = DatManager.PortalDat.ReadFromDat<ClothingTable>(clothingBaseId);
+            var json = JsonConvert.SerializeObject(cbToExport, Formatting.Indented);
+
+            try
+            {
+                // Convert the JSON string to a MemoryStream for sending it as a file
+                using (MemoryStream mem = new MemoryStream())
+                {
+                    using (StreamWriter sw = new StreamWriter(mem))
+                    {
+                        sw.AutoFlush = true;
+                        sw.WriteLine(json); // Write the JSON content to the memory stream
+
+                        // Send the JSON content to Discord as a file
+                        DiscordChatManager.SendDiscordFile(session.Player.Name, $"ClothingBase {clothingBaseId:X8}.json", (long)ConfigManager.Config.Chat.ClothingModExportChannelId, new Discord.FileAttachment(mem, $"{clothingBaseId:X8}.json"));
+
+                        CommandHandlerHelper.WriteOutputInfo(session, $"Exported ClothingBase {clothingBaseId:X8} to Discord.");
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                CommandHandlerHelper.WriteOutputInfo(session, $"Error exporting ClothingBase {clothingBaseId:X8} to Discord: {ex.Message}");
+            }
+        }
 
         [CommandHandler("export-discord", AccessLevel.Developer, CommandHandlerFlag.None, 1, "Exports content from database to SQL file and load to Discord", "<wcid> [content-type]")]
         public static void HandleExportSqlToDiscord(Session session, params string[] parameters)

--- a/Source/ACE.Server/Managers/DiscordChatManager.cs
+++ b/Source/ACE.Server/Managers/DiscordChatManager.cs
@@ -88,6 +88,46 @@ namespace ACE.Server.Managers
             return res;
         }
 
+        public static string GetJsonFromDiscordMessage(int topN, string identifier)
+        {
+            string res = "";
+
+            try
+            {
+                _discordSocketClient.GetGuild((ulong)ConfigManager.Config.Chat.ServerId)
+                    .GetTextChannel((ulong)ConfigManager.Config.Chat.ClothingModUploadChannelId)
+                    .GetMessagesAsync(limit: topN)
+                    .FlattenAsync().Result.ToList()
+                    .ForEach(x =>
+                    {
+                        if (x.Content == identifier)
+                        {
+                            if (x.Attachments.Count == 1)
+                            {
+                                IAttachment attachment = x.Attachments.First();
+                                if (attachment.Filename.ToLowerInvariant().Contains(".json"))
+                                {
+                                    // Using HttpClient to download the JSON
+                                    using (var client = new HttpClient())
+                                    {
+                                        res = client.GetStringAsync(attachment.Url).Result; // Fetching the JSON content synchronously
+                                        return;
+                                    }
+                                }
+                            }
+                        }
+                    });
+            }
+            catch (Exception ex)
+            {
+                log.Error("Error getting discord messages, " + ex.Message);
+            }
+
+            return res;
+        }
+
+
+
         public static void Initialize()
         {
             _discordSocketClient = new DiscordSocketClient();


### PR DESCRIPTION
Allows for import and export of clothing base to discord. Export via command /export-discord-clothing <id> where id is the desired clothing base did. It will take the decimal number and convert it to a hex json file.  Importing via /import-discord-clothing <id>. That will pull the id from the discord channel and save the json file in the correct server folder. Clothingupload and Clothingexport channels will need to be created and mapped in the config.js. Also will need to update the folder location for the import function to save the file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added commands to import and export clothing data as JSON files via Discord integration.
	- Introduced audit notifications for landblock instance creation and removal, providing detailed activity logs.
- **Enhancements**
	- Expanded chat configuration options, including new channel and webhook settings for improved integration.
	- Enabled retrieval of JSON content directly from Discord messages for streamlined data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->