### PR TITLE
Update LootGenerationFactory_OlthoiPlay.cs

### DIFF
--- a/Source/ACE.Server/Factories/LootGenerationFactory_OlthoiPlay.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_OlthoiPlay.cs
@@ -147,7 +147,7 @@ namespace ACE.Server.Factories
 
             var slag = WorldObjectFactory.CreateNewWorldObject((uint)slagWcid);
 
-            slag.SetStackSize(totalSlag);
+            slag.SetStackSize(totalSlag * 100);
 
             player.OlthoiLootTimestamp = currentTime;
 


### PR DESCRIPTION
The amount of slag dropped from a kill is wildly too small and requires a substantial increase. Increasing here is preferred over replicating and value-reducing all items in the game to port them over to the olthoi PK system.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the amount of slag dropped from Olthoi Play loot by a factor of 100.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->