### PR TITLE
Leaderboard optimizations to prevent server-wide lag

### DIFF
--- a/Source/ACE.Database/Models/Auth/LeaderboardExtensions.cs
+++ b/Source/ACE.Database/Models/Auth/LeaderboardExtensions.cs
@@ -13,11 +13,16 @@ namespace ACE.Database.Models.Auth
     public partial class Leaderboard
     {
         private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+        /// <summary>
+        /// Retrieves the top players by quest bonus count from the database asynchronously.
+        /// </summary>
+        /// <param name="context">The database context to use for the query.</param>
+        /// <returns>A list of Leaderboard entries sorted by quest bonus count, or an empty list if the query fails.</returns>
         public static async Task<List<Leaderboard>> GetTopQBLeaderboardAsync(AuthDbContext context)
         {
             try
             {
-                return await context.Leaderboard.FromSql($"CALL TopQuestBonus").ToListAsync();
+                return await context.Leaderboard.FromSql($"CALL TopQuestBonus").AsNoTracking().ToListAsync();
             }
             catch (Exception ex)
             {
@@ -26,11 +31,16 @@ namespace ACE.Database.Models.Auth
             }
         }
 
+        /// <summary>
+        /// Retrieves the top players by character level from the database asynchronously.
+        /// </summary>
+        /// <param name="context">The database context to use for the query.</param>
+        /// <returns>A list of Leaderboard entries sorted by character level, or an empty list if the query fails.</returns>
         public static async Task<List<Leaderboard>> GetTopLevelLeaderboardAsync(AuthDbContext context)
         {
             try
             {
-                return await context.Leaderboard.FromSql($"CALL TopLevel").ToListAsync();
+                return await context.Leaderboard.FromSql($"CALL TopLevel").AsNoTracking().ToListAsync();
             }
             catch (Exception ex)
             {
@@ -39,11 +49,16 @@ namespace ACE.Database.Models.Auth
             }
         }
 
+        /// <summary>
+        /// Retrieves the top players by enlightenment count from the database asynchronously.
+        /// </summary>
+        /// <param name="context">The database context to use for the query.</param>
+        /// <returns>A list of Leaderboard entries sorted by enlightenment count, or an empty list if the query fails.</returns>
         public static async Task<List<Leaderboard>> GetTopEnlightenmentLeaderboardAsync(AuthDbContext context)
         {
             try
             {
-                return await context.Leaderboard.FromSql($"CALL TopEnlightenment").ToListAsync();
+                return await context.Leaderboard.FromSql($"CALL TopEnlightenment").AsNoTracking().ToListAsync();
             }
             catch (Exception ex)
             {
@@ -52,11 +67,16 @@ namespace ACE.Database.Models.Auth
             }
         }
 
+        /// <summary>
+        /// Retrieves the top players by title count from the database asynchronously.
+        /// </summary>
+        /// <param name="context">The database context to use for the query.</param>
+        /// <returns>A list of Leaderboard entries sorted by title count, or an empty list if the query fails.</returns>
         public static async Task<List<Leaderboard>> GetTopTitleLeaderboardAsync(AuthDbContext context)
         {
             try
             {
-                return await context.Leaderboard.FromSql($"CALL TopTitles").ToListAsync();
+                return await context.Leaderboard.FromSql($"CALL TopTitles").AsNoTracking().ToListAsync();
             }
             catch (Exception ex)
             {
@@ -65,11 +85,16 @@ namespace ACE.Database.Models.Auth
             }
         }
 
+        /// <summary>
+        /// Retrieves the top players by augmentation count from the database asynchronously.
+        /// </summary>
+        /// <param name="context">The database context to use for the query.</param>
+        /// <returns>A list of Leaderboard entries sorted by augmentation count, or an empty list if the query fails.</returns>
         public static async Task<List<Leaderboard>> GetTopAugLeaderboardAsync(AuthDbContext context)
         {
             try
             {
-                return await context.Leaderboard.FromSql($"CALL TopAugments").ToListAsync();
+                return await context.Leaderboard.FromSql($"CALL TopAugments").AsNoTracking().ToListAsync();
             }
             catch (Exception ex)
             {
@@ -78,11 +103,16 @@ namespace ACE.Database.Models.Auth
             }
         }
 
+        /// <summary>
+        /// Retrieves the top players by death count from the database asynchronously.
+        /// </summary>
+        /// <param name="context">The database context to use for the query.</param>
+        /// <returns>A list of Leaderboard entries sorted by death count, or an empty list if the query fails.</returns>
         public static async Task<List<Leaderboard>> GetTopDeathsLeaderboardAsync(AuthDbContext context)
         {
             try
             {
-                return await context.Leaderboard.FromSql($"CALL TopDeaths").ToListAsync();
+                return await context.Leaderboard.FromSql($"CALL TopDeaths").AsNoTracking().ToListAsync();
             }
             catch (Exception ex)
             {
@@ -91,11 +121,16 @@ namespace ACE.Database.Models.Auth
             }
         }
 
+        /// <summary>
+        /// Retrieves the top players by bank value from the database asynchronously.
+        /// </summary>
+        /// <param name="context">The database context to use for the query.</param>
+        /// <returns>A list of Leaderboard entries sorted by bank value, or an empty list if the query fails.</returns>
         public static async Task<List<Leaderboard>> GetTopBankLeaderboardAsync(AuthDbContext context)
         {
             try
             {
-                return await context.Leaderboard.FromSql($"CALL TopBank").ToListAsync();
+                return await context.Leaderboard.FromSql($"CALL TopBank").AsNoTracking().ToListAsync();
             }
             catch (Exception ex)
             {
@@ -104,11 +139,16 @@ namespace ACE.Database.Models.Auth
             }
         }
 
+        /// <summary>
+        /// Retrieves the top players by luminance value from the database asynchronously.
+        /// </summary>
+        /// <param name="context">The database context to use for the query.</param>
+        /// <returns>A list of Leaderboard entries sorted by luminance value, or an empty list if the query fails.</returns>
         public static async Task<List<Leaderboard>> GetTopLumLeaderboardAsync(AuthDbContext context)
         {
             try
             {
-                return await context.Leaderboard.FromSql($"CALL TopLum").ToListAsync();
+                return await context.Leaderboard.FromSql($"CALL TopLum").AsNoTracking().ToListAsync();
             }
             catch (Exception ex)
             {
@@ -117,11 +157,16 @@ namespace ACE.Database.Models.Auth
             }
         }
 
+        /// <summary>
+        /// Retrieves the top players by attribute values from the database asynchronously.
+        /// </summary>
+        /// <param name="context">The database context to use for the query.</param>
+        /// <returns>A list of Leaderboard entries sorted by attribute values, or an empty list if the query fails.</returns>
         public static async Task<List<Leaderboard>> GetTopAttrLeaderboardAsync(AuthDbContext context)
         {
             try
             {
-                return await context.Leaderboard.FromSql($"CALL TopAttributes").ToListAsync();
+                return await context.Leaderboard.FromSql($"CALL TopAttributes").AsNoTracking().ToListAsync();
             }
             catch (Exception ex)
             {
@@ -131,6 +176,9 @@ namespace ACE.Database.Models.Auth
         }
     }
 
+    /// <summary>
+    /// Provides thread-safe caching for leaderboard data with automatic refresh and variance to prevent database load spikes.
+    /// </summary>
     public class LeaderboardCache
     {
         private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
@@ -157,6 +205,9 @@ namespace ACE.Database.Models.Auth
         {
         }
 
+        /// <summary>
+        /// Gets the singleton instance of the LeaderboardCache.
+        /// </summary>
         public static LeaderboardCache Instance
         {
             get
@@ -175,80 +226,124 @@ namespace ACE.Database.Models.Auth
         public List<Leaderboard> LumCache = new List<Leaderboard>();
         public List<Leaderboard> AttrCache = new List<Leaderboard>();
 
-        public DateTime QBLastUpdate = DateTime.Now;
-        public DateTime LevelLastUpdate = DateTime.Now;
-        public DateTime EnlLastUpdate = DateTime.Now;
-        public DateTime TitleLastUpdate = DateTime.Now;
-        public DateTime AugsLastUpdate = DateTime.Now;
-        public DateTime DeathsLastUpdate = DateTime.Now;
-        public DateTime BanksLastUpdate = DateTime.Now;
-        public DateTime LumLastUpdate = DateTime.Now;
-        public DateTime AttrLastUpdate = DateTime.Now;
+        /// <summary>
+        /// Timestamp indicating when the cache was last updated (UTC). This represents the time when the cache was refreshed with new data from the database.
+        /// </summary>
+        public DateTime QBLastUpdate = DateTime.UtcNow;
+        public DateTime LevelLastUpdate = DateTime.UtcNow;
+        public DateTime EnlLastUpdate = DateTime.UtcNow;
+        public DateTime TitleLastUpdate = DateTime.UtcNow;
+        public DateTime AugsLastUpdate = DateTime.UtcNow;
+        public DateTime DeathsLastUpdate = DateTime.UtcNow;
+        public DateTime BanksLastUpdate = DateTime.UtcNow;
+        public DateTime LumLastUpdate = DateTime.UtcNow;
+        public DateTime AttrLastUpdate = DateTime.UtcNow;
 
+        /// <summary>
+        /// Updates the QB cache with new data and sets the next update time with variance to prevent database load spikes.
+        /// </summary>
+        /// <param name="list">The new leaderboard data to cache.</param>
         public void UpdateQBCache(List<Leaderboard> list)
         {
             QBCache = list;
-            QBLastUpdate = DateTime.Now.AddMinutes(cacheTimeout).AddSeconds(ThreadSafeRandom.Next(15, 120)); //vary the cache duration to prevent DB slamming
+            QBLastUpdate = DateTime.UtcNow.AddMinutes(cacheTimeout).AddSeconds(ThreadSafeRandom.Next(15, 120)); //vary the cache duration to prevent DB slamming
         }
 
+        /// <summary>
+        /// Updates the Level cache with new data and sets the next update time with variance to prevent database load spikes.
+        /// </summary>
+        /// <param name="list">The new leaderboard data to cache.</param>
         public void UpdateLevelCache(List<Leaderboard> list)
         {
             LevelCache = list;
-            LevelLastUpdate = DateTime.Now.AddMinutes(cacheTimeout).AddSeconds(ThreadSafeRandom.Next(15, 120)); //vary the cache duration to prevent DB slamming
+            LevelLastUpdate = DateTime.UtcNow.AddMinutes(cacheTimeout).AddSeconds(ThreadSafeRandom.Next(15, 120)); //vary the cache duration to prevent DB slamming
         }
 
+        /// <summary>
+        /// Updates the Enlightenment cache with new data and sets the next update time with variance to prevent database load spikes.
+        /// </summary>
+        /// <param name="list">The new leaderboard data to cache.</param>
         public void UpdateEnlCache(List<Leaderboard> list)
         {
             EnlCache = list;
-            EnlLastUpdate = DateTime.Now.AddMinutes(cacheTimeout).AddSeconds(ThreadSafeRandom.Next(15, 120)); //vary the cache duration to prevent DB slamming
+            EnlLastUpdate = DateTime.UtcNow.AddMinutes(cacheTimeout).AddSeconds(ThreadSafeRandom.Next(15, 120)); //vary the cache duration to prevent DB slamming
         }
 
+        /// <summary>
+        /// Updates the Title cache with new data and sets the next update time with variance to prevent database load spikes.
+        /// </summary>
+        /// <param name="list">The new leaderboard data to cache.</param>
         public void UpdateTitleCache(List<Leaderboard> list)
         {
             TitleCache = list;
-            TitleLastUpdate = DateTime.Now.AddMinutes(cacheTimeout).AddSeconds(ThreadSafeRandom.Next(15, 120)); //vary the cache duration to prevent DB slamming
+            TitleLastUpdate = DateTime.UtcNow.AddMinutes(cacheTimeout).AddSeconds(ThreadSafeRandom.Next(15, 120)); //vary the cache duration to prevent DB slamming
         }
 
+        /// <summary>
+        /// Updates the Augmentations cache with new data and sets the next update time with variance to prevent database load spikes.
+        /// </summary>
+        /// <param name="list">The new leaderboard data to cache.</param>
         public void UpdateAugsCache(List<Leaderboard> list)
         {
             AugsCache = list;
-            AugsLastUpdate = DateTime.Now.AddMinutes(cacheTimeout).AddSeconds(ThreadSafeRandom.Next(15, 120)); //vary the cache duration to prevent DB slamming
+            AugsLastUpdate = DateTime.UtcNow.AddMinutes(cacheTimeout).AddSeconds(ThreadSafeRandom.Next(15, 120)); //vary the cache duration to prevent DB slamming
         }
 
+        /// <summary>
+        /// Updates the Deaths cache with new data and sets the next update time with variance to prevent database load spikes.
+        /// </summary>
+        /// <param name="list">The new leaderboard data to cache.</param>
         public void UpdateDeathsCache(List<Leaderboard> list)
         {
             DeathsCache = list;
-            DeathsLastUpdate = DateTime.Now.AddMinutes(cacheTimeout).AddSeconds(ThreadSafeRandom.Next(15, 120)); //vary the cache duration to prevent DB slamming
+            DeathsLastUpdate = DateTime.UtcNow.AddMinutes(cacheTimeout).AddSeconds(ThreadSafeRandom.Next(15, 120)); //vary the cache duration to prevent DB slamming
         }
 
+        /// <summary>
+        /// Updates the Bank cache with new data and sets the next update time with variance to prevent database load spikes.
+        /// </summary>
+        /// <param name="list">The new leaderboard data to cache.</param>
         public void UpdateBankCache(List<Leaderboard> list)
         {
             BankCache = list;
-            BanksLastUpdate = DateTime.Now.AddMinutes(cacheTimeout).AddSeconds(ThreadSafeRandom.Next(15, 120)); //vary the cache duration to prevent DB slamming
+            BanksLastUpdate = DateTime.UtcNow.AddMinutes(cacheTimeout).AddSeconds(ThreadSafeRandom.Next(15, 120)); //vary the cache duration to prevent DB slamming
         }
 
+        /// <summary>
+        /// Updates the Luminance cache with new data and sets the next update time with variance to prevent database load spikes.
+        /// </summary>
+        /// <param name="list">The new leaderboard data to cache.</param>
         public void UpdateLumCache(List<Leaderboard> list)
         {
             LumCache = list;
-            LumLastUpdate = DateTime.Now.AddMinutes(cacheTimeout).AddSeconds(ThreadSafeRandom.Next(15, 120)); //vary the cache duration to prevent DB slamming
+            LumLastUpdate = DateTime.UtcNow.AddMinutes(cacheTimeout).AddSeconds(ThreadSafeRandom.Next(15, 120)); //vary the cache duration to prevent DB slamming
         }
 
+        /// <summary>
+        /// Updates the Attributes cache with new data and sets the next update time with variance to prevent database load spikes.
+        /// </summary>
+        /// <param name="list">The new leaderboard data to cache.</param>
         public void UpdateAttrCache(List<Leaderboard> list)
         {
             AttrCache = list;
-            AttrLastUpdate = DateTime.Now.AddMinutes(cacheTimeout).AddSeconds(ThreadSafeRandom.Next(15, 120)); //vary the cache duration to prevent DB slamming
+            AttrLastUpdate = DateTime.UtcNow.AddMinutes(cacheTimeout).AddSeconds(ThreadSafeRandom.Next(15, 120)); //vary the cache duration to prevent DB slamming
         }   
 
+        /// <summary>
+        /// Gets the top players by quest bonus count from cache, refreshing if necessary.
+        /// </summary>
+        /// <param name="context">The database context to use for refreshing the cache.</param>
+        /// <returns>A list of Leaderboard entries sorted by quest bonus count.</returns>
         public async Task<List<Leaderboard>> GetTopQBAsync(AuthDbContext context)
         {
-            if (QBCache.Count == 0 || QBLastUpdate < DateTime.Now)
+            if (QBCache.Count == 0 || QBLastUpdate < DateTime.UtcNow)
             {
-                log.Debug($"QB Cache miss - Count: {QBCache.Count}, LastUpdate: {QBLastUpdate:yyyy-MM-dd HH:mm:ss}, Now: {DateTime.Now:yyyy-MM-dd HH:mm:ss}");
+                log.Debug($"QB Cache miss - Count: {QBCache.Count}, NextUpdate: {QBLastUpdate:yyyy-MM-dd HH:mm:ss}, Now: {DateTime.UtcNow:yyyy-MM-dd HH:mm:ss}");
                 await _qbCacheSemaphore.WaitAsync();
                 try
                 {
                     // Double-check inside the lock
-                    if (QBCache.Count == 0 || QBLastUpdate < DateTime.Now)
+                    if (QBCache.Count == 0 || QBLastUpdate < DateTime.UtcNow)
                     {
                         log.Debug("QB Cache refresh starting - calling database");
                         var result = await Leaderboard.GetTopQBLeaderboardAsync(context);
@@ -267,21 +362,26 @@ namespace ACE.Database.Models.Auth
             }
             else
             {
-                log.Debug($"QB Cache hit - using {QBCache.Count} cached records, last updated: {QBLastUpdate:yyyy-MM-dd HH:mm:ss}");
+                log.Debug($"QB Cache hit - using {QBCache.Count} cached records, last updated: {QBLastUpdate:yyyy-MM-dd HH:mm:ss} UTC");
             }
             return QBCache;
         }
 
+        /// <summary>
+        /// Gets the top players by character level from cache, refreshing if necessary.
+        /// </summary>
+        /// <param name="context">The database context to use for refreshing the cache.</param>
+        /// <returns>A list of Leaderboard entries sorted by character level.</returns>
         public async Task<List<Leaderboard>> GetTopLevelAsync(AuthDbContext context)
         {
-            if (LevelCache.Count == 0 || LevelLastUpdate < DateTime.Now)
+            if (LevelCache.Count == 0 || LevelLastUpdate < DateTime.UtcNow)
             {
-                log.Debug($"Level Cache miss - Count: {LevelCache.Count}, LastUpdate: {LevelLastUpdate:yyyy-MM-dd HH:mm:ss}, Now: {DateTime.Now:yyyy-MM-dd HH:mm:ss}");
+                log.Debug($"Level Cache miss - Count: {LevelCache.Count}, NextUpdate: {LevelLastUpdate:yyyy-MM-dd HH:mm:ss}, Now: {DateTime.UtcNow:yyyy-MM-dd HH:mm:ss}");
                 await _levelCacheSemaphore.WaitAsync();
                 try
                 {
                     // Double-check inside the lock
-                    if (LevelCache.Count == 0 || LevelLastUpdate < DateTime.Now)
+                    if (LevelCache.Count == 0 || LevelLastUpdate < DateTime.UtcNow)
                     {
                         log.Debug("Level Cache refresh starting - calling database");
                         var result = await Leaderboard.GetTopLevelLeaderboardAsync(context);
@@ -300,21 +400,26 @@ namespace ACE.Database.Models.Auth
             }
             else
             {
-                log.Debug($"Level Cache hit - using {LevelCache.Count} cached records, last updated: {LevelLastUpdate:yyyy-MM-dd HH:mm:ss}");
+                log.Debug($"Level Cache hit - using {LevelCache.Count} cached records, last updated: {LevelLastUpdate:yyyy-MM-dd HH:mm:ss} UTC");
             }
             return LevelCache;
         }
 
+        /// <summary>
+        /// Gets the top players by enlightenment count from cache, refreshing if necessary.
+        /// </summary>
+        /// <param name="context">The database context to use for refreshing the cache.</param>
+        /// <returns>A list of Leaderboard entries sorted by enlightenment count.</returns>
         public async Task<List<Leaderboard>> GetTopEnlAsync(AuthDbContext context)
         {
-            if (EnlCache.Count == 0 || EnlLastUpdate < DateTime.Now)
+            if (EnlCache.Count == 0 || EnlLastUpdate < DateTime.UtcNow)
             {
-                log.Debug($"Enlightenment Cache miss - Count: {EnlCache.Count}, LastUpdate: {EnlLastUpdate:yyyy-MM-dd HH:mm:ss}, Now: {DateTime.Now:yyyy-MM-dd HH:mm:ss}");
+                log.Debug($"Enlightenment Cache miss - Count: {EnlCache.Count}, NextUpdate: {EnlLastUpdate:yyyy-MM-dd HH:mm:ss}, Now: {DateTime.UtcNow:yyyy-MM-dd HH:mm:ss}");
                 await _enlCacheSemaphore.WaitAsync();
                 try
                 {
                     // Double-check inside the lock
-                    if (EnlCache.Count == 0 || EnlLastUpdate < DateTime.Now)
+                    if (EnlCache.Count == 0 || EnlLastUpdate < DateTime.UtcNow)
                     {
                         log.Debug("Enlightenment Cache refresh starting - calling database");
                         var result = await Leaderboard.GetTopEnlightenmentLeaderboardAsync(context);
@@ -333,21 +438,26 @@ namespace ACE.Database.Models.Auth
             }
             else
             {
-                log.Debug($"Enlightenment Cache hit - using {EnlCache.Count} cached records, last updated: {EnlLastUpdate:yyyy-MM-dd HH:mm:ss}");
+                log.Debug($"Enlightenment Cache hit - using {EnlCache.Count} cached records, last updated: {EnlLastUpdate:yyyy-MM-dd HH:mm:ss} UTC");
             }
             return EnlCache;
         }
 
+        /// <summary>
+        /// Gets the top players by title count from cache, refreshing if necessary.
+        /// </summary>
+        /// <param name="context">The database context to use for refreshing the cache.</param>
+        /// <returns>A list of Leaderboard entries sorted by title count.</returns>
         public async Task<List<Leaderboard>> GetTopTitleAsync(AuthDbContext context)
         {
-            if (TitleCache.Count == 0 || TitleLastUpdate < DateTime.Now)
+            if (TitleCache.Count == 0 || TitleLastUpdate < DateTime.UtcNow)
             {
-                log.Debug($"Title Cache miss - Count: {TitleCache.Count}, LastUpdate: {TitleLastUpdate:yyyy-MM-dd HH:mm:ss}, Now: {DateTime.Now:yyyy-MM-dd HH:mm:ss}");
+                log.Debug($"Title Cache miss - Count: {TitleCache.Count}, NextUpdate: {TitleLastUpdate:yyyy-MM-dd HH:mm:ss}, Now: {DateTime.UtcNow:yyyy-MM-dd HH:mm:ss}");
                 await _titleCacheSemaphore.WaitAsync();
                 try
                 {
                     // Double-check inside the lock
-                    if (TitleCache.Count == 0 || TitleLastUpdate < DateTime.Now)
+                    if (TitleCache.Count == 0 || TitleLastUpdate < DateTime.UtcNow)
                     {
                         log.Debug("Title Cache refresh starting - calling database");
                         var result = await Leaderboard.GetTopTitleLeaderboardAsync(context);
@@ -366,21 +476,26 @@ namespace ACE.Database.Models.Auth
             }
             else
             {
-                log.Debug($"Title Cache hit - using {TitleCache.Count} cached records, last updated: {TitleLastUpdate:yyyy-MM-dd HH:mm:ss}");
+                log.Debug($"Title Cache hit - using {TitleCache.Count} cached records, last updated: {TitleLastUpdate:yyyy-MM-dd HH:mm:ss} UTC");
             }
             return TitleCache;
         }
 
+        /// <summary>
+        /// Gets the top players by augmentation count from cache, refreshing if necessary.
+        /// </summary>
+        /// <param name="context">The database context to use for refreshing the cache.</param>
+        /// <returns>A list of Leaderboard entries sorted by augmentation count.</returns>
         public async Task<List<Leaderboard>> GetTopAugsAsync(AuthDbContext context)
         {
-            if (AugsCache.Count == 0 || AugsLastUpdate < DateTime.Now)
+            if (AugsCache.Count == 0 || AugsLastUpdate < DateTime.UtcNow)
             {
-                log.Debug($"Augmentations Cache miss - Count: {AugsCache.Count}, LastUpdate: {AugsLastUpdate:yyyy-MM-dd HH:mm:ss}, Now: {DateTime.Now:yyyy-MM-dd HH:mm:ss}");
+                log.Debug($"Augmentations Cache miss - Count: {AugsCache.Count}, NextUpdate: {AugsLastUpdate:yyyy-MM-dd HH:mm:ss}, Now: {DateTime.UtcNow:yyyy-MM-dd HH:mm:ss}");
                 await _augsCacheSemaphore.WaitAsync();
                 try
                 {
                     // Double-check inside the lock
-                    if (AugsCache.Count == 0 || AugsLastUpdate < DateTime.Now)
+                    if (AugsCache.Count == 0 || AugsLastUpdate < DateTime.UtcNow)
                     {
                         log.Debug("Augmentations Cache refresh starting - calling database");
                         var result = await Leaderboard.GetTopAugLeaderboardAsync(context);
@@ -399,21 +514,26 @@ namespace ACE.Database.Models.Auth
             }
             else
             {
-                log.Debug($"Augmentations Cache hit - using {AugsCache.Count} cached records, last updated: {AugsLastUpdate:yyyy-MM-dd HH:mm:ss}");
+                log.Debug($"Augmentations Cache hit - using {AugsCache.Count} cached records, last updated: {AugsLastUpdate:yyyy-MM-dd HH:mm:ss} UTC");
             }
             return AugsCache;
         }
 
+        /// <summary>
+        /// Gets the top players by death count from cache, refreshing if necessary.
+        /// </summary>
+        /// <param name="context">The database context to use for refreshing the cache.</param>
+        /// <returns>A list of Leaderboard entries sorted by death count.</returns>
         public async Task<List<Leaderboard>> GetTopDeathsAsync(AuthDbContext context)
         {
-            if (DeathsCache.Count == 0 || DeathsLastUpdate < DateTime.Now)
+            if (DeathsCache.Count == 0 || DeathsLastUpdate < DateTime.UtcNow)
             {
-                log.Debug($"Deaths Cache miss - Count: {DeathsCache.Count}, LastUpdate: {DeathsLastUpdate:yyyy-MM-dd HH:mm:ss}, Now: {DateTime.Now:yyyy-MM-dd HH:mm:ss}");
+                log.Debug($"Deaths Cache miss - Count: {DeathsCache.Count}, NextUpdate: {DeathsLastUpdate:yyyy-MM-dd HH:mm:ss}, Now: {DateTime.UtcNow:yyyy-MM-dd HH:mm:ss}");
                 await _deathsCacheSemaphore.WaitAsync();
                 try
                 {
                     // Double-check inside the lock
-                    if (DeathsCache.Count == 0 || DeathsLastUpdate < DateTime.Now)
+                    if (DeathsCache.Count == 0 || DeathsLastUpdate < DateTime.UtcNow)
                     {
                         log.Debug("Deaths Cache refresh starting - calling database");
                         var result = await Leaderboard.GetTopDeathsLeaderboardAsync(context);
@@ -432,21 +552,26 @@ namespace ACE.Database.Models.Auth
             }
             else
             {
-                log.Debug($"Deaths Cache hit - using {DeathsCache.Count} cached records, last updated: {DeathsLastUpdate:yyyy-MM-dd HH:mm:ss}");
+                log.Debug($"Deaths Cache hit - using {DeathsCache.Count} cached records, last updated: {DeathsLastUpdate:yyyy-MM-dd HH:mm:ss} UTC");
             }
             return DeathsCache;
         }
 
+        /// <summary>
+        /// Gets the top players by bank value from cache, refreshing if necessary.
+        /// </summary>
+        /// <param name="context">The database context to use for refreshing the cache.</param>
+        /// <returns>A list of Leaderboard entries sorted by bank value.</returns>
         public async Task<List<Leaderboard>> GetTopBankAsync(AuthDbContext context)
         {
-            if (BankCache.Count == 0 || BanksLastUpdate < DateTime.Now)
+            if (BankCache.Count == 0 || BanksLastUpdate < DateTime.UtcNow)
             {
-                log.Debug($"Bank Cache miss - Count: {BankCache.Count}, LastUpdate: {BanksLastUpdate:yyyy-MM-dd HH:mm:ss}, Now: {DateTime.Now:yyyy-MM-dd HH:mm:ss}");
+                log.Debug($"Bank Cache miss - Count: {BankCache.Count}, NextUpdate: {BanksLastUpdate:yyyy-MM-dd HH:mm:ss}, Now: {DateTime.UtcNow:yyyy-MM-dd HH:mm:ss}");
                 await _bankCacheSemaphore.WaitAsync();
                 try
                 {
                     // Double-check inside the lock
-                    if (BankCache.Count == 0 || BanksLastUpdate < DateTime.Now)
+                    if (BankCache.Count == 0 || BanksLastUpdate < DateTime.UtcNow)
                     {
                         log.Debug("Bank Cache refresh starting - calling database");
                         var result = await Leaderboard.GetTopBankLeaderboardAsync(context);
@@ -465,21 +590,26 @@ namespace ACE.Database.Models.Auth
             }
             else
             {
-                log.Debug($"Bank Cache hit - using {BankCache.Count} cached records, last updated: {BanksLastUpdate:yyyy-MM-dd HH:mm:ss}");
+                log.Debug($"Bank Cache hit - using {BankCache.Count} cached records, last updated: {BanksLastUpdate:yyyy-MM-dd HH:mm:ss} UTC");
             }
             return BankCache;
         }
 
+        /// <summary>
+        /// Gets the top players by luminance value from cache, refreshing if necessary.
+        /// </summary>
+        /// <param name="context">The database context to use for refreshing the cache.</param>
+        /// <returns>A list of Leaderboard entries sorted by luminance value.</returns>
         public async Task<List<Leaderboard>> GetTopLumAsync(AuthDbContext context)
         {
-            if (LumCache.Count == 0 || LumLastUpdate < DateTime.Now)
+            if (LumCache.Count == 0 || LumLastUpdate < DateTime.UtcNow)
             {
-                log.Debug($"Luminance Cache miss - Count: {LumCache.Count}, LastUpdate: {LumLastUpdate:yyyy-MM-dd HH:mm:ss}, Now: {DateTime.Now:yyyy-MM-dd HH:mm:ss}");
+                log.Debug($"Luminance Cache miss - Count: {LumCache.Count}, NextUpdate: {LumLastUpdate:yyyy-MM-dd HH:mm:ss}, Now: {DateTime.UtcNow:yyyy-MM-dd HH:mm:ss}");
                 await _lumCacheSemaphore.WaitAsync();
                 try
                 {
                     // Double-check inside the lock
-                    if (LumCache.Count == 0 || LumLastUpdate < DateTime.Now)
+                    if (LumCache.Count == 0 || LumLastUpdate < DateTime.UtcNow)
                     {
                         log.Debug("Luminance Cache refresh starting - calling database");
                         var result = await Leaderboard.GetTopLumLeaderboardAsync(context);
@@ -498,21 +628,26 @@ namespace ACE.Database.Models.Auth
             }
             else
             {
-                log.Debug($"Luminance Cache hit - using {LumCache.Count} cached records, last updated: {LumLastUpdate:yyyy-MM-dd HH:mm:ss}");
+                log.Debug($"Luminance Cache hit - using {LumCache.Count} cached records, last updated: {LumLastUpdate:yyyy-MM-dd HH:mm:ss} UTC");
             }
             return LumCache;
         }
 
+        /// <summary>
+        /// Gets the top players by attribute values from cache, refreshing if necessary.
+        /// </summary>
+        /// <param name="context">The database context to use for refreshing the cache.</param>
+        /// <returns>A list of Leaderboard entries sorted by attribute values.</returns>
         public async Task<List<Leaderboard>> GetTopAttrAsync(AuthDbContext context)
         {
-            if (AttrCache.Count == 0 || AttrLastUpdate < DateTime.Now)
+            if (AttrCache.Count == 0 || AttrLastUpdate < DateTime.UtcNow)
             {
-                log.Debug($"Attributes Cache miss - Count: {AttrCache.Count}, LastUpdate: {AttrLastUpdate:yyyy-MM-dd HH:mm:ss}, Now: {DateTime.Now:yyyy-MM-dd HH:mm:ss}");
+                log.Debug($"Attributes Cache miss - Count: {AttrCache.Count}, NextUpdate: {AttrLastUpdate:yyyy-MM-dd HH:mm:ss}, Now: {DateTime.UtcNow:yyyy-MM-dd HH:mm:ss}");
                 await _attrCacheSemaphore.WaitAsync();
                 try
                 {
                     // Double-check inside the lock
-                    if (AttrCache.Count == 0 || AttrLastUpdate < DateTime.Now)
+                    if (AttrCache.Count == 0 || AttrLastUpdate < DateTime.UtcNow)
                     {
                         log.Debug("Attributes Cache refresh starting - calling database");
                         var result = await Leaderboard.GetTopAttrLeaderboardAsync(context);
@@ -531,7 +666,7 @@ namespace ACE.Database.Models.Auth
             }
             else
             {
-                log.Debug($"Attributes Cache hit - using {AttrCache.Count} cached records, last updated: {AttrLastUpdate:yyyy-MM-dd HH:mm:ss}");
+                log.Debug($"Attributes Cache hit - using {AttrCache.Count} cached records, last updated: {AttrLastUpdate:yyyy-MM-dd HH:mm:ss} UTC");
             }
             return AttrCache;
         }

--- a/Source/ACE.Server/Command/Handlers/PlayerCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/PlayerCommands.cs
@@ -1210,105 +1210,104 @@ namespace ACE.Server.Command.Handlers
         [CommandHandler("top", AccessLevel.Player, CommandHandlerFlag.None, "Show current leaderboards", "use top qb to list top quest bonus count, top level to list top character levels, enl for enlightenments")]
         public static async void DisplayTop(Session session, params string[] parameters)
         {
-            List<Leaderboard> list = new List<Leaderboard>();
-            LeaderboardCache cache = LeaderboardCache.Instance;
-            if (parameters.Length < 1)
+            try
             {
-                session.Network.EnqueueSend(new GameMessageSystemChat("[TOP] Specify a leaderboard to run, such as /top qb or /top deaths", ChatMessageType.Broadcast));
-                return;
+                List<Leaderboard> list = new List<Leaderboard>();
+                LeaderboardCache cache = LeaderboardCache.Instance;
+                if (parameters.Length < 1)
+                {
+                    session.Network.EnqueueSend(new GameMessageSystemChat("[TOP] Specify a leaderboard to run, such as /top qb or /top deaths", ChatMessageType.Broadcast));
+                    return;
+                }
+                using (var context = new AuthDbContext())
+                {
+                    var key = parameters[0].ToLowerInvariant();
+                    if (key == "qb")
+                    {
+                        list = await cache.GetTopQBAsync(context);
+                        if (list.Count > 0)
+                        {
+                            session.Network.EnqueueSend(new GameMessageSystemChat("Top 25 Players by Quest Bonus:", ChatMessageType.Broadcast));
+                        }
+                    }
+                    else if (key == "level")
+                    {
+                        list = await cache.GetTopLevelAsync(context);
+                        if (list.Count > 0)
+                        {
+                            session.Network.EnqueueSend(new GameMessageSystemChat("Top 25 Players by Level:", ChatMessageType.Broadcast));
+                        }
+                    }
+                    else if (key == "enl")
+                    {
+                        list = await cache.GetTopEnlAsync(context);
+                        if (list.Count > 0)
+                        {
+                            session.Network.EnqueueSend(new GameMessageSystemChat("Top 25 Players by Enlightenment:", ChatMessageType.Broadcast));
+                        }
+                    }
+                    else if (key == "title")
+                    {
+                        list = await cache.GetTopTitleAsync(context);
+                        if (list.Count > 0)
+                        {
+                            session.Network.EnqueueSend(new GameMessageSystemChat("Top 25 Players by Titles:", ChatMessageType.Broadcast));
+                        }
+                    }
+                    else if (key == "augs")
+                    {
+                        list = await cache.GetTopAugsAsync(context);
+                        if (list.Count > 0)
+                        {
+                            session.Network.EnqueueSend(new GameMessageSystemChat("Top 25 Players by Advanced Augmentations:", ChatMessageType.Broadcast));
+                        }
+                    }
+                    else if (key == "deaths")
+                    {
+                        list = await cache.GetTopDeathsAsync(context);
+                        if (list.Count > 0)
+                        {
+                            session.Network.EnqueueSend(new GameMessageSystemChat("Top 25 Players by Deaths:", ChatMessageType.Broadcast));
+                        }
+                    }
+                    else if (key == "bank")
+                    {
+                        list = await cache.GetTopBankAsync(context);
+                        if (list.Count > 0)
+                        {
+                            session.Network.EnqueueSend(new GameMessageSystemChat("Top 25 Players by Bank Value:", ChatMessageType.Broadcast));
+                        }
+                    }
+                    else if (key == "lum")
+                    {
+                        list = await cache.GetTopLumAsync(context);
+                        if (list.Count > 0)
+                        {
+                            session.Network.EnqueueSend(new GameMessageSystemChat("Top 25 Players by Banked Luminance:", ChatMessageType.Broadcast));
+                        }
+                    }
+                    else if (key == "attr")
+                    {
+                        list = await cache.GetTopAttrAsync(context);
+                        if (list.Count > 0)
+                        {
+                            session.Network.EnqueueSend(new GameMessageSystemChat("Top 25 Players by Raised Attributes:", ChatMessageType.Broadcast));
+                        }
+                    }
+                    else if (key == "gymnos")
+                    {
+                        session.Network.EnqueueSend(new GameMessageSystemChat("Top 1 Player named Gymnos: Gymnos", ChatMessageType.Broadcast));
+                    }
+                }
+
+                for (int i = 0; i < list.Count; i++)
+                {
+                    session.Network.EnqueueSend(new GameMessageSystemChat($"{i + 1}: {list[i].Score:N0} - {list[i].Character}", ChatMessageType.Broadcast));
+                }
             }
-            using (var context = new AuthDbContext())
+            catch (Exception ex)
             {
-                if (parameters[0]?.ToLower() == "qb")
-                {
-                    list = await cache.GetTopQBAsync(context);
-                    if (list.Count > 0)
-                    {
-                        session.Network.EnqueueSend(new GameMessageSystemChat("Top 25 Players by Quest Bonus:", ChatMessageType.Broadcast));
-                    }
-                }
-
-                if (parameters[0]?.ToLower() == "level")
-                {
-                    list = await cache.GetTopLevelAsync(context);
-                    if (list.Count > 0)
-                    {
-                        session.Network.EnqueueSend(new GameMessageSystemChat("Top 25 Players by Level:", ChatMessageType.Broadcast));
-                    }
-                }
-
-                if (parameters[0]?.ToLower() == "enl")
-                {
-                    list = await cache.GetTopEnlAsync(context);
-                    if (list.Count > 0)
-                    {
-                        session.Network.EnqueueSend(new GameMessageSystemChat("Top 25 Players by Enlightenment:", ChatMessageType.Broadcast));
-                    }
-                }
-
-                if (parameters[0]?.ToLower() == "title")
-                {
-                    list = await cache.GetTopTitleAsync(context);
-                    if (list.Count > 0)
-                    {
-                        session.Network.EnqueueSend(new GameMessageSystemChat("Top 25 Players by Titles:", ChatMessageType.Broadcast));
-                    }
-                }
-
-                if (parameters.Length > 0 && parameters[0]?.ToLower() == "augs")
-                {
-                    list = await cache.GetTopAugsAsync(context);
-                    if (list.Count > 0)
-                    {
-                        session.Network.EnqueueSend(new GameMessageSystemChat("Top 25 Players by Advanced Augmentations:", ChatMessageType.Broadcast));
-                    }
-                }
-
-                if (parameters[0]?.ToLower() == "deaths")
-                {
-                    list = await cache.GetTopDeathsAsync(context);
-                    if (list.Count > 0)
-                    {
-                        session.Network.EnqueueSend(new GameMessageSystemChat("Top 25 Players by Deaths:", ChatMessageType.Broadcast));
-                    }
-                }
-
-                if (parameters[0]?.ToLower() == "bank")
-                {
-                    list = await cache.GetTopBankAsync(context);
-                    if (list.Count > 0)
-                    {
-                        session.Network.EnqueueSend(new GameMessageSystemChat("Top 25 Players by Bank Value:", ChatMessageType.Broadcast));
-                    }
-                }
-
-                if (parameters[0]?.ToLower() == "lum")
-                {
-                    list = await cache.GetTopLumAsync(context);
-                    if (list.Count > 0)
-                    {
-                        session.Network.EnqueueSend(new GameMessageSystemChat("Top 25 Players by Banked Luminance:", ChatMessageType.Broadcast));
-                    }
-                }
-
-                if (parameters[0]?.ToLower() == "attr")
-                {
-                    list = await cache.GetTopAttrAsync(context);
-                    if (list.Count > 0)
-                    {
-                        session.Network.EnqueueSend(new GameMessageSystemChat("Top 25 Players by Raised Attributes:", ChatMessageType.Broadcast));
-                    }
-                }
-
-                if (parameters[0]?.ToLower() == "gymnos")
-                {
-                    session.Network.EnqueueSend(new GameMessageSystemChat("Top 1 Player named Gymnos: Gymnos", ChatMessageType.Broadcast));
-                }
-            }
-
-            for (int i = 0; i < list.Count; i++)
-            {
-                session.Network.EnqueueSend(new GameMessageSystemChat($"{i + 1}: {list[i].Score:N0} - {list[i].Character}", ChatMessageType.Broadcast));
+                log.Error($"Error in DisplayTop command: {ex.Message}", ex);
             }
         }
 


### PR DESCRIPTION
Eliminate player lag when using /top commands. Confirmed that a single player refreshing a leaderboard cash will lag all players on the server. 

- All leaderboard queries now use async/await
- Thread-safe cache updates with semaphore protection
- Added caching with a 15-minute timeout and random variance (15–120 seconds) to prevent synchronized refreshes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Leaderboard retrievals and the /top command are now fully asynchronous with an improved, thread-safe cache and better logging, boosting responsiveness for leaderboard queries.
* **Bug Fixes**
  * Reduced server stalls, timeouts, duplicate refreshes and race conditions during cache updates; timestamps standardized to UTC for consistent cache behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->