### PR TITLE
When casting nullable variables to non-nullable variables, ensure it has a value first.

### DIFF
--- a/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
@@ -953,17 +953,17 @@ namespace ACE.Server.WorldObjects.Managers
                     if (WorldObject == null || WorldObject.CurrentMotionState == null) break;
 
                     // TODO: REFACTOR ME
-                    if (emoteSet.Category != EmoteCategory.Vendor && emoteSet.Style != null)
+                    if (emoteSet.Category != EmoteCategory.Vendor && emoteSet.Style.HasValue && emoteSet.Substyle.HasValue && emote.Motion.HasValue)
                     {
-                        var startingMotion = new Motion((MotionStance)emoteSet.Style, (MotionCommand)emoteSet.Substyle);
-                        motion = new Motion((MotionStance)emoteSet.Style, (MotionCommand)emote.Motion, emote.Extent);
+                        var startingMotion = new Motion(emoteSet.Style.Value, emoteSet.Substyle.Value);
+                        motion = new Motion(emoteSet.Style.Value, emote.Motion.Value, emote.Extent);
 
                         if (WorldObject.CurrentMotionState.Stance != startingMotion.Stance)
                         {
                             if (WorldObject.CurrentMotionState.Stance == MotionStance.Invalid)
                             {
                                 if (debugMotion)
-                                    Console.WriteLine($"{WorldObject.Name} running starting motion {(MotionStance)emoteSet.Style}, {(MotionCommand)emoteSet.Substyle}");
+                                    Console.WriteLine($"{WorldObject.Name} running starting motion {emoteSet.Style.Value}, {emoteSet.Substyle.Value}");
 
                                 delay = WorldObject.ExecuteMotion(startingMotion);
                             }

--- a/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
@@ -953,8 +953,14 @@ namespace ACE.Server.WorldObjects.Managers
                     if (WorldObject == null || WorldObject.CurrentMotionState == null) break;
 
                     // TODO: REFACTOR ME
-                    if (emoteSet.Category != EmoteCategory.Vendor && emoteSet.Style.HasValue && emoteSet.Substyle.HasValue && emote.Motion.HasValue)
+                    if (emoteSet.Category != EmoteCategory.Vendor && emoteSet.Style.HasValue)
                     {
+                        if (!emoteSet.Substyle.HasValue || !emote.Motion.HasValue)
+                        {
+                            log.Warn($"{WorldObject.Name} has an invalid motion emote with a missing Substyle or Motion value");
+                            break;
+                        }
+
                         var startingMotion = new Motion(emoteSet.Style.Value, emoteSet.Substyle.Value);
                         motion = new Motion(emoteSet.Style.Value, emote.Motion.Value, emote.Extent);
 

--- a/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
@@ -955,9 +955,9 @@ namespace ACE.Server.WorldObjects.Managers
                     // TODO: REFACTOR ME
                     if (emoteSet.Category != EmoteCategory.Vendor && emoteSet.Style.HasValue)
                     {
-                        if (!emoteSet.Substyle.HasValue || !emote.Motion.HasValue)
+                        if (!emoteSet.Substyle.HasValue)
                         {
-                            log.Warn($"{WorldObject.Name} has an invalid motion emote with a missing Substyle or Motion value");
+                            log.Warn($"{WorldObject.Name} has an invalid motion emote with a missing Substyle value");
                             break;
                         }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of motion emotes to prevent errors when required style or substyle values are missing.
  - Added warning messages for invalid motion emotes with missing substyle information, enhancing reliability and user feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->