### PR TITLE
updated getcritrating and getcritresistrating

### DIFF
--- a/Source/ACE.Server/WorldObjects/Creature_Rating.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Rating.cs
@@ -305,13 +305,16 @@ namespace ACE.Server.WorldObjects
             // additive enchantments
             var enchantments = EnchantmentManager.GetRating(PropertyInt.CritRating);
 
+            // equipment ratings
+            var equipment = GetEquippedItemsRatingSum(PropertyInt.GearCrit);
+
             // augmentations
             var augBonus = 0;
 
             if (this is Player player)
                 augBonus = player.AugmentationCriticalExpertise;
 
-            return critChanceRating + enchantments + augBonus;
+            return critChanceRating + enchantments + equipment + augBonus;
         }
 
         public int GetCritDamageRating()
@@ -348,8 +351,11 @@ namespace ACE.Server.WorldObjects
             // additive enchantments
             var enchantments = EnchantmentManager.GetRating(PropertyInt.CritResistRating);
 
+            // equipment ratings
+            var equipment = GetEquippedItemsRatingSum(PropertyInt.GearCritResist);
+
             // no augs / lum augs?
-            return critResistRating + enchantments;
+            return critResistRating + enchantments + equipment;
         }
 
         public int GetCritDamageResistRating()


### PR DESCRIPTION
updated to match ACEmulator functions around crit ratings where gear is taken into consideration for crit chance

https://github.com/ACEmulator/ACE/blob/197d256b467e0f796a21b8498343ec8bc78f34c1/Source/ACE.Server/WorldObjects/Creature_Rating.cs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Equipped gear now contributes to Critical Hit Rating, alongside enchantments and augmentations.
  * Equipped gear now contributes to Critical Resistance Rating, alongside enchantments.
  * Players may notice adjusted critical chance and critical resistance values based on their gear bonuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->