### PR TITLE
Portal Requirement & XP Multiplier Refactor

### DIFF
--- a/Source/ACE.Entity/Enum/PortalRequirement.cs
+++ b/Source/ACE.Entity/Enum/PortalRequirement.cs
@@ -8,17 +8,7 @@ namespace ACE.Entity.Enum
          LifeAug     = 3,
          Enlighten   = 4,
          QuestBonus  = 5,
+         XPMultiplier = 6,
            
      }
-
-    public enum PortalRequirement2
-    {
-        None = 0,
-        CreatureAug = 1,
-        ItemAug = 2,
-        LifeAug = 3,
-        Enlighten = 4,
-        QuestBonus = 5,
-
-    }
-}
+ }

--- a/Source/ACE.Server/Command/Handlers/PlayerCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/PlayerCommands.cs
@@ -6,26 +6,17 @@ using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
 using ACE.Server.Entity;
 using ACE.Server.Entity.Actions;
-using ACE.Server.Factories.Tables;
 using ACE.Server.Managers;
 using ACE.Server.Network;
 using ACE.Server.Network.GameEvent.Events;
 using ACE.Server.Network.GameMessages.Messages;
 using ACE.Server.WorldObjects;
-using Lifestoned.DataModel.DerethForever;
 using log4net;
-using MySqlX.XDevAPI.Common;
-using Org.BouncyCastle.Utilities.Net;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Timers;
-using System.Xml.Linq;
-using static System.Net.Mime.MediaTypeNames;
-//using ACE.Server.Factories;
-//using Org.BouncyCastle.Ocsp;
-//using System.Diagnostics.Metrics;
 
 namespace ACE.Server.Command.Handlers
 {
@@ -1156,15 +1147,13 @@ namespace ACE.Server.Command.Handlers
         [CommandHandler("bonus", AccessLevel.Player, CommandHandlerFlag.RequiresWorld, 0, "Handles Experience Checks", "Leave blank for level, pass first 3 letters of attribute for specific attribute cost")]
         public static void HandleMultiplier(Session session, params string[] paramters)
         {
-            session.Player.QuestCompletionCount = session.Player.Account.GetCharacterQuestCompletions();
-            var qb = session.Player.GetQuestCountXPBonus();
-            var eq = session.Player.GetXPAndLuminanceModifier(XpType.Kill);
-            var en = session.Player.GetEnglightenmentXPBonus();
-
-            session.Network.EnqueueSend(new GameMessageSystemChat($"[BONUS] Your XP multiplier from Quests is: {qb - 1:P}", ChatMessageType.System));
-            session.Network.EnqueueSend(new GameMessageSystemChat($"[BONUS] Your XP multiplier from Equipment is: {eq - 1:P}", ChatMessageType.System));
-            session.Network.EnqueueSend(new GameMessageSystemChat($"[BONUS] Your XP multiplier from Enlightenment is: {en - 1:P}", ChatMessageType.System));
-            session.Network.EnqueueSend(new GameMessageSystemChat($"[BONUS] Your Total XP multiplier is: {(qb * eq * en) - 1:P}", ChatMessageType.System));
+            var player = session.Player;
+            player.QuestCompletionCount = player.Account.GetCharacterQuestCompletions();
+            
+            session.Network.EnqueueSend(new GameMessageSystemChat($"[BONUS] Your XP multiplier from Quests is: x{player.GetQuestCountXPBonus():N2}", ChatMessageType.System));
+            session.Network.EnqueueSend(new GameMessageSystemChat($"[BONUS] Your XP multiplier from Equipment is: x{player.GetXPAndLuminanceModifier(XpType.Kill):N2}", ChatMessageType.System));
+            session.Network.EnqueueSend(new GameMessageSystemChat($"[BONUS] Your XP multiplier from Enlightenment is: x{player.GetEnglightenmentXPBonus():N2}", ChatMessageType.System));
+            session.Network.EnqueueSend(new GameMessageSystemChat($"[BONUS] Your Total XP multiplier is: x{player.GetTotalXPBonusMultiplier():N2}", ChatMessageType.System));
         }
 
         [CommandHandler("xp", AccessLevel.Player, CommandHandlerFlag.RequiresWorld, 0, "Handles Experience Checks", "Leave blank for level, pass first 3 letters of attribute for specific attribute cost")]

--- a/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
+++ b/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
@@ -233,11 +233,11 @@ namespace ACE.Server.Network.Structure
                     string msg;
 
                     if (req.max.GetValueOrDefault() > 0 && req.max.GetValueOrDefault() != 999 && req.value.GetValueOrDefault() > 0)
-                        msg = $"Restricted to characters of {typeName} between {prefix}{req.value.Value.ToString("D2")} and {prefix}{req.max.Value.ToString(format)}.";
+                        msg = $"Restricted to characters of {typeName} between {prefix}{req.value.Value} and {prefix}{req.max.Value}.";
                     else if (req.value.GetValueOrDefault() > 0)
-                        msg = $"Restricted to characters of {typeName} {prefix}{req.value.Value.ToString(format)} or greater.";
+                        msg = $"Restricted to characters of {typeName} {prefix}{req.value.Value} or greater.";
                     else
-                        msg = $"Restricted to characters of {typeName} {prefix}{req.max.Value.ToString(format)} or lower.";
+                        msg = $"Restricted to characters of {typeName} {prefix}{req.max.Value} or lower.";
 
                     if (PropertiesString.ContainsKey(PropertyString.LongDesc))
                         PropertiesString[PropertyString.LongDesc] += $"\n\n{msg}";

--- a/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
+++ b/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
@@ -204,6 +204,47 @@ namespace ACE.Server.Network.Structure
                         PropertiesString[PropertyString.LongDesc] = msg;
                 }
 
+                var reqs = new (PortalRequirement type, int? value, int? max)[]
+                {
+                    (portal.PortalReqType, portal.PortalReqValue, portal.PortalReqMaxValue),
+                    (portal.PortalReqType2, portal.PortalReqValue2, portal.PortalReqMaxValue2)
+                };
+
+                foreach (var req in reqs)
+                {
+                    if (req.type == PortalRequirement.None) continue;
+                    if (req.value.GetValueOrDefault() <= 0 && (req.max.GetValueOrDefault() <= 0 || req.max.GetValueOrDefault() == 999)) continue;
+
+                    string typeName;
+                    bool isMultiplier = false;
+
+                    switch (req.type)
+                    {
+                        case PortalRequirement.CreatureAug: typeName = "Creature Augmentations"; break;
+                        case PortalRequirement.ItemAug: typeName = "Item Augmentations"; break;
+                        case PortalRequirement.LifeAug: typeName = "Life Augmentations"; break;
+                        case PortalRequirement.Enlighten: typeName = "Enlightenment"; break;
+                        case PortalRequirement.QuestBonus: typeName = "Quest Bonus"; break;
+                        case PortalRequirement.XPMultiplier: typeName = "XP Multiplier"; isMultiplier = true; break;
+                        default: continue;
+                    }
+
+                    var prefix = isMultiplier ? "x" : "";
+                    string msg;
+
+                    if (req.max.GetValueOrDefault() > 0 && req.max.GetValueOrDefault() != 999 && req.value.GetValueOrDefault() > 0)
+                        msg = $"Restricted to characters of {typeName} between {prefix}{req.value} and {prefix}{req.max}.";
+                    else if (req.value.GetValueOrDefault() > 0)
+                        msg = $"Restricted to characters of {typeName} {prefix}{req.value} or greater.";
+                    else
+                        msg = $"Restricted to characters of {typeName} {prefix}{req.max} or lower.";
+
+                    if (PropertiesString.ContainsKey(PropertyString.LongDesc))
+                        PropertiesString[PropertyString.LongDesc] += $"\n\n{msg}";
+                    else
+                        PropertiesString[PropertyString.LongDesc] = msg;
+                }
+
                 var timeToRot = portal.TimeToRot;
                 if (timeToRot.HasValue && timeToRot.Value != -1) // -1 is a special value meaning "Never"
                 {

--- a/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
+++ b/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
@@ -233,11 +233,11 @@ namespace ACE.Server.Network.Structure
                     string msg;
 
                     if (req.max.GetValueOrDefault() > 0 && req.max.GetValueOrDefault() != 999 && req.value.GetValueOrDefault() > 0)
-                        msg = $"Restricted to characters of {typeName} between {prefix}{req.value} and {prefix}{req.max}.";
+                        msg = $"Restricted to characters of {typeName} between {prefix}{req.value.Value.ToString("D2")} and {prefix}{req.max.Value.ToString(format)}.";
                     else if (req.value.GetValueOrDefault() > 0)
-                        msg = $"Restricted to characters of {typeName} {prefix}{req.value} or greater.";
+                        msg = $"Restricted to characters of {typeName} {prefix}{req.value.Value.ToString(format)} or greater.";
                     else
-                        msg = $"Restricted to characters of {typeName} {prefix}{req.max} or lower.";
+                        msg = $"Restricted to characters of {typeName} {prefix}{req.max.Value.ToString(format)} or lower.";
 
                     if (PropertiesString.ContainsKey(PropertyString.LongDesc))
                         PropertiesString[PropertyString.LongDesc] += $"\n\n{msg}";

--- a/Source/ACE.Server/WorldObjects/Player_Xp.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Xp.cs
@@ -723,5 +723,10 @@ namespace ACE.Server.WorldObjects
         {
             return 1 + (this.Enlightenment * enlightenmentToBonusRatio);
         }
+
+        public double GetTotalXPBonusMultiplier()
+        {
+            return GetQuestCountXPBonus() * GetXPAndLuminanceModifier(XpType.Kill) * GetEnglightenmentXPBonus();
+        }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Portal.cs
+++ b/Source/ACE.Server/WorldObjects/Portal.cs
@@ -236,16 +236,14 @@ namespace ACE.Server.WorldObjects
 
                 if (PortalReqType != PortalRequirement.None && PortalReqValue.GetValueOrDefault() > 0)
                 {
-                    // Primary requirement check
                     if (!CheckPortalRequirement(player, PortalReqType, PortalReqValue.GetValueOrDefault(), PortalReqMaxValue.GetValueOrDefault(), "Primary Requirement"))
                         return new ActivationResult(false);
+                }
 
-                    // Secondary requirement check
-                    if (PortalReqType2 != PortalRequirement.None && PortalReqValue2.GetValueOrDefault() > 0)
-                    {
-                        if (!CheckPortalRequirement(player, PortalReqType2, PortalReqValue2.GetValueOrDefault(), PortalReqMaxValue2.GetValueOrDefault(), "Secondary Requirement"))
-                            return new ActivationResult(false);
-                    }
+                if (PortalReqType2 != PortalRequirement.None && PortalReqValue2.GetValueOrDefault() > 0)
+                {
+                    if (!CheckPortalRequirement(player, PortalReqType2, PortalReqValue2.GetValueOrDefault(), PortalReqMaxValue2.GetValueOrDefault(), "Secondary Requirement"))
+                        return new ActivationResult(false);
                 }
             }
 
@@ -285,43 +283,43 @@ namespace ACE.Server.WorldObjects
                 case PortalRequirement.CreatureAug:
                     if (player.LuminanceAugmentCreatureCount < reqValue)
                         message = $"You must augment your creature magic {reqValue} times to interact with that portal!";
-                    else if (reqMaxValue > reqValue && player.LuminanceAugmentCreatureCount > reqMaxValue)
+                    else if (reqMaxValue > reqValue && reqMaxValue != 999 && player.LuminanceAugmentCreatureCount > reqMaxValue)
                         message = $"You have augmented your creature magic more than {reqMaxValue} times and cannot interact with that portal!";
                     break;
 
                 case PortalRequirement.ItemAug:
                     if (player.LuminanceAugmentItemCount < reqValue)
                         message = $"You must augment your item magic {reqValue} times to interact with that portal!";
-                    else if (reqMaxValue > reqValue && player.LuminanceAugmentItemCount > reqMaxValue)
+                    else if (reqMaxValue > reqValue && reqMaxValue != 999 && player.LuminanceAugmentItemCount > reqMaxValue)
                         message = $"You have augmented your item magic more than {reqMaxValue} times and cannot interact with that portal!";
                     break;
 
                 case PortalRequirement.LifeAug:
                     if (player.LuminanceAugmentLifeCount < reqValue)
                         message = $"You must augment your life magic {reqValue} times to interact with that portal!";
-                    else if (reqMaxValue > reqValue && player.LuminanceAugmentLifeCount > reqMaxValue)
+                    else if (reqMaxValue > reqValue && reqMaxValue != 999 && player.LuminanceAugmentLifeCount > reqMaxValue)
                         message = $"You have augmented your life magic more than {reqMaxValue} times and cannot interact with that portal!";
                     break;
 
                 case PortalRequirement.Enlighten:
                     if (player.Enlightenment < reqValue)
                         message = $"You must enlighten {reqValue} times to interact with that portal!";
-                    else if (reqMaxValue > reqValue && player.Enlightenment > reqMaxValue)
+                    else if (reqMaxValue > reqValue && reqMaxValue != 999 && player.Enlightenment > reqMaxValue)
                         message = $"You have enlightened more than {reqMaxValue} times and cannot interact with that portal!";
                     break;
 
                 case PortalRequirement.QuestBonus:
                     if (player.QuestCompletionCount < reqValue)
                         message = $"You must have {reqValue} quest bonus to interact with that portal!";
-                    else if (reqMaxValue > reqValue && player.QuestCompletionCount > reqMaxValue)
+                    else if (reqMaxValue > reqValue && reqMaxValue != 999 && player.QuestCompletionCount > reqMaxValue)
                         message = $"Your quest bonus is too superior to interact with this portal. {reqMaxValue} is the highest quest bonus allowable!";
                     break;
 
                 case PortalRequirement.XPMultiplier:
-                    var bonusMultiplier = (long)player.GetTotalXPBonusMultiplier();
+                    double bonusMultiplier = player.GetTotalXPBonusMultiplier();
                     if (bonusMultiplier < reqValue)
                         message = $"You must have a XP bonus multiplier of x{reqValue} to interact with that portal!";
-                    else if (reqMaxValue > reqValue && bonusMultiplier > reqMaxValue)
+                    else if (reqMaxValue > reqValue && reqMaxValue != 999 && bonusMultiplier > reqMaxValue)
                         message = $"Your XP bonus multiplier is too high to interact with this portal. x{reqMaxValue} is the highest allowable!";
                     break;
 

--- a/Source/ACE.Server/WorldObjects/Portal.cs
+++ b/Source/ACE.Server/WorldObjects/Portal.cs
@@ -241,7 +241,7 @@ namespace ACE.Server.WorldObjects
                         return new ActivationResult(false);
 
                     // Secondary requirement check
-                    if (PortalReqType2 != PortalRequirement2.None && PortalReqValue2.GetValueOrDefault() > 0)
+                    if (PortalReqType2 != PortalRequirement.None && PortalReqValue2.GetValueOrDefault() > 0)
                     {
                         if (!CheckPortalRequirement(player, PortalReqType2, PortalReqValue2.GetValueOrDefault(), PortalReqMaxValue2.GetValueOrDefault(), "Secondary Requirement"))
                             return new ActivationResult(false);
@@ -276,15 +276,13 @@ namespace ACE.Server.WorldObjects
             return new ActivationResult(true);
         }
 
-        private static bool CheckPortalRequirement(Player player, Enum reqType, int reqValue, int reqMaxValue, string requirementLabel)
+        private static bool CheckPortalRequirement(Player player, PortalRequirement reqType, int reqValue, int reqMaxValue, string requirementLabel)
         {
             string message = string.Empty;
 
-            // Use a switch-case to handle both PortalRequirement and PortalRequirement2
             switch (reqType)
             {
                 case PortalRequirement.CreatureAug:
-                case PortalRequirement2.CreatureAug:
                     if (player.LuminanceAugmentCreatureCount < reqValue)
                         message = $"You must augment your creature magic {reqValue} times to interact with that portal!";
                     else if (reqMaxValue > reqValue && player.LuminanceAugmentCreatureCount > reqMaxValue)
@@ -292,7 +290,6 @@ namespace ACE.Server.WorldObjects
                     break;
 
                 case PortalRequirement.ItemAug:
-                case PortalRequirement2.ItemAug:
                     if (player.LuminanceAugmentItemCount < reqValue)
                         message = $"You must augment your item magic {reqValue} times to interact with that portal!";
                     else if (reqMaxValue > reqValue && player.LuminanceAugmentItemCount > reqMaxValue)
@@ -300,7 +297,6 @@ namespace ACE.Server.WorldObjects
                     break;
 
                 case PortalRequirement.LifeAug:
-                case PortalRequirement2.LifeAug:
                     if (player.LuminanceAugmentLifeCount < reqValue)
                         message = $"You must augment your life magic {reqValue} times to interact with that portal!";
                     else if (reqMaxValue > reqValue && player.LuminanceAugmentLifeCount > reqMaxValue)
@@ -308,7 +304,6 @@ namespace ACE.Server.WorldObjects
                     break;
 
                 case PortalRequirement.Enlighten:
-                case PortalRequirement2.Enlighten:
                     if (player.Enlightenment < reqValue)
                         message = $"You must enlighten {reqValue} times to interact with that portal!";
                     else if (reqMaxValue > reqValue && player.Enlightenment > reqMaxValue)
@@ -316,11 +311,18 @@ namespace ACE.Server.WorldObjects
                     break;
 
                 case PortalRequirement.QuestBonus:
-                case PortalRequirement2.QuestBonus:
                     if (player.QuestCompletionCount < reqValue)
                         message = $"You must have {reqValue} quest bonus to interact with that portal!";
                     else if (reqMaxValue > reqValue && player.QuestCompletionCount > reqMaxValue)
                         message = $"Your quest bonus is too superior to interact with this portal. {reqMaxValue} is the highest quest bonus allowable!";
+                    break;
+
+                case PortalRequirement.XPMultiplier:
+                    var bonusMultiplier = (long)player.GetTotalXPBonusMultiplier();
+                    if (bonusMultiplier < reqValue)
+                        message = $"You must have a XP bonus multiplier of x{reqValue} to interact with that portal!";
+                    else if (reqMaxValue > reqValue && bonusMultiplier > reqMaxValue)
+                        message = $"Your XP bonus multiplier is too high to interact with this portal. x{reqMaxValue} is the highest allowable!";
                     break;
 
                 default:

--- a/Source/ACE.Server/WorldObjects/Portal.cs
+++ b/Source/ACE.Server/WorldObjects/Portal.cs
@@ -234,13 +234,13 @@ namespace ACE.Server.WorldObjects
                     return new ActivationResult(new GameEventWeenieError(player.Session, WeenieError.YouMustBeAnAdvocateToUsePortal));
                 }
 
-                if (PortalReqType != PortalRequirement.None && PortalReqValue.GetValueOrDefault() > 0)
+                if (PortalReqType != PortalRequirement.None && (PortalReqValue.GetValueOrDefault() > 0 || (PortalReqMaxValue.GetValueOrDefault() > 0 && PortalReqMaxValue.GetValueOrDefault() != 999)))
                 {
                     if (!CheckPortalRequirement(player, PortalReqType, PortalReqValue.GetValueOrDefault(), PortalReqMaxValue.GetValueOrDefault(), "Primary Requirement"))
                         return new ActivationResult(false);
                 }
 
-                if (PortalReqType2 != PortalRequirement.None && PortalReqValue2.GetValueOrDefault() > 0)
+                if (PortalReqType2 != PortalRequirement.None && (PortalReqValue2.GetValueOrDefault() > 0 || (PortalReqMaxValue2.GetValueOrDefault() > 0 && PortalReqMaxValue2.GetValueOrDefault() != 999)))
                 {
                     if (!CheckPortalRequirement(player, PortalReqType2, PortalReqValue2.GetValueOrDefault(), PortalReqMaxValue2.GetValueOrDefault(), "Secondary Requirement"))
                         return new ActivationResult(false);

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -2548,10 +2548,10 @@ namespace ACE.Server.WorldObjects
             set { if (!value.HasValue) RemoveProperty(PropertyInt.PortalReqMaxValue); else SetProperty(PropertyInt.PortalReqMaxValue, value.Value); }
         }
 
-        public PortalRequirement2 PortalReqType2
+        public PortalRequirement PortalReqType2
         {
-            get => (PortalRequirement2)(GetProperty(PropertyInt.PortalReqType2) ?? 0);
-            set { if (value == PortalRequirement2.None) RemoveProperty(PropertyInt.PortalReqType2); else SetProperty(PropertyInt.PortalReqType2, (int)value); }
+            get => (PortalRequirement)(GetProperty(PropertyInt.PortalReqType2) ?? 0);
+            set { if (value == PortalRequirement.None) RemoveProperty(PropertyInt.PortalReqType2); else SetProperty(PropertyInt.PortalReqType2, (int)value); }
         }
 
         public int? PortalReqValue2


### PR DESCRIPTION
This PR streamlines the portal restriction system and modernizes the XP bonus display for better clarity:

*   **XP Multipliers**: Refactored the bonus system to use raw multipliers (e.g., `x40.35`) instead of percentages in the `/bonus` command for clarity.
*   **Unified Enums**: Merged `PortalRequirement` and `PortalRequirement2` into a single unified enum.
*   **UX Improvements**: Implemented client-style phrasing (*"Restricted to characters of..."*) for all portal requirements in the Identify panel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Portals can require an overall XP multiplier to enter.
  * Portal descriptions now list all restrictions (augments, quest bonuses, XP multipliers).
  * `/bonus` command shows multipliers as clearer x-prefixed, two-decimal values and reports total multiplier.

* **Refactor**
  * Portal requirement checks and XP bonus calculation/reporting have been simplified and centralized for more consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->