### PR TITLE
Enrage Boss Mechanics

### DIFF
--- a/Source/ACE.Entity/Enum/Properties/PropertyBool.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyBool.cs
@@ -186,6 +186,10 @@ namespace ACE.Entity.Enum.Properties
         FreeMasteryResetRenewed          = 9010,
         ExcludeFromLeaderboards          = 9011,
         IsVPHardcore                     = 9012,
-        DisableCreate                    = 9013
+        DisableCreate                    = 9013,
+        CanEnrage                        = 9014,
+        CanGrapple                       = 9015,
+        CanAOE                           = 9016,
+        EnragedHotspot                   = 9017,
     }
 }

--- a/Source/ACE.Entity/Enum/Properties/PropertyFloat.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyFloat.cs
@@ -233,5 +233,8 @@ namespace ACE.Entity.Enum.Properties
         SpentExperienceHealth          = 9008,
         SpentExperienceStamina         = 9009,
         SpentExperienceMana            = 9010,
+        EnrageDamageMultiplier         = 9011,
+        EnrageDamageReduction          = 9012,
+        EnrageThreshold                = 9013,
     }
 }

--- a/Source/ACE.Entity/Enum/Properties/PropertyInt.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyInt.cs
@@ -695,6 +695,9 @@ namespace ACE.Entity.Enum.Properties
         PortalReqType2                          = 9022,
         PortalReqValue2                         = 9023,
         PortalReqMaxValue2                      = 9024,
+        EnrageFogColor                          = 9025,
+        EnrageSound                             = 9026,
+        EnrageVisualEffect                      = 9027,
 
     }
 

--- a/Source/ACE.Server/Command/Handlers/PlayerCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/PlayerCommands.cs
@@ -661,9 +661,9 @@ namespace ACE.Server.Command.Handlers
             int blueComboCount = Math.Min(totalBlueAetheriaCount, falatacotTrinketCount);
 
             // Calculate MMD cost only for Coalesced Aetheria and Chunks (Red and Blue)
-            int totalClapCost =
-                ((redComboCount - redPowderCount > 0 ? Math.Min(redComboCount, redAetheriaCount + redChunkCount) : 0) * ClapCostPerUnit) +
-                ((blueComboCount - bluePowderCount > 0 ? Math.Min(blueComboCount, blueAetheriaCount + blueChunkCount) : 0) * ClapCostPerUnit);
+            int redNonPowderUsed = Math.Min(redComboCount, redAetheriaCount + redChunkCount);
+            int blueNonPowderUsed = Math.Min(blueComboCount, blueAetheriaCount + blueChunkCount);
+            int totalClapCost = (redNonPowderUsed + blueNonPowderUsed) * ClapCostPerUnit;
 
             if (session.Player.BankedPyreals < totalClapCost)
             {

--- a/Source/ACE.Server/Entity/DamageEvent.cs
+++ b/Source/ACE.Server/Entity/DamageEvent.cs
@@ -217,11 +217,10 @@ namespace ACE.Server.Entity
             // NEW: Apply enrage multiplier if the attacker is a mob and enraged
             if (attacker.IsEnraged && !(attacker is Player))
             {
-                var enrageMultiplier = attacker.EnrageDamageMultiplier ?? 0.0f;
+                var enrageMultiplier = attacker.EnrageDamageMultiplier ?? 1.0f;
                 BaseDamage *= enrageMultiplier;
                // Console.WriteLine($"[DEBUG] Mob Attacker Enrage Multiplier Applied: {enrageMultiplier}, Updated Base Damage: {BaseDamage}");
             }
-
 
             if (DamageType == DamageType.Undef)
             {
@@ -269,15 +268,7 @@ namespace ACE.Server.Entity
             // damage before mitigation
             DamageBeforeMitigation = BaseDamage * AttributeMod * PowerMod * SlayerMod * DamageRatingMod;
 
-            Console.WriteLine($"[DEBUG] Damage Before Mitigation: {DamageBeforeMitigation}");
-
-            // NEW: Apply enrage damage reduction if the defender is a mob and enraged
-            if (defender.IsEnraged && !(defender is Player))
-            {
-                var damageReduction = defender.EnrageDamageReduction ?? 0.0f; // Default to no reduction
-                DamageBeforeMitigation *= (1.0f - damageReduction);
-                //Console.WriteLine($"[DEBUG] Mob Defender Enrage Damage Reduction Applied: {damageReduction * 100}%, Reduced Damage: {DamageBeforeMitigation}");
-            }
+            //Console.WriteLine($"[DEBUG] Damage Before Mitigation: {DamageBeforeMitigation}");
 
             // critical hit?
             var attackSkill = attacker.GetCreatureSkill(attacker.GetCurrentWeaponSkill());
@@ -335,14 +326,6 @@ namespace ACE.Server.Entity
 
                     //Console.WriteLine($"[DEBUG] Damage Before Mitigation (Critical): {DamageBeforeMitigation}");
 
-                    // Apply enrage damage reduction if defender is the mob and enraged
-                    if (defender.IsEnraged && !(defender is Player))
-                    {
-                        var damageReduction = defender.EnrageDamageReduction ?? 0.0f; // Default to no reduction
-                        DamageBeforeMitigation *= (1.0f - damageReduction); // Reduce critical hit damage
-                        //Console.WriteLine($"[DEBUG] Mob Defender Enrage Damage Reduction Applied: {damageReduction * 100}%, Final Damage Before Mitigation: {DamageBeforeMitigation}");
-                    }
-
                     CriticalDamageRatingMod = Creature.GetPositiveRatingMod(attacker.GetCritDamageRating());
 
                     // Recklessness excluded from crits
@@ -352,7 +335,8 @@ namespace ACE.Server.Entity
                     if (pkBattle)
                         DamageRatingMod = Creature.AdditiveCombine(DamageRatingMod, PkDamageMod);
 
-                    DamageBeforeMitigation = BaseDamageMod.MaxDamage * AttributeMod * PowerMod * SlayerMod * DamageRatingMod * CriticalDamageMod;
+                    DamageBeforeMitigation *= Creature.AdditiveCombine(CriticalDamageRatingMod, 1.0f); // Apply only crit bonus
+
                 }
             }
 

--- a/Source/ACE.Server/Entity/DamageEvent.cs
+++ b/Source/ACE.Server/Entity/DamageEvent.cs
@@ -12,6 +12,7 @@ using ACE.Server.Managers;
 using ACE.Server.Network.GameMessages.Messages;
 using ACE.Server.WorldObjects;
 using ACE.DatLoader.Entity;
+using ACE.Entity.Enum.Properties;
 
 namespace ACE.Server.Entity
 {
@@ -213,6 +214,15 @@ namespace ACE.Server.Entity
             else
                 GetBaseDamage(attacker, AttackMotion ?? MotionCommand.Invalid, AttackHook);
 
+            // NEW: Apply enrage multiplier if the attacker is a mob and enraged
+            if (attacker.IsEnraged && !(attacker is Player))
+            {
+                var enrageMultiplier = attacker.EnrageDamageMultiplier ?? 0.0f;
+                BaseDamage *= enrageMultiplier;
+               // Console.WriteLine($"[DEBUG] Mob Attacker Enrage Multiplier Applied: {enrageMultiplier}, Updated Base Damage: {BaseDamage}");
+            }
+
+
             if (DamageType == DamageType.Undef)
             {
                 if ((attacker?.Guid.IsPlayer() ?? false) || (damageSource?.Guid.IsPlayer() ?? false))
@@ -259,6 +269,16 @@ namespace ACE.Server.Entity
             // damage before mitigation
             DamageBeforeMitigation = BaseDamage * AttributeMod * PowerMod * SlayerMod * DamageRatingMod;
 
+            Console.WriteLine($"[DEBUG] Damage Before Mitigation: {DamageBeforeMitigation}");
+
+            // NEW: Apply enrage damage reduction if the defender is a mob and enraged
+            if (defender.IsEnraged && !(defender is Player))
+            {
+                var damageReduction = defender.EnrageDamageReduction ?? 0.0f; // Default to no reduction
+                DamageBeforeMitigation *= (1.0f - damageReduction);
+                //Console.WriteLine($"[DEBUG] Mob Defender Enrage Damage Reduction Applied: {damageReduction * 100}%, Reduced Damage: {DamageBeforeMitigation}");
+            }
+
             // critical hit?
             var attackSkill = attacker.GetCreatureSkill(attacker.GetCurrentWeaponSkill());
             CriticalChance = WorldObject.GetWeaponCriticalChance(Weapon, attacker, attackSkill, defender);
@@ -302,6 +322,26 @@ namespace ACE.Server.Entity
 
                     // Update the CriticalDamageMod to include luminance augment bonus
                     CriticalDamageMod = 1.0f + WorldObject.GetWeaponCritDamageMod(Weapon, attacker, attackSkill, defender) + luminanceAugmentBonus;
+
+                    // NEW: Apply enrage multiplier if attacker is a mob and enraged
+                    if (attacker.IsEnraged && !(attacker is Player))
+                    {
+                        CriticalDamageMod *= attacker.EnrageDamageMultiplier ?? 1.0f;
+                        //Console.WriteLine($"[DEBUG] CriticalDamageMod After Mob Attacker Enrage Multiplier: {CriticalDamageMod}");
+                    }
+
+                    // Calculate damage before mitigation
+                    DamageBeforeMitigation = BaseDamageMod.MaxDamage * AttributeMod * PowerMod * SlayerMod * DamageRatingMod * CriticalDamageMod;
+
+                    //Console.WriteLine($"[DEBUG] Damage Before Mitigation (Critical): {DamageBeforeMitigation}");
+
+                    // Apply enrage damage reduction if defender is the mob and enraged
+                    if (defender.IsEnraged && !(defender is Player))
+                    {
+                        var damageReduction = defender.EnrageDamageReduction ?? 0.0f; // Default to no reduction
+                        DamageBeforeMitigation *= (1.0f - damageReduction); // Reduce critical hit damage
+                        //Console.WriteLine($"[DEBUG] Mob Defender Enrage Damage Reduction Applied: {damageReduction * 100}%, Final Damage Before Mitigation: {DamageBeforeMitigation}");
+                    }
 
                     CriticalDamageRatingMod = Creature.GetPositiveRatingMod(attacker.GetCritDamageRating());
 
@@ -392,8 +432,17 @@ namespace ACE.Server.Entity
             // calculate final output damage
             Damage = DamageBeforeMitigation * ArmorMod * ShieldMod * ResistanceMod * DamageResistanceRatingMod;
 
+            // NEW: Apply enrage damage reduction to the final output damage if the defender is a mob and enraged
+            if (defender.IsEnraged && !(defender is Player))
+            {
+                var damageReduction = defender.EnrageDamageReduction ?? 0.0f; // Default to no reduction
+                Damage *= (1.0f - damageReduction); // Apply reduction (e.g., 0.5 = 50% reduction)
+                //Console.WriteLine($"[DEBUG] Final Mob Defender Enrage Damage Reduction Applied: {damageReduction * 100}%, Final Damage: {Damage}");
+            }
+
             DamageMitigated = DamageBeforeMitigation - Damage;
 
+            //Console.WriteLine($"[DEBUG] Final Damage: {Damage}");
             return Damage;
         }
 

--- a/Source/ACE.Server/Physics/CylSphere.cs
+++ b/Source/ACE.Server/Physics/CylSphere.cs
@@ -204,6 +204,20 @@ namespace ACE.Server.Physics
         /// </summary>
         public bool CollidesWithSphere(Sphere checkPos, Vector3 disp, float radsum)
         {
+            return CollidesWithSphereWithScaling(checkPos, disp, radsum, 1.0f);
+        }
+
+        public bool CollidesWithSphereEnragedHotspot(Sphere checkPos, Vector3 disp, float radsum)
+        {
+            return CollidesWithSphereWithScaling(checkPos, disp, radsum, 3.0f);
+        }
+
+        private bool CollidesWithSphereWithScaling(Sphere checkPos, Vector3 disp, float radsum, float scalingFactor)
+        {
+            radsum *= scalingFactor;
+
+            //Console.WriteLine($"[DEBUG] Scaling radsum in CollidesWithSphereWithScaling: {radsum} (scalingFactor: {scalingFactor})");
+
             var result = false;
 
             if (disp.X * disp.X + disp.Y * disp.Y <= radsum * radsum)

--- a/Source/ACE.Server/Physics/Sphere.cs
+++ b/Source/ACE.Server/Physics/Sphere.cs
@@ -151,8 +151,18 @@ namespace ACE.Server.Physics
         /// </summary>
         public bool Intersects(Sphere sphere)
         {
+            return IntersectsWithScaling(sphere, 1.0f);
+        }
+
+        public bool IntersectsEnragedHotspot(Sphere sphere)
+        {
+            return IntersectsWithScaling(sphere, 7.0f);
+        }
+
+        private bool IntersectsWithScaling(Sphere sphere, float scalingFactor)
+        {
             var delta = sphere.Center - Center;
-            var radSum = Radius + sphere.Radius;
+            var radSum = (Radius + sphere.Radius) * scalingFactor;
             return delta.LengthSquared() < radSum * radSum;
         }
 

--- a/Source/ACE.Server/WorldObjects/Creature_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Death.cs
@@ -39,6 +39,18 @@ namespace ACE.Server.WorldObjects
             IsTurning = false;
             IsMoving = false;
 
+            // Reset fog to Clear upon death only if the creature was enraged
+            if (IsEnraged && CurrentLandblock != null)
+            {
+                var fogResetType = EnvironChangeType.Clear;
+                CurrentLandblock.SendEnvironChange(fogResetType);
+                //Console.WriteLine("[DEBUG] EnvironChange reset to Clear upon mob death (Enraged state detected).");
+            }
+            else if (IsEnraged)
+            {
+                //Console.WriteLine("[ERROR] CurrentLandblock is null. Unable to reset fog upon mob death.");
+            }
+
             //QuestManager.OnDeath(lastDamager?.TryGetAttacker());
 
             if (KillQuest != null)

--- a/Source/ACE.Server/WorldObjects/Creature_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Death.cs
@@ -39,6 +39,9 @@ namespace ACE.Server.WorldObjects
             IsTurning = false;
             IsMoving = false;
 
+            grappleLoopCTS?.Cancel();
+            hotspotLoopCTS?.Cancel();
+
             // Reset fog to Clear upon death only if the creature was enraged
             if (IsEnraged && CurrentLandblock != null)
             {

--- a/Source/ACE.Server/WorldObjects/Creature_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Properties.cs
@@ -414,6 +414,24 @@ namespace ACE.Server.WorldObjects
             set { if (!value.HasValue) RemoveProperty(PropertyInt64.LumAugMagicDefenseCount); else SetProperty(PropertyInt64.LumAugMagicDefenseCount, value.Value); }
         }
 
+        public bool CanEnrage
+        {
+            get => GetProperty(PropertyBool.CanEnrage) ?? false; // Default to false
+            set { if (!value) RemoveProperty(PropertyBool.CanEnrage); else SetProperty(PropertyBool.CanEnrage, value); }
+        }
+
+        public bool CanGrapple
+        {
+            get => GetProperty(PropertyBool.CanGrapple) ?? false; // Default to false
+            set { if (!value) RemoveProperty(PropertyBool.CanGrapple); else SetProperty(PropertyBool.CanGrapple, value); }
+        }
+
+        public bool CanAOE
+        {
+            get => GetProperty(PropertyBool.CanAOE) ?? false; // Default to false
+            set { if (!value) RemoveProperty(PropertyBool.CanAOE); else SetProperty(PropertyBool.CanAOE, value); }
+        }
+
         public FactionBits Society => Faction1Bits ?? FactionBits.None;
     }
 }

--- a/Source/ACE.Server/WorldObjects/Hotspot.cs
+++ b/Source/ACE.Server/WorldObjects/Hotspot.cs
@@ -9,6 +9,7 @@ using ACE.Entity.Enum.Properties;
 using ACE.Entity.Models;
 using ACE.Server.Entity.Actions;
 using ACE.Server.Network.GameMessages.Messages;
+using ACE.Server.Physics;
 
 namespace ACE.Server.WorldObjects
 {
@@ -75,7 +76,15 @@ namespace ACE.Server.WorldObjects
                 {
                     if (Creatures != null && Creatures.Any())
                     {
-                        Activate();
+                        //check if the hotspot is enraged
+                        if (EnragedHotspot)
+                        {
+                            ActivateEnragedHotspot();
+                        }
+                        else
+                        {
+                            Activate();
+                        }
                         NextActionLoop.EnqueueChain();
                     }
                     else
@@ -143,7 +152,13 @@ namespace ACE.Server.WorldObjects
             set { if (!value) RemoveProperty(PropertyBool.AffectsAis); else SetProperty(PropertyBool.AffectsAis, value); }
         }
 
-        private void Activate()
+        public bool EnragedHotspot
+        {
+            get => GetProperty(PropertyBool.EnragedHotspot) ?? false;
+            set { if (!value) RemoveProperty(PropertyBool.EnragedHotspot); else SetProperty(PropertyBool.EnragedHotspot, value); }
+        }
+
+        private void ActivateCommon(Func<PhysicsObj, bool> collisionCheck, Action<Creature> activationAction)
         {
             if (Creatures == null) return;
             foreach (var creatureGuid in Creatures.ToList())
@@ -155,19 +170,35 @@ namespace ACE.Server.WorldObjects
                 var creature = CurrentLandblock.GetObject(creatureGuid) as Creature;
 
                 // verify current state of collision here
-                if (creature == null || !creature.PhysicsObj.is_touching(PhysicsObj))
+                if (creature == null || !collisionCheck(creature.PhysicsObj))
                 {
                     //Console.WriteLine($"{Name} ({Guid}).OnCollideObjectEnd({creature?.Name})");
                     Creatures.Remove(creatureGuid);
                     continue;
                 }
-                Activate(creature);
+                activationAction(creature);
             }
         }
 
-        private void Activate(Creature creature)
+        private void Activate()
         {
-            if (!IsHot) return;
+            ActivateCommon(
+                (PhysicsObj obj) => obj.is_touching(PhysicsObj),
+                (Creature creature) => Activate(creature)
+            );
+        }
+
+        private void ActivateEnragedHotspot()
+        {
+            ActivateCommon(
+                (PhysicsObj obj) => obj.is_touchingEnragedHotspot(PhysicsObj),
+                (Creature creature) => ActivateEnragedHotspot(creature)
+            );
+        }
+
+        private void ActivateCommon(Creature creature, bool isActive, Func<Creature, bool> isDamageable)
+        {
+            if (!IsActive) return;
 
             var amount = DamageNext;
             var iAmount = (int)Math.Round(amount);
@@ -220,6 +251,16 @@ namespace ACE.Server.WorldObjects
             // perform activation emote
             if (ActivationResponse.HasFlag(ActivationResponse.Emote))
                 OnEmote(creature);
+        }
+
+        private void Activate(Creature creature)
+        {
+            ActivateCommon(creature, IsHot, (Creature c) => !c.Invincible && !c.IsDead);
+        }
+
+        private void ActivateEnragedHotspot(Creature creature)
+        {
+            ActivateCommon(creature, EnragedHotspot, (Creature c) => !c.Invincible && !c.IsDead);
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Monster_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Combat.cs
@@ -490,7 +490,11 @@ namespace ACE.Server.WorldObjects
             grappleLoopCTS?.Cancel();
             grappleLoopCTS = new CancellationTokenSource();
 
-            _ = Task.Run(() => StartGrappleLoopAsync(grappleLoopCTS.Token));
+            _ = Task.Run(async () =>
+            {
+                await Task.Delay(TimeSpan.FromSeconds(6), grappleLoopCTS.Token);
+                await StartGrappleLoopAsync(grappleLoopCTS.Token);
+            });
         }
 
         private async Task StartGrappleLoopAsync(CancellationToken ct)

--- a/Source/ACE.Server/WorldObjects/Monster_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Combat.cs
@@ -468,34 +468,51 @@ namespace ACE.Server.WorldObjects
         }
 
         private CancellationTokenSource hotspotLoopCTS;
+        private Task? hotspotLoopTask;
 
         public void StartHotspotSpawnLoopWithDelay()
         {
             hotspotLoopCTS?.Cancel();
             hotspotLoopCTS = new CancellationTokenSource();
 
-             _ = Task.Run(async () =>
+            hotspotLoopTask = Task.Run(async () =>
             {
-                await Task.Delay(TimeSpan.FromSeconds(5), hotspotLoopCTS.Token);
-                await StartHotspotSpawnLoopAsync(hotspotLoopCTS.Token);
+                try
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(5), hotspotLoopCTS.Token);
+                    await StartHotspotSpawnLoopAsync(hotspotLoopCTS.Token);
+                }
+                catch (Exception ex) when (ex is not TaskCanceledException)
+                {
+                    Logger.Warn(ex, $"{Name}: hotspot loop terminated unexpectedly.");
+                }
             });
         }
+
 
 
         private CancellationTokenSource grappleLoopCTS;
+        private Task? grappleLoopTask;
 
         public void StartGrappleLoopWithDelay()
         {
-            // Cancel any existing loop
             grappleLoopCTS?.Cancel();
             grappleLoopCTS = new CancellationTokenSource();
 
-            _ = Task.Run(async () =>
+            grappleLoopTask = Task.Run(async () =>
             {
-                await Task.Delay(TimeSpan.FromSeconds(6), grappleLoopCTS.Token);
-                await StartGrappleLoopAsync(grappleLoopCTS.Token);
+                try
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(5), grappleLoopCTS.Token);
+                    await StartGrappleLoopAsync(grappleLoopCTS.Token);
+                }
+                catch (Exception ex) when (ex is not TaskCanceledException)
+                {
+                    Logger.Warn(ex, $"{Name}: grapple loop terminated unexpectedly.");
+                }
             });
         }
+
 
         private async Task StartGrappleLoopAsync(CancellationToken ct)
         {

--- a/Source/ACE.Server/WorldObjects/Player_Location.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Location.cs
@@ -786,6 +786,9 @@ namespace ACE.Server.WorldObjects
                     if (p.CurrentLandblock != null && Landblock.connectionExemptLandblocks.Contains(p.CurrentLandblock.Id.Landblock))
                         continue;
 
+                    if (p.IsPlussed)
+                        continue;
+
                     if (++nonexemptCount > ConfigManager.Config.Server.Network.MaximumAllowedSessionsPerIPAddress)
                     {
                         p.SendMessage($"Booting due to exceeding {ConfigManager.Config.Server.Network.MaximumAllowedSessionsPerIPAddress} allowed outside of exempt areas.");

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -756,6 +756,18 @@ namespace ACE.Server.WorldObjects
 
             WorldObject equippedCloak = null;
 
+            if (target.CanEnrage && !target.IsEnraged && target.Health.Current > 0)
+            {
+                var healthPercentage = (float)target.Health.Current / target.Health.MaxValue;
+                var enrageThreshold = (float)(target.GetProperty(PropertyFloat.EnrageThreshold) ?? 0.2f); // Default to 20%
+
+                if (healthPercentage <= enrageThreshold)
+                {
+                    target.Enrage(); // Trigger enrage
+                    //Console.WriteLine($"[DEBUG] {target.Name} has enraged due to magic damage!");
+                }
+            }
+
             // handle life projectiles for stamina / mana
             if (Spell.Category == SpellCategory.StaminaLowering)
             {
@@ -804,6 +816,14 @@ namespace ACE.Server.WorldObjects
                 }
 
                 damage *= damageRatingMod * damageResistRatingMod;
+
+                // Apply enrage damage reduction for the defender
+                if (target.IsEnraged)
+                {
+                    var enrageReduction = target.EnrageDamageReduction ?? 0.0f; // Default to 0% reduction
+                    damage *= (1.0f - enrageReduction);
+                    //Console.WriteLine($"[DEBUG] Enrage Damage Reduction Applied by Defender: {enrageReduction * 100}%, Final Damage: {damage}");
+                }
 
                 percent = damage / target.Health.MaxValue;
 

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -2545,6 +2545,42 @@ namespace ACE.Server.WorldObjects
             }
         }
 
+        public float? EnrageDamageMultiplier
+        {
+            get => (float?)GetProperty(PropertyFloat.EnrageDamageMultiplier);
+            set { if (!value.HasValue) RemoveProperty(PropertyFloat.EnrageDamageMultiplier); else SetProperty(PropertyFloat.EnrageDamageMultiplier, value.Value); }
+        }
+
+        public float? EnrageDamageReduction
+        {
+            get => (float?)GetProperty(PropertyFloat.EnrageDamageReduction);
+            set { if (!value.HasValue) RemoveProperty(PropertyFloat.EnrageDamageReduction); else SetProperty(PropertyFloat.EnrageDamageReduction, value.Value); }
+        }
+
+        public float? EnrageThreshold
+        {
+            get => (float?)GetProperty(PropertyFloat.EnrageThreshold);
+            set { if (!value.HasValue) RemoveProperty(PropertyFloat.EnrageThreshold); else SetProperty(PropertyFloat.EnrageThreshold, value.Value); }
+        }
+
+        public int? EnrageFogColor
+        {
+            get => GetProperty(PropertyInt.EnrageFogColor);
+            set { if (!value.HasValue) RemoveProperty(PropertyInt.EnrageFogColor); else SetProperty(PropertyInt.EnrageFogColor, value.Value); }
+        }
+
+        public int? EnrageSound
+        {
+            get => GetProperty(PropertyInt.EnrageSound);
+            set { if (!value.HasValue) RemoveProperty(PropertyInt.EnrageSound); else SetProperty(PropertyInt.EnrageSound, value.Value); }
+        }
+
+        public int? EnrageVisualEffect
+        {
+            get => GetProperty(PropertyInt.EnrageVisualEffect);
+            set { if (!value.HasValue) RemoveProperty(PropertyInt.EnrageVisualEffect); else SetProperty(PropertyInt.EnrageVisualEffect, value.Value); }
+        }
+
         /// <summary>
         /// <para>Used to mark when EnterWorld has completed for first time for this object's instance.</para>
         /// Currently used by Generators and Players


### PR DESCRIPTION
Event boss mechanics to enrage causing additional damage, drop hotspots on random players, and grapple random players to the boss.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an "enrage" mechanic for monsters, including enrage state, health thresholds, and related visual, audio, and environmental effects.
  - Added grapple and area-of-effect (AOE) hotspot behaviors during monster enrage, with player targeting and messaging.
  - Monsters can now reduce incoming damage and increase outgoing damage while enraged.
  - Hotspots can now have an "enraged" state with expanded effects.
  - New monster properties: CanEnrage, CanGrapple, CanAOE, and customizable enrage effects including damage multipliers, reductions, fog colors, sounds, and visual effects.
  - Enhanced collision detection and activation logic to support enraged hotspots with scaled interaction ranges.
- **Bug Fixes**
  - Improved session counting logic to exempt certain players from session limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->