### PR TITLE
Performance tuning

### DIFF
--- a/Source/ACE.Database/SerializedShardDatabase.cs
+++ b/Source/ACE.Database/SerializedShardDatabase.cs
@@ -31,8 +31,6 @@ namespace ACE.Database
         private Thread _workerThread;
         private Thread _workerThreadReadOnly;
 
-        private int MaxParallel = 5;
-
         internal SerializedShardDatabase(ShardDatabase shardDatabase)
         {
             BaseDatabase = shardDatabase;

--- a/Source/ACE.Entity/Position.cs
+++ b/Source/ACE.Entity/Position.cs
@@ -84,16 +84,6 @@ namespace ACE.Entity
             return Vector3.Normalize(Vector3.Transform(Vector3.UnitY, Rotation));
         }
 
-        /// <summary>
-        /// Returns this vector as a unit vector
-        /// with a length of 1
-        /// </summary>
-        public Vector3 Normalize(Vector3 v)
-        {
-            var invLen = 1.0f / v.Length();
-            return v * invLen;
-        }
-
         public Position InFrontOf(double distanceInFront, bool rotate180 = false)
         {
             float qw = RotationW; // north
@@ -384,7 +374,7 @@ namespace ACE.Entity
             }
         }
 
-        private uint GetCellFromBase(uint baseX, uint baseY)
+        private static uint GetCellFromBase(uint baseX, uint baseY)
         {
             byte blockX = (byte)(baseX >> 3);
             byte blockY = (byte)(baseY >> 3);

--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -3926,7 +3926,7 @@ namespace ACE.Server.Command.Handlers
                             return;
                         }
 
-                        var maxSolves = creature.QuestManager.GetMaxSolves(questName);
+                        var maxSolves = QuestManager.GetMaxSolves(questName);
                         var maxSolvesBinary = Convert.ToString(maxSolves, 2);
 
                         var questEntry = "";

--- a/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
@@ -2736,7 +2736,7 @@ namespace ACE.Server.Command.Handlers
             {
                 var dist = player.Location.Distance2D(fellow.Location);
 
-                var distanceScalar = fellowship.GetDistanceScalar(player, fellow, XpType.Kill);
+                var distanceScalar = Fellowship.GetDistanceScalar(player, fellow, XpType.Kill);
 
                 session.Network.EnqueueSend(new GameMessageSystemChat($"{fellow.Name}: {Math.Round(dist):N0} ({distanceScalar:F2}) - {fellow.Location}", ChatMessageType.Broadcast));
             }
@@ -2762,7 +2762,7 @@ namespace ACE.Server.Command.Handlers
                 var dist2d = session.Player.Location.Distance2D(fellow.Location);
                 var dist3d = session.Player.Location.DistanceTo(fellow.Location);
 
-                var scalar = session.Player.Fellowship.GetDistanceScalar(session.Player, fellow, XpType.Kill);
+                var scalar = Fellowship.GetDistanceScalar(session.Player, fellow, XpType.Kill);
 
                 session.Network.EnqueueSend(new GameMessageSystemChat($"{fellow.Name} | 2d: {dist2d:N0} | 3d: {dist3d:N0} | Scalar: {scalar:N0}", ChatMessageType.Broadcast));
             }

--- a/Source/ACE.Server/Command/Handlers/PlayerCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/PlayerCommands.cs
@@ -779,7 +779,7 @@ namespace ACE.Server.Command.Handlers
         [CommandHandler("dynamicabandon", AccessLevel.Player, CommandHandlerFlag.RequiresWorld, 0, "Abandons the most recent dynamic quest", "")]
         public static void AbandonDynamicQuest(Session session, params string[] parameters)
         {
-            session.Player.QuestManager.AbandonDynamicQuests(session.Player);
+            QuestManager.AbandonDynamicQuests(session.Player);
         }
 
         [CommandHandler("bonus", AccessLevel.Player, CommandHandlerFlag.RequiresWorld, 0, "Handles Experience Checks", "Leave blank for level, pass first 3 letters of attribute for specific attribute cost")]

--- a/Source/ACE.Server/Entity/AttackList.cs
+++ b/Source/ACE.Server/Entity/AttackList.cs
@@ -33,8 +33,8 @@ namespace ACE.Server.Entity
 
         public void Add(WorldObject damager, uint amount)
         {
-            if (Damagers.ContainsKey(damager))
-                Damagers[damager] += amount;
+            if (Damagers.TryGetValue(damager, out uint value))
+                Damagers[damager] = value + amount;
             else
                 Damagers.Add(damager, amount);
         }

--- a/Source/ACE.Server/Entity/BodyPart.cs
+++ b/Source/ACE.Server/Entity/BodyPart.cs
@@ -26,11 +26,11 @@ namespace ACE.Server.Entity
 
     public class BodyParts
     {
-        public static BodyPart Upper = BodyPart.Head | BodyPart.Chest | BodyPart.UpperArm;
-        public static BodyPart Mid = BodyPart.Chest | BodyPart.Abdomen | BodyPart.UpperArm | BodyPart.LowerArm | BodyPart.Hand | BodyPart.UpperLeg;
-        public static BodyPart Lower = BodyPart.Foot | BodyPart.LowerLeg;
+        private static readonly BodyPart Upper = BodyPart.Head | BodyPart.Chest | BodyPart.UpperArm;
+        private static readonly BodyPart Mid = BodyPart.Chest | BodyPart.Abdomen | BodyPart.UpperArm | BodyPart.LowerArm | BodyPart.Hand | BodyPart.UpperLeg;
+        private static readonly BodyPart Lower = BodyPart.Foot | BodyPart.LowerLeg;
 
-        public static Dictionary<BodyPart, int> Indices;
+        public static readonly Dictionary<BodyPart, int> Indices;
 
         static BodyParts()
         {

--- a/Source/ACE.Server/Entity/DamageEvent.cs
+++ b/Source/ACE.Server/Entity/DamageEvent.cs
@@ -135,19 +135,6 @@ namespace ACE.Server.Entity
 
         public bool CriticalDefended;
 
-        public static HashSet<uint> AllowDamageTypeUndef = new HashSet<uint>()
-        {
-            22545,  // Obsidian Spines
-            35191,  // Thunder Chicken
-            38406,  // Blessed Moar
-            38587,  // Ardent Moar
-            38588,  // Blessed Moar
-            38586,  // Verdant Moar
-            40298,  // Ardent Moar
-            40300,  // Blessed Moar
-            40301,  // Verdant Moar
-        };
-
         public static DamageEvent CalculateDamage(Creature attacker, Creature defender, WorldObject damageSource, MotionCommand? attackMotion = null, AttackHook attackHook = null)
         {
             var damageEvent = new DamageEvent();
@@ -356,7 +343,7 @@ namespace ACE.Server.Entity
                 GetBodyPart(AttackHeight);
 
                 // get player armor pieces
-                Armor = attacker.GetArmorLayers(playerDefender, BodyPart);
+                Armor = playerDefender.GetArmorLayers(BodyPart);
 
                 // get armor modifiers
                 ArmorMod = attacker.GetArmorMod(playerDefender, DamageType, Armor, Weapon, ignoreArmorMod);
@@ -430,7 +417,7 @@ namespace ACE.Server.Entity
             return Damage;
         }
 
-        public Quadrant GetQuadrant(Creature defender, Creature attacker, AttackHeight attackHeight, WorldObject damageSource)
+        private static Quadrant GetQuadrant(Creature defender, Creature attacker, AttackHeight attackHeight, WorldObject damageSource)
         {
             var quadrant = attackHeight.ToQuadrant();
 

--- a/Source/ACE.Server/Entity/Fellowship.cs
+++ b/Source/ACE.Server/Entity/Fellowship.cs
@@ -23,7 +23,7 @@ namespace ACE.Server.Entity
         /// <summary>
         /// The maximum # of fellowship members
         /// </summary>
-        public static int MaxFellows = 29;
+        private static readonly int MaxFellows = 29;
 
         public string FellowshipName;
         public uint FellowshipLeaderGuid;
@@ -697,7 +697,7 @@ namespace ACE.Server.Entity
         /// Returns the amount to scale the XP for a fellow
         /// based on distance from the earner
         /// </summary>
-        public double GetDistanceScalar(Player earner, Player fellow, XpType xpType)
+        public static double GetDistanceScalar(Player earner, Player fellow, XpType xpType)
         {
             if (earner == null || fellow == null)
                 return 0.0f;

--- a/Source/ACE.Server/Entity/GeneratorProfile.cs
+++ b/Source/ACE.Server/Entity/GeneratorProfile.cs
@@ -161,7 +161,7 @@ namespace ACE.Server.Entity
         /// Determines the spawn times for initial object spawning,
         /// and for respawning
         /// </summary>
-        public DateTime GetSpawnTime()
+        private static DateTime GetSpawnTime()
         {
                 return DateTime.UtcNow;
         }
@@ -443,7 +443,7 @@ namespace ACE.Server.Entity
             return true;
         }
 
-        public bool VerifyWalkableSlope(WorldObject obj)
+        private static bool VerifyWalkableSlope(WorldObject obj)
         {
             if (!obj.Location.Indoors && !obj.Location.IsWalkable() && !VerifyWalkableSlopeExcludedLandblocks.Contains(obj.Location.LandblockId.Landblock))
             {
@@ -459,7 +459,7 @@ namespace ACE.Server.Entity
         /// TODO gmriggs
         /// Hack until this can be looked into more.
         /// </summary>
-        public static HashSet<ushort> VerifyWalkableSlopeExcludedLandblocks = new HashSet<ushort>()
+        private static HashSet<ushort> VerifyWalkableSlopeExcludedLandblocks = new HashSet<ushort>()
         {
             0x9EE5,     // Northwatch Castle
             0xF92F,     // Freebooter Keep

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Gem.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Gem.cs
@@ -13,7 +13,7 @@ namespace ACE.Server.Factories
 {
     public static partial class LootGenerationFactory
     {
-        private static WorldObject CreateGem(TreasureDeath profile, bool isMagical, bool mutate = true)
+        private static Gem CreateGem(TreasureDeath profile, bool isMagical, bool mutate = true)
         {
             var idx = profile.Tier - 1;
 

--- a/Source/ACE.Server/Factories/Tables/ArmorTypeChance.cs
+++ b/Source/ACE.Server/Factories/Tables/ArmorTypeChance.cs
@@ -8,14 +8,14 @@ namespace ACE.Server.Factories.Tables
 {
     public static class ArmorTypeChance
     {
-        private static ChanceTable<TreasureArmorType> T1_Chances = new ChanceTable<TreasureArmorType>()
+        private static readonly ChanceTable<TreasureArmorType> T1_Chances = new ChanceTable<TreasureArmorType>()
         {
             ( TreasureArmorType.Leather,        0.34f ),
             ( TreasureArmorType.StuddedLeather, 0.33f ),
             ( TreasureArmorType.Chainmail,      0.33f ),
         };
 
-        private static ChanceTable<TreasureArmorType> T2_Chances = new ChanceTable<TreasureArmorType>()
+        private static readonly ChanceTable<TreasureArmorType> T2_Chances = new ChanceTable<TreasureArmorType>()
         {
             ( TreasureArmorType.Leather,        0.25f ),
             ( TreasureArmorType.StuddedLeather, 0.25f ),
@@ -23,7 +23,7 @@ namespace ACE.Server.Factories.Tables
             ( TreasureArmorType.Platemail,      0.25f ),
         };
 
-        private static ChanceTable<TreasureArmorType> T3_Chances = new ChanceTable<TreasureArmorType>()
+        private static readonly ChanceTable<TreasureArmorType> T3_Chances = new ChanceTable<TreasureArmorType>()
         {
             ( TreasureArmorType.Leather,        0.22f ),
             ( TreasureArmorType.StuddedLeather, 0.22f ),
@@ -34,7 +34,7 @@ namespace ACE.Server.Factories.Tables
             ( TreasureArmorType.Overrobe,       0.02f ),    // added
         };
 
-        private static ChanceTable<TreasureArmorType> T4_Chances = new ChanceTable<TreasureArmorType>()
+        private static readonly ChanceTable<TreasureArmorType> T4_Chances = new ChanceTable<TreasureArmorType>()
         {
             ( TreasureArmorType.Leather,        0.16f ),
             ( TreasureArmorType.StuddedLeather, 0.16f ),
@@ -45,7 +45,7 @@ namespace ACE.Server.Factories.Tables
             ( TreasureArmorType.Overrobe,       0.02f ),    // added
         };
 
-        private static ChanceTable<TreasureArmorType> T5_Chances = new ChanceTable<TreasureArmorType>()
+        private static readonly ChanceTable<TreasureArmorType> T5_Chances = new ChanceTable<TreasureArmorType>()
         {
             ( TreasureArmorType.Leather,        0.15f ),
             ( TreasureArmorType.StuddedLeather, 0.15f ),
@@ -57,7 +57,7 @@ namespace ACE.Server.Factories.Tables
             ( TreasureArmorType.Overrobe,       0.02f ),    // added
         };
 
-        private static ChanceTable<TreasureArmorType> T6_Chances = new ChanceTable<TreasureArmorType>()
+        private static readonly ChanceTable<TreasureArmorType> T6_Chances = new ChanceTable<TreasureArmorType>()
         {
             ( TreasureArmorType.Leather,        0.12f ),
             ( TreasureArmorType.StuddedLeather, 0.12f ),
@@ -73,7 +73,7 @@ namespace ACE.Server.Factories.Tables
         };
 
         // added, from mag-loot logs
-        private static ChanceTable<TreasureArmorType> T7_Chances = new ChanceTable<TreasureArmorType>()
+        private static readonly ChanceTable<TreasureArmorType> T7_Chances = new ChanceTable<TreasureArmorType>()
         {
             ( TreasureArmorType.Leather,        0.11f ),
             ( TreasureArmorType.StuddedLeather, 0.11f ),
@@ -91,7 +91,7 @@ namespace ACE.Server.Factories.Tables
         };
 
 
-        private static ChanceTable<TreasureArmorType> T8_Chances = new ChanceTable<TreasureArmorType>()
+        private static readonly ChanceTable<TreasureArmorType> T8_Chances = new ChanceTable<TreasureArmorType>()
         {
             ( TreasureArmorType.Leather,        0.10f ),
             ( TreasureArmorType.StuddedLeather, 0.10f ),
@@ -107,7 +107,7 @@ namespace ACE.Server.Factories.Tables
             ( TreasureArmorType.Sedgemail,      0.02f ),
             ( TreasureArmorType.Overrobe,       0.02f ),
         };
-        private static ChanceTable<TreasureArmorType> T9_Chances = new ChanceTable<TreasureArmorType>()
+        private static readonly ChanceTable<TreasureArmorType> T9_Chances = new ChanceTable<TreasureArmorType>()
         {
             ( TreasureArmorType.Leather,        0.10f ),
             ( TreasureArmorType.StuddedLeather, 0.10f ),

--- a/Source/ACE.Server/Factories/Tables/Cantrips/CantripChance.cs
+++ b/Source/ACE.Server/Factories/Tables/Cantrips/CantripChance.cs
@@ -14,26 +14,26 @@ namespace ACE.Server.Factories.Tables
     {
         private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
-        private static ChanceTable<int> T1_NumCantrips = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T1_NumCantrips = new ChanceTable<int>()
         {
             ( 0, 0.95f ),
             ( 1, 0.05f ),
         };
 
-        private static ChanceTable<int> T2_NumCantrips = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T2_NumCantrips = new ChanceTable<int>()
         {
             ( 0, 0.90f ),
             ( 1, 0.10f ),
         };
 
-        private static ChanceTable<int> T3_NumCantrips = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T3_NumCantrips = new ChanceTable<int>()
         {
             ( 0, 0.725f ),
             ( 1, 0.250f ),
             ( 2, 0.025f ),
         };
 
-        private static ChanceTable<int> T4_NumCantrips = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T4_NumCantrips = new ChanceTable<int>()
         {
             ( 0, 0.62f ),
             ( 1, 0.32f ),
@@ -41,7 +41,7 @@ namespace ACE.Server.Factories.Tables
             ( 3, 0.005f ),
         };
 
-        private static ChanceTable<int> T5_NumCantrips = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T5_NumCantrips = new ChanceTable<int>()
         {
             ( 0, 0.40f ),
             ( 1, 0.42f ),
@@ -50,7 +50,7 @@ namespace ACE.Server.Factories.Tables
             ( 4, 0.001f ),
         };
 
-        private static ChanceTable<int> T6_NumCantrips = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T6_NumCantrips = new ChanceTable<int>()
         {
             ( 0, 0.25f ),
             ( 1, 0.40f ),
@@ -60,7 +60,7 @@ namespace ACE.Server.Factories.Tables
             ( 5, 0.001f ),
         };
 
-        private static ChanceTable<int> T7_T8_NumCantrips = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T7_T8_NumCantrips = new ChanceTable<int>()
         {
             ( 1, 0.81f ),
             ( 2, 0.17f ),
@@ -68,7 +68,7 @@ namespace ACE.Server.Factories.Tables
             ( 4, 0.004f ),
         };
 
-        private static ChanceTable<int> T9_NumCantrips = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T9_NumCantrips = new ChanceTable<int>()
         {
             ( 1, 0.81f ),
             ( 2, 0.17f ),
@@ -96,43 +96,43 @@ namespace ACE.Server.Factories.Tables
         }
 
 
-        private static ChanceTable<int> T1_T2_CantripLevel = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T1_T2_CantripLevel = new ChanceTable<int>()
         {
             ( 1, 1.0f )
         };
 
-        private static ChanceTable<int> T3_CantripLevel = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T3_CantripLevel = new ChanceTable<int>()
         {
             ( 1, 0.97f ),
             ( 2, 0.03f ),
         };
 
-        private static ChanceTable<int> T4_CantripLevel = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T4_CantripLevel = new ChanceTable<int>()
         {
             ( 1, 0.90f ),
             ( 2, 0.10f ),
         };
 
-        private static ChanceTable<int> T5_CantripLevel = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T5_CantripLevel = new ChanceTable<int>()
         {
             ( 1, 0.85f ),
             ( 2, 0.15f ),
         };
 
-        private static ChanceTable<int> T6_CantripLevel = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T6_CantripLevel = new ChanceTable<int>()
         {
             ( 1, 0.80f ),
             ( 2, 0.20f ),
         };
 
-        private static ChanceTable<int> T7_CantripLevel = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T7_CantripLevel = new ChanceTable<int>()
         {
             ( 1, 0.15f ),
             ( 2, 0.60f ),
             ( 3, 0.25f )
         };
 
-        private static ChanceTable<int> T8_CantripLevel = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T8_CantripLevel = new ChanceTable<int>()
         {
             ( 1, 0.02f ),
             ( 2, 0.46f ),
@@ -140,7 +140,7 @@ namespace ACE.Server.Factories.Tables
             ( 4, 0.10f )
         };
 
-        private static ChanceTable<int> T9_CantripLevel = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T9_CantripLevel = new ChanceTable<int>()
         {
 
             ( 2, 0.46f ),

--- a/Source/ACE.Server/Factories/Tables/Cantrips/NumCantrips.cs
+++ b/Source/ACE.Server/Factories/Tables/Cantrips/NumCantrips.cs
@@ -7,26 +7,26 @@ namespace ACE.Server.Factories.Tables
 {
     public static class NumCantrips
     {
-        private static ChanceTable<int> T1_NumCantrips = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T1_NumCantrips = new ChanceTable<int>()
         {
             ( 0, 0.95f ),
             ( 1, 0.05f ),
         };
 
-        private static ChanceTable<int> T2_NumCantrips = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T2_NumCantrips = new ChanceTable<int>()
         {
             ( 0, 0.90f ),
             ( 1, 0.10f ),
         };
 
-        private static ChanceTable<int> T3_NumCantrips = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T3_NumCantrips = new ChanceTable<int>()
         {
             ( 0, 0.725f ),
             ( 1, 0.250f ),
             ( 2, 0.025f ),
         };
 
-        private static ChanceTable<int> T4_NumCantrips = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T4_NumCantrips = new ChanceTable<int>()
         {
             ( 0, 0.62f ),
             ( 1, 0.32f ),
@@ -34,7 +34,7 @@ namespace ACE.Server.Factories.Tables
             ( 3, 0.005f ),
         };
 
-        private static ChanceTable<int> T5_NumCantrips = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T5_NumCantrips = new ChanceTable<int>()
         {
             ( 0, 0.40f ),
             ( 1, 0.42f ),
@@ -43,7 +43,7 @@ namespace ACE.Server.Factories.Tables
             ( 4, 0.001f ),
         };
 
-        private static ChanceTable<int> T6_NumCantrips = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T6_NumCantrips = new ChanceTable<int>()
         {
             ( 0, 0.25f ),
             ( 1, 0.40f ),
@@ -53,7 +53,7 @@ namespace ACE.Server.Factories.Tables
             ( 5, 0.001f ),
         };
 
-        private static ChanceTable<int> T7_T8_NumCantrips = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T7_T8_NumCantrips = new ChanceTable<int>()
         {
             ( 1, 0.81f ),
             ( 2, 0.17f ),
@@ -61,7 +61,7 @@ namespace ACE.Server.Factories.Tables
             ( 4, 0.004f ),
         };
 
-        private static ChanceTable<int> T9_NumCantrips = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T9_NumCantrips = new ChanceTable<int>()
         {
             ( 1, 0.0f ),
             ( 2, 0.81f ),
@@ -88,43 +88,43 @@ namespace ACE.Server.Factories.Tables
             return numCantrips[tier - 1].Roll(profile.LootQualityMod);
         }
 
-        private static ChanceTable<int> T1_T2_CantripLevel = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T1_T2_CantripLevel = new ChanceTable<int>()
         {
             ( 1, 1.0f )
         };
 
-        private static ChanceTable<int> T3_CantripLevel = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T3_CantripLevel = new ChanceTable<int>()
         {
             ( 1, 0.97f ),
             ( 2, 0.03f ),
         };
 
-        private static ChanceTable<int> T4_CantripLevel = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T4_CantripLevel = new ChanceTable<int>()
         {
             ( 1, 0.90f ),
             ( 2, 0.10f ),
         };
 
-        private static ChanceTable<int> T5_CantripLevel = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T5_CantripLevel = new ChanceTable<int>()
         {
             ( 1, 0.85f ),
             ( 2, 0.15f ),
         };
 
-        private static ChanceTable<int> T6_CantripLevel = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T6_CantripLevel = new ChanceTable<int>()
         {
             ( 1, 0.80f ),
             ( 2, 0.20f ),
         };
 
-        private static ChanceTable<int> T7_CantripLevel = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T7_CantripLevel = new ChanceTable<int>()
         {
             ( 1, 0.15f ),
             ( 2, 0.60f ),
             ( 3, 0.25f )
         };
 
-        private static ChanceTable<int> T8_CantripLevel = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T8_CantripLevel = new ChanceTable<int>()
         {
             ( 1, 0.02f ),
             ( 2, 0.46f ),
@@ -132,7 +132,7 @@ namespace ACE.Server.Factories.Tables
             ( 4, 0.10f )
         };
 
-        private static ChanceTable<int> T9_CantripLevel = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T9_CantripLevel = new ChanceTable<int>()
         {
             ( 1, 0.0f ),
             ( 2, 0.40f ),

--- a/Source/ACE.Server/Factories/Tables/CloakChance.cs
+++ b/Source/ACE.Server/Factories/Tables/CloakChance.cs
@@ -9,25 +9,25 @@ namespace ACE.Server.Factories.Tables
 {
     public static class CloakChance
     {
-        private static ChanceTable<int> T1_ItemMaxLevel = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T1_ItemMaxLevel = new ChanceTable<int>()
         {
             ( 1, 1.0f )
         };
 
-        private static ChanceTable<int> T2_ItemMaxLevel = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T2_ItemMaxLevel = new ChanceTable<int>()
         {
             ( 1, 0.99f ),
             ( 2, 0.01f ),
         };
 
-        private static ChanceTable<int> T3_T4_ItemMaxLevel = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T3_T4_ItemMaxLevel = new ChanceTable<int>()
         {
             ( 1, 0.44f ),
             ( 2, 0.55f ),
             ( 3, 0.01f ),
         };
 
-        private static ChanceTable<int> T5_ItemMaxLevel = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T5_ItemMaxLevel = new ChanceTable<int>()
         {
             ( 1, 0.04f ),
             ( 2, 0.40f ),
@@ -35,7 +35,7 @@ namespace ACE.Server.Factories.Tables
             ( 4, 0.01f ),
         };
 
-        private static ChanceTable<int> T6_ItemMaxLevel = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T6_ItemMaxLevel = new ChanceTable<int>()
         {
             ( 1, 0.04f ),
             ( 2, 0.30f ),
@@ -43,21 +43,21 @@ namespace ACE.Server.Factories.Tables
             ( 4, 0.01f ),
         };
 
-        private static ChanceTable<int> T7_T8_ItemMaxLevel = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T7_T8_ItemMaxLevel = new ChanceTable<int>()
         {
             ( 2, 0.45f ),
             ( 3, 0.50f ),
             ( 4, 0.04f ),
             ( 5, 0.01f ),
         };
-        private static ChanceTable<int> T9_ItemMaxLevel = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T9_ItemMaxLevel = new ChanceTable<int>()
         {
             ( 3, 0.65f ),
             ( 4, 0.30f ),
             ( 5, 0.05f ),
         };
 
-        private static List<ChanceTable<int>> cloakLevels = new List<ChanceTable<int>>()
+        private static readonly List<ChanceTable<int>> cloakLevels = new List<ChanceTable<int>>()
         {
             T1_ItemMaxLevel,
             T2_ItemMaxLevel,

--- a/Source/ACE.Server/Factories/Tables/PetDeviceChance.cs
+++ b/Source/ACE.Server/Factories/Tables/PetDeviceChance.cs
@@ -7,25 +7,25 @@ namespace ACE.Server.Factories.Tables
 {
     public static class PetDeviceChance
     {
-        private static ChanceTable<int> T1_T3_PetLevelChances = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T1_T3_PetLevelChances = new ChanceTable<int>()
         {
             ( 50, 1.0f )
         };
 
-        private static ChanceTable<int> T4_PetLevelChances = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T4_PetLevelChances = new ChanceTable<int>()
         {
             ( 50, 0.75f ),
             ( 80, 0.25f )
         };
 
-        private static ChanceTable<int> T5_PetLevelChances = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T5_PetLevelChances = new ChanceTable<int>()
         {
             ( 50,  0.15f ),
             ( 80,  0.65f ),
             ( 100, 0.20f ),
         };
 
-        private static ChanceTable<int> T6_PetLevelChances = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T6_PetLevelChances = new ChanceTable<int>()
         {
             ( 80,  0.15f ),
             ( 100, 0.25f ),
@@ -33,7 +33,7 @@ namespace ACE.Server.Factories.Tables
             ( 150, 0.10f ),
         };
 
-        private static ChanceTable<int> T7_PetLevelChances = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T7_PetLevelChances = new ChanceTable<int>()
         {
             ( 100, 0.15f ),
             ( 125, 0.25f ),
@@ -41,7 +41,7 @@ namespace ACE.Server.Factories.Tables
             ( 180, 0.10f ),
         };
 
-        private static ChanceTable<int> T8_PetLevelChances = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T8_PetLevelChances = new ChanceTable<int>()
         {
             ( 100, 0.0125f ),
             ( 125, 0.025f ),
@@ -50,7 +50,7 @@ namespace ACE.Server.Factories.Tables
             ( 200, 0.4125f ),
         };
 
-        private static ChanceTable<int> T9_PetLevelChances = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T9_PetLevelChances = new ChanceTable<int>()
         {
             ( 125, 0.0150f ),
             ( 150, 0.05f ),

--- a/Source/ACE.Server/Factories/Tables/SpellLevelChance.cs
+++ b/Source/ACE.Server/Factories/Tables/SpellLevelChance.cs
@@ -18,7 +18,7 @@ namespace ACE.Server.Factories.Tables
             8: 7-8 (should be 6-8)
         */
 
-        private static ChanceTable<int> T1_SpellLevelChances = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T1_SpellLevelChances = new ChanceTable<int>()
         {
             // 15/60/25?
             ( 1, 0.25f ),
@@ -26,54 +26,54 @@ namespace ACE.Server.Factories.Tables
             ( 3, 0.25f ),
         };
 
-        private static ChanceTable<int> T2_SpellLevelChances = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T2_SpellLevelChances = new ChanceTable<int>()
         {
             ( 3, 0.25f ),
             ( 4, 0.50f ),
             ( 5, 0.25f ),
         };
 
-        private static ChanceTable<int> T3_SpellLevelChances = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T3_SpellLevelChances = new ChanceTable<int>()
         {
             ( 4, 0.25f ),
             ( 5, 0.50f ),
             ( 6, 0.25f ),
         };
 
-        private static ChanceTable<int> T4_SpellLevelChances = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T4_SpellLevelChances = new ChanceTable<int>()
         {
             ( 5, 0.75f ),
             ( 6, 0.25f ),
         };
 
-        private static ChanceTable<int> T5_SpellLevelChances = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T5_SpellLevelChances = new ChanceTable<int>()
         {
             ( 5, 0.30f ),
             ( 6, 0.50f ),
             ( 7, 0.20f ),
         };
 
-        private static ChanceTable<int> T6_SpellLevelChances = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T6_SpellLevelChances = new ChanceTable<int>()
         {
             ( 6, 0.60f ),
             ( 7, 0.40f ),
         };
 
-        private static ChanceTable<int> T7_SpellLevelChances = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T7_SpellLevelChances = new ChanceTable<int>()
         {
             ( 6, 0.25f ),
             ( 7, 0.50f ),
             ( 8, 0.25f ),
         };
 
-        private static ChanceTable<int> T8_SpellLevelChances = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T8_SpellLevelChances = new ChanceTable<int>()
         {
             ( 6, 0.15f ),
             ( 7, 0.50f ),
             ( 8, 0.35f ),
         };
 
-        private static ChanceTable<int> T9_SpellLevelChances = new ChanceTable<int>()
+        private static readonly ChanceTable<int> T9_SpellLevelChances = new ChanceTable<int>()
         {
             ( 6, 0.15f ),
             ( 7, 0.50f ),

--- a/Source/ACE.Server/Factories/Tables/Wcids/ConsumeWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/ConsumeWcids.cs
@@ -8,7 +8,7 @@ namespace ACE.Server.Factories.Tables.Wcids
 {
     public static class ConsumeWcids
     {
-        private static ChanceTable<WeenieClassName> T1_Chances = new ChanceTable<WeenieClassName>()
+        private static readonly ChanceTable<WeenieClassName> T1_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.apple,           0.01f ),
             ( WeenieClassName.bread,           0.01f ),
@@ -28,7 +28,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.staminatincture, 0.08f ),
         };
 
-        private static ChanceTable<WeenieClassName> T2_Chances = new ChanceTable<WeenieClassName>()
+        private static readonly ChanceTable<WeenieClassName> T2_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.healthdraught,   0.08f ),
             ( WeenieClassName.manadraught,     0.08f ),
@@ -41,7 +41,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.staminaelixir,   0.08f ),
         };
 
-        private static ChanceTable<WeenieClassName> T3_Chances = new ChanceTable<WeenieClassName>()
+        private static readonly ChanceTable<WeenieClassName> T3_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.healthpotion,    0.08f ),
             ( WeenieClassName.manapotion,      0.08f ),
@@ -54,7 +54,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.staminabrew,     0.08f ),
         };
 
-        private static ChanceTable<WeenieClassName> T4_Chances = new ChanceTable<WeenieClassName>()
+        private static readonly ChanceTable<WeenieClassName> T4_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.healthtincture,  0.08f ),
             ( WeenieClassName.manatincture,    0.08f ),
@@ -67,7 +67,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.staminatonic,    0.08f ),
         };
 
-        private static ChanceTable<WeenieClassName> T5_Chances = new ChanceTable<WeenieClassName>()
+        private static readonly ChanceTable<WeenieClassName> T5_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.healthelixir,    0.08f ),
             ( WeenieClassName.manaelixir,      0.08f ),
@@ -80,7 +80,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.staminaphiltre,  0.08f ),
         };
 
-        private static ChanceTable<WeenieClassName> T6_T8_Chances = new ChanceTable<WeenieClassName>()
+        private static readonly ChanceTable<WeenieClassName> T6_T8_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.healthtonic,     0.08f ),
             ( WeenieClassName.manatonic,       0.08f ),
@@ -90,7 +90,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.staminaphiltre,  0.25f ),
         };
 
-        private static ChanceTable<WeenieClassName> T9_Chances = new ChanceTable<WeenieClassName>()
+        private static readonly ChanceTable<WeenieClassName> T9_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.healthtonic,     0.08f ),
             ( WeenieClassName.manatonic,       0.08f ),

--- a/Source/ACE.Server/Factories/Tables/Wcids/HealKitWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/HealKitWcids.cs
@@ -8,47 +8,47 @@ namespace ACE.Server.Factories.Tables.Wcids
 {
     public static class HealKitWcids
     {
-        private static ChanceTable<WeenieClassName> T1_Chances = new ChanceTable<WeenieClassName>()
+        private static readonly ChanceTable<WeenieClassName> T1_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.healingkitcrude,     0.75f ),
             ( WeenieClassName.healingkitplain,     0.25f ),
         };
 
-        private static ChanceTable<WeenieClassName> T2_Chances = new ChanceTable<WeenieClassName>()
+        private static readonly ChanceTable<WeenieClassName> T2_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.healingkitcrude,     0.25f ),
             ( WeenieClassName.healingkitplain,     0.50f ),
             ( WeenieClassName.healingkitgood,      0.25f ),
         };
 
-        private static ChanceTable<WeenieClassName> T3_Chances = new ChanceTable<WeenieClassName>()
+        private static readonly ChanceTable<WeenieClassName> T3_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.healingkitplain,     0.25f ),
             ( WeenieClassName.healingkitgood,      0.50f ),
             ( WeenieClassName.healingkitexcellent, 0.25f ),
         };
 
-        private static ChanceTable<WeenieClassName> T4_Chances = new ChanceTable<WeenieClassName>()
+        private static readonly ChanceTable<WeenieClassName> T4_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.healingkitgood,      0.25f ),
             ( WeenieClassName.healingkitexcellent, 0.50f ),
             ( WeenieClassName.healingkitpeerless,  0.25f ),
         };
 
-        private static ChanceTable<WeenieClassName> T5_Chances = new ChanceTable<WeenieClassName>()
+        private static readonly ChanceTable<WeenieClassName> T5_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.healingkitexcellent, 0.25f ),
             ( WeenieClassName.healingkitpeerless,  0.50f ),
             ( WeenieClassName.healingkittreated,   0.25f ),
         };
 
-        private static ChanceTable<WeenieClassName> T6_T8_Chances = new ChanceTable<WeenieClassName>()
+        private static readonly ChanceTable<WeenieClassName> T6_T8_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.healingkitpeerless,  0.25f ),
             ( WeenieClassName.healingkittreated,   0.75f ),
         };
 
-        private static ChanceTable<WeenieClassName> T9_Chances = new ChanceTable<WeenieClassName>()
+        private static readonly ChanceTable<WeenieClassName> T9_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.healingkitpeerless,  0.25f ),
             ( WeenieClassName.healingkittreated,   0.75f ),

--- a/Source/ACE.Server/Factories/Tables/Wcids/LockpickWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/LockpickWcids.cs
@@ -8,47 +8,47 @@ namespace ACE.Server.Factories.Tables.Wcids
 {
     public static class LockpickWcids
     {
-        private static ChanceTable<WeenieClassName> T1_Chances = new ChanceTable<WeenieClassName>()
+        private static readonly ChanceTable<WeenieClassName> T1_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.lockpickplain,    0.75f ),
             ( WeenieClassName.lockpickreliable, 0.25f ),
         };
 
-        private static ChanceTable<WeenieClassName> T2_Chances = new ChanceTable<WeenieClassName>()
+        private static readonly ChanceTable<WeenieClassName> T2_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.lockpickplain,    0.25f ),
             ( WeenieClassName.lockpickreliable, 0.50f ),
             ( WeenieClassName.lockpickgood,     0.25f ),
         };
 
-        private static ChanceTable<WeenieClassName> T3_Chances = new ChanceTable<WeenieClassName>()
+        private static readonly ChanceTable<WeenieClassName> T3_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.lockpickreliable, 0.25f ),
             ( WeenieClassName.lockpickgood,     0.50f ),
             ( WeenieClassName.lockpickexcell,   0.25f ),
         };
 
-        private static ChanceTable<WeenieClassName> T4_Chances = new ChanceTable<WeenieClassName>()
+        private static readonly ChanceTable<WeenieClassName> T4_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.lockpickgood,     0.25f ),
             ( WeenieClassName.lockpickexcell,   0.50f ),
             ( WeenieClassName.lockpicksuperb,   0.25f ),
         };
 
-        private static ChanceTable<WeenieClassName> T5_Chances = new ChanceTable<WeenieClassName>()
+        private static readonly ChanceTable<WeenieClassName> T5_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.lockpickexcell,   0.25f ),
             ( WeenieClassName.lockpicksuperb,   0.50f ),
             ( WeenieClassName.lockpickpeer,     0.25f ),
         };
 
-        private static ChanceTable<WeenieClassName> T6_T8_Chances = new ChanceTable<WeenieClassName>()
+        private static readonly ChanceTable<WeenieClassName> T6_T8_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.lockpicksuperb,   0.25f ),
             ( WeenieClassName.lockpickpeer,     0.75f ),
         };
 
-        private static ChanceTable<WeenieClassName> T9_Chances = new ChanceTable<WeenieClassName>()
+        private static readonly ChanceTable<WeenieClassName> T9_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.lockpicksuperb,   0.25f ),
             ( WeenieClassName.lockpickpeer,     0.75f ),

--- a/Source/ACE.Server/Factories/Tables/Wcids/ManaStoneWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/ManaStoneWcids.cs
@@ -8,47 +8,47 @@ namespace ACE.Server.Factories.Tables.Wcids
 {
     public static class ManaStoneWcids
     {
-        private static ChanceTable<WeenieClassName> T1_Chances = new ChanceTable<WeenieClassName>()
+        private static readonly ChanceTable<WeenieClassName> T1_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.manastoneminor,   0.75f ),
             ( WeenieClassName.manastonelesser,  0.25f ),
         };
 
-        private static ChanceTable<WeenieClassName> T2_Chances = new ChanceTable<WeenieClassName>()
+        private static readonly ChanceTable<WeenieClassName> T2_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.manastoneminor,   0.25f ),
             ( WeenieClassName.manastonelesser,  0.50f ),
             ( WeenieClassName.manastone,        0.25f ),
         };
 
-        private static ChanceTable<WeenieClassName> T3_Chances = new ChanceTable<WeenieClassName>()
+        private static readonly ChanceTable<WeenieClassName> T3_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.manastonelesser,  0.25f ),
             ( WeenieClassName.manastone,        0.50f ),
             ( WeenieClassName.manastonemedium,  0.25f ),
         };
 
-        private static ChanceTable<WeenieClassName> T4_Chances = new ChanceTable<WeenieClassName>()
+        private static readonly ChanceTable<WeenieClassName> T4_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.manastone,        0.25f ),
             ( WeenieClassName.manastonemedium,  0.50f ),
             ( WeenieClassName.manastonegreater, 0.25f ),
         };
 
-        private static ChanceTable<WeenieClassName> T5_Chances = new ChanceTable<WeenieClassName>()
+        private static readonly ChanceTable<WeenieClassName> T5_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.manastonemedium,  0.25f ),
             ( WeenieClassName.manastonegreater, 0.50f ),
             ( WeenieClassName.manastonemajor,   0.25f ),
         };
 
-        private static ChanceTable<WeenieClassName> T6_T8_Chances = new ChanceTable<WeenieClassName>()
+        private static readonly ChanceTable<WeenieClassName> T6_T8_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.manastonegreater, 0.25f ),
             ( WeenieClassName.manastonemajor,   0.75f ),
         };
 
-        private static ChanceTable<WeenieClassName> T9_Chances = new ChanceTable<WeenieClassName>()
+        private static readonly ChanceTable<WeenieClassName> T9_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.manastonegreater, 0.25f ),
             ( WeenieClassName.manastonemajor,   0.75f ),

--- a/Source/ACE.Server/Factories/Tables/Wcids/SpellComponentWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/SpellComponentWcids.cs
@@ -9,39 +9,39 @@ namespace ACE.Server.Factories.Tables.Wcids
 {
     public static class SpellComponentWcids
     {
-        private static ChanceTable<WeenieClassName> T1_Chances = new ChanceTable<WeenieClassName>()
+        private static readonly ChanceTable<WeenieClassName> T1_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.peascarablead,   1.00f ),
         };
 
-        private static ChanceTable<WeenieClassName> T2_Chances = new ChanceTable<WeenieClassName>()
+        private static readonly ChanceTable<WeenieClassName> T2_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.peascarablead,   0.50f ),
             ( WeenieClassName.peascarabiron,   0.50f ),
         };
 
-        private static ChanceTable<WeenieClassName> T3_Chances = new ChanceTable<WeenieClassName>()
+        private static readonly ChanceTable<WeenieClassName> T3_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.peascarablead,   0.25f ),
             ( WeenieClassName.peascarabiron,   0.50f ),
             ( WeenieClassName.peascarabcopper, 0.25f ),
         };
 
-        private static ChanceTable<WeenieClassName> T4_Chances = new ChanceTable<WeenieClassName>()
+        private static readonly ChanceTable<WeenieClassName> T4_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.peascarabiron,   0.25f ),
             ( WeenieClassName.peascarabcopper, 0.50f ),
             ( WeenieClassName.peascarabsilver, 0.25f ),
         };
 
-        private static ChanceTable<WeenieClassName> T5_Chances = new ChanceTable<WeenieClassName>()
+        private static readonly ChanceTable<WeenieClassName> T5_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.peascarabcopper, 0.25f ),
             ( WeenieClassName.peascarabsilver, 0.50f ),
             ( WeenieClassName.peascarabgold,   0.25f ),
         };
 
-        private static ChanceTable<WeenieClassName> T6_T8_Chances = new ChanceTable<WeenieClassName>()
+        private static readonly ChanceTable<WeenieClassName> T6_T8_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.peascarabsilver, 0.25f ),
             ( WeenieClassName.peascarabgold,   0.50f ),
@@ -69,7 +69,7 @@ namespace ACE.Server.Factories.Tables.Wcids
         };
 
         // level 8 spell components have a chance of dropping in t7 / t8
-        private static ChanceTable<bool> level8SpellComponentChance = new ChanceTable<bool>()
+        private static readonly ChanceTable<bool> level8SpellComponentChance = new ChanceTable<bool>()
         {
             ( false, 0.6f ),
             ( true,  0.4f ),
@@ -93,7 +93,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             return table.Roll(profile.LootQualityMod);
         }
 
-        private static ChanceTable<WeenieClassName> Quills = new ChanceTable<WeenieClassName>()
+        private static readonly ChanceTable<WeenieClassName> Quills = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.ace37363_quillofinfliction,    0.50f ),   // war/debuff (other)
             ( WeenieClassName.ace37364_quillofintrospection, 0.35f ),   // beneficial (self)
@@ -101,7 +101,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace37362_quillofextraction,    0.05f ),   // drain (other)
         };
 
-        private static ChanceTable<WeenieClassName> Inks = new ChanceTable<WeenieClassName>()
+        private static readonly ChanceTable<WeenieClassName> Inks = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.ace37353_inkofformation,       0.30f ),   // self (can only be used with introspection quills)
             ( WeenieClassName.ace37360_inkofconveyance,      0.24f ),   // other (can only be used with benevolence, infliction, and extraction quills)

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/CasterWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/CasterWcids.cs
@@ -8,7 +8,7 @@ namespace ACE.Server.Factories.Tables.Wcids
 {
     public static class CasterWcids
     {
-        private static ChanceTable<WeenieClassName> T1_T2_Chances = new ChanceTable<WeenieClassName>()
+        private static readonly ChanceTable<WeenieClassName> T1_T2_Chances = new ChanceTable<WeenieClassName>()
         {
             (WeenieClassName.orb,     0.25f ),
             (WeenieClassName.sceptre, 0.25f ),
@@ -16,7 +16,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             (WeenieClassName.wand,    0.25f ),
         };
 
-        private static ChanceTable<WeenieClassName> T3_Chances = new ChanceTable<WeenieClassName>()
+        private static readonly ChanceTable<WeenieClassName> T3_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.orb,                    0.17f ),
             ( WeenieClassName.sceptre,                0.17f ),
@@ -40,7 +40,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace43382_netherbaton,   0.02f ),
         };
 
-        private static ChanceTable<WeenieClassName> T4_Chances = new ChanceTable<WeenieClassName>()
+        private static readonly ChanceTable<WeenieClassName> T4_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.orb,                    0.13f ),
             ( WeenieClassName.sceptre,                0.13f ),
@@ -64,7 +64,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace43382_netherbaton,   0.03f ),
         };
 
-        private static ChanceTable<WeenieClassName> T5_T6_Chances = new ChanceTable<WeenieClassName>()
+        private static readonly ChanceTable<WeenieClassName> T5_T6_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.orb,                    0.05f ),
             ( WeenieClassName.sceptre,                0.05f ),
@@ -88,7 +88,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace43382_netherbaton,   0.05f ),
         };
 
-        private static ChanceTable<WeenieClassName> T7_Chances = new ChanceTable<WeenieClassName>()
+        private static readonly ChanceTable<WeenieClassName> T7_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.orb,                    0.04f ),
             ( WeenieClassName.sceptre,                0.04f ),
@@ -120,7 +120,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace43383_netherstaff,   0.015f ),
         };
 
-        private static ChanceTable<WeenieClassName> T8_Chances = new ChanceTable<WeenieClassName>()
+        private static readonly ChanceTable<WeenieClassName> T8_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.orb,                    0.036f ),
             ( WeenieClassName.sceptre,                0.036f ),
@@ -152,7 +152,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace43383_netherstaff,   0.035f ),
         };
 
-        private static ChanceTable<WeenieClassName> T9_Chances = new ChanceTable<WeenieClassName>()
+        private static readonly ChanceTable<WeenieClassName> T9_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.orb,                    0.036f ),
             ( WeenieClassName.sceptre,                0.036f ),

--- a/Source/ACE.Server/Managers/AllegianceManager.cs
+++ b/Source/ACE.Server/Managers/AllegianceManager.cs
@@ -54,8 +54,8 @@ namespace ACE.Server.Managers
             if (monarch == null) return null;
 
             // is this allegiance already loaded / cached?
-            if (Players.ContainsKey(monarch.Guid))
-                return Players[monarch.Guid].Allegiance;
+            if (Players.TryGetValue(monarch.Guid, out AllegianceNode monarchNode))
+                return monarchNode.Allegiance;
 
             // try to load biota
             var allegianceID = DatabaseManager.Shard.BaseDatabase.GetAllegianceID(monarch.Guid.Full);
@@ -158,10 +158,7 @@ namespace ACE.Server.Managers
                 var player = member.Key;
                 var allegianceNode = member.Value;
 
-                if (!Players.ContainsKey(player))
-                    Players.Add(player, allegianceNode);
-                else
-                    Players[player] = allegianceNode;
+                Players[player] = allegianceNode;
             }
         }
 

--- a/Source/ACE.Server/Managers/DiscordChatManager.cs
+++ b/Source/ACE.Server/Managers/DiscordChatManager.cs
@@ -66,7 +66,7 @@ namespace ACE.Server.Managers
                             if(x.Attachments.Count == 1)
                             {
                                 IAttachment attachment = x.Attachments.First();
-                                if (attachment.Filename.ToLowerInvariant().Contains(".sql"))
+                                if (attachment.Filename.Contains(".sql", StringComparison.InvariantCultureIgnoreCase))
                                 {
                                     using (var client = new WebClient())
                                     {
@@ -105,7 +105,7 @@ namespace ACE.Server.Managers
                             if (x.Attachments.Count == 1)
                             {
                                 IAttachment attachment = x.Attachments.First();
-                                if (attachment.Filename.ToLowerInvariant().Contains(".json"))
+                                if (attachment.Filename.Contains(".json", StringComparison.InvariantCultureIgnoreCase))
                                 {
                                     // Using HttpClient to download the JSON
                                     using (var client = new System.Net.Http.HttpClient())

--- a/Source/ACE.Server/Managers/HouseManager.cs
+++ b/Source/ACE.Server/Managers/HouseManager.cs
@@ -39,7 +39,7 @@ namespace ACE.Server.Managers
         /// <summary>
         /// HouseManager actions to run when slumlord inventory has completed loading
         /// </summary>
-        private static Dictionary<uint, List<HouseCallback>> SlumlordCallbacks = new Dictionary<uint, List<HouseCallback>>();
+        private static readonly Dictionary<uint, List<HouseCallback>> SlumlordCallbacks = new Dictionary<uint, List<HouseCallback>>();
 
         /// <summary>
         /// The rate at which HouseManager.Tick() executes
@@ -254,9 +254,9 @@ namespace ACE.Server.Managers
 
             if (PropertyManager.GetBool("house_per_char").Item)
             {
-                var results = playerHouses.Where(i => i.Value.Count() > 1).OrderByDescending(i => i.Value.Count());
+                var results = playerHouses.Where(i => i.Value.Count > 1).OrderByDescending(i => i.Value.Count);
 
-                if (results.Count() > 0)
+                if (results.Any())
                     Console.WriteLine("Multi-house owners:");
 
                 foreach (var playerHouse in results)
@@ -269,9 +269,9 @@ namespace ACE.Server.Managers
             }
             else
             {
-                var results = accountHouses.Where(i => i.Value.Count() > 1).OrderByDescending(i => i.Value.Count());
+                var results = accountHouses.Where(i => i.Value.Count > 1).OrderByDescending(i => i.Value.Count);
 
-                if (results.Count() > 0)
+                if (results.Any())
                     Console.WriteLine("Multi-house owners:");
 
                 foreach (var accountHouse in results)

--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -98,8 +98,10 @@ namespace ACE.Server.Managers
             // first, check the cache. If the key exists in the cache, grab it regardless of its modified value
             // then, check the database. if the key exists in the database, grab it and cache it
             // finally, set it to a default of false.
-            if (CachedBooleanSettings.ContainsKey(key))
-                return new Property<bool>(CachedBooleanSettings[key].Item, CachedBooleanSettings[key].Description);
+            if (CachedBooleanSettings.TryGetValue(key, out ConfigurationEntry<bool> cachedBooleanSetting))
+            {
+                return new Property<bool>(cachedBooleanSetting.Item, cachedBooleanSetting.Description);
+            }
 
             var dbValue = DatabaseManager.ShardConfig.GetBool(key);
 
@@ -121,21 +123,21 @@ namespace ACE.Server.Managers
         /// <returns>true if the property was modified, false if no property exists with the given key</returns>
         public static bool ModifyBool(string key, bool newVal)
         {
-            if (!DefaultPropertyManager.DefaultBooleanProperties.ContainsKey(key))
+            if (!DefaultPropertyManager.DefaultBooleanProperties.TryGetValue(key, out Property<bool> defaultBooleanProperty))
                 return false;
 
-            if (CachedBooleanSettings.ContainsKey(key))
-                CachedBooleanSettings[key].Modify(newVal);
+            if (CachedBooleanSettings.TryGetValue(key, out ConfigurationEntry<bool> cachedBooleanSetting))
+                cachedBooleanSetting.Modify(newVal);
             else
-                CachedBooleanSettings[key] = new ConfigurationEntry<bool>(true, newVal, DefaultPropertyManager.DefaultBooleanProperties[key].Description);
+                CachedBooleanSettings[key] = new ConfigurationEntry<bool>(true, newVal, defaultBooleanProperty.Description);
 
             return true;
         }
 
         public static void ModifyBoolDescription(string key, string description)
         {
-            if (CachedBooleanSettings.ContainsKey(key))
-                CachedBooleanSettings[key].ModifyDescription(description);
+            if (CachedBooleanSettings.TryGetValue(key, out ConfigurationEntry<bool> cachedBooleanSetting))
+                cachedBooleanSetting.ModifyDescription(description);
             else
                 log.Warn($"Attempted to modify {key} which did not exist in the BOOL cache.");
         }
@@ -149,8 +151,8 @@ namespace ACE.Server.Managers
         /// <returns>An integer value representing the property</returns>
         public static Property<long> GetLong(string key, long fallback = 0, bool cacheFallback = true)
         {
-            if (CachedLongSettings.ContainsKey(key))
-                return new Property<long>(CachedLongSettings[key].Item, CachedLongSettings[key].Description);
+            if (CachedLongSettings.TryGetValue(key, out ConfigurationEntry<long> cachedLongSetting))
+                return new Property<long>(cachedLongSetting.Item, cachedLongSetting.Description);
 
             var dbValue = DatabaseManager.ShardConfig.GetLong(key);
 
@@ -172,20 +174,20 @@ namespace ACE.Server.Managers
         /// <returns>true if the property was modified, false if no property exists with the given key</returns>
         public static bool ModifyLong(string key, long newVal)
         {
-            if (!DefaultPropertyManager.DefaultLongProperties.ContainsKey(key))
+            if (!DefaultPropertyManager.DefaultLongProperties.TryGetValue(key, out Property<long> defaultLongProperty))
                 return false;
 
-            if (CachedLongSettings.ContainsKey(key))
-                CachedLongSettings[key].Modify(newVal);
+            if (CachedLongSettings.TryGetValue(key, out ConfigurationEntry<long> cachedLongSetting))
+                cachedLongSetting.Modify(newVal);
             else
-                CachedLongSettings[key] = new ConfigurationEntry<long>(true, newVal, DefaultPropertyManager.DefaultLongProperties[key].Description);
+                CachedLongSettings[key] = new ConfigurationEntry<long>(true, newVal, defaultLongProperty.Description);
             return true;
         }
 
         public static void ModifyLongDescription(string key, string description)
         {
-            if (CachedLongSettings.ContainsKey(key))
-                CachedLongSettings[key].ModifyDescription(description);
+            if (CachedLongSettings.TryGetValue(key, out ConfigurationEntry<long> cachedLongSetting))
+                cachedLongSetting.ModifyDescription(description);
             else
                 log.Warn($"Attempted to modify {key} which did not exist in the LONG cache.");
         }
@@ -199,8 +201,8 @@ namespace ACE.Server.Managers
         /// <returns>A float value representing the property</returns>
         public static Property<double> GetDouble(string key, double fallback = 0.0f, bool cacheFallback = true)
         {
-            if (CachedDoubleSettings.ContainsKey(key))
-                return new Property<double>(CachedDoubleSettings[key].Item, CachedDoubleSettings[key].Description);
+            if (CachedDoubleSettings.TryGetValue(key, out ConfigurationEntry<double> cachedDoubleSetting))
+                return new Property<double>(cachedDoubleSetting.Item, cachedDoubleSetting.Description);
 
             var dbValue = DatabaseManager.ShardConfig.GetDouble(key);
 
@@ -221,12 +223,13 @@ namespace ACE.Server.Managers
         /// <param name="newVal">The value to replace the old value with</param>
         public static bool ModifyDouble(string key, double newVal, bool init = false)
         {
-            if (!DefaultPropertyManager.DefaultDoubleProperties.ContainsKey(key))
+            if (!DefaultPropertyManager.DefaultDoubleProperties.TryGetValue(key, out Property<double> defaultDoubleProperty))
                 return false;
-            if (CachedDoubleSettings.ContainsKey(key))
-                CachedDoubleSettings[key].Modify(newVal);
+
+            if (CachedDoubleSettings.TryGetValue(key, out ConfigurationEntry<double> cachedDoubleSetting))
+                cachedDoubleSetting.Modify(newVal);
             else
-                CachedDoubleSettings[key] = new ConfigurationEntry<double>(true, newVal, DefaultPropertyManager.DefaultDoubleProperties[key].Description);
+                CachedDoubleSettings[key] = new ConfigurationEntry<double>(true, newVal, defaultDoubleProperty.Description);
 
             if (!init)
             {
@@ -248,8 +251,8 @@ namespace ACE.Server.Managers
 
         public static void ModifyDoubleDescription(string key, string description)
         {
-            if (CachedDoubleSettings.ContainsKey(key))
-                CachedDoubleSettings[key].ModifyDescription(description);
+            if (CachedDoubleSettings.TryGetValue(key, out ConfigurationEntry<double> cachedDoubleSetting))
+                cachedDoubleSetting.ModifyDescription(description);
             else
                 log.Warn($"Attempted to modify the description of {key} which did not exist in the DOUBLE cache.");
         }
@@ -263,8 +266,8 @@ namespace ACE.Server.Managers
         /// <returns>A string value representing the property</returns>
         public static Property<string> GetString(string key, string fallback = "", bool cacheFallback = true)
         {
-            if (CachedStringSettings.ContainsKey(key))
-                return new Property<string>(CachedStringSettings[key].Item, CachedStringSettings[key].Description);
+            if (CachedStringSettings.TryGetValue(key, out ConfigurationEntry<string> cachedStringSetting))
+                return new Property<string>(cachedStringSetting.Item, cachedStringSetting.Description);
 
             var dbValue = DatabaseManager.ShardConfig.GetString(key);
 
@@ -286,20 +289,20 @@ namespace ACE.Server.Managers
         /// <returns>true if the property was modified, false if no property exists with the given key</returns>
         public static bool ModifyString(string key, string newVal)
         {
-            if (!DefaultPropertyManager.DefaultStringProperties.ContainsKey(key))
+            if (!DefaultPropertyManager.DefaultStringProperties.TryGetValue(key, out Property<string> defaultStringProperty))
                 return false;
 
-            if (CachedStringSettings.ContainsKey(key))
-                CachedStringSettings[key].Modify(newVal);
+            if (CachedStringSettings.TryGetValue(key, out ConfigurationEntry<string> cachedStringSetting))
+                cachedStringSetting.Modify(newVal);
             else
-                CachedStringSettings[key] = new ConfigurationEntry<string>(true, newVal, DefaultPropertyManager.DefaultStringProperties[key].Description);
+                CachedStringSettings[key] = new ConfigurationEntry<string>(true, newVal, defaultStringProperty.Description);
             return true;
         }
 
         public static void ModifyStringDescription(string key, string description)
         {
-            if (CachedStringSettings.ContainsKey(key))
-                CachedStringSettings[key].ModifyDescription(description);
+            if (CachedStringSettings.TryGetValue(key, out ConfigurationEntry<string> cachedStringSetting))
+                cachedStringSetting.ModifyDescription(description);
             else
                 log.Warn($"Attempted to modify {key} which did not exist in the STRING cache.");
         }
@@ -405,7 +408,7 @@ namespace ACE.Server.Managers
         }
     }
 
-    public struct Property<T>
+    public readonly struct Property<T>
     {
         public Property(T item, string description) : this()
         {

--- a/Source/ACE.Server/Managers/QuestManager.cs
+++ b/Source/ACE.Server/Managers/QuestManager.cs
@@ -67,7 +67,7 @@ namespace ACE.Server.Managers
             }
         }
 
-        public static bool Debug = false;
+        private static readonly bool Debug = false;
 
         /// <summary>
         /// Constructs a new QuestManager for a Player / Creature
@@ -364,7 +364,7 @@ namespace ACE.Server.Managers
         /// <summary>
         /// Returns the maximum # of solves for this quest
         /// </summary>
-        public int GetMaxSolves(string questFormat)
+        public static int GetMaxSolves(string questFormat)
         {
             var questName = GetQuestName(questFormat);
 
@@ -697,13 +697,6 @@ namespace ACE.Server.Managers
             player.Session.Network.EnqueueSend(new GameMessageSystemChat(msg, ChatMessageType.Broadcast));
         }
 
-        /// <summary>
-        /// Called when a player kills Creature
-        /// </summary>
-        public void OnDeath(WorldObject killer)
-        {
-        }
-
         public static string RandomString(int length)
         {
             const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyz!@#$^&";
@@ -711,7 +704,7 @@ namespace ACE.Server.Managers
                 .Select(s => s[ThreadSafeRandom.Next(0, s.Length - 1)]).ToArray());
         }
 
-        private bool WeenieHasDynamicQuest(Weenie npcTarget)
+        private static bool WeenieHasDynamicQuest(Weenie npcTarget)
         {
             if (npcTarget == null || npcTarget.PropertiesEmote == null)
             {
@@ -1402,7 +1395,7 @@ namespace ACE.Server.Managers
             return responseEmote;
         }
 
-        public void AbandonDynamicQuests(Player player)
+        public static void AbandonDynamicQuests(Player player)
         {
             using (var db = new Database.Models.Shard.ShardDbContext())
             {
@@ -1415,7 +1408,7 @@ namespace ACE.Server.Managers
             }
         }
 
-        public bool IsDynamicQuestEligible(Player player)
+        public static bool IsDynamicQuestEligible(Player player)
         {
             using (var db = new Database.Models.Shard.ShardDbContext())
             {
@@ -1521,7 +1514,7 @@ namespace ACE.Server.Managers
             SetQuestCompletions(questFormat, questBits);
         }
 
-        public void UpdatePlayerQuestCompletions(Player player, string questName, out bool stampedNew, out bool stampedCompletion, uint solves = 0)
+        private static void UpdatePlayerQuestCompletions(Player player, string questName, out bool stampedNew, out bool stampedCompletion, uint solves = 0)
         {
             stampedNew = false;
             stampedCompletion = false;

--- a/Source/ACE.Server/Network/NetworkSession.cs
+++ b/Source/ACE.Server/Network/NetworkSession.cs
@@ -50,7 +50,7 @@ namespace ACE.Server.Network
 
         // Ack should be sent after a 2 second delay, so start enabled with the delay.
         // Sending this too early seems to cause issues with clients disconnecting.
-        private bool sendAck = true;
+        private readonly bool sendAck = true;
         private DateTime nextAck = DateTime.UtcNow.AddMilliseconds(timeBetweenAck);
 
         private uint lastReceivedPacketSequence = 1;
@@ -261,7 +261,7 @@ namespace ACE.Server.Network
                     .Where(sequence => !Retransmit(sequence))
                     .ToList();
 
-                if (uncached.Any())
+                if (uncached.Count != 0)
                 {
                     // Sends a response packet w/ PacketHeader.RejectRetransmit
                     var packetRejectRetransmit = new PacketRejectRetransmit(uncached);
@@ -644,7 +644,7 @@ namespace ACE.Server.Network
                 return true;
             }
 
-            if (cachedPackets.Count > 0)
+            if (!cachedPackets.IsEmpty)
             {
                 // This is to catch a race condition between .Count and .Min() and .Max()
                 try

--- a/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
+++ b/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
@@ -175,8 +175,7 @@ namespace ACE.Server.Network.Structure
 
             if (wo is Portal)
             {
-                if (PropertiesInt.ContainsKey(PropertyInt.EncumbranceVal))
-                    PropertiesInt.Remove(PropertyInt.EncumbranceVal);
+                PropertiesInt.Remove(PropertyInt.EncumbranceVal);
             }
 
             if (wo is SlumLord slumLord)
@@ -328,8 +327,7 @@ namespace ACE.Server.Network.Structure
 
             if (wo is CraftTool && (wo.ItemType == ItemType.TinkeringMaterial || wo.WeenieClassId >= 36619 && wo.WeenieClassId <= 36628 || wo.WeenieClassId >= 36634 && wo.WeenieClassId <= 36636))
             {
-                if (PropertiesInt.ContainsKey(PropertyInt.Structure))
-                    PropertiesInt.Remove(PropertyInt.Structure);
+                PropertiesInt.Remove(PropertyInt.Structure);
             }
 
             if (!Success)

--- a/Source/ACE.Server/Physics/Common/EnvCell.cs
+++ b/Source/ACE.Server/Physics/Common/EnvCell.cs
@@ -30,7 +30,7 @@ namespace ACE.Server.Physics.Common
         //public List<ushort> LightArray;
         //public int InCellTimestamp;
         public List<ushort> VisibleCellIDs;
-        public new ConcurrentDictionary<uint, EnvCell> VisibleCells;
+        public ConcurrentDictionary<uint, EnvCell> VisibleCells;
         //public EnvCellFlags Flags;
         public uint EnvironmentID;
         //public DatLoader.FileTypes.EnvCell _envCell;
@@ -452,6 +452,11 @@ namespace ACE.Server.Physics.Common
                 return false;
 
             return ID == envCell.ID;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as EnvCell);
         }
 
         public override int GetHashCode()

--- a/Source/ACE.Server/Physics/Common/LandCell.cs
+++ b/Source/ACE.Server/Physics/Common/LandCell.cs
@@ -60,7 +60,7 @@ namespace ACE.Server.Physics.Common
             return objInfo.ValidateWalkable(checkPos, walkable.Plane, WaterType != LandDefs.WaterType.NotWater, waterDepth, transition, ID);
         }
 
-        public new static LandCell Get(uint cellID, int? variationId)
+        public static LandCell Get(uint cellID, int? variationId)
         {
             return (LandCell)LScape.get_landcell(cellID, variationId);
         }

--- a/Source/ACE.Server/Physics/Common/Landblock.cs
+++ b/Source/ACE.Server/Physics/Common/Landblock.cs
@@ -35,7 +35,7 @@ namespace ACE.Server.Physics.Common
         public List<PhysicsObj> ServerObjects { get; set; }
 
 
-        public static bool UseSceneFiles = true;
+        private static bool UseSceneFiles = true;
 
         public Landblock(CellLandblock landblock, int? Variation)
             : base(landblock, Variation)
@@ -54,7 +54,7 @@ namespace ACE.Server.Physics.Common
             
         }
 
-        public new void Init()
+        public void Init()
         {
             //InView = BoundingType.Outside;
             //Dir = LandDefs.Direction.Unknown;
@@ -283,8 +283,8 @@ namespace ACE.Server.Physics.Common
             //Console.WriteLine("Landblock " + ID.ToString("X8") + " scenery count: " + Scenery.Count);
         }
 
-        public static float RoadWidth = 5.0f;
-        public static float TileLength = 24.0f;
+        private static float RoadWidth = 5.0f;
+        private static float TileLength = 24.0f;
 
         /// <summary>
         /// Returns TRUE if x,y is located on a road cell
@@ -424,12 +424,6 @@ namespace ACE.Server.Physics.Common
             return Terrain[(int)lcoord.X * 255 * 9 + (int)lcoord.Y];
         }
 
-        public void grab_visible_cells()
-        {
-            // legacy method
-            //EnvCell.grab_visible(StabList);
-        }
-
         public void init_buildings()
         {
             if (Info == null || SideCellCount != 8) return;
@@ -515,8 +509,10 @@ namespace ACE.Server.Physics.Common
 
                         var idx = ((int)lcoord.Value.Y & 7) + ((int)lcoord.Value.X & 7) * SideCellCount;
                         var cacheKey = new VariantCacheId { Landblock = (ushort)idx, Variant = VariationId ?? 0 };
-                        if (LandCells.ContainsKey(cacheKey))
-                            LandCells[cacheKey].RestrictionObj = kvp.Value;
+                        if (LandCells.TryGetValue(cacheKey, out ObjCell landcell))
+                        {
+                            landcell.RestrictionObj = kvp.Value;
+                        }
                     }
                 }
             }
@@ -559,12 +555,6 @@ namespace ACE.Server.Physics.Common
         {
             foreach (var cell in LandCells.Values)
                 cell.release_shadow_objs();
-        }
-
-        public void release_visible_cells()
-        {
-            // legacy method
-            //EnvCell.release_visible(StabList);
         }
 
         private bool? isDungeon;

--- a/Source/ACE.Server/Physics/Common/ObjCell.cs
+++ b/Source/ACE.Server/Physics/Common/ObjCell.cs
@@ -73,7 +73,7 @@ namespace ACE.Server.Physics.Common
             {
                 if (voyeur_id != obj.ID && voyeur_id != 0)
                 {
-                    var voyeur = obj.GetObjectA(voyeur_id);
+                    var voyeur = PhysicsObj.GetObjectA(voyeur_id);
                     if (voyeur == null) continue;
 
                     //var info = new DetectionInfo(obj.ID, DetectionType.EnteredDetection);
@@ -103,6 +103,16 @@ namespace ACE.Server.Physics.Common
                 return false;
 
             return ID.Equals(objCell.ID);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as ObjCell);
+        }
+
+        public override int GetHashCode()
+        {
+            return ID.GetHashCode();
         }
 
         public virtual TransitionState FindCollisions(Transition transition)
@@ -465,7 +475,7 @@ namespace ACE.Server.Physics.Common
             {
                 if (voyeur_id != obj.ID && voyeur_id != 0)
                 {
-                    var voyeur = obj.GetObjectA(voyeur_id);
+                    var voyeur = PhysicsObj.GetObjectA(voyeur_id);
                     if (voyeur == null) continue;
 
                     //var info = new DetectionInfo(obj.ID, type);

--- a/Source/ACE.Server/Physics/Common/Position.cs
+++ b/Source/ACE.Server/Physics/Common/Position.cs
@@ -286,6 +286,16 @@ namespace ACE.Server.Physics.Common
             return ObjCellID == pos.ObjCellID && Frame.Equals(pos.Frame) && Variation == pos.Variation;
         }
 
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as Position);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(ObjCellID, Variation, Frame.GetHashCode());
+        }
+
         public override string ToString()
         {
             if (Variation != null)

--- a/Source/ACE.Server/Physics/ObjectInfo.cs
+++ b/Source/ACE.Server/Physics/ObjectInfo.cs
@@ -33,9 +33,9 @@ namespace ACE.Server.Physics.Animation
         public bool StepDown;
         public uint TargetID;
 
-        public float GetWalkableZ()
+        public static float GetWalkableZ()
         {
-            return Object.get_walkable_z();
+            return PhysicsObj.get_walkable_z();
         }
 
         public void Init(PhysicsObj obj, ObjectInfoState state)

--- a/Source/ACE.Server/Physics/PhysicsObj.cs
+++ b/Source/ACE.Server/Physics/PhysicsObj.cs
@@ -186,7 +186,7 @@ namespace ACE.Server.Physics
             }
         }
 
-        public ObjCell AdjustPosition(Position position, Vector3 low_pt, bool dontCreateCells, bool searchCells)
+        private static ObjCell AdjustPosition(Position position, Vector3 low_pt, bool searchCells)
         {
             var cellID = position.ObjCellID & 0xFFFF;
             //Console.WriteLine("AdjustPosition variation: {0:X4}", position.Variation);
@@ -243,7 +243,7 @@ namespace ACE.Server.Physics
                 PartArray.CheckForCompletedMotions();
         }
 
-        public bool CheckPositionInternal(ObjCell newCell, Position newPos, Transition transition, SetPosition setPos)
+        private static bool CheckPositionInternal(ObjCell newCell, Position newPos, Transition transition, SetPosition setPos)
         {
             transition.InitPath(newCell, null, newPos);
 
@@ -477,7 +477,7 @@ namespace ACE.Server.Physics
             return PartArray.GetHeight();
         }
 
-        public PhysicsObj GetObjectA(uint objectID)
+        public static PhysicsObj GetObjectA(uint objectID)
         {
             return ServerObjectManager.GetObjectA(objectID);
         }
@@ -969,7 +969,7 @@ namespace ACE.Server.Physics
         {
             if (CurCell == null) prepare_to_enter_world();
 
-            var newCell = AdjustPosition(pos, transition.SpherePath.LocalSphere[0].Center, setPos.Flags.HasFlag(SetPositionFlags.DontCreateCells), true);
+            var newCell = AdjustPosition(pos, transition.SpherePath.LocalSphere[0].Center, true);
 
             if (newCell == null)
             {
@@ -1078,7 +1078,7 @@ namespace ACE.Server.Physics
                 PartArray.SetScaleInternal(new Vector3(scale, scale, scale));
         }
 
-        public static float ScatterThreshold_Z = 10.0f;
+        private static float ScatterThreshold_Z = 10.0f;
 
         public SetPositionError SetScatterPositionInternal(SetPosition setPos, Transition transition)
         {
@@ -1542,12 +1542,9 @@ namespace ACE.Server.Physics
                     if (cell == null) continue; // fixme
 
                     var shadowObj = new ShadowObj(this, cell);
-                    if (!ShadowObjects.ContainsKey(cell.ID))
-                        ShadowObjects.Add(cell.ID, shadowObj);
-                    else
-                        ShadowObjects[cell.ID] = shadowObj;
+                    ShadowObjects[cell.ID] = shadowObj;
 
-                    if (cell != null) cell.AddShadowObject(shadowObj);
+                    cell.AddShadowObject(shadowObj);
 
                     if (PartArray != null)
                         PartArray.AddPartsShadow(cell, NumShadowObjects);
@@ -1726,7 +1723,7 @@ namespace ACE.Server.Physics
         /// This is to mitigate possible decal crashes w/ CO messages being sent
         /// for objects when the client landblock is very early in the loading state
         /// </summary>
-        public static TimeSpan TeleportCreateObjectDelay = TimeSpan.FromSeconds(1);
+        private static TimeSpan TeleportCreateObjectDelay = TimeSpan.FromSeconds(1);
 
         public void enqueue_objs(IEnumerable<PhysicsObj> newlyVisible)
         {
@@ -2066,7 +2063,7 @@ namespace ACE.Server.Physics
             return CachedVelocity;
         }
 
-        public float get_walkable_z()
+        public static float get_walkable_z()
         {
             return PhysicsGlobals.FloorZ;
         }
@@ -3051,7 +3048,7 @@ namespace ACE.Server.Physics
                 PositionManager.Unstick();
         }
 
-        public static float TickRate = 1.0f / 30.0f;
+        private static float TickRate = 1.0f / 30.0f;
 
         public bool update_object()
         {

--- a/Source/ACE.Server/WorldObjects/Allegiance.cs
+++ b/Source/ACE.Server/WorldObjects/Allegiance.cs
@@ -133,7 +133,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Build a mapping of patron guids => vassal guids
         /// </summary>
-        public Dictionary<uint, List<IPlayer>> BuildPatronVassals(List<IPlayer> members)
+        private static Dictionary<uint, List<IPlayer>> BuildPatronVassals(List<IPlayer> members)
         {
             var patronVassals = new Dictionary<uint, List<IPlayer>>();
 

--- a/Source/ACE.Server/WorldObjects/Creature_BodyPart.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_BodyPart.cs
@@ -72,11 +72,10 @@ namespace ACE.Server.WorldObjects
         /// Returns the effective AL for 1 piece of armor/clothing
         /// </summary>
         /// <param name="armor">A piece of armor or clothing</param>
-        public float GetArmorMod(WorldObject armor, DamageType damageType, bool ignoreMagicArmor)
+        private static float GetArmorMod(WorldObject armor, DamageType damageType, bool ignoreMagicArmor)
         {
             // get base armor/resistance level
             var baseArmor = armor.GetProperty(PropertyInt.ArmorLevel) ?? 0;
-            var armorType = armor.GetProperty(PropertyInt.ArmorType) ?? 0;
             var resistance = Creature.GetResistance(armor, damageType);
 
             /*Console.WriteLine(armor.Name);

--- a/Source/ACE.Server/WorldObjects/Creature_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Combat.cs
@@ -135,14 +135,12 @@ namespace ACE.Server.WorldObjects
             if (CurrentMotionState.Stance == MotionStance.NonCombat || CurrentMotionState.Stance == MotionStance.Invalid || IsMonster)
                 return 0.0f;
 
-            var combatStance = GetCombatStance();
-
-            float peace1 = 0.0f, unarmed = 0.0f, peace2 = 0.0f;
+            float unarmed = 0.0f, peace2 = 0.0f;
 
             // this is now handled as a proper 2-step process in HandleActionChangeCombatMode / NextUseTime
 
             // FIXME: just call generic method to switch to HandCombat first
-            peace1 = MotionTable.GetAnimationLength(MotionTableId, CurrentMotionState.Stance, MotionCommand.Ready, MotionCommand.NonCombat);
+            float peace1 = MotionTable.GetAnimationLength(MotionTableId, CurrentMotionState.Stance, MotionCommand.Ready, MotionCommand.NonCombat);
             /*if (CurrentMotionState.Stance != MotionStance.HandCombat && combatStance != MotionStance.HandCombat)
             {
                 unarmed = MotionTable.GetAnimationLength(MotionTableId, MotionStance.NonCombat, MotionCommand.Ready, MotionCommand.HandCombat);
@@ -347,7 +345,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Adds the shield stance to an existing combat stance
         /// </summary>
-        public MotionStance AddShieldStance(MotionStance combatStance)
+        private MotionStance AddShieldStance(MotionStance combatStance)
         {
             switch (combatStance)
             {
@@ -649,19 +647,6 @@ namespace ACE.Server.WorldObjects
             }
 
             return resistance;
-        }
-
-        /// <summary>
-        /// Reduces a creatures's attack skill while exhausted
-        /// </summary>
-        public uint GetExhaustedSkill(uint attackSkill)
-        {
-            var halfSkill = (uint)Math.Round(attackSkill / 2.0f);
-
-            uint maxPenalty = 50;
-            var reducedSkill = attackSkill >= maxPenalty ? attackSkill - maxPenalty : 0;
-
-            return Math.Max(reducedSkill, halfSkill);
         }
 
         /// <summary>
@@ -1232,7 +1217,7 @@ namespace ACE.Server.WorldObjects
         /// True  = Formula A / ratings method
         /// False = Formula B / critical defense method
         /// </summary>
-        public static bool OverpowerMethod = false;
+        private static bool OverpowerMethod = false;
 
         public static bool GetOverpower(Creature attacker, Creature defender)
         {
@@ -1321,8 +1306,7 @@ namespace ACE.Server.WorldObjects
                 return 0.0f;
 
             var overpowerChance = (attacker.Overpower ?? 0) * 0.01f;
-            var overpowerResistChance = 0f;
-            overpowerResistChance = (defender.OverpowerResist ?? 0) * 0.01f;
+            float overpowerResistChance = (defender.OverpowerResist ?? 0) * 0.01f;
             if (defender.GetEffectiveDefenseSkill(attacker.GetCombatType()) > OverpowerResistAdditionThreshold)
             {
                 overpowerResistChance += (int)(defender.GetEffectiveDefenseSkill(attacker.GetCombatType()) - OverpowerResistAdditionThreshold) / 50;

--- a/Source/ACE.Server/WorldObjects/Creature_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Death.cs
@@ -771,7 +771,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// A list of landblocks the player gains no xp from creature kills
         /// </summary>
-        public static HashSet<ushort> NoDeathXP_Landblocks = new HashSet<ushort>()
+        private static HashSet<ushort> NoDeathXP_Landblocks = new HashSet<ushort>()
         {
             0x00B0,     // Colosseum Arena One
             0x00B1,     // Colosseum Arena Two
@@ -792,7 +792,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// landblock required for using /clap command
         /// </summary>
-        public static HashSet<ushort> Marketplace_Landblocks = new HashSet<ushort>()
+        private static HashSet<ushort> Marketplace_Landblocks = new HashSet<ushort>()
         {
             0x016C,     // Marketplace
         };

--- a/Source/ACE.Server/WorldObjects/Creature_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Melee.cs
@@ -30,29 +30,9 @@ namespace ACE.Server.WorldObjects
         public bool TwoHandedCombat { get => CurrentMotionState?.Stance == MotionStance.TwoHandedSwordCombat || CurrentMotionState?.Stance == MotionStance.TwoHandedStaffCombat; }
 
         /// <summary>
-        /// Determines if a weapon can double or triple strike,
-        /// and appends the appropriate multistrike prefix to a MotionCommand
-        /// </summary>
-        public string MultiStrike(AttackType attackType, string action)
-        {
-            if ((attackType & AttackType.MultiStrike) == 0)
-                return action;
-
-            var doubleStrike = action.EndsWith("Thrust") ? AttackType.DoubleThrust : AttackType.DoubleSlash;
-            var tripleStrike = (AttackType)((int)doubleStrike * 2);
-
-            if (attackType.HasFlag(tripleStrike))
-                return $"Triple{action}";
-            if (attackType.HasFlag(doubleStrike))
-                return $"Double{action}";
-            else
-                return action;
-        }
-
-        /// <summary>
         /// Returns the attack types for a weapon
         /// </summary>
-        public AttackType GetWeaponAttackType(WorldObject weapon)
+        protected static AttackType GetWeaponAttackType(WorldObject weapon)
         {
             if (weapon == null)
                 return AttackType.Undef;

--- a/Source/ACE.Server/WorldObjects/Creature_Rating.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Rating.cs
@@ -63,105 +63,105 @@ namespace ACE.Server.WorldObjects
 
         // - Damage rating - increases all damage done to a target, including critical hits
         // Formula: (100 + <total damage rating>) / 100 = 1.xx modifier to damage
-        public float GetDamageRating(int damageRating)
+        public static float GetDamageRating(int damageRating)
         {
             return GetPositiveRatingMod(damageRating);
         }
 
         // - Critical damage rating - increases critical hit damage done to a target
         // Formula: (100 + <total critical damage rating>) / 100 = 1.xx modifier to critical damage
-        public float GetCriticalDamageRating(int criticalDmgRating)
+        public static float GetCriticalDamageRating(int criticalDmgRating)
         {
             return GetPositiveRatingMod(criticalDmgRating);
         }
 
         // - Damage resistance rating - decreases the amount of all incoming damage, including critical hits
         // Formula: 100 / (100 + <total damage resistance rating>) = 0.xxx modifier to incoming damage
-        public float GetDamageResistanceRating(int damageResistanceRating)
+        public static float GetDamageResistanceRating(int damageResistanceRating)
         {
             return GetNegativeRatingMod(damageResistanceRating);
         }
 
         // - Critical damage resistance rating - decreases critical hit damage received
         // Formula: 100 / (100 + <total critical damage resistance rating>) = 0.xxx modifier to critical hit damage received
-        public float GetCriticalDamageResistanceRating(int criticalDmgResistanceRating)
+        public static float GetCriticalDamageResistanceRating(int criticalDmgResistanceRating)
         {
             return GetNegativeRatingMod(criticalDmgResistanceRating);
         }
 
         // - DoT resistance rating - decreases the effectiveness of damage over time (DoT) spells cast upon the user
         // Formula: 100 / (100 + <total DoT reduction rating> = 0.xxx modifier to outgoing incoming DoT attacks
-        public float GetDamageOverTimeResistanceRating(int dotResistanceRating)
+        public static float GetDamageOverTimeResistanceRating(int dotResistanceRating)
         {
             return GetNegativeRatingMod(dotResistanceRating);
         }
 
         // - Health drain resistance rating - decreases the effect of drain spells cast upon the target
         // Formula: 100 / (100 + <total health drain resistance rating>) = 0.xxx modifier to incoming health drains
-        public float GetHealthDrainResistanceRating(int healthDrainResistRating)
+        public static float GetHealthDrainResistanceRating(int healthDrainResistRating)
         {
             return GetNegativeRatingMod(healthDrainResistRating);
         }
 
         // - Healing boost rating - increases the amount of health received from consumables, healing kits, and life magic
         // Formula: (100 + <total healing rating>) / 100 = 1.xx modifier to healing
-        public float GetHealingBoostRating(int healingBoostRating)
+        public static float GetHealingBoostRating(int healingBoostRating)
         {
             return GetPositiveRatingMod(healingBoostRating);
         }
 
         // - Aetheria Surge rating - increases the chance that Aetheria will surge
         // Formula: (100 + <aetheria surge rating>) / 100 = 1.xx modifier to Aetheria Surges
-        public float GetAetheriaSurgeRating(int aetheriaSurgeRating)
+        public static float GetAetheriaSurgeRating(int aetheriaSurgeRating)
         {
             return GetPositiveRatingMod(aetheriaSurgeRating);
         }
 
         // - Mana charge rating - increases the amount of mana released from mana stones into magical items
         // Formula: (100 + <mana charge rating>) / 100 = 1.xx modifier to mana charges
-        public float GetManaChargeRating(int manaChargeRating)
+        public static float GetManaChargeRating(int manaChargeRating)
         {
             return GetPositiveRatingMod(manaChargeRating);
         }
 
         // - Mana reduction rating - decreases the amount of mana consumed in equipped magical items
         // Formula: 100 / (100 + <mana reduction rating>) = 0.xxx modifier to magical item mana consumed
-        public float GetManaReductionRating(int manaReductionRating)
+        public static float GetManaReductionRating(int manaReductionRating)
         {
             return GetNegativeRatingMod(manaReductionRating);
         }
 
         // - Damage reduction rating - debuff applied to decrease the effective damage rating of the target
         // Formula: 100 / (100 + <total damage reduction rating>) = 0.xxx modifier to outgoing damage
-        public float GetDamageReductionRating(int damageReductionRating)
+        public static float GetDamageReductionRating(int damageReductionRating)
         {
             return GetNegativeRatingMod(damageReductionRating);
         }
 
         // - Healing reduction rating - debuff applied to decrease the effective healing rate of the target
         // Formula: 100 / (100 + <total healing reduction rating>) = 0.xxx modifier to healing
-        public float GetHealingReductionRating(int healingReductionRating)
+        public static float GetHealingReductionRating(int healingReductionRating)
         {
             return GetNegativeRatingMod(healingReductionRating);
         }
 
         // - Damage resistance reduction rating - debuff applied to decrease the effective damage resistance rating of the target
         // Formula: 100 / (100 + <total damage resistance reduction rating>) = 0.xxx modifier to incoming damage
-        public float GetDamageResistanceReductionRating(int damageResistReduceRating)
+        public static float GetDamageResistanceReductionRating(int damageResistReduceRating)
         {
             return GetNegativeRatingMod(damageResistReduceRating);
         }
 
         // - Player Killer damage rating - increases all damage done to other players, including critical hits
         // Formula: (100 + <total PK damage rating> / 100 = 1.xx modifier to PK damage
-        public float GetPKDamageRating(int pkDamageRating)
+        public static float GetPKDamageRating(int pkDamageRating)
         {
             return GetPositiveRatingMod(pkDamageRating);
         }
 
         // - Player Killer damage resistance rating - decreases all incoming damage done by other players, including critical hits
         // Formula: 100 / (100 + <total PK damage resistance rating>) = 0.xxx modifier to incoming PK damage
-        public float GetPKDamageResistanceRating(int pkDamageResistRating)
+        public static float GetPKDamageResistanceRating(int pkDamageResistRating)
         {
             return GetNegativeRatingMod(pkDamageResistRating);
         }

--- a/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
@@ -34,7 +34,7 @@ namespace ACE.Server.WorldObjects.Managers
 
         public WorldObject WorldObject => _proxy ?? _worldObject;
 
-        private WorldObject _worldObject;
+        private readonly WorldObject _worldObject;
         private WorldObject _proxy;
 
         /// <summary>
@@ -1569,7 +1569,7 @@ namespace ACE.Server.WorldObjects.Managers
                 case EmoteType.StartDynamicQuest:
                     if (player != null)
                     {
-                        if (player.QuestManager.IsDynamicQuestEligible(player))
+                        if (QuestManager.IsDynamicQuestEligible(player))
                         {
                             player.QuestManager.ComputeDynamicQuest("Dynamic_1", player.Session, false);
                         }
@@ -2512,7 +2512,7 @@ namespace ACE.Server.WorldObjects.Managers
             if (category == EmoteCategory.Refuse && questName != null)
             {
                 emoteSet = emoteSet.Where(e => e.Quest != null && e.Quest.Equals(questName, StringComparison.OrdinalIgnoreCase));
-                if (emoteSet.Count() == 0 && _worldObject.Biota.DynamicEmoteList != null) //pre-refresh dynamic quests
+                if (!emoteSet.Any() && _worldObject.Biota.DynamicEmoteList != null) //pre-refresh dynamic quests
                 {
                     emoteSet = _worldObject.Biota.DynamicEmoteList.Where(e => e.Quest == questName);
                 }
@@ -2707,7 +2707,7 @@ namespace ACE.Server.WorldObjects.Managers
             }
         }
 
-        private bool EmoteIsBranchingType(PropertiesEmoteAction emote)
+        private static bool EmoteIsBranchingType(PropertiesEmoteAction emote)
         {
             if (emote == null)
                 return false;
@@ -2831,7 +2831,7 @@ namespace ACE.Server.WorldObjects.Managers
             //result = result.Replace("%p", $"{???}"); // patron?
 
             // Find quest in standard or LSD custom usage for %tqt and %CDtime
-            var embeddedQuestName = result.Contains("@") ? message.Split("@")[0] : null;
+            var embeddedQuestName = result.Contains('@') ? message.Split("@")[0] : null;
             var questName = !string.IsNullOrWhiteSpace(embeddedQuestName) ? embeddedQuestName : quest;
 
             // LSD custom tqt usage
@@ -2851,7 +2851,7 @@ namespace ACE.Server.WorldObjects.Managers
 
                 result = result.Replace("%fqt", !string.IsNullOrWhiteSpace(quest) && targetPlayer.Fellowship != null ? targetPlayer.Fellowship.QuestManager.GetNextSolveTime(questName).GetFriendlyString() : "");
 
-                result = result.Replace("%tqm", !string.IsNullOrWhiteSpace(quest) ? targetPlayer.QuestManager.GetMaxSolves(questName).ToString() : "");
+                result = result.Replace("%tqm", !string.IsNullOrWhiteSpace(quest) ? QuestManager.GetMaxSolves(questName).ToString() : "");
 
                 result = result.Replace("%tqc", !string.IsNullOrWhiteSpace(quest) ? targetPlayer.QuestManager.GetCurrentSolves(questName).ToString() : "");
             }

--- a/Source/ACE.Server/WorldObjects/Monster_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Combat.cs
@@ -469,7 +469,7 @@ namespace ACE.Server.WorldObjects
         }
 
         private CancellationTokenSource hotspotLoopCTS;
-        private Task? hotspotLoopTask;
+        private Task hotspotLoopTask;
 
         public void StartHotspotSpawnLoopWithDelay()
         {
@@ -493,7 +493,7 @@ namespace ACE.Server.WorldObjects
 
 
         private CancellationTokenSource grappleLoopCTS;
-        private Task? grappleLoopTask;
+        private Task grappleLoopTask;
 
         public void StartGrappleLoopWithDelay()
         {

--- a/Source/ACE.Server/WorldObjects/Monster_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Melee.cs
@@ -406,14 +406,14 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Returns the creature armor for a body part
         /// </summary>
-        public List<WorldObject> GetArmorLayers(Player target, BodyPart bodyPart)
+        public List<WorldObject> GetArmorLayers(BodyPart bodyPart)
         {
             //Console.WriteLine("BodyPart: " + bodyPart);
             //Console.WriteLine("===");
 
             var coverageMask = BodyParts.GetCoverageMask(bodyPart);
 
-            var equipped = target.EquippedObjects.Values.Where(e => e is Clothing && (e.ClothingPriority & coverageMask) != 0).ToList();
+            var equipped = EquippedObjects.Values.Where(e => e is Clothing && (e.ClothingPriority & coverageMask) != 0).ToList();
 
             return equipped;
         }
@@ -535,7 +535,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Returns the natural resistance to DamageType for a piece of armor
         /// </summary>
-        public double GetResistance(WorldObject armor, DamageType damageType)
+        public static double GetResistance(WorldObject armor, DamageType damageType)
         {
             switch (damageType)
             {
@@ -558,22 +558,6 @@ namespace ACE.Server.WorldObjects
                 default:
                     return 0.0;
             }
-        }
-
-        /// <summary>
-        /// Displays all of the natural resistances for a piece of armor
-        /// </summary>
-        public void ShowResistance(WorldObject armor)
-        {
-            Console.WriteLine("Resistance:");
-            Console.WriteLine("Slashing: " + armor.GetProperty(PropertyFloat.ArmorModVsSlash));
-            Console.WriteLine("Piercing: " + armor.GetProperty(PropertyFloat.ArmorModVsPierce));
-            Console.WriteLine("Bludgeoning: " + armor.GetProperty(PropertyFloat.ArmorModVsBludgeon));
-            Console.WriteLine("Fire: " + armor.GetProperty(PropertyFloat.ArmorModVsFire));
-            Console.WriteLine("Ice: " + armor.GetProperty(PropertyFloat.ArmorModVsCold));
-            Console.WriteLine("Acid: " + armor.GetProperty(PropertyFloat.ArmorModVsAcid));
-            Console.WriteLine("Lightning: " + armor.GetProperty(PropertyFloat.ArmorModVsElectric));
-            Console.WriteLine("Nether: " + armor.GetProperty(PropertyFloat.ArmorModVsNether));
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/Monster_Navigation.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Navigation.cs
@@ -282,8 +282,8 @@ namespace ACE.Server.WorldObjects
         {
             if (AttackTarget == null) return;
 
-            var dist = GetDistanceToTarget();
-            var angle = GetAngle(AttackTarget);
+            //var dist = GetDistanceToTarget();
+            //var angle = GetAngle(AttackTarget);
             //Console.WriteLine("Dist: " + dist);
             //Console.WriteLine("Angle: " + angle);
         }
@@ -378,7 +378,7 @@ namespace ACE.Server.WorldObjects
             set { if (!value.HasValue) RemoveProperty(PropertyFloat.HomeRadius); else SetProperty(PropertyFloat.HomeRadius, value.Value); }
         }
 
-        public static float DefaultHomeRadius = 192.0f;
+        private static readonly float DefaultHomeRadius = 192.0f;
         //public static float DefaultHomeRadiusSq = DefaultHomeRadius * DefaultHomeRadius;
 
         private float? homeRadiusSq;

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -668,13 +668,6 @@ namespace ACE.Server.WorldObjects
             Session.Network.EnqueueSend(new GameMessageSystemChat($"Bypass Housing Barriers now set to: {IgnoreHouseBarriers}", ChatMessageType.Broadcast));
         }
 
-        public void SendAutonomousPosition()
-        {
-            // Session.Network.EnqueueSend(new GameMessageAutonomousPosition(this));
-        }
-
-
-
         public void HandleActionFinishBarber(ClientMessage message)
         {
             // Read the payload sent from the client...

--- a/Source/ACE.Server/WorldObjects/Player_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Combat.cs
@@ -392,7 +392,7 @@ namespace ACE.Server.WorldObjects
             return GetCombatType() == CombatType.Missile ? AccuracyLevel : PowerLevel;
         }
 
-        public Sound GetHitSound(WorldObject source, BodyPart bodyPart)
+        private static Sound GetHitSound(WorldObject source, BodyPart bodyPart)
         {
             /*var creature = source as Creature;
             var armors = creature.GetArmor(bodyPart);
@@ -423,7 +423,7 @@ namespace ACE.Server.WorldObjects
             var percent = (float)amount / Health.MaxValue;
 
             // update health
-            var damageTaken = (uint)-UpdateVitalDelta(Health, (int)-amount);
+            UpdateVitalDelta(Health, (int)-amount);
 
             // update stamina
             //UpdateVitalDelta(Stamina, -1);
@@ -571,13 +571,6 @@ namespace ACE.Server.WorldObjects
                 UpdatePKTimers(attacker, this);
 
             return (int)damageTaken;
-        }
-
-        public string GetArmorType(BodyPart bodyPart)
-        {
-            // Flesh, Leather, Chain, Plate
-            // for hit sounds
-            return null;
         }
 
         /// <summary>
@@ -989,7 +982,7 @@ namespace ACE.Server.WorldObjects
         /// If a player has been involved in a PK battle this recently,
         /// logging off leaves their character in a frozen state for 20 seconds
         /// </summary>
-        public static TimeSpan PKLogoffTimer = TimeSpan.FromMinutes(2);
+        private static TimeSpan PKLogoffTimer = TimeSpan.FromMinutes(2);
 
         public void UpdatePKTimer()
         {

--- a/Source/ACE.Server/WorldObjects/Player_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Death.cs
@@ -702,7 +702,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Builds the network text message for list of items dropped
         /// </summary>
-        public string DropMessage(List<WorldObject> dropItems, int numCoinsDropped)
+        private static string DropMessage(List<WorldObject> dropItems, int numCoinsDropped)
         {
             var msg = "";
             var coinMsg = true;
@@ -746,7 +746,7 @@ namespace ACE.Server.WorldObjects
             return msg;
         }
 
-        public static TimeSpan PermitTime = TimeSpan.FromHours(1);
+        private static TimeSpan PermitTime = TimeSpan.FromHours(1);
 
         public void HandleActionAddPlayerPermission(string playerName)
         {
@@ -931,7 +931,7 @@ namespace ACE.Server.WorldObjects
             EnqueueBroadcast(new GameMessageScript(Guid, PlayScript.ShieldUpBlue));
         }
 
-        public static TimeSpan LifestoneProtectionTime = TimeSpan.FromMinutes(1);
+        private static TimeSpan LifestoneProtectionTime = TimeSpan.FromMinutes(1);
 
         public void LifestoneProtectionTick()
         {

--- a/Source/ACE.Server/WorldObjects/Player_Move.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Move.cs
@@ -179,7 +179,7 @@ namespace ACE.Server.WorldObjects
             MoveTo_Tick();
         }
 
-        public static float MoveToRate = 0.1f;
+        private static readonly float MoveToRate = 0.1f;
 
         public void MoveTo_Tick()
         {
@@ -230,7 +230,7 @@ namespace ACE.Server.WorldObjects
             }
         }
 
-        public MovementParameters GetChargeParameters()
+        private static MovementParameters GetChargeParameters()
         {
             var mvp = new MovementParameters();
 

--- a/Source/ACE.Server/WorldObjects/Player_Move2.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Move2.cs
@@ -133,7 +133,7 @@ namespace ACE.Server.WorldObjects
             return mvp;
         }
 
-        public MovementParameters GetTurnToParams(bool stopCompletely = false)
+        private static MovementParameters GetTurnToParams(bool stopCompletely = false)
         {
             var mvp = new MovementParameters();
 

--- a/Source/ACE.Server/WorldObjects/Portal.cs
+++ b/Source/ACE.Server/WorldObjects/Portal.cs
@@ -270,7 +270,7 @@ namespace ACE.Server.WorldObjects
             return new ActivationResult(true);
         }
 
-        private bool CheckPortalRequirement(Player player, Enum reqType, int reqValue, int reqMaxValue, string requirementLabel)
+        private static bool CheckPortalRequirement(Player player, Enum reqType, int reqValue, int reqMaxValue, string requirementLabel)
         {
             string message = string.Empty;
 

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -693,7 +693,7 @@ namespace ACE.Server.WorldObjects
         /// Calculates the damage reduction modifier for bows and casters
         /// with 'Magic Absorbing' property
         /// </summary>
-        public float AbsorbMagic(Creature target, WorldObject item)
+        private static float AbsorbMagic(Creature target, WorldObject item)
         {
             // https://asheron.fandom.com/wiki/Category:Magic_Absorbing
 
@@ -864,7 +864,6 @@ namespace ACE.Server.WorldObjects
             {
                 string verb = null, plural = null;
                 Strings.GetAttackVerb(Spell.DamageType, percent, ref verb, ref plural);
-                var type = Spell.DamageType.GetName().ToLower();
 
                 var critMsg = critical ? "Critical hit! " : "";
                 var sneakMsg = sneakAttackMod > 1.0f ? "Sneak Attack! " : "";

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -353,7 +353,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Plays the caster/target effects for a spell
         /// </summary>
-        protected void DoSpellEffects(Spell spell, WorldObject caster, WorldObject target, bool projectileHit = false)
+        protected static void DoSpellEffects(Spell spell, WorldObject caster, WorldObject target, bool projectileHit = false)
         {
             if (spell.CasterEffect != 0 && (!spell.IsProjectile || !projectileHit))
                 caster.EnqueueBroadcast(new GameMessageScript(caster.Guid, spell.CasterEffect, spell.Formula.Scale));
@@ -684,7 +684,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Checks for death from a boost / transfer spell
         /// </summary>
-        private void HandleBoostTransferDeath(Creature caster, Creature target)
+        private static void HandleBoostTransferDeath(Creature caster, Creature target)
         {
             if (caster != null && caster.IsDead)
             {
@@ -1338,7 +1338,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Handles casting SpellType.PortalSending spells
         /// </summary>
-        private void HandleCastSpell_PortalSending(Spell spell, Creature targetCreature, WorldObject itemCaster)
+        private static void HandleCastSpell_PortalSending(Spell spell, Creature targetCreature, WorldObject itemCaster)
         {
             if (targetCreature is Player targetPlayer)
             {

--- a/Source/ACE.Server/WorldObjects/WorldObject_Networking.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Networking.cs
@@ -900,11 +900,10 @@ namespace ACE.Server.WorldObjects
                 return objDesc;
             }
 
-            if (item.ClothingBaseEffects.ContainsKey(SetupTableId))
+            if (item.ClothingBaseEffects.TryGetValue(SetupTableId, out ClothingBaseEffect clothingBaseEffect))
             // Check if the ClothingBase is applicable for this Setup. (Gear Knights, this is usually you.)
             {
                 // Add the model and texture(s)
-                ClothingBaseEffect clothingBaseEffect = item.ClothingBaseEffects[SetupTableId];
                 foreach (CloObjectEffect t in clothingBaseEffect.CloObjectEffects)
                 {
                     byte partNum = (byte)t.Index;
@@ -1281,7 +1280,7 @@ namespace ACE.Server.WorldObjects
             return animLength;
         }
 
-        public static bool EnqueueBroadcastMotion_Physics = true;
+        private static readonly bool EnqueueBroadcastMotion_Physics = true;
 
         public void EnqueueBroadcastMotion(Motion motion, float? maxRange = null, bool? applyPhysics = null)
         {


### PR DESCRIPTION
Use static where applicable
Use readonly where applicable
Use private where applicable
Remove unused methods
Remove unnecessary calls to Dictionary.ContainsKey()
Use more performant logic for case-insensitive string comparisons
Updated uses of Count, Count(), and Any() to use the most performant approach for that scenario
Add Equals and GetHashCode methods