### PR TITLE
TimeSpanExtensions update

### DIFF
--- a/Source/ACE.Common/Extensions/TimeSpanExtensions.cs
+++ b/Source/ACE.Common/Extensions/TimeSpanExtensions.cs
@@ -7,11 +7,10 @@ namespace ACE.Common.Extensions
     {
         public static string GetFriendlyString(this TimeSpan timeSpan)
         {
-            int totalMs = (int)timeSpan.TotalMilliseconds;
-            if (totalMs < 1000)
+            if (timeSpan < TimeSpan.FromSeconds(1))
             {
-                if (totalMs >= 1) return $"{totalMs}ms";
-                if (totalMs < 0) return "negative time";
+                if (timeSpan > TimeSpan.FromMilliseconds(1)) return $"{timeSpan.TotalMilliseconds}ms";
+                if (timeSpan < TimeSpan.Zero) return "negative time";
                 return "0s";
             }
 
@@ -31,11 +30,10 @@ namespace ACE.Common.Extensions
 
         public static string GetFriendlyLongString(this TimeSpan timeSpan)
         {
-            int totalMs = (int)timeSpan.TotalMilliseconds;
-            if (totalMs < 1000)
+            if (timeSpan < TimeSpan.FromSeconds(1))
             {
-                if (totalMs >= 1) return $"{totalMs} millisecond{((totalMs > 1) ? "s" : "")}";
-                if (totalMs < 0) return "negative time";
+                if (timeSpan > TimeSpan.FromMilliseconds(1)) return $"{timeSpan.TotalMilliseconds} millisecond{((timeSpan.TotalMilliseconds > 1) ? "s" : "")}";
+                if (timeSpan < TimeSpan.Zero) return "negative time";
                 return "0 seconds";
             }
 

--- a/Source/ACE.Common/Extensions/TimeSpanExtensions.cs
+++ b/Source/ACE.Common/Extensions/TimeSpanExtensions.cs
@@ -7,10 +7,13 @@ namespace ACE.Common.Extensions
     {
         public static string GetFriendlyString(this TimeSpan timeSpan)
         {
-            // use datetime here?
-            // this probably won't work with numDays...
-            //var numYears = timeSpan.GetYears();
-            //var numMonths = timeSpan.GetMonths();
+            int totalMs = (int)timeSpan.TotalMilliseconds;
+            if (totalMs < 1000)
+            {
+                if (totalMs >= 1) return $"{totalMs}ms";
+                if (totalMs < 0) return "negative time";
+                return "0s";
+            }
 
             var numDays = timeSpan.ToString("%d");
             var numHours = timeSpan.ToString("%h");
@@ -18,12 +21,6 @@ namespace ACE.Common.Extensions
             var numSeconds = timeSpan.ToString("%s");
 
             var sb = new StringBuilder();
-
-            // did retail display months/years?
-
-            //if (numYears > 0) sb.Append(numYears + "y ");
-            //if (numMonths > 0) sb.Append(numMonths + "mo ");
-
             if (numDays != "0") sb.Append(numDays + "d ");
             if (numHours != "0") sb.Append(numHours + "h ");
             if (numMinutes != "0") sb.Append(numMinutes + "m ");
@@ -34,13 +31,20 @@ namespace ACE.Common.Extensions
 
         public static string GetFriendlyLongString(this TimeSpan timeSpan)
         {
+            int totalMs = (int)timeSpan.TotalMilliseconds;
+            if (totalMs < 1000)
+            {
+                if (totalMs >= 1) return $"{totalMs} millisecond{((totalMs > 1) ? "s" : "")}";
+                if (totalMs < 0) return "negative time";
+                return "0 seconds";
+            }
+
             var numDays = timeSpan.ToString("%d");
             var numHours = timeSpan.ToString("%h");
             var numMinutes = timeSpan.ToString("%m");
             var numSeconds = timeSpan.ToString("%s");
 
             var sb = new StringBuilder();
-
             if (numDays != "0") sb.Append(numDays + $" day{((timeSpan.Days > 1) ? "s" : "")} ");
             if (numHours != "0") sb.Append($"{((numDays != "0") ? ", " : "")}" + numHours + $" hour{((timeSpan.Hours > 1) ? "s" : "")} ");
             if (numMinutes != "0") sb.Append($"{((numDays != "0" || numHours != "0") ? ", " : "")}" + numMinutes + $" minute{((timeSpan.Minutes > 1) ? "s" : "")} ");


### PR DESCRIPTION
Updated TimeSpanExtensions to provide millisecond precision in GetFriendlyString and GetFriendlyLongString for sub-1-second durations. Added a 0 seconds and negative time fallback for durations under 1 millisecond.

This avoids returning a blank string for sub-1-second spans.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duration display for very short intervals: durations under 1 second now show millisecond precision (e.g., "123ms") instead of rounding to seconds.
  * Better handling of edge cases: zero durations display "0s"/"0 seconds" and negative durations now show a clear "negative time" indicator; long-form pluralization is handled correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->