### PR TITLE
Copy TimeToRot from Monster to Corpse

### DIFF
--- a/Source/ACE.Server/WorldObjects/Creature_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Death.cs
@@ -603,6 +603,9 @@ namespace ACE.Server.WorldObjects
             {
                 corpse.IsMonster = true;
 
+                // Copy TimeToRot from Monster to Corpse
+                corpse.TimeToRot = TimeToRot;
+
                 if (killer == null || !killer.IsOlthoiPlayer)
                     GenerateTreasure(killer, corpse);
                 else


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Monster corpses now inherit the monster’s decay timer, ensuring they despawn on the expected schedule.
  * Resolves inconsistencies where some corpses lingered too long or vanished sooner than anticipated.
  * Improves predictability for loot windows and cleanup timing in the world.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->