### PR TITLE
If a player has vassals, don't set their Monarch to null when Breaking Allegiance

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Allegiance.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Allegiance.cs
@@ -1491,7 +1491,7 @@ namespace ACE.Server.WorldObjects
             // walk the allegiance tree from this node, update monarch ids
             if (Allegiance.Members.TryGetValue(player.Guid, out var targetNode))
             {
-                player.UpdateProperty(PropertyInstanceId.Monarch, Guid.Full, true);
+                player.UpdateProperty(PropertyInstanceId.Monarch, player.Guid.Full, true);
             }
 
             targetNode.Walk((node) =>

--- a/Source/ACE.Server/WorldObjects/Player_Allegiance.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Allegiance.cs
@@ -226,7 +226,14 @@ namespace ACE.Server.WorldObjects
             {
                 // vassal breaking from patron
                 PatronId = null;
-                UpdateProperty(PropertyInstanceId.Monarch, null, true);
+                if (AllegianceNode.Vassals.Count > 0)
+                {
+                    UpdateProperty(PropertyInstanceId.Monarch, Guid.Full, true);
+                }
+                else
+                {
+                    UpdateProperty(PropertyInstanceId.Monarch, null, true);
+                }
 
                 // walk the allegiance tree from this node, update monarch ids
                 AllegianceNode.Walk((node) =>
@@ -1482,7 +1489,10 @@ namespace ACE.Server.WorldObjects
             player.UpdateProperty(PropertyInstanceId.Monarch, null, true);
 
             // walk the allegiance tree from this node, update monarch ids
-            Allegiance.Members.TryGetValue(player.Guid, out var targetNode);
+            if (Allegiance.Members.TryGetValue(player.Guid, out var targetNode))
+            {
+                player.UpdateProperty(PropertyInstanceId.Monarch, Guid.Full, true);
+            }
 
             targetNode.Walk((node) =>
             {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of allegiance status updates when breaking allegiance, ensuring the monarch information correctly reflects the player's current role.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->