### PR TITLE
If TreasureGenerator() returns null Spawn() should return null

### DIFF
--- a/Source/ACE.Server/Entity/GeneratorProfile.cs
+++ b/Source/ACE.Server/Entity/GeneratorProfile.cs
@@ -247,8 +247,10 @@ namespace ACE.Server.Entity
             if (RegenLocationType.HasFlag(RegenLocationType.Treasure))
             {
                 objects = TreasureGenerator();
+                if (objects == null)
+                    return null;
 
-                if (objects != null && objects.Count > 0)
+                if (objects.Count > 0)
                 {
                     Generator.GeneratedTreasureItem = true;
                     GeneratedTreasureItem = true;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of treasure generation failures to prevent further processing when no treasure is generated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->