### PR TITLE
Split arrow damage fix

### DIFF
--- a/Source/ACE.Database/Adapter/BiotaConverter.cs
+++ b/Source/ACE.Database/Adapter/BiotaConverter.cs
@@ -14,6 +14,11 @@ namespace ACE.Database.Adapter
     {
         public static ACE.Entity.Models.Biota ConvertToEntityBiota(ACE.Database.Models.Shard.Biota biota, bool instantiateEmptyCollections = false)
         {
+            if (biota == null)
+            {
+                throw new ArgumentNullException(nameof(biota), "Cannot convert null biota to entity biota");
+            }
+
             var result = new ACE.Entity.Models.Biota();
 
             result.Id = biota.Id;

--- a/Source/ACE.Server/Entity/DamageEvent.cs
+++ b/Source/ACE.Server/Entity/DamageEvent.cs
@@ -19,6 +19,8 @@ namespace ACE.Server.Entity
     public class DamageEvent
     {
         private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+        
+        private const float DefaultSplitArrowDamageMultiplier = 0.6f;
 
         // factors:
         // - lifestone protection
@@ -415,7 +417,8 @@ namespace ACE.Server.Entity
             // Apply split arrow damage multiplier if this is a split arrow
             if (DamageSource.GetProperty(PropertyBool.IsSplitArrow) == true)
             {
-                var splitMultiplier = (float)(DamageSource.ProjectileLauncher?.GetProperty(PropertyFloat.SplitArrowDamageMultiplier) ?? 0.6f);
+                var splitMultiplier = (float)(DamageSource.ProjectileLauncher?.GetProperty(PropertyFloat.SplitArrowDamageMultiplier) ?? 
+                                             DefaultSplitArrowDamageMultiplier);
                 Damage *= splitMultiplier;
             }
 

--- a/Source/ACE.Server/Entity/DamageEvent.cs
+++ b/Source/ACE.Server/Entity/DamageEvent.cs
@@ -254,6 +254,7 @@ namespace ACE.Server.Entity
 
             // damage before mitigation
             DamageBeforeMitigation = BaseDamage * AttributeMod * PowerMod * SlayerMod * DamageRatingMod;
+            
 
             //Console.WriteLine($"[DEBUG] Damage Before Mitigation: {DamageBeforeMitigation}");
 
@@ -320,7 +321,6 @@ namespace ACE.Server.Entity
                     // Calculate damage before mitigation
                     DamageBeforeMitigation = BaseDamageMod.MaxDamage * AttributeMod * PowerMod * SlayerMod * DamageRatingMod * CriticalDamageMod;
 
-                    //Console.WriteLine($"[DEBUG] Damage Before Mitigation (Critical): {DamageBeforeMitigation}");
 
                     CriticalDamageRatingMod = Creature.GetPositiveRatingMod(attacker.GetCritDamageRating());
 
@@ -411,6 +411,13 @@ namespace ACE.Server.Entity
 
             // calculate final output damage
             Damage = DamageBeforeMitigation * ArmorMod * ShieldMod * ResistanceMod * DamageResistanceRatingMod;
+
+            // Apply split arrow damage multiplier if this is a split arrow
+            if (DamageSource.GetProperty(PropertyBool.IsSplitArrow) == true)
+            {
+                var splitMultiplier = (float)(DamageSource.ProjectileLauncher?.GetProperty(PropertyFloat.SplitArrowDamageMultiplier) ?? 0.6f);
+                Damage *= splitMultiplier;
+            }
 
             // NEW: Apply enrage damage reduction to the final output damage if the defender is a mob and enraged
             if (defender.IsEnraged && !(defender is Player))

--- a/Source/ACE.Server/Factories/WorldObjectFactory.cs
+++ b/Source/ACE.Server/Factories/WorldObjectFactory.cs
@@ -263,6 +263,12 @@ namespace ACE.Server.Factories
         /// </summary>
         public static WorldObject CreateWorldObject(Biota databaseBiota)
         {
+            if (databaseBiota == null)
+            {
+                log.Error("CreateWorldObject called with null databaseBiota");
+                return null;
+            }
+
             var biota = ACE.Database.Adapter.BiotaConverter.ConvertToEntityBiota(databaseBiota);
 
             return CreateWorldObject(biota);

--- a/Source/ACE.Server/WorldObjects/Creature_Missile.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Missile.cs
@@ -593,22 +593,6 @@ namespace ACE.Server.WorldObjects
                 // This enables death message modification to prevent VirindiTank kill attribution issues
                 splitProj.SetProperty(PropertyBool.IsSplitArrow, true);
                     
-                    // Reduce damage for split arrows using cached damage multiplier
-                    var damageValue = splitProj.GetProperty(PropertyInt.Damage);
-                    if (damageValue.HasValue)
-                    {
-                        var reducedDamage = (int)(damageValue.Value * damageMultiplier);
-                        
-                        // Skip/destroy projectiles with zero or non-positive reduced damage
-                        if (reducedDamage <= 0)
-                        {
-                            splitProj.Destroy();
-                            continue;
-                        }
-                        
-                        splitProj.SetProperty(PropertyInt.Damage, reducedDamage);
-                    }
-                    
                     // Calculate velocity to new target using the SAME method as main arrows
                     // Each split arrow needs its own aim level and spawn origin based on its target distance
                     var splitAimVelocity = GetAimVelocity(splitTarget, cachedSpeed);


### PR DESCRIPTION
… for null biota that caused me to crash

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented errors when creating world objects or loading creature/templates from missing data.

* **Gameplay Changes**
  * Split-arrow projectiles no longer have their damage reduced on spawn — their damage is consistent at creation.
  * Split-arrow damage is now adjusted dynamically during combat using a defined multiplier (defaults applied when unspecified).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->