### PR TITLE
Spell login fix #2

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -129,9 +129,6 @@ namespace ACE.Server.WorldObjects
             AddBiotasToEquippedObjects(wieldedItems);
 
             UpdateCoinValue(false);
-
-            // Rebuild self-cast buff registry using stacking logic
-            RebuildBuffRegistryFromDatabase();
         }
 
         public override void InitPhysicsObj(int? VariationId)
@@ -241,36 +238,7 @@ namespace ACE.Server.WorldObjects
         public bool IsDeleted => Character.IsDeleted;
         public bool IsPendingDeletion => Character.DeleteTime > 0 && !IsDeleted;
 
-        public void RebuildBuffRegistryFromDatabase()
-        {
-            var originalBuffs = new List<PropertiesEnchantmentRegistry>(Biota.PropertiesEnchantmentRegistry);
-            Biota.PropertiesEnchantmentRegistry.Clear();
 
-            // Apply item buffs first
-            foreach (var entry in originalBuffs)
-            {
-                if (entry == null) continue;
-                if (entry.Duration != -1) continue;
-                var spell = new Spell(entry.SpellId);
-                if (spell == null || spell.NotFound)
-                    continue;
-
-                if (EquippedObjects != null && EquippedObjects.TryGetValue(new ObjectGuid(entry.CasterObjectId), out var item) && item != null)
-                    EnchantmentManager.Add(spell, item, null, equip: true);
-            }
-
-            // Then apply self-cast buffs
-            foreach (var entry in originalBuffs)
-            {
-                if (entry == null) continue;
-                if (entry.Duration == -1) continue;
-                var spell = new Spell(entry.SpellId);
-                if (spell == null || spell.NotFound)
-                    continue;
-
-                EnchantmentManager.Add(spell, this, null, equip: false);
-            }
-        }
 
         // ******************************************************************* OLD CODE BELOW ********************************
         // ******************************************************************* OLD CODE BELOW ********************************


### PR DESCRIPTION
removes the rebuild. sends top layer instead to the client at login.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how enchantments are selected and categorized, ensuring more accurate handling of "Vitae" enchantments and dispel operations.

* **Refactor**
  * Removed the method responsible for rebuilding the player's buff registry during database restoration, streamlining player initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->