### PR TITLE
Serialize create object fix

### DIFF
--- a/Source/ACE.Server/WorldObjects/WorldObject_Networking.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Networking.cs
@@ -173,21 +173,27 @@ namespace ACE.Server.WorldObjects
             if ((weenieFlags & WeenieHeaderFlag.HouseRestrictions) != 0)
             {
                 var house = this as House;
-
-                // if house object is in dungeon,
-                // send the permissions from the outdoor house
-                if (house.HouseType != HouseType.Apartment && house.CurrentLandblock.IsDungeon)
+                if (house is null)
                 {
-                    house = house.RootHouse;
+                    log.Warn($"SerializeCreateObject(): World Object with Guid {Guid} based on Weenie {WeenieClassId} has HouseRestrictions flag but is not a house");
                 }
                 else
                 {
-                    // if mansion or villa, send permissions from master copy
-                    if (house.HouseType == HouseType.Villa || house.HouseType == HouseType.Mansion)
+                    // if house object is in dungeon,
+                    // send the permissions from the outdoor house
+                    if (house.HouseType != HouseType.Apartment && house.CurrentLandblock.IsDungeon)
+                    {
                         house = house.RootHouse;
-                }
+                    }
+                    else
+                    {
+                        // if mansion or villa, send permissions from master copy
+                        if (house.HouseType == HouseType.Villa || house.HouseType == HouseType.Mansion)
+                            house = house.RootHouse;
+                    }
 
-                writer.Write(new RestrictionDB(house));
+                    writer.Write(new RestrictionDB(house));
+                }
             }
 
             if ((weenieFlags & WeenieHeaderFlag.HookItemTypes) != 0)

--- a/Source/ACE.Server/WorldObjects/WorldObject_Networking.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Networking.cs
@@ -173,11 +173,7 @@ namespace ACE.Server.WorldObjects
             if ((weenieFlags & WeenieHeaderFlag.HouseRestrictions) != 0)
             {
                 var house = this as House;
-                if (house is null)
-                {
-                    log.Warn($"SerializeCreateObject(): World Object with Guid {Guid} based on Weenie {WeenieClassId} has HouseRestrictions flag but is not a house");
-                }
-                else
+                if (house != null)
                 {
                     // if house object is in dungeon,
                     // send the permissions from the outdoor house
@@ -194,6 +190,11 @@ namespace ACE.Server.WorldObjects
 
                     writer.Write(new RestrictionDB(house));
                 }
+                else
+                {
+                    log.Warn($"SerializeCreateObject(): World Object with Guid {Guid} based on Weenie {WeenieClassId} has HouseRestrictions flag but is not a house");
+                }
+
             }
 
             if ((weenieFlags & WeenieHeaderFlag.HookItemTypes) != 0)


### PR DESCRIPTION
Don't assume a WorldObject is a House just because it has the HouseRestrictions flag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of house restrictions to prevent errors when processing non-house objects.
  - Added warning logs for unexpected cases where house restrictions are applied to non-house objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->