### PR TITLE
Update LootGenerationFactory_OlthoiPlay.cs

### DIFF
--- a/Source/ACE.Server/Factories/LootGenerationFactory_OlthoiPlay.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_OlthoiPlay.cs
@@ -147,6 +147,12 @@ namespace ACE.Server.Factories
 
             var slag = WorldObjectFactory.CreateNewWorldObject((uint)slagWcid);
 
+            //Multiply totalSlag by 5 to make olthoi equiptment more accessible
+            totalSlag *= 5;
+
+            // Cap totalSlag at 9999
+            if (totalSlag > 9999) totalSlag = 9999;
+            
             slag.SetStackSize(totalSlag);
 
             player.OlthoiLootTimestamp = currentTime;


### PR DESCRIPTION
Multiply total slag dropped by 5 and clamp max slag dropped to 9,999 to ensure it cannot exceed max stack size