### PR TITLE
copy/pasta error with aug cost increases

### DIFF
--- a/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
@@ -1616,9 +1616,9 @@ namespace ACE.Server.WorldObjects.Managers
                                     {
                                         additionalMultiplier = 8; // Apply 8x multiplier for augments >= 2500
                                     }
-                                    else if (creatureAugs >= 1750)
+                                    else if (creatureAugs >= 2750)
                                     {
-                                        additionalMultiplier = 4; // Apply 4x multiplier for augments >= 1750
+                                        additionalMultiplier = 4; // Apply 4x multiplier for augments >= 2750
                                     }
 
                                     totalCost *= additionalMultiplier;
@@ -1692,9 +1692,9 @@ namespace ACE.Server.WorldObjects.Managers
                                     {
                                         additionalMultiplier = 8; // Apply 8x multiplier for augments >= 2500
                                     }
-                                    else if (itemAugs >= 1750)
+                                    else if (itemAugs >= 1250)
                                     {
-                                        additionalMultiplier = 4; // Apply 4x multiplier for augments >= 1750
+                                        additionalMultiplier = 4; // Apply 4x multiplier for augments >= 1250
                                     }
 
                                     totalCost *= additionalMultiplier;
@@ -1767,9 +1767,9 @@ namespace ACE.Server.WorldObjects.Managers
                                     {
                                         additionalMultiplier = 8; // Apply 8x multiplier for augments >= 2500
                                     }
-                                    else if (lifeAugs >= 1750)
+                                    else if (lifeAugs >= 1000)
                                     {
-                                        additionalMultiplier = 4; // Apply 4x multiplier for augments >= 1750
+                                        additionalMultiplier = 4; // Apply 4x multiplier for augments >= 1000
                                     }
 
                                     totalCost *= additionalMultiplier;
@@ -2139,9 +2139,9 @@ namespace ACE.Server.WorldObjects.Managers
                                     {
                                         additionalMultiplier = 8; // Apply 8x multiplier for augments >= 2500
                                     }
-                                    else if (durationAugs >= 1750)
+                                    else if (durationAugs >= 1000)
                                     {
-                                        additionalMultiplier = 4; // Apply 4x multiplier for augments >= 1750
+                                        additionalMultiplier = 4; // Apply 4x multiplier for augments >= 1000
                                     }
 
                                     totalCost *= additionalMultiplier;


### PR DESCRIPTION
copy/paste error forgot to update values of old threshold

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Balance Changes**
  - Adjusted the augmentation thresholds for luminance cost multipliers across several augment categories:
    - "Creature" category: Increased the 4x multiplier threshold.
    - "Item" category: Lowered the 4x multiplier threshold.
    - "Life" and "Duration" categories: Lowered the 4x multiplier threshold.
  - The cost multipliers themselves remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->