### PR TITLE
Ensure we don't attempt to get a Treasure Profile Tier outside the bounds of our static arrays.

### DIFF
--- a/Source/ACE.Server/Factories/LootGenerationFactory.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory.cs
@@ -1254,7 +1254,9 @@ namespace ACE.Server.Factories
 
         private static void MutateCoins(WorldObject wo, TreasureDeath profile)
         {
-            var tierRange = coinRanges[profile.Tier - 1];
+            var tier = Math.Clamp(profile.Tier, 1, 9);
+
+            var tierRange = coinRanges[tier - 1];
 
             // flat rng range, according to magloot corpse logs
             var rng = ThreadSafeRandom.Next(tierRange.min, tierRange.max);

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Gem.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Gem.cs
@@ -74,7 +74,8 @@ namespace ACE.Server.Factories
         private static void AssignMagic_Gem(WorldObject wo, TreasureDeath profile)
         {
             var spellLevelIdx = ThreadSafeRandom.Next(0, 1);
-            var spellLevel = LootTables.GemSpellIndexMatrix[profile.Tier - 1][spellLevelIdx];
+            var tier = Math.Clamp(profile.Tier, 1, 8);
+            var spellLevel = LootTables.GemSpellIndexMatrix[tier - 1][spellLevelIdx];
 
             var magicSchool = ThreadSafeRandom.Next(0, 1);
 

--- a/Source/ACE.Server/Factories/Tables/ArmorTypeChance.cs
+++ b/Source/ACE.Server/Factories/Tables/ArmorTypeChance.cs
@@ -139,6 +139,8 @@ namespace ACE.Server.Factories.Tables
 
         public static TreasureArmorType Roll(int tier)
         {
+            tier = Math.Clamp(tier, 1, 9);
+
             return armorTiers[tier - 1].Roll();
         }
     }

--- a/Source/ACE.Server/Factories/Tables/Cantrips/CantripChance.cs
+++ b/Source/ACE.Server/Factories/Tables/Cantrips/CantripChance.cs
@@ -91,7 +91,8 @@ namespace ACE.Server.Factories.Tables
 
         public static int RollNumCantrips(TreasureDeath profile)
         {
-            return numCantrips[profile.Tier - 1].Roll(profile.LootQualityMod);
+            var tier = Math.Clamp(profile.Tier, 1, 9);
+            return numCantrips[tier - 1].Roll(profile.LootQualityMod);
         }
 
 
@@ -162,7 +163,8 @@ namespace ACE.Server.Factories.Tables
 
         public static int RollCantripLevel(TreasureDeath profile)
         {
-            return cantripLevels[profile.Tier - 1].Roll(profile.LootQualityMod);
+            var tier = Math.Clamp(profile.Tier, 1, 9);
+            return cantripLevels[tier - 1].Roll(profile.LootQualityMod);
         }
 
 

--- a/Source/ACE.Server/Factories/Tables/Cantrips/NumCantrips.cs
+++ b/Source/ACE.Server/Factories/Tables/Cantrips/NumCantrips.cs
@@ -1,7 +1,7 @@
-using System.Collections.Generic;
-
 using ACE.Database.Models.World;
 using ACE.Server.Factories.Entity;
+using System;
+using System.Collections.Generic;
 
 namespace ACE.Server.Factories.Tables
 {
@@ -84,7 +84,8 @@ namespace ACE.Server.Factories.Tables
 
         public static int RollNumCantrips(TreasureDeath profile)
         {
-            return numCantrips[profile.Tier - 1].Roll(profile.LootQualityMod);
+            var tier = Math.Clamp(profile.Tier, 1, 9);
+            return numCantrips[tier - 1].Roll(profile.LootQualityMod);
         }
 
         private static ChanceTable<int> T1_T2_CantripLevel = new ChanceTable<int>()
@@ -154,7 +155,8 @@ namespace ACE.Server.Factories.Tables
 
         public static int RollCantripLevel(TreasureDeath profile)
         {
-            return cantripLevels[profile.Tier - 1].Roll(profile.LootQualityMod);
+            var tier = Math.Clamp(profile.Tier, 1, 9);
+            return cantripLevels[tier - 1].Roll(profile.LootQualityMod);
         }
     }
 }

--- a/Source/ACE.Server/Factories/Tables/CloakChance.cs
+++ b/Source/ACE.Server/Factories/Tables/CloakChance.cs
@@ -1,9 +1,9 @@
-using System.Collections.Generic;
-
 using ACE.Common;
 using ACE.Database.Models.World;
 using ACE.Entity.Enum;
 using ACE.Server.Factories.Entity;
+using System;
+using System.Collections.Generic;
 
 namespace ACE.Server.Factories.Tables
 {
@@ -72,7 +72,8 @@ namespace ACE.Server.Factories.Tables
 
         public static int Roll_ItemMaxLevel(TreasureDeath profile)
         {
-            var table = cloakLevels[profile.Tier - 1];
+            var tier = Math.Clamp(profile.Tier, 1, 9);
+            var table = cloakLevels[tier - 1];
 
             return table.Roll(profile.LootQualityMod);
         }

--- a/Source/ACE.Server/Factories/Tables/PetDeviceChance.cs
+++ b/Source/ACE.Server/Factories/Tables/PetDeviceChance.cs
@@ -1,7 +1,7 @@
-using System.Collections.Generic;
-
 using ACE.Database.Models.World;
 using ACE.Server.Factories.Entity;
+using System;
+using System.Collections.Generic;
 
 namespace ACE.Server.Factories.Tables
 {
@@ -76,7 +76,8 @@ namespace ACE.Server.Factories.Tables
         /// </summary>
         public static int Roll(TreasureDeath profile)
         {
-            var table = petLevelChances[profile.Tier - 1];
+            var tier = Math.Clamp(profile.Tier, 1, 9);
+            var table = petLevelChances[tier - 1];
 
             return table.Roll(profile.LootQualityMod);
         }

--- a/Source/ACE.Server/Factories/Tables/QualityChance.cs
+++ b/Source/ACE.Server/Factories/Tables/QualityChance.cs
@@ -1,9 +1,8 @@
-using System.Collections.Generic;
-
-using log4net;
-
 using ACE.Common;
 using ACE.Database.Models.World;
+using log4net;
+using System;
+using System.Collections.Generic;
 
 namespace ACE.Server.Factories.Tables
 {
@@ -203,7 +202,8 @@ namespace ACE.Server.Factories.Tables
         /// <param name="treasureDeath">The chances are based on treasureDeath.Tier, and can be increased with treasureDeath.LootQualityMod</param>
         private static bool RollTierChance(TreasureDeath treasureDeath)
         {
-            var tierChance = QualityChancePerTier[treasureDeath.Tier - 1];
+            var tier = Math.Clamp(treasureDeath.Tier, 1, 9);
+            var tierChance = QualityChancePerTier[tier - 1];
 
             // use for initial roll? logic seems backwards here...
             var rng = ThreadSafeRandom.NextInterval(treasureDeath.LootQualityMod);

--- a/Source/ACE.Server/Factories/Tables/SpellLevelChance.cs
+++ b/Source/ACE.Server/Factories/Tables/SpellLevelChance.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 using ACE.Server.Factories.Entity;
@@ -97,6 +98,8 @@ namespace ACE.Server.Factories.Tables
         /// </summary>
         public static int Roll(int tier)
         {
+            tier = Math.Clamp(tier, 1, 9);
+
             return spellLevelChances[tier - 1].Roll();
         }
     }

--- a/Source/ACE.Server/Factories/Tables/Wcids/ConsumeWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/ConsumeWcids.cs
@@ -115,8 +115,9 @@ namespace ACE.Server.Factories.Tables.Wcids
 
         public static WeenieClassName Roll(TreasureDeath profile)
         {
+            var tier = Math.Clamp(profile.Tier, 1, 9);
             // todo: verify t7 / t8 chances
-            var table = consumeTiers[profile.Tier - 1];
+            var table = consumeTiers[tier - 1];
 
             // quality mod?
             return table.Roll(profile.LootQualityMod);

--- a/Source/ACE.Server/Factories/Tables/Wcids/HealKitWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/HealKitWcids.cs
@@ -70,8 +70,9 @@ namespace ACE.Server.Factories.Tables.Wcids
 
         public static WeenieClassName Roll(TreasureDeath profile)
         {
+            var tier = Math.Clamp(profile.Tier, 1, 9);
             // todo: verify t7 / t8 chances
-            var table = healKitTiers[profile.Tier - 1];
+            var table = healKitTiers[tier - 1];
 
             return table.Roll(profile.LootQualityMod);
         }

--- a/Source/ACE.Server/Factories/Tables/Wcids/LockpickWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/LockpickWcids.cs
@@ -69,8 +69,9 @@ namespace ACE.Server.Factories.Tables.Wcids
 
         public static WeenieClassName Roll(TreasureDeath profile)
         {
+            var tier = Math.Clamp(profile.Tier, 1, 9);
             // todo: verify t7 / t8 chances
-            var table = lockpickTiers[profile.Tier - 1];
+            var table = lockpickTiers[tier - 1];
 
             return table.Roll(profile.LootQualityMod);
         }

--- a/Source/ACE.Server/Factories/Tables/Wcids/ManaStoneWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/ManaStoneWcids.cs
@@ -69,8 +69,9 @@ namespace ACE.Server.Factories.Tables.Wcids
 
         public static WeenieClassName Roll(TreasureDeath profile)
         {
+            var tier = Math.Clamp(profile.Tier, 1, 9);
             // todo: verify t7 / t8 chances
-            var table = manaStoneTiers[profile.Tier - 1];
+            var table = manaStoneTiers[tier - 1];
 
             return table.Roll(profile.LootQualityMod);
         }

--- a/Source/ACE.Server/Factories/Tables/Wcids/SpellComponentWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/SpellComponentWcids.cs
@@ -1,9 +1,9 @@
-using System.Collections.Generic;
-
 using ACE.Common;
 using ACE.Database.Models.World;
 using ACE.Server.Factories.Entity;
 using ACE.Server.Factories.Enum;
+using System;
+using System.Collections.Generic;
 
 namespace ACE.Server.Factories.Tables.Wcids
 {
@@ -87,8 +87,8 @@ namespace ACE.Server.Factories.Tables.Wcids
                 if (level8SpellComponent)
                     return Roll_Level8SpellComponent(profile);
             }
-
-            var table = peaTiers[profile.Tier - 1];
+            var tier = Math.Clamp(profile.Tier, 1, 9);
+            var table = peaTiers[tier - 1];
 
             return table.Roll(profile.LootQualityMod);
         }

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/CasterWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/CasterWcids.cs
@@ -199,6 +199,8 @@ namespace ACE.Server.Factories.Tables.Wcids
 
         public static WeenieClassName Roll(int tier)
         {
+            tier = Math.Clamp(tier, 1, 9);
+
             return casterTiers[tier - 1].Roll();
         }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of loot and item generation by ensuring tier values are always within valid bounds, preventing potential errors when generating coins, gems, armor, cantrips, cloaks, pet devices, spell levels, consumables, and other loot types. This results in more consistent and stable loot drops for all tiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->