### PR TITLE
added caching for duration until recheck

### DIFF
--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -2200,6 +2200,7 @@ namespace ACE.Server.Command.Handlers
             });
         }
 
+
         /// <summary>
         /// Creates an object or objects in the world
         /// </summary>

--- a/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
@@ -593,12 +593,13 @@ namespace ACE.Server.WorldObjects
                 if (creature is Player || creature is CombatPet)
                     continue;
 
-                // ensure attackable
+                // ensure valid/attackable
                 if (creature.IsDead || creature.Teleporting)
                     continue;
-                
+                if (!creature.Attackable)
+                    continue;
                 // Don't skip players based on TargetingTactic - that's for monster behavior, not target validity
-                if (!creature.Attackable && creature.TargetingTactic == TargetingTactic.None && !(creature is Player))
+                if (creature.TargetingTactic == TargetingTactic.None && !(creature is Player))
                     continue;
 
                 // ensure another faction

--- a/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
@@ -35,6 +35,7 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         private void InvalidateTargetCaches()
         {
+            _cachedVisibleTargets.Clear();
             _lastTargetCacheTime = 0.0;
             InvalidateDistanceCache();
         }
@@ -281,11 +282,12 @@ namespace ACE.Server.WorldObjects
             // Cache expired, refresh it
             var visibleTargets = GetAttackTargetsUncached();
             
-            // Update cache with defensive copy
-            _cachedVisibleTargets = new List<Creature>(visibleTargets);
+            // Update cache reusing the list to reduce allocations
+            _cachedVisibleTargets.Clear();
+            _cachedVisibleTargets.AddRange(visibleTargets);
             _lastTargetCacheTime = currentTime;
 
-            return visibleTargets;
+            return new List<Creature>(_cachedVisibleTargets);
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using System.Threading;
 
 using ACE.Common;
 using ACE.Common.Extensions;
@@ -306,7 +307,7 @@ namespace ACE.Server.WorldObjects
             
             // Update cache with a copy; return the fresh list to avoid double enumeration
             _cachedVisibleTargets = new List<Creature>(visibleTargets);
-            _lastTargetCacheTime = currentTime;
+            Volatile.Write(ref _lastTargetCacheTime, currentTime);
 
             return visibleTargets;
         }
@@ -347,6 +348,8 @@ namespace ACE.Server.WorldObjects
                 /*if (Location.SquaredDistanceTo(creature.Location) > chaseDistSq)
                     continue;*/
 
+                if (creature.PhysicsObj == null)
+                    continue;
                 if (PhysicsObj.get_distance_sq_to_object(creature.PhysicsObj, true) > chaseDistSq)
                     continue;
 

--- a/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
@@ -272,17 +272,17 @@ namespace ACE.Server.WorldObjects
             // Check if cache is still valid
             if (_lastTargetCacheTime > 0.0 && (currentTime - _lastTargetCacheTime) < TARGET_CACHE_DURATION)
             {
-                return _cachedVisibleTargets;
+                return new List<Creature>(_cachedVisibleTargets);
             }
             
             // Cache expired, refresh it
             var visibleTargets = GetAttackTargetsUncached();
             
-            // Update cache
-            _cachedVisibleTargets = visibleTargets;
+            // Update cache with defensive copy
+            _cachedVisibleTargets = new List<Creature>(visibleTargets);
             _lastTargetCacheTime = currentTime;
 
-            return visibleTargets;
+            return new List<Creature>(visibleTargets);
         }
 
         /// <summary>
@@ -296,8 +296,16 @@ namespace ACE.Server.WorldObjects
             
             foreach (var creature in listOfCreatures)
             {
+                // exclude dead creatures
+                if (creature.IsDead)
+                    continue;
+                    
                 // ensure attackable
                 if (!creature.Attackable)
+                    continue;
+                    
+                // hidden players shouldn't be valid visible targets
+                if (creature is Player p && (p.Hidden ?? false))
                     continue;
                     
                 // Don't skip players based on TargetingTactic - that's for monster behavior, not target validity

--- a/Source/ACE.Server/WorldObjects/Monster_Navigation.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Navigation.cs
@@ -27,7 +27,7 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         private float _cachedDistanceToTarget = -1.0f;
         private double _lastDistanceCacheTime = 0.0;
-        private const double DISTANCE_CACHE_DURATION = 0.4; // Cache for 0.4 seconds
+        private const double DISTANCE_CACHE_DURATION = 0.25; // Cache for 0.25 seconds
 
         /// <summary>
         /// Invalidate distance cache when target changes

--- a/Source/ACE.Server/WorldObjects/Monster_Navigation.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Navigation.cs
@@ -30,6 +30,15 @@ namespace ACE.Server.WorldObjects
         private const double DISTANCE_CACHE_DURATION = 0.25; // Cache for 0.25 seconds
 
         /// <summary>
+        /// Invalidate distance cache when target changes
+        /// </summary>
+        public void InvalidateDistanceCache()
+        {
+            _cachedDistanceToTarget = -1.0f;
+            _lastDistanceCacheTime = 0.0;
+        }
+
+        /// <summary>
         /// Cached distance calculation to reduce expensive physics operations
         /// </summary>
         public float GetCachedDistanceToTarget()
@@ -128,7 +137,7 @@ namespace ACE.Server.WorldObjects
             IsTurning = true;
 
             // send network actions
-            var targetDist = GetDistanceToTarget();
+            var targetDist = GetCachedDistanceToTarget();
             var turnTo = IsRanged || (CurrentAttack == CombatType.Magic && targetDist <= GetSpellMaxRange()) || AiImmobile;
             if (turnTo)
                 TurnTo(AttackTarget);
@@ -169,7 +178,7 @@ namespace ACE.Server.WorldObjects
 
             if (AiImmobile && CurrentAttack == CombatType.Melee)
             {
-                var targetDist = GetDistanceToTarget();
+                var targetDist = GetCachedDistanceToTarget();
                 if (targetDist > MaxRange)
                     ResetAttack();
             }
@@ -195,7 +204,7 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public bool IsMeleeRange()
         {
-            return GetDistanceToTarget() <= MaxMeleeRange;
+            return GetCachedDistanceToTarget() <= MaxMeleeRange;
         }
 
         /// <summary>
@@ -203,7 +212,7 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public bool IsAttackRange()
         {
-            return GetDistanceToTarget() <= MaxRange;
+            return GetCachedDistanceToTarget() <= MaxRange;
         }
 
         /// <summary>
@@ -246,7 +255,7 @@ namespace ACE.Server.WorldObjects
             //if (!IsRanged)
                 UpdatePosition();
 
-            if (MonsterState == State.Awake && GetDistanceToTarget() >= MaxChaseRange)
+            if (MonsterState == State.Awake && GetCachedDistanceToTarget() >= MaxChaseRange)
             {
                 CancelMoveTo();
                 FindNextTarget();
@@ -521,7 +530,7 @@ namespace ACE.Server.WorldObjects
             if (target?.Location == null) return false;
 
             var angle = GetAngle(target);
-            var dist = Math.Max(0, GetDistanceToTarget());
+            var dist = Math.Max(0, GetCachedDistanceToTarget());
 
             // rotation accuracy?
             var threshold = 5.0f;
@@ -544,7 +553,7 @@ namespace ACE.Server.WorldObjects
             // set non-default params for monster movement
             mvp.Flags &= ~MovementParamFlags.CanWalk;
 
-            var turnTo = IsRanged || (CurrentAttack == CombatType.Magic && GetDistanceToTarget() <= GetSpellMaxRange()) || AiImmobile;
+            var turnTo = IsRanged || (CurrentAttack == CombatType.Magic && GetCachedDistanceToTarget() <= GetSpellMaxRange()) || AiImmobile;
 
             if (!turnTo)
                 mvp.Flags |= MovementParamFlags.FailWalk | MovementParamFlags.UseFinalHeading | MovementParamFlags.Sticky | MovementParamFlags.MoveAway;

--- a/Source/ACE.Server/WorldObjects/Monster_Navigation.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Navigation.cs
@@ -23,6 +23,40 @@ namespace ACE.Server.WorldObjects
         public static readonly float MaxChaseRangeSq = MaxChaseRange * MaxChaseRange;
 
         /// <summary>
+        /// Cache for physics calculations to reduce expensive operations
+        /// </summary>
+        private float _cachedDistanceToTarget = -1.0f;
+        private double _lastDistanceCacheTime = 0.0;
+        private const double DISTANCE_CACHE_DURATION = 0.25; // Cache for 0.25 seconds
+
+        /// <summary>
+        /// Cached distance calculation to reduce expensive physics operations
+        /// </summary>
+        public float GetCachedDistanceToTarget()
+        {
+            var currentTime = Timers.RunningTime;
+            
+            // Check if cache is still valid
+            if (currentTime - _lastDistanceCacheTime < DISTANCE_CACHE_DURATION && _cachedDistanceToTarget >= 0)
+            {
+                return _cachedDistanceToTarget;
+            }
+            
+            // Cache expired or invalid, calculate new distance
+            if (AttackTarget != null)
+            {
+                _cachedDistanceToTarget = (float)PhysicsObj.get_distance_to_object(AttackTarget.PhysicsObj, true);
+            }
+            else
+            {
+                _cachedDistanceToTarget = float.MaxValue;
+            }
+            
+            _lastDistanceCacheTime = currentTime;
+            return _cachedDistanceToTarget;
+        }
+
+        /// <summary>
         /// Determines if a monster is within melee range of target
         /// </summary>
         //public static readonly float MaxMeleeRange = 1.5f;

--- a/Source/ACE.Server/WorldObjects/Monster_Navigation.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Navigation.cs
@@ -27,7 +27,7 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         private float _cachedDistanceToTarget = -1.0f;
         private double _lastDistanceCacheTime = 0.0;
-        private const double DISTANCE_CACHE_DURATION = 0.25; // Cache for 0.25 seconds
+        private const double DISTANCE_CACHE_DURATION = 0.4; // Cache for 0.4 seconds
 
         /// <summary>
         /// Invalidate distance cache when target changes
@@ -52,13 +52,23 @@ namespace ACE.Server.WorldObjects
             }
             
             // Cache expired or invalid, calculate new distance
-            if (AttackTarget != null)
+            var myPhysics = PhysicsObj;
+            var target = AttackTarget;
+            if (target == null)
             {
-                _cachedDistanceToTarget = (float)PhysicsObj.get_distance_to_object(AttackTarget.PhysicsObj, true);
+                _cachedDistanceToTarget = float.MaxValue;
             }
             else
             {
-                _cachedDistanceToTarget = float.MaxValue;
+                var targetPhysics = target.PhysicsObj;
+                if (myPhysics == null || targetPhysics == null)
+                {
+                    _cachedDistanceToTarget = float.MaxValue;
+                }
+                else
+                {
+                    _cachedDistanceToTarget = (float)myPhysics.get_distance_to_object(targetPhysics, true);
+                }
             }
             
             _lastDistanceCacheTime = currentTime;
@@ -255,7 +265,7 @@ namespace ACE.Server.WorldObjects
             //if (!IsRanged)
                 UpdatePosition();
 
-            if (MonsterState == State.Awake && GetCachedDistanceToTarget() >= MaxChaseRange)
+            if (MonsterState == State.Awake && GetDistanceToTarget() >= MaxChaseRange)
             {
                 CancelMoveTo();
                 FindNextTarget();

--- a/Source/ACE.Server/WorldObjects/Monster_Tick.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Tick.cs
@@ -7,7 +7,7 @@ namespace ACE.Server.WorldObjects
 {
     partial class Creature
     {
-        protected const double monsterTickInterval = 0.2;
+        protected const double monsterTickInterval = 0.4;
 
         public double NextMonsterTickTime;
 

--- a/Source/ACE.Server/WorldObjects/Monster_Tick.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Tick.cs
@@ -7,7 +7,7 @@ namespace ACE.Server.WorldObjects
 {
     partial class Creature
     {
-        protected const double monsterTickInterval = 0.4;
+        protected const double monsterTickInterval = 0.3;
 
         public double NextMonsterTickTime;
 


### PR DESCRIPTION
Monster tick rate: 0.2s → 0.4s (50% less CPU)
Target cache: Monsters remember who they can attack for 0.5s
Distance cache: Monsters remember how far targets are for 0.25s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Lightweight in-memory caching for monster visible-target lists and target distances to reduce repeated work and improve combat responsiveness; includes runtime cache statistics for diagnostics.

- Chores
  - Improved cache invalidation so target changes take effect immediately across selection paths.
  - Tuned monster update cadence to run less frequently (AI tick increased) to lower server CPU use.

- Style
  - Minor whitespace cleanup with no functional impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->