### PR TITLE
changed logic for SplitArrowCount so prop represents additional arrows

### DIFF
--- a/Source/ACE.Server/WorldObjects/Creature_Missile.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Missile.cs
@@ -74,7 +74,7 @@ namespace ACE.Server.WorldObjects
         private const float DEFAULT_SPLIT_ARROW_DAMAGE_MULTIPLIER = 0.6f;
         
         // Split arrow validation constants
-        private const int SPLIT_ARROW_COUNT_MIN = 1;
+        private const int SPLIT_ARROW_COUNT_MIN = 0;
         private const int SPLIT_ARROW_COUNT_MAX = 10;
         private const float SPLIT_ARROW_RANGE_MIN = 0f;
         private const float SPLIT_ARROW_RANGE_MAX = 50f;
@@ -149,7 +149,11 @@ namespace ACE.Server.WorldObjects
                 var hasSplitArrows = weapon.GetProperty(PropertyBool.SplitArrows);
                 if (hasSplitArrows == true)
                 {
-                    CreateSplitArrows(weapon, ammo, target, origin, orientation);
+                    var splitCount = weapon.GetProperty(PropertyInt.SplitArrowCount) ?? DEFAULT_SPLIT_ARROW_COUNT;
+                    if (splitCount > 0)
+                    {
+                        CreateSplitArrows(weapon, ammo, target, origin, orientation);
+                    }
                 }
             }
 
@@ -545,7 +549,7 @@ namespace ACE.Server.WorldObjects
                 
                 // Removed verbose debug logging
                 
-                var additionalArrowCount = splitCount - 1; // We already have the main arrow
+                var additionalArrowCount = splitCount; // SplitArrowCount now directly represents number of split arrows to create
                 
                 var validTargets = FindValidSplitTargets(origin, target, splitRange, additionalArrowCount);
                 


### PR DESCRIPTION
This will make the behavior:
SplitArrowCount = 0: Fires only 1 normal arrow
SplitArrowCount = 1: Fires 1 normal + 1 split = 2 total arrows
SplitArrowCount = 2: Fires 1 normal + 2 split = 3 total arrows
etc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Split arrows now compute per-target trajectories with safe spawn offsets and proper world visibility/broadcast behavior.
- Bug Fixes
  - Corrected split arrow count handling (spawns only when count > 0 and creates the intended number).
  - Improved targeting: validates targets, supports cross-zone targets, deduplicates, and enforces forward-angle and PK rules.
  - Prevents invalid or zero-damage projectiles; enhances reliability with robust error handling.
  - Aligns split arrow damage with intended scaling across multiple arrows, reducing unintended over/under-damage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->