### PR TITLE
Added QueueReport and ReadOnlyQueueReport Console Commands to list out contents of the Shard Database Queue

### DIFF
--- a/Source/ACE.Database/SerializedShardDatabase.cs
+++ b/Source/ACE.Database/SerializedShardDatabase.cs
@@ -59,6 +59,16 @@ namespace ACE.Database
             _workerThreadReadOnly.Join();
         }
 
+        public List<string> QueueReport()
+        {
+            return _queue.Select(x => x.AsyncState.ToString()).ToList();
+        }
+
+        public List<string> ReadOnlyQueueReport()
+        {
+            return _readOnlyQueue.Select(x => x.AsyncState.ToString()).ToList();
+        }
+
         private void DoReadOnlyWork()
         {
             while (!_readOnlyQueue.IsAddingCompleted)

--- a/Source/ACE.Database/SerializedShardDatabase.cs
+++ b/Source/ACE.Database/SerializedShardDatabase.cs
@@ -61,12 +61,12 @@ namespace ACE.Database
 
         public List<string> QueueReport()
         {
-            return _queue.Select(x => x.AsyncState.ToString()).ToList();
+            return _queue.Select(x => x.AsyncState.ToString() ?? "Unknown Task").ToList();
         }
 
         public List<string> ReadOnlyQueueReport()
         {
-            return _readOnlyQueue.Select(x => x.AsyncState.ToString()).ToList();
+            return _readOnlyQueue.Select(x => x.AsyncState.ToString() ?? "Unknown Task").ToList();
         }
 
         private void DoReadOnlyWork()

--- a/Source/ACE.Server/Command/Handlers/ConsoleCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/ConsoleCommands.cs
@@ -1,11 +1,11 @@
-using System;
-using System.Collections.Generic;
-
+using ACE.Database;
 using ACE.DatLoader;
 using ACE.DatLoader.FileTypes;
 using ACE.Entity.Enum;
 using ACE.Server.Managers;
 using ACE.Server.Network;
+using System;
+using System.Collections.Generic;
 
 namespace ACE.Server.Command.Handlers
 {
@@ -27,6 +27,30 @@ namespace ACE.Server.Command.Handlers
             {
                 Console.WriteLine($"LB Keys: {LI.Value.Id.Raw}, {LI.Value.VariationId}");
             }
+        }
+
+        [CommandHandler("queuereport", AccessLevel.Admin, CommandHandlerFlag.ConsoleInvoke, 0, "Write out all tasks in the Shard Database Queue")]
+        public static void QueueReport(Session session, params string[] parameters)
+        {
+            var tasks = DatabaseManager.Shard.QueueReport();
+            Console.WriteLine($"QueueReport, Currently {tasks.Count} Shard Database Tasks");
+            foreach (var task in tasks)
+            {
+                Console.WriteLine(task);
+            }
+            Console.WriteLine("End QueueReport");
+        }
+
+        [CommandHandler("readonlyqueuereport", AccessLevel.Admin, CommandHandlerFlag.ConsoleInvoke, 0, "Write out all tasks in the Shard Database Queue")]
+        public static void ReadOnlyQueueReport(Session session, params string[] parameters)
+        {
+            var tasks = DatabaseManager.Shard.ReadOnlyQueueReport();
+            Console.WriteLine($"ReadOnlyQueueReport, Currently {tasks.Count} Shard Database Tasks");
+            foreach (var task in tasks)
+            {
+                Console.WriteLine(task);
+            }
+            Console.WriteLine("End ReadOnlyQueueReport");
         }
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new admin console commands to display reports of current tasks in both the main and read-only shard database queues, including task counts and details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->