### PR TITLE
Fix `/gps` to use `/location`

### DIFF
--- a/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
@@ -703,8 +703,7 @@ namespace ACE.Server.Command.Handlers
         [CommandHandler("gps", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, "Display location.")]
         public static void HandleDebugGPS(Session session, params string[] parameters)
         {
-            var position = session.Player.Location;
-            ChatPacket.SendServerMessage(session, $"Position: [Cell: 0x{position.LandblockId.Landblock:X4} | Offset: {position.PositionX}, {position.PositionY}, {position.PositionZ} | Facing: {position.RotationX}, {position.RotationY}, {position.RotationZ}, {position.RotationW}]", ChatMessageType.Broadcast);
+            PlayerCommands.HandleLocation(session, parameters);
         }
 
 


### PR DESCRIPTION
`/location` which includes the same information plus variation.

This is a simplification / standardization of the call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code organization by centralizing developer command handling logic for GPS/location display functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->