### PR TITLE
Stop recording the action type to the histogram exported to Grafana.

### DIFF
--- a/Source/ACE.Server/Entity/Actions/ActionQueue.cs
+++ b/Source/ACE.Server/Entity/Actions/ActionQueue.cs
@@ -126,10 +126,7 @@ namespace ACE.Server.Entity.Actions
                                 sw.Stop();
                                 var elapsedMs = sw.Elapsed.TotalMilliseconds;
 
-                                var tags = new TagList
-                                {
-                                    { "ActionType", result.Type.ToString() }
-                                };
+                                var tags = new TagList{};
                                 MetricsManager.actionLatencies.Record(elapsedMs * 1000.0, tags);
 
                                 if (elapsedMs >= trackThresholdMs)


### PR DESCRIPTION
Grafana isn't really happy about this - we have something like 30k streams of data being pushed (N histogram buckets * M action tags).  This is far above the free tier limit anyway (10k streams) and it's all being used by a single metric.  Cardinality explosion, so we need to get rid of this.