### PR TITLE
Web Portal Skill and Stat Fixes

### DIFF
--- a/Source/ACE.Server/Controllers/CharacterController.cs
+++ b/Source/ACE.Server/Controllers/CharacterController.cs
@@ -1,27 +1,23 @@
-using ACE.Common.Extensions;
 using ACE.Database;
 using ACE.Database.Adapter;
-using ACE.Database.Entity;
-using ACE.Database.Models.Auth;
 using ACE.Database.Models.Shard;
 using ACE.DatLoader;
+using ACE.DatLoader.Entity;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
 using ACE.Entity.Models;
 using ACE.Server.Entity;
 using ACE.Server.Managers;
-using ACE.Server.Network.Enum;
 using ACE.Server.Network.GameMessages.Messages;
 using ACE.Server.Web.Controllers;
 using ACE.Server.WorldObjects;
-using Google.Protobuf.WellKnownTypes;
-using Lifestoned.DataModel.Gdle;
+using ACE.Server.WorldObjects.Entity;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Security.Claims;
+using System.Numerics;
 using System.Threading.Tasks;
 
 using Biota = ACE.Entity.Models.Biota;
@@ -47,12 +43,20 @@ namespace ACE.Server.Controllers
          *     and maximizing concurrency.
          */
 
-        private struct StatValue
+        private class StatValue
         {
-            public uint Innate { get; set; }
-            public uint Ranks { get; set; }
-            public uint Total { get; set; }
+            public uint Innate { get; set; } = 0;
+            public uint Ranks { get; set; } = 0;
+            public uint Total { get; set; } = 0;
         }
+        private class SkillValue
+        {
+            public string Name { get; set; } = "";
+            public string Sac { get; set; } = "";
+            public bool isUsable { get; set; } = true;
+            public uint Base { get; set; } = 0;
+            public uint Total { get; set; } = 0;
+        };
 
         [HttpGet("list")]
         public IActionResult GetList()
@@ -209,10 +213,11 @@ namespace ACE.Server.Controllers
         [HttpGet("stats/{guid}")]
         public IActionResult GetStats(uint guid)
         {
-            if (!IsAuthorizedForCharacter(guid, out var player))
+            if (!IsAuthorizedForCharacter(guid, out IPlayer player))
                 return Unauthorized();
 
             var snapshot = GetBiotaSnapshot(player);
+            Player online = player as Player;
 
             return Ok(new
             {
@@ -220,26 +225,26 @@ namespace ACE.Server.Controllers
                 enlightenment = snapshot.GetProperty(PropertyInt.Enlightenment) ?? 0,
                 attributes = new
                 {
-                    strength = GetAttribute(snapshot, PropertyAttribute.Strength),
-                    endurance = GetAttribute(snapshot, PropertyAttribute.Endurance),
-                    quickness = GetAttribute(snapshot, PropertyAttribute.Quickness),
-                    coordination = GetAttribute(snapshot, PropertyAttribute.Coordination),
-                    focus = GetAttribute(snapshot, PropertyAttribute.Focus),
-                    self = GetAttribute(snapshot, PropertyAttribute.Self)
+                    strength = GetAttribute(player, snapshot, PropertyAttribute.Strength),
+                    endurance = GetAttribute(player, snapshot, PropertyAttribute.Endurance),
+                    quickness = GetAttribute(player, snapshot, PropertyAttribute.Quickness),
+                    coordination = GetAttribute(player, snapshot, PropertyAttribute.Coordination),
+                    focus = GetAttribute(player, snapshot, PropertyAttribute.Focus),
+                    self = GetAttribute(player, snapshot, PropertyAttribute.Self)
                 },
                 vitals = new
                 {
-                    health = GetVital(snapshot, PropertyAttribute2nd.MaxHealth),
-                    stamina = GetVital(snapshot, PropertyAttribute2nd.MaxStamina),
-                    mana = GetVital(snapshot, PropertyAttribute2nd.MaxMana)
+                    health = GetVital(player, snapshot, PropertyAttribute2nd.MaxHealth),
+                    stamina = GetVital(player, snapshot, PropertyAttribute2nd.MaxStamina),
+                    mana = GetVital(player, snapshot, PropertyAttribute2nd.MaxMana)
                 },
                 ratings = new
                 {
-                    emd = GetEMD(player), // EMD still needs authoritative engine check for online
-                    dr = snapshot.GetProperty(PropertyInt.DamageResistRating) ?? 0,
-                    cdr = snapshot.GetProperty(PropertyInt.CritDamageResistRating) ?? 0,
-                    damage = snapshot.GetProperty(PropertyInt.DamageRating) ?? 0,
-                    critDamage = snapshot.GetProperty(PropertyInt.CritDamageRating) ?? 0
+                    emd = online != null ? online.GetEffectiveDefenseSkill(CombatType.Melee) : (uint?)null,
+                    damage = online != null ? online.GetDamageRating() : (int?)null,
+                    critDamage = online != null ? online.GetCritDamageRating() : (int?)null,
+                    dr = online != null ? online.GetDamageResistRating() : (int?)null,
+                    cdr = online != null ? online.GetCritDamageResistRating() : (int?)null,
                 },
                 augmentations = GetAugmentations(snapshot),
                 bank = GetBankedProperties(snapshot)
@@ -253,51 +258,10 @@ namespace ACE.Server.Controllers
                 return Unauthorized();
 
             var snapshot = GetBiotaSnapshot(player);
-            var result = new List<object>();
             var validSkills = SkillHelper.ValidSkills.OrderBy(s => s.ToString());
 
-            foreach (var skillEnum in validSkills)
-            {
-                var skillName = skillEnum.ToSentence();
-                var sac = SkillAdvancementClass.Untrained;
-                var baseVal = 0;
-                int? total = 0;
-                var isUsable = false;
-
-                if (snapshot.PropertiesSkill != null && snapshot.PropertiesSkill.TryGetValue(skillEnum, out var skillProp))
-                {
-                    sac = skillProp.SAC;
-                    baseVal = (int)(skillProp.InitLevel + skillProp.LevelFromPP);
-                    
-                    if (sac == SkillAdvancementClass.Trained || sac == SkillAdvancementClass.Specialized)
-                        isUsable = true;
-                }
-                
-                // Calculate skill formula base
-                if (DatManager.PortalDat.SkillTable.SkillBaseHash.TryGetValue((uint)skillEnum, out var skillTableRecord))
-                {
-                    baseVal += (int)AttributeFormula.GetFormula(snapshot, skillTableRecord.Formula);
-
-                    if (sac == SkillAdvancementClass.Untrained)
-                        isUsable = skillTableRecord.MinLevel == 1;
-                }
-
-                // If online, we can show the authoritative 'Current' value
-                if (player is Player online && online.Skills.TryGetValue(skillEnum, out var creatureSkill))
-                    total = (int)creatureSkill.Current;
-                else
-                    total = null;
-
-                result.Add(new
-                {
-                    name = skillName,
-                    sac = sac.ToString(),
-                    @base = baseVal,
-                    total = total,
-                    isUsable = isUsable
-                });
-            }
-
+            var result = new List<object>();
+            foreach (Skill skill in validSkills) result.Add(GetSkill(player, snapshot, skill));
             return Ok(result);
         }
 
@@ -411,26 +375,12 @@ namespace ACE.Server.Controllers
             return Ok(new { message = "Administrative logout signal sent" });
         }
 
-        private double? GetEMD(IPlayer player)
-        {
-            if (player is Player online)
-            {
-                // Use the server's native defense skill calculation for online players
-                // This includes weapon bonuses, enchantments, and stance modifiers
-                return online.GetEffectiveDefenseSkill(CombatType.Melee);
-            }
-            
-            // Effective Melee Defense requires authoritative engine calculation (weapon/shield buffs etc)
-            // so we return null for offline players
-            return null;
-        }
-
         private bool IsAuthorizedForCharacter(uint guid, out IPlayer player)
         {
             player = null;
             if (CurrentAccountId == null) return false;
 
-            var p = PlayerManager.FindByGuid(guid);
+            IPlayer p = PlayerManager.FindByGuid(guid);
             if (p == null) return false;
 
             // Check if this character belongs to the account
@@ -487,7 +437,24 @@ namespace ACE.Server.Controllers
             throw new InvalidOperationException("Unknown player type");
         }
 
-        private StatValue GetAttribute(Biota snapshot, PropertyAttribute attr)
+        private static StatValue GetAttribute(IPlayer player, Biota snapshot, PropertyAttribute attr)
+        {
+            if (player is Player online) return GetOnlineAttribute(online, attr);
+            return GetOfflineAttribute(snapshot, attr);
+        }
+
+        private static StatValue GetOnlineAttribute(Player player, PropertyAttribute attr)
+        {
+            if (!player.Attributes.TryGetValue(attr, out CreatureAttribute creatureAttribute)) return new();
+            return new StatValue
+            {
+                Innate = creatureAttribute.StartingValue,
+                Ranks = creatureAttribute.Ranks,
+                Total = creatureAttribute.Current
+            };
+        }
+
+        private static StatValue GetOfflineAttribute(Biota snapshot, PropertyAttribute attr)
         {
             if (snapshot.PropertiesAttribute == null) return new();
             if (!snapshot.PropertiesAttribute.TryGetValue(attr, out PropertiesAttribute prop)) return new();
@@ -499,17 +466,113 @@ namespace ACE.Server.Controllers
             };
         }
 
-        private static StatValue GetVital(Biota snapshot, PropertyAttribute2nd vital)
+        private static StatValue GetVital(IPlayer player, Biota snapshot, PropertyAttribute2nd vital)
         {
-            if (snapshot.PropertiesAttribute2nd == null) return new();
-            if (!snapshot.PropertiesAttribute2nd.TryGetValue(vital, out PropertiesAttribute2nd prop)) return new();
+            if (player is Player online) return GetOnlineVital(online, vital);
+            return GetOfflineVital(snapshot, vital);
+        }
+        private static StatValue GetOnlineVital(Player player, PropertyAttribute2nd vital)
+        {
+            if (!player.Vitals.TryGetValue(vital, out CreatureVital creatureVital)) return new();
             return new StatValue
             {
-                Innate = AttributeFormula.GetFormula(snapshot, vital),
-                Ranks = prop.LevelFromCP,
-                Total = prop.CurrentLevel
+                // Base includes Ranks (which is its own field) and GearBonus (not innate)
+                Innate = creatureVital.Base - creatureVital.Ranks - creatureVital.GearBonus,
+                Ranks = creatureVital.Ranks,
+                Total = creatureVital.MaxValue
             };
+        }
+        private static StatValue GetOfflineVital(Biota snapshot, PropertyAttribute2nd vital)
+        {
+            StatValue statValue = new();
+            if (snapshot.PropertiesAttribute2nd == null) return statValue;
+            if (!snapshot.PropertiesAttribute2nd.TryGetValue(vital, out PropertiesAttribute2nd prop)) return statValue;
 
+            // Innate
+            statValue.Innate =
+                prop.InitLevel
+                + AttributeFormula.GetFormula(snapshot, vital)
+                + ((vital == PropertyAttribute2nd.MaxHealth) ? ((uint)(snapshot.GetProperty(PropertyInt.Enlightenment) ?? 0) * 2) : 0);
+
+            // Ranks
+            statValue.Ranks = prop.LevelFromCP;
+
+            // Total
+            statValue.Total =
+                statValue.Innate
+                + statValue.Ranks
+                + ((vital == PropertyAttribute2nd.MaxHealth) ? ((uint)(snapshot.GetProperty(PropertyInt.GearMaxHealth) ?? 0)) : 0);
+
+            return statValue;
+        }
+
+        private static SkillValue GetSkill(IPlayer player, Biota snapshot, Skill skill)
+        {
+            if (player is Player online) return GetOnlineSkill(online, skill);
+            return GetOfflineSkill(snapshot, skill);
+        }
+        private static SkillValue GetOnlineSkill(Player player, Skill skill)
+        {
+            if (!player.Skills.TryGetValue(skill, out CreatureSkill creatureSkill)) return new();
+            return new SkillValue
+            {
+                Name = skill.ToSentence(),
+                Sac = creatureSkill.AdvancementClass.ToString(),
+                isUsable = creatureSkill.IsUsable,
+                Base = creatureSkill.Base,
+                Total = creatureSkill.Current
+            };
+        }
+        private static SkillValue GetOfflineSkill(Biota snapshot, Skill skill)
+        {
+            SkillValue skillValue = new()
+            {
+                Name = skill.ToSentence(),
+                Sac = SkillAdvancementClass.Untrained.ToString(),
+            };
+            if (snapshot.PropertiesSkill == null) return skillValue;
+            if (!snapshot.PropertiesSkill.TryGetValue(skill, out PropertiesSkill prop)) return skillValue;
+
+            skillValue.Sac = prop.SAC.ToString();
+            skillValue.isUsable = true;
+
+            if (prop.SAC == SkillAdvancementClass.Untrained)
+            {
+                DatManager.PortalDat.SkillTable.SkillBaseHash.TryGetValue((uint)skill, out SkillBase skillTableRecord);
+                if (skillTableRecord?.MinLevel != 1) skillValue.isUsable = false;
+            }
+
+            if (!skillValue.isUsable)
+            {
+                skillValue.Base = 0;
+                skillValue.Total = 0;
+            }
+            else
+            {
+                uint fromAttributes = AttributeFormula.GetFormula(snapshot, skill);
+                uint enlBonus = (prop.SAC >= SkillAdvancementClass.Trained ? (uint)(snapshot.GetProperty(PropertyInt.Enlightenment) ?? 0) : 0);
+                uint augBaseBonus =
+                    (uint)(snapshot.GetProperty(PropertyInt.LumAugAllSkills) ?? 0)
+                    + (Player.MeleeSkills.Contains(skill) ? (uint)(10 * (snapshot.GetProperty(PropertyInt.AugmentationSkilledMelee) ?? 0)) : 0)
+                    + (Player.MissileSkills.Contains(skill) ? (uint)(10 * (snapshot.GetProperty(PropertyInt.AugmentationSkilledMissile) ?? 0)) : 0)
+                    + (Player.MagicSkills.Contains(skill) ? (uint)(10 * (snapshot.GetProperty(PropertyInt.AugmentationSkilledMagic) ?? 0)) : 0);
+                uint augTotalBonus =
+                    (uint)(5 * (snapshot.GetProperty(PropertyInt.AugmentationJackOfAllTrades) ?? 0))
+                    + (prop.SAC >= SkillAdvancementClass.Specialized ? (uint)(2 * (snapshot.GetProperty(PropertyInt.LumAugSkilledSpec) ?? 0)) : 0);
+
+                skillValue.Base =
+                    prop.InitLevel +
+                    + fromAttributes
+                    + prop.LevelFromPP
+                    + augBaseBonus
+                    + enlBonus;
+
+                skillValue.Total =
+                    skillValue.Base
+                    + augTotalBonus;
+            }
+
+            return skillValue;
         }
     }
 }

--- a/Source/ACE.Server/Controllers/CharacterController.cs
+++ b/Source/ACE.Server/Controllers/CharacterController.cs
@@ -145,7 +145,7 @@ namespace ACE.Server.Controllers
 
             var online = PlayerManager.GetAllOnline();
             var result = online.Select(p => {
-                var isAdmin = p.Account.AccessLevel > 0;
+                var isAdmin = (p.Account?.AccessLevel ?? 0) > 0;
                 var charName = isAdmin && !p.Name.StartsWith("+") ? $"+{p.Name}" : p.Name;
                 return new
                 {
@@ -175,7 +175,7 @@ namespace ACE.Server.Controllers
             var result = stubs.Select(s =>
             {
                 var player = PlayerManager.FindByGuid(s.Id);
-                var isAdmin = player.Account.AccessLevel > 0;
+                var isAdmin = (player?.Account?.AccessLevel ?? 0) > 0;
                 var charName = isAdmin && !s.Name.StartsWith("+") ? $"+{s.Name}" : s.Name;
 
                 return new
@@ -194,9 +194,9 @@ namespace ACE.Server.Controllers
         public IActionResult GetDetail(uint guid)
         {
             if (!IsAuthorizedForCharacter(guid, out IPlayer player)) return Unauthorized();
-
-            var isAdmin = player.Account.AccessLevel > 0;
-            var charName = isAdmin && !player.Name.StartsWith("+") ? $"+{player.Name}" : player.Name;
+            
+            var isAdmin = (player?.Account?.AccessLevel ?? 0) > 0;
+            var charName = isAdmin && !player?.Name.StartsWith("+") == true ? $"+{player?.Name}" : player?.Name;
 
             return Ok(new
             {
@@ -274,7 +274,7 @@ namespace ACE.Server.Controllers
             player = null;
             if (CurrentAccountId == null) return false;
             IPlayer p = PlayerManager.FindByGuid(guid);
-            if (p == null) return false;
+            if (p == null || p.Account == null) return false;
             if (!IsAuthorizedForAccount(p.Account.AccountId)) return false;
             player = p;
             return true;

--- a/Source/ACE.Server/Controllers/CharacterController.cs
+++ b/Source/ACE.Server/Controllers/CharacterController.cs
@@ -30,57 +30,107 @@ namespace ACE.Server.Controllers
     public class CharacterController : BaseController
     {
         /*
-         *  ARCHITECTURAL NOTE: THE SNAPSHOT PATTERN
-         *  ----------------------------------------
-         *  To ensure thread-safety and high performance for the Web Portal, we use a 
-         *  "Captured Snapshot" pattern for character data retrieval.
+         *  ARCHITECTURAL NOTE: AUTHORITATIVE ATOMIC PLUCKING
+         *  -------------------------------------------------
+         *  To ensure thread-safety and high performance without the overhead of deep clones,
+         *  we use an "Authoritative Atomic Plucking" pattern for character data retrieval.
          *  
-         *  1. GetBiotaSnapshot(player): Enters the character's BiotaDatabaseLock once,
-         *     performs a deep clone of the Biota properties, and exits.
-         *  2. JSON Generation: The rest of the request works on this private 'clone'.
-         *  3. Lock-Free Logic: Because the clone is isolated, we use the lock-free 
-         *     IWeenieExtensions for all lookups, avoiding complex lock recursion 
-         *     and maximizing concurrency.
+         *  1. Discrete Locking: We enter the character's BiotaDatabaseLock briefly to pluck 
+         *     raw property values or internal dictionary references.
+         *  2. Pluck and Release: The lock is released immediately after extraction.
+         *  3. Authoritative Engines: Calculations (Attributes, Skills, Vitals) that call 
+         *     into authoritative server engines (and acquire their own locks) are performed 
+         *     OUTSIDE the controller-level lock to prevent LockRecursionException.
          */
 
-        private class StatValue
+        private class StatValueDto
         {
             public uint Innate { get; set; } = 0;
             public uint Ranks { get; set; } = 0;
             public uint Total { get; set; } = 0;
         }
-        private class SkillValue
+
+        private class SkillValueDto
         {
             public string Name { get; set; } = "";
             public string Sac { get; set; } = "";
             public bool isUsable { get; set; } = true;
             public uint Base { get; set; } = 0;
             public uint Total { get; set; } = 0;
-        };
+        }
+
+        private class CharacterStatsDto
+        {
+            public int Level { get; set; }
+            public int Enlightenment { get; set; }
+            public StatAttributesDto Attributes { get; set; } = new();
+            public StatVitalsDto Vitals { get; set; } = new();
+            public StatRatingsDto Ratings { get; set; } = new();
+            public Dictionary<string, long> Augmentations { get; set; } = new();
+            public Dictionary<string, long> Bank { get; set; } = new();
+        }
+
+        private class StatAttributesDto
+        {
+            public StatValueDto Strength { get; set; } = new();
+            public StatValueDto Endurance { get; set; } = new();
+            public StatValueDto Quickness { get; set; } = new();
+            public StatValueDto Coordination { get; set; } = new();
+            public StatValueDto Focus { get; set; } = new();
+            public StatValueDto Self { get; set; } = new();
+        }
+
+        private class StatVitalsDto
+        {
+            public StatValueDto Health { get; set; } = new();
+            public StatValueDto Stamina { get; set; } = new();
+            public StatValueDto Mana { get; set; } = new();
+        }
+
+        private class StatRatingsDto
+        {
+            public uint? Emd { get; set; }
+            public int? Damage { get; set; }
+            public int? CritDamage { get; set; }
+            public int? Dr { get; set; }
+            public int? Cdr { get; set; }
+        }
+
+        private class InventoryItemDto
+        {
+            public uint Guid { get; set; }
+            public uint ContainerGuid { get; set; }
+            public uint WeenieType { get; set; }
+            public bool RequiresBackpackSlot { get; set; }
+            public bool IsContainer { get; set; }
+            public string Name { get; set; }
+            public int Wcid { get; set; }
+            public int StackSize { get; set; }
+            public bool IsEquipped { get; set; }
+            public uint IconId { get; set; }
+            public uint IconUnderlayId { get; set; }
+            public uint IconOverlayId { get; set; }
+            public uint IconOverlaySecondaryId { get; set; }
+            public uint ItemType { get; set; }
+            public uint UiEffects { get; set; }
+        }
 
         [HttpGet("list")]
         public IActionResult GetList()
         {
             var accountId = CurrentAccountId;
-            if (accountId == null)
-                return Unauthorized();
-
-            var account = DatabaseManager.Authentication.GetAccountById(accountId.Value);
-            var isAdmin = account?.AccessLevel > 0;
+            if (accountId == null) return Unauthorized();
 
             var characters = DatabaseManager.Shard.BaseDatabase.GetCharacters(accountId.Value, false);
             var result = characters.Select(c => {
-                var iPlayer = PlayerManager.FindByGuid(c.Id);
+                var isAdmin = c.IsPlussed;
                 var charName = isAdmin && !c.Name.StartsWith("+") ? $"+{c.Name}" : c.Name;
-
                 return new
                 {
                     guid = c.Id,
                     name = charName,
-                    level = iPlayer?.Level ?? 0,
-                    enlightenment = iPlayer?.GetProperty(PropertyInt.Enlightenment) ?? 0,
                     isOnline = PlayerManager.GetOnlinePlayer(c.Id) != null,
-                    isAdmin = isAdmin
+                    isAdmin
                 };
             });
 
@@ -101,49 +151,14 @@ namespace ACE.Server.Controllers
                 {
                     guid = p.Guid.Full,
                     name = charName,
-                    level = p.Level ?? 0,
-                    enlightenment = p.GetProperty(PropertyInt.Enlightenment) ?? 0,
-                    isAdmin = isAdmin
+                    isOnline = true,
+                    isAdmin
                 };
             });
 
             return Ok(result.OrderBy(r => r.name));
         }
 
-        [HttpGet("search-offline/{name}")]
-        public IActionResult SearchOffline(string name)
-        {
-            if (!IsAdmin)
-                return Unauthorized();
-
-            if (string.IsNullOrWhiteSpace(name))
-                return Ok(new List<object>());
-
-            // Search only characters who are not currently online
-            var stubs = DatabaseManager.Shard.BaseDatabase.GetCharacterStubsByPartialName(name)
-                .Where(s => PlayerManager.GetOnlinePlayer(s.Id) == null)
-                .Select(s => {
-                    var iPlayer = PlayerManager.FindByGuid(s.Id);
-                    var accessLevel = 0;
-                    if (iPlayer is Player online) accessLevel = (int)online.Account.AccessLevel;
-                    else if (iPlayer is OfflinePlayer offline) accessLevel = (int)offline.Account.AccessLevel;
-
-                    var isAdminChar = accessLevel > 0;
-                    var charName = isAdminChar && !s.Name.StartsWith("+") ? $"+{s.Name}" : s.Name;
-
-                    return new
-                    {
-                        guid = s.Id,
-                        name = charName,
-                        level = iPlayer?.Level ?? 0,
-                        enlightenment = iPlayer?.GetProperty(PropertyInt.Enlightenment) ?? 0,
-                        isOnline = false,
-                        isAdmin = isAdminChar
-                    };
-                });
-
-            return Ok(stubs);
-        }
 
         [HttpGet("search-all/{name}")]
         public IActionResult SearchAll(string name)
@@ -159,23 +174,16 @@ namespace ACE.Server.Controllers
             
             var result = stubs.Select(s =>
             {
-                var isOnline = PlayerManager.GetOnlinePlayer(s.Id) != null;
                 var player = PlayerManager.FindByGuid(s.Id);
-                var accessLevel = 0;
-                if (player is Player online) accessLevel = (int)online.Account.AccessLevel;
-                else if (player is OfflinePlayer offline) accessLevel = (int)offline.Account.AccessLevel;
-
-                var isAdminChar = accessLevel > 0;
-                var charName = isAdminChar && !s.Name.StartsWith("+") ? $"+{s.Name}" : s.Name;
+                var isAdmin = player.Account.AccessLevel > 0;
+                var charName = isAdmin && !s.Name.StartsWith("+") ? $"+{s.Name}" : s.Name;
 
                 return new
                 {
                     guid = s.Id,
                     name = charName,
-                    level = player?.Level ?? 0,
-                    enlightenment = player?.GetProperty(PropertyInt.Enlightenment) ?? 0,
-                    isOnline,
-                    isAdmin = isAdminChar
+                    isOnline = PlayerManager.GetOnlinePlayer(s.Id) != null,
+                    isAdmin
                 };
             });
 
@@ -185,173 +193,59 @@ namespace ACE.Server.Controllers
         [HttpGet("detail/{guid}")]
         public IActionResult GetDetail(uint guid)
         {
-            if (!IsAuthorizedForCharacter(guid, out var player))
-                return Unauthorized();
+            if (!IsAuthorizedForCharacter(guid, out IPlayer player)) return Unauthorized();
 
-            var snapshot = GetBiotaSnapshot(player);
-            var level = snapshot.GetProperty(PropertyInt.Level) ?? 0;
-            var enlightenment = snapshot.GetProperty(PropertyInt.Enlightenment) ?? 0;
-            
-            var accessLevel = 0;
-            if (player is Player pOnline) accessLevel = (int)pOnline.Account.AccessLevel;
-            else if (player is OfflinePlayer pOffline) accessLevel = (int)pOffline.Account.AccessLevel;
-            var isAdminChar = accessLevel > 0;
-            var charName = isAdminChar && !player.Name.StartsWith("+") ? $"+{player.Name}" : player.Name;
+            var isAdmin = player.Account.AccessLevel > 0;
+            var charName = isAdmin && !player.Name.StartsWith("+") ? $"+{player.Name}" : player.Name;
 
             return Ok(new
             {
                 guid,
                 name = charName,
-                level,
-                enlightenment,
-                augmentations = GetAugmentations(snapshot),
                 isOnline = PlayerManager.GetOnlinePlayer(guid) != null,
-                isAdmin = isAdminChar
+                isAdmin
             });
         }
 
         [HttpGet("stats/{guid}")]
         public IActionResult GetStats(uint guid)
         {
-            if (!IsAuthorizedForCharacter(guid, out IPlayer player))
-                return Unauthorized();
+            if (!IsAuthorizedForCharacter(guid, out IPlayer player)) return Unauthorized();
 
-            var snapshot = GetBiotaSnapshot(player);
-            Player online = player as Player;
-
-            return Ok(new
-            {
-                level = snapshot.GetProperty(PropertyInt.Level) ?? 0,
-                enlightenment = snapshot.GetProperty(PropertyInt.Enlightenment) ?? 0,
-                attributes = new
-                {
-                    strength = GetAttribute(player, snapshot, PropertyAttribute.Strength),
-                    endurance = GetAttribute(player, snapshot, PropertyAttribute.Endurance),
-                    quickness = GetAttribute(player, snapshot, PropertyAttribute.Quickness),
-                    coordination = GetAttribute(player, snapshot, PropertyAttribute.Coordination),
-                    focus = GetAttribute(player, snapshot, PropertyAttribute.Focus),
-                    self = GetAttribute(player, snapshot, PropertyAttribute.Self)
-                },
-                vitals = new
-                {
-                    health = GetVital(player, snapshot, PropertyAttribute2nd.MaxHealth),
-                    stamina = GetVital(player, snapshot, PropertyAttribute2nd.MaxStamina),
-                    mana = GetVital(player, snapshot, PropertyAttribute2nd.MaxMana)
-                },
-                ratings = new
-                {
-                    emd = online != null ? online.GetEffectiveDefenseSkill(CombatType.Melee) : (uint?)null,
-                    damage = online != null ? online.GetDamageRating() : (int?)null,
-                    critDamage = online != null ? online.GetCritDamageRating() : (int?)null,
-                    dr = online != null ? online.GetDamageResistRating() : (int?)null,
-                    cdr = online != null ? online.GetCritDamageResistRating() : (int?)null,
-                },
-                augmentations = GetAugmentations(snapshot),
-                bank = GetBankedProperties(snapshot)
-            });
+            if (player is Player online)
+                return Ok(GetOnlineStats(online));
+            else
+                return Ok(GetOfflineStats(RetrieveBiota(player)));
         }
 
         [HttpGet("skills/{guid}")]
         public IActionResult GetSkills(uint guid)
         {
-            if (!IsAuthorizedForCharacter(guid, out var player))
-                return Unauthorized();
+            if (!IsAuthorizedForCharacter(guid, out IPlayer player)) return Unauthorized();
 
-            var snapshot = GetBiotaSnapshot(player);
-            var validSkills = SkillHelper.ValidSkills.OrderBy(s => s.ToString());
-
-            var result = new List<object>();
-            foreach (Skill skill in validSkills) result.Add(GetSkill(player, snapshot, skill));
-            return Ok(result);
+            if (player is Player online)
+                return Ok(GetOnlineSkills(online));
+            else
+                return Ok(GetOfflineSkills(RetrieveBiota(player)));
         }
 
         [HttpGet("inventory/{guid}")]
         public IActionResult GetInventory(uint guid)
         {
-            if (!IsAuthorizedForCharacter(guid, out var player))
-                return Unauthorized();
+            if (!IsAuthorizedForCharacter(guid, out IPlayer player)) return Unauthorized();
 
-            var inventoryItems = new List<Biota>();
-            var onlinePlayer = PlayerManager.GetOnlinePlayer(guid);
-
-            HashSet<uint> equippedIds;
-
-            if (onlinePlayer != null)
-            {
-                // Memory-First: Get live inventory
-                onlinePlayer.BiotaDatabaseLock.EnterReadLock();
-                try
-                {
-                    CollectInventoryRecursive(onlinePlayer, inventoryItems);
-                }
-                finally { onlinePlayer.BiotaDatabaseLock.ExitReadLock(); }
-
-                equippedIds = new HashSet<uint>(onlinePlayer.EquippedObjects.Keys.Select(g => g.Full));
-            }
+            if (player is Player online)
+                return Ok(GetOnlineInventory(online));
             else
-            {
-                // Offline: Fallback to Shard database
-                var possessedBiotas = DatabaseManager.Shard.BaseDatabase.GetPossessedBiotasInParallel(guid);
-                foreach (var dbBiom in possessedBiotas.Inventory.Concat(possessedBiotas.WieldedItems))
-                    inventoryItems.Add(BiotaConverter.ConvertToEntityBiota(dbBiom));
-
-                equippedIds = new HashSet<uint>(possessedBiotas.WieldedItems.Select(w => w.Id));
-            }
-
-            var result = inventoryItems.Select(biom => new
-            {
-                guid = biom.Id,
-                containerGuid = biom.GetProperty(PropertyInstanceId.Container) ?? 0,
-                weenieType = (uint)biom.WeenieType,
-                requiresBackpackSlot = biom.RequiresBackpackSlotOrIsContainer(),
-                isContainer = biom.WeenieType == WeenieType.Container,
-                name = biom.GetProperty(PropertyString.Name) ?? "Unknown Item",
-                wcid = biom.WeenieClassId,
-                stackSize = biom.GetProperty(PropertyInt.StackSize) ?? 1,
-                isEquipped = equippedIds.Contains(biom.Id),
-                iconId = biom.GetProperty(PropertyDataId.Icon) ?? 0,
-                iconUnderlayId = biom.GetProperty(PropertyDataId.IconUnderlay) ?? 0,
-                iconOverlayId = biom.GetProperty(PropertyDataId.IconOverlay) ?? 0,
-                iconOverlaySecondaryId = biom.GetProperty(PropertyDataId.IconOverlaySecondary) ?? 0,
-                itemType = (uint)biom.GetItemType(),
-                uiEffects = biom.GetProperty(PropertyInt.UiEffects) ?? 0
-            });
-
-            return Ok(result.OrderBy(i => i.name));
-        }
-
-        private void CollectInventoryRecursive(Container container, List<Biota> items)
-        {
-            // Add items in this container
-            foreach (var wo in container.Inventory.Values)
-            {
-                items.Add(wo.Biota.Clone()); // Isolated clone for snapshot
-
-                if (wo is Container subContainer)
-                    CollectInventoryRecursive(subContainer, items);
-            }
-
-            // Also add equipped items if this is a creature/player
-            if (container is Creature creature)
-            {
-                foreach (var eq in creature.EquippedObjects.Values)
-                    items.Add(eq.Biota.Clone());
-            }
+                return Ok(GetOfflineInventory(guid));
         }
         
         [HttpGet("stamps/{guid}")]
         public IActionResult GetStamps(uint guid)
         {
-            if (!IsAuthorizedForCharacter(guid, out var player))
-                return Unauthorized();
+            if (!IsAuthorizedForCharacter(guid, out IPlayer player)) return Unauthorized();
 
-            uint accountId = 0;
-            if (player is Player online)
-                accountId = online.Session.AccountId;
-            else if (player is OfflinePlayer offline)
-                accountId = offline.Account.AccountId;
-
-            var stamps = DatabaseManager.Authentication.GetAccountQuests(accountId)
+            var stamps = DatabaseManager.Authentication.GetAccountQuests(player.Account.AccountId)
                 .Where(q => q.NumTimesCompleted >= 1)
                 .Select(q => q.Quest)
                 .Distinct()
@@ -379,54 +273,44 @@ namespace ACE.Server.Controllers
         {
             player = null;
             if (CurrentAccountId == null) return false;
-
             IPlayer p = PlayerManager.FindByGuid(guid);
             if (p == null) return false;
-
-            // Check if this character belongs to the account
-            uint playerAccountId = 0;
-            if (p is Player online)
-                playerAccountId = online.Session.AccountId;
-            else if (p is OfflinePlayer offline)
-                playerAccountId = offline.Account.AccountId;
-
-            if (!IsAuthorizedForAccount(playerAccountId)) return false;
-
+            if (!IsAuthorizedForAccount(p.Account.AccountId)) return false;
             player = p;
             return true;
         }
 
-        private Dictionary<string, long> GetBankedProperties(Biota snapshot)
+        private static Dictionary<string, long> GetBankedProperties(Biota biota)
         {
             return new Dictionary<string, long>
             {
-                ["Pyreals"] = snapshot.GetProperty(PropertyInt64.BankedPyreals) ?? 0,
-                ["Luminance"] = snapshot.GetProperty(PropertyInt64.BankedLuminance) ?? 0,
-                ["EnlightenedCoins"] = snapshot.GetProperty(PropertyInt64.BankedEnlightenedCoins) ?? 0,
-                ["WeaklyEnlightenedCoins"] = snapshot.GetProperty(PropertyInt64.BankedWeaklyEnlightenedCoins) ?? 0,
-                ["LegendaryKeys"] = snapshot.GetProperty(PropertyInt64.BankedLegendaryKeys) ?? 0,
-                ["MythicalKeys"] = snapshot.GetProperty(PropertyInt64.BankedMythicalKeys) ?? 0
+                ["Pyreals"] = biota.GetProperty(PropertyInt64.BankedPyreals) ?? 0,
+                ["Luminance"] = biota.GetProperty(PropertyInt64.BankedLuminance) ?? 0,
+                ["EnlightenedCoins"] = biota.GetProperty(PropertyInt64.BankedEnlightenedCoins) ?? 0,
+                ["WeaklyEnlightenedCoins"] = biota.GetProperty(PropertyInt64.BankedWeaklyEnlightenedCoins) ?? 0,
+                ["LegendaryKeys"] = biota.GetProperty(PropertyInt64.BankedLegendaryKeys) ?? 0,
+                ["MythicalKeys"] = biota.GetProperty(PropertyInt64.BankedMythicalKeys) ?? 0
             };
         }
 
-        private Dictionary<string, long> GetAugmentations(Biota snapshot)
+        private static Dictionary<string, long> GetAugmentations(Biota biota)
         {
             return new Dictionary<string, long>
             {
-                ["Creature"] = snapshot.GetProperty(PropertyInt64.LumAugCreatureCount) ?? 0,
-                ["Item"] = snapshot.GetProperty(PropertyInt64.LumAugItemCount) ?? 0,
-                ["Life"] = snapshot.GetProperty(PropertyInt64.LumAugLifeCount) ?? 0,
-                ["War"] = snapshot.GetProperty(PropertyInt64.LumAugWarCount) ?? 0,
-                ["Void"] = snapshot.GetProperty(PropertyInt64.LumAugVoidCount) ?? 0,
-                ["Duration"] = snapshot.GetProperty(PropertyInt64.LumAugDurationCount) ?? 0,
-                ["Specialize"] = snapshot.GetProperty(PropertyInt64.LumAugSpecializeCount) ?? 0,
-                ["Summon"] = snapshot.GetProperty(PropertyInt64.LumAugSummonCount) ?? 0,
-                ["Melee"] = snapshot.GetProperty(PropertyInt64.LumAugMeleeCount) ?? 0,
-                ["Missile"] = snapshot.GetProperty(PropertyInt64.LumAugMissileCount) ?? 0
+                ["Creature"] = biota.GetProperty(PropertyInt64.LumAugCreatureCount) ?? 0,
+                ["Item"] = biota.GetProperty(PropertyInt64.LumAugItemCount) ?? 0,
+                ["Life"] = biota.GetProperty(PropertyInt64.LumAugLifeCount) ?? 0,
+                ["War"] = biota.GetProperty(PropertyInt64.LumAugWarCount) ?? 0,
+                ["Void"] = biota.GetProperty(PropertyInt64.LumAugVoidCount) ?? 0,
+                ["Duration"] = biota.GetProperty(PropertyInt64.LumAugDurationCount) ?? 0,
+                ["Specialize"] = biota.GetProperty(PropertyInt64.LumAugSpecializeCount) ?? 0,
+                ["Summon"] = biota.GetProperty(PropertyInt64.LumAugSummonCount) ?? 0,
+                ["Melee"] = biota.GetProperty(PropertyInt64.LumAugMeleeCount) ?? 0,
+                ["Missile"] = biota.GetProperty(PropertyInt64.LumAugMissileCount) ?? 0
             };
         }
 
-        private Biota GetBiotaSnapshot(IPlayer player)
+        private static Biota RetrieveBiota(IPlayer player)
         {
             if (player is Player online)
                 return online.Biota.Clone(online.BiotaDatabaseLock);
@@ -437,16 +321,10 @@ namespace ACE.Server.Controllers
             throw new InvalidOperationException("Unknown player type");
         }
 
-        private static StatValue GetAttribute(IPlayer player, Biota snapshot, PropertyAttribute attr)
-        {
-            if (player is Player online) return GetOnlineAttribute(online, attr);
-            return GetOfflineAttribute(snapshot, attr);
-        }
-
-        private static StatValue GetOnlineAttribute(Player player, PropertyAttribute attr)
+        private static StatValueDto GetOnlineAttribute(Player player, PropertyAttribute attr)
         {
             if (!player.Attributes.TryGetValue(attr, out CreatureAttribute creatureAttribute)) return new();
-            return new StatValue
+            return new StatValueDto
             {
                 Innate = creatureAttribute.StartingValue,
                 Ranks = creatureAttribute.Ranks,
@@ -454,11 +332,11 @@ namespace ACE.Server.Controllers
             };
         }
 
-        private static StatValue GetOfflineAttribute(Biota snapshot, PropertyAttribute attr)
+        private static StatValueDto GetOfflineAttribute(Biota biota, PropertyAttribute attr)
         {
-            if (snapshot.PropertiesAttribute == null) return new();
-            if (!snapshot.PropertiesAttribute.TryGetValue(attr, out PropertiesAttribute prop)) return new();
-            return new StatValue
+            if (biota.PropertiesAttribute == null) return new();
+            if (!biota.PropertiesAttribute.TryGetValue(attr, out PropertiesAttribute prop)) return new();
+            return new StatValueDto
             {
                 Innate = prop.InitLevel,
                 Ranks = prop.LevelFromCP,
@@ -466,33 +344,30 @@ namespace ACE.Server.Controllers
             };
         }
 
-        private static StatValue GetVital(IPlayer player, Biota snapshot, PropertyAttribute2nd vital)
-        {
-            if (player is Player online) return GetOnlineVital(online, vital);
-            return GetOfflineVital(snapshot, vital);
-        }
-        private static StatValue GetOnlineVital(Player player, PropertyAttribute2nd vital)
+        private static StatValueDto GetOnlineVital(Player player, PropertyAttribute2nd vital)
         {
             if (!player.Vitals.TryGetValue(vital, out CreatureVital creatureVital)) return new();
-            return new StatValue
+            uint removeFromBase = creatureVital.Ranks + creatureVital.GearBonus;
+            return new StatValueDto
             {
                 // Base includes Ranks (which is its own field) and GearBonus (not innate)
-                Innate = creatureVital.Base - creatureVital.Ranks - creatureVital.GearBonus,
+                Innate = removeFromBase > creatureVital.Base ? 0 : creatureVital.Base - removeFromBase,
                 Ranks = creatureVital.Ranks,
                 Total = creatureVital.MaxValue
             };
         }
-        private static StatValue GetOfflineVital(Biota snapshot, PropertyAttribute2nd vital)
+
+        private static StatValueDto GetOfflineVital(Biota biota, PropertyAttribute2nd vital)
         {
-            StatValue statValue = new();
-            if (snapshot.PropertiesAttribute2nd == null) return statValue;
-            if (!snapshot.PropertiesAttribute2nd.TryGetValue(vital, out PropertiesAttribute2nd prop)) return statValue;
+            StatValueDto statValue = new();
+            if (biota.PropertiesAttribute2nd == null) return statValue;
+            if (!biota.PropertiesAttribute2nd.TryGetValue(vital, out PropertiesAttribute2nd prop)) return statValue;
 
             // Innate
             statValue.Innate =
                 prop.InitLevel
-                + AttributeFormula.GetFormula(snapshot, vital)
-                + ((vital == PropertyAttribute2nd.MaxHealth) ? ((uint)(snapshot.GetProperty(PropertyInt.Enlightenment) ?? 0) * 2) : 0);
+                + AttributeFormula.GetFormula(biota, vital)
+                + ((vital == PropertyAttribute2nd.MaxHealth) ? ((uint)(biota.GetProperty(PropertyInt.Enlightenment) ?? 0) * 2) : 0);
 
             // Ranks
             statValue.Ranks = prop.LevelFromCP;
@@ -501,70 +376,217 @@ namespace ACE.Server.Controllers
             statValue.Total =
                 statValue.Innate
                 + statValue.Ranks
-                + ((vital == PropertyAttribute2nd.MaxHealth) ? ((uint)(snapshot.GetProperty(PropertyInt.GearMaxHealth) ?? 0)) : 0);
+                + ((vital == PropertyAttribute2nd.MaxHealth) ? ((uint)(biota.GetProperty(PropertyInt.GearMaxHealth) ?? 0)) : 0);
 
             return statValue;
         }
 
-        private static SkillValue GetSkill(IPlayer player, Biota snapshot, Skill skill)
+        private static CharacterStatsDto GetOnlineStats(Player online)
         {
-            if (player is Player online) return GetOnlineSkill(online, skill);
-            return GetOfflineSkill(snapshot, skill);
-        }
-        private static SkillValue GetOnlineSkill(Player player, Skill skill)
-        {
-            if (!player.Skills.TryGetValue(skill, out CreatureSkill creatureSkill)) return new();
-            return new SkillValue
-            {
-                Name = skill.ToSentence(),
-                Sac = creatureSkill.AdvancementClass.ToString(),
-                isUsable = creatureSkill.IsUsable,
-                Base = creatureSkill.Base,
-                Total = creatureSkill.Current
-            };
-        }
-        private static SkillValue GetOfflineSkill(Biota snapshot, Skill skill)
-        {
-            SkillValue skillValue = new()
-            {
-                Name = skill.ToSentence(),
-                Sac = SkillAdvancementClass.Untrained.ToString(),
-            };
-            if (snapshot.PropertiesSkill == null) return skillValue;
-            if (!snapshot.PropertiesSkill.TryGetValue(skill, out PropertiesSkill prop)) return skillValue;
+            var stats = new CharacterStatsDto();
 
-            skillValue.Sac = prop.SAC.ToString();
-            skillValue.isUsable = true;
-
-            if (prop.SAC == SkillAdvancementClass.Untrained)
+            // DISCRETE PLUCKING:
+            // We use a brief lock for raw property extraction, but release it before
+            // calling authoritative engine methods (Attributes, Vitals, Ratings) 
+            // to avoid LockRecursionException in ACE's non-recursive locks.
+            online.BiotaDatabaseLock.EnterReadLock();
+            try
             {
-                DatManager.PortalDat.SkillTable.SkillBaseHash.TryGetValue((uint)skill, out SkillBase skillTableRecord);
-                if (skillTableRecord?.MinLevel != 1) skillValue.isUsable = false;
+                stats.Level = online.Level ?? 0;
+                stats.Enlightenment = online.GetProperty(PropertyInt.Enlightenment) ?? 0;
+                stats.Bank = GetBankedProperties(online.Biota);
+                stats.Augmentations = GetAugmentations(online.Biota);
+            }
+            finally { online.BiotaDatabaseLock.ExitReadLock(); }
+
+            // Authoritative engine calls - MUST be outside the lock
+            stats.Attributes.Strength = GetOnlineAttribute(online, PropertyAttribute.Strength);
+            stats.Attributes.Endurance = GetOnlineAttribute(online, PropertyAttribute.Endurance);
+            stats.Attributes.Quickness = GetOnlineAttribute(online, PropertyAttribute.Quickness);
+            stats.Attributes.Coordination = GetOnlineAttribute(online, PropertyAttribute.Coordination);
+            stats.Attributes.Focus = GetOnlineAttribute(online, PropertyAttribute.Focus);
+            stats.Attributes.Self = GetOnlineAttribute(online, PropertyAttribute.Self);
+            
+            stats.Vitals.Health = GetOnlineVital(online, PropertyAttribute2nd.MaxHealth);
+            stats.Vitals.Stamina = GetOnlineVital(online, PropertyAttribute2nd.MaxStamina);
+            stats.Vitals.Mana = GetOnlineVital(online, PropertyAttribute2nd.MaxMana);
+
+            stats.Ratings.Emd = online.GetEffectiveDefenseSkill(CombatType.Melee);
+            stats.Ratings.Damage = online.GetDamageRating();
+            stats.Ratings.CritDamage = online.GetCritDamageRating();
+            stats.Ratings.Dr = online.GetDamageResistRating();
+            stats.Ratings.Cdr = online.GetCritDamageResistRating();
+
+            return stats;
+        }
+
+        private static CharacterStatsDto GetOfflineStats(Biota biota)
+        {
+            var stats = new CharacterStatsDto();
+            stats.Level = biota.GetProperty(PropertyInt.Level) ?? 0;
+            stats.Enlightenment = biota.GetProperty(PropertyInt.Enlightenment) ?? 0;
+            stats.Attributes.Strength = GetOfflineAttribute(biota, PropertyAttribute.Strength);
+            stats.Attributes.Endurance = GetOfflineAttribute(biota, PropertyAttribute.Endurance);
+            stats.Attributes.Quickness = GetOfflineAttribute(biota, PropertyAttribute.Quickness);
+            stats.Attributes.Coordination = GetOfflineAttribute(biota, PropertyAttribute.Coordination);
+            stats.Attributes.Focus = GetOfflineAttribute(biota, PropertyAttribute.Focus);
+            stats.Attributes.Self = GetOfflineAttribute(biota, PropertyAttribute.Self);
+            
+            stats.Vitals.Health = GetOfflineVital(biota, PropertyAttribute2nd.MaxHealth);
+            stats.Vitals.Stamina = GetOfflineVital(biota, PropertyAttribute2nd.MaxStamina);
+            stats.Vitals.Mana = GetOfflineVital(biota, PropertyAttribute2nd.MaxMana);
+
+            stats.Bank = GetBankedProperties(biota);
+            stats.Augmentations = GetAugmentations(biota);
+
+            return stats;
+        }
+
+        private static List<SkillValueDto> GetOnlineSkills(Player online)
+        {
+            var result = new List<SkillValueDto>();
+            var pluckedSkills = new List<CreatureSkill>();
+
+            // DISCRETE PLUCKING:
+            // We use a brief lock for dictionary safety (to get references to the skill objects), 
+            // but we MUST release the lock before calling .Base or .Current.
+            // Those properties call into the EnchantmentManager, which attempts to acquire
+            // the same BiotaDatabaseLock. Since ACE locks are non-recursive, holding the lock
+            // here would cause a LockRecursionException and crash the thread.
+            online.BiotaDatabaseLock.EnterReadLock();
+            try
+            {
+                foreach (var skill in SkillHelper.ValidSkills)
+                {
+                    if (online.Skills.TryGetValue(skill, out var creatureSkill))
+                        pluckedSkills.Add(creatureSkill);
+                }
+            }
+            finally { online.BiotaDatabaseLock.ExitReadLock(); }
+
+            foreach (var creatureSkill in pluckedSkills)
+            {
+                result.Add(new SkillValueDto
+                {
+                    Name = creatureSkill.Skill.ToSentence(),
+                    Sac = creatureSkill.AdvancementClass.ToString(),
+                    isUsable = creatureSkill.IsUsable,
+                    Base = creatureSkill.Base,
+                    Total = creatureSkill.Current
+                });
+            }
+            return result;
+        }
+
+        private static List<SkillValueDto> GetOfflineSkills(Biota biota)
+        {
+            var result = new List<SkillValueDto>();
+            if (biota.PropertiesSkill == null) return result;
+
+            foreach (var skill in SkillHelper.ValidSkills)
+            {
+                if (!biota.PropertiesSkill.TryGetValue(skill, out PropertiesSkill prop))
+                    continue;
+
+                SkillValueDto skillValue = new()
+                {
+                    Name = skill.ToSentence(),
+                    Sac = prop.SAC.ToString(),
+                    isUsable = true,
+                };
+
+                if (prop.SAC == SkillAdvancementClass.Untrained)
+                {
+                    DatManager.PortalDat.SkillTable.SkillBaseHash.TryGetValue((uint)skill, out SkillBase skillTableRecord);
+                    if (skillTableRecord?.MinLevel != 1) skillValue.isUsable = false;
+                }
+
+                uint fromAttributes = skillValue.isUsable ? AttributeFormula.GetFormula(biota, skill) : 0;
+                uint enlBonus = (prop.SAC >= SkillAdvancementClass.Trained ? (uint)(biota.GetProperty(PropertyInt.Enlightenment) ?? 0) : 0);
+                uint augBaseBonus =
+                    (uint)(biota.GetProperty(PropertyInt.LumAugAllSkills) ?? 0)
+                    + (Player.MeleeSkills.Contains(skill) ? (uint)(10 * (biota.GetProperty(PropertyInt.AugmentationSkilledMelee) ?? 0)) : 0)
+                    + (Player.MissileSkills.Contains(skill) ? (uint)(10 * (biota.GetProperty(PropertyInt.AugmentationSkilledMissile) ?? 0)) : 0)
+                    + (Player.MagicSkills.Contains(skill) ? (uint)(10 * (biota.GetProperty(PropertyInt.AugmentationSkilledMagic) ?? 0)) : 0);
+                uint augTotalBonus =
+                    (uint)(5 * (biota.GetProperty(PropertyInt.AugmentationJackOfAllTrades) ?? 0))
+                    + (prop.SAC >= SkillAdvancementClass.Specialized ? (uint)(2 * (biota.GetProperty(PropertyInt.LumAugSkilledSpec) ?? 0)) : 0);
+
+                skillValue.Base = prop.InitLevel + fromAttributes + prop.LevelFromPP + augBaseBonus + enlBonus;
+                skillValue.Total = skillValue.Base + augTotalBonus;
+
+                result.Add(skillValue);
             }
 
-            uint fromAttributes = skillValue.isUsable ? AttributeFormula.GetFormula(snapshot, skill) : 0;
-            uint enlBonus = (prop.SAC >= SkillAdvancementClass.Trained ? (uint)(snapshot.GetProperty(PropertyInt.Enlightenment) ?? 0) : 0);
-            uint augBaseBonus =
-                (uint)(snapshot.GetProperty(PropertyInt.LumAugAllSkills) ?? 0)
-                + (Player.MeleeSkills.Contains(skill) ? (uint)(10 * (snapshot.GetProperty(PropertyInt.AugmentationSkilledMelee) ?? 0)) : 0)
-                + (Player.MissileSkills.Contains(skill) ? (uint)(10 * (snapshot.GetProperty(PropertyInt.AugmentationSkilledMissile) ?? 0)) : 0)
-                + (Player.MagicSkills.Contains(skill) ? (uint)(10 * (snapshot.GetProperty(PropertyInt.AugmentationSkilledMagic) ?? 0)) : 0);
-            uint augTotalBonus =
-                (uint)(5 * (snapshot.GetProperty(PropertyInt.AugmentationJackOfAllTrades) ?? 0))
-                + (prop.SAC >= SkillAdvancementClass.Specialized ? (uint)(2 * (snapshot.GetProperty(PropertyInt.LumAugSkilledSpec) ?? 0)) : 0);
+            return result;
+        }
 
-            skillValue.Base =
-                prop.InitLevel +
-                + fromAttributes
-                + prop.LevelFromPP
-                + augBaseBonus
-                + enlBonus;
+        private static List<InventoryItemDto> GetOnlineInventory(Player online)
+        {
+            var result = new List<InventoryItemDto>();
+            online.BiotaDatabaseLock.EnterReadLock();
+            try
+            {
+                var equippedIds = new HashSet<uint>(online.EquippedObjects.Keys.Select(g => g.Full));
+                CollectInventoryRecursive(online, result, equippedIds);
+            }
+            finally { online.BiotaDatabaseLock.ExitReadLock(); }
 
-            skillValue.Total =
-                skillValue.Base
-                + augTotalBonus;
+            return result.OrderBy(i => i.Name).ToList();
+        }
 
-            return skillValue;
+        private static List<InventoryItemDto> GetOfflineInventory(uint guid)
+        {
+            var result = new List<InventoryItemDto>();
+            var possessedBiotas = DatabaseManager.Shard.BaseDatabase.GetPossessedBiotasInParallel(guid);
+            var equippedIds = new HashSet<uint>(possessedBiotas.WieldedItems.Select(w => w.Id));
+
+            foreach (var dbBiota in possessedBiotas.Inventory.Concat(possessedBiotas.WieldedItems))
+            {
+                var biota = BiotaConverter.ConvertToEntityBiota(dbBiota);
+                result.Add(MapToDto(biota, equippedIds.Contains(biota.Id)));
+            }
+
+            return result.OrderBy(i => i.Name).ToList();
+        }
+
+        private static InventoryItemDto MapToDto(Biota biota, bool isEquipped, uint? containerGuid = null)
+        {
+            return new InventoryItemDto
+            {
+                Guid = biota.Id,
+                ContainerGuid = containerGuid ?? biota.GetProperty(PropertyInstanceId.Container) ?? 0,
+                WeenieType = (uint)biota.WeenieType,
+                RequiresBackpackSlot = biota.RequiresBackpackSlotOrIsContainer(),
+                IsContainer = biota.WeenieType == WeenieType.Container,
+                Name = biota.GetProperty(PropertyString.Name) ?? "Unknown Item",
+                Wcid = (int)biota.WeenieClassId,
+                StackSize = biota.GetProperty(PropertyInt.StackSize) ?? 1,
+                IsEquipped = isEquipped,
+                IconId = biota.GetProperty(PropertyDataId.Icon) ?? 0,
+                IconUnderlayId = biota.GetProperty(PropertyDataId.IconUnderlay) ?? 0,
+                IconOverlayId = biota.GetProperty(PropertyDataId.IconOverlay) ?? 0,
+                IconOverlaySecondaryId = biota.GetProperty(PropertyDataId.IconOverlaySecondary) ?? 0,
+                ItemType = (uint)biota.GetItemType(),
+                UiEffects = (uint)(biota.GetProperty(PropertyInt.UiEffects) ?? 0)
+            };
+        }
+
+        private static void CollectInventoryRecursive(Container container, List<InventoryItemDto> items, HashSet<uint> equippedIds)
+        {
+            foreach (var wo in container.Inventory.Values)
+            {
+                items.Add(MapToDto(wo.Biota, equippedIds.Contains(wo.Guid.Full), (uint)container.Guid.Full));
+
+                if (wo is Container subContainer)
+                    CollectInventoryRecursive(subContainer, items, equippedIds);
+            }
+
+            if (container is Creature creature)
+            {
+                foreach (var eq in creature.EquippedObjects.Values)
+                    items.Add(MapToDto(eq.Biota, true, (uint)container.Guid.Full));
+            }
         }
     }
 }

--- a/Source/ACE.Server/Controllers/CharacterController.cs
+++ b/Source/ACE.Server/Controllers/CharacterController.cs
@@ -542,35 +542,27 @@ namespace ACE.Server.Controllers
                 if (skillTableRecord?.MinLevel != 1) skillValue.isUsable = false;
             }
 
-            if (!skillValue.isUsable)
-            {
-                skillValue.Base = 0;
-                skillValue.Total = 0;
-            }
-            else
-            {
-                uint fromAttributes = AttributeFormula.GetFormula(snapshot, skill);
-                uint enlBonus = (prop.SAC >= SkillAdvancementClass.Trained ? (uint)(snapshot.GetProperty(PropertyInt.Enlightenment) ?? 0) : 0);
-                uint augBaseBonus =
-                    (uint)(snapshot.GetProperty(PropertyInt.LumAugAllSkills) ?? 0)
-                    + (Player.MeleeSkills.Contains(skill) ? (uint)(10 * (snapshot.GetProperty(PropertyInt.AugmentationSkilledMelee) ?? 0)) : 0)
-                    + (Player.MissileSkills.Contains(skill) ? (uint)(10 * (snapshot.GetProperty(PropertyInt.AugmentationSkilledMissile) ?? 0)) : 0)
-                    + (Player.MagicSkills.Contains(skill) ? (uint)(10 * (snapshot.GetProperty(PropertyInt.AugmentationSkilledMagic) ?? 0)) : 0);
-                uint augTotalBonus =
-                    (uint)(5 * (snapshot.GetProperty(PropertyInt.AugmentationJackOfAllTrades) ?? 0))
-                    + (prop.SAC >= SkillAdvancementClass.Specialized ? (uint)(2 * (snapshot.GetProperty(PropertyInt.LumAugSkilledSpec) ?? 0)) : 0);
+            uint fromAttributes = skillValue.isUsable ? AttributeFormula.GetFormula(snapshot, skill) : 0;
+            uint enlBonus = (prop.SAC >= SkillAdvancementClass.Trained ? (uint)(snapshot.GetProperty(PropertyInt.Enlightenment) ?? 0) : 0);
+            uint augBaseBonus =
+                (uint)(snapshot.GetProperty(PropertyInt.LumAugAllSkills) ?? 0)
+                + (Player.MeleeSkills.Contains(skill) ? (uint)(10 * (snapshot.GetProperty(PropertyInt.AugmentationSkilledMelee) ?? 0)) : 0)
+                + (Player.MissileSkills.Contains(skill) ? (uint)(10 * (snapshot.GetProperty(PropertyInt.AugmentationSkilledMissile) ?? 0)) : 0)
+                + (Player.MagicSkills.Contains(skill) ? (uint)(10 * (snapshot.GetProperty(PropertyInt.AugmentationSkilledMagic) ?? 0)) : 0);
+            uint augTotalBonus =
+                (uint)(5 * (snapshot.GetProperty(PropertyInt.AugmentationJackOfAllTrades) ?? 0))
+                + (prop.SAC >= SkillAdvancementClass.Specialized ? (uint)(2 * (snapshot.GetProperty(PropertyInt.LumAugSkilledSpec) ?? 0)) : 0);
 
-                skillValue.Base =
-                    prop.InitLevel +
-                    + fromAttributes
-                    + prop.LevelFromPP
-                    + augBaseBonus
-                    + enlBonus;
+            skillValue.Base =
+                prop.InitLevel +
+                + fromAttributes
+                + prop.LevelFromPP
+                + augBaseBonus
+                + enlBonus;
 
-                skillValue.Total =
-                    skillValue.Base
-                    + augTotalBonus;
-            }
+            skillValue.Total =
+                skillValue.Base
+                + augTotalBonus;
 
             return skillValue;
         }

--- a/Source/ACE.Server/Controllers/CharacterController.cs
+++ b/Source/ACE.Server/Controllers/CharacterController.cs
@@ -14,6 +14,8 @@ using ACE.Server.Network.Enum;
 using ACE.Server.Network.GameMessages.Messages;
 using ACE.Server.Web.Controllers;
 using ACE.Server.WorldObjects;
+using Google.Protobuf.WellKnownTypes;
+using Lifestoned.DataModel.Gdle;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System;
@@ -44,6 +46,13 @@ namespace ACE.Server.Controllers
          *     IWeenieExtensions for all lookups, avoiding complex lock recursion 
          *     and maximizing concurrency.
          */
+
+        private struct StatValue
+        {
+            public uint Innate { get; set; }
+            public uint Ranks { get; set; }
+            public uint Total { get; set; }
+        }
 
         [HttpGet("list")]
         public IActionResult GetList()
@@ -478,31 +487,29 @@ namespace ACE.Server.Controllers
             throw new InvalidOperationException("Unknown player type");
         }
 
-        private object GetAttribute(Biota snapshot, PropertyAttribute attr)
+        private StatValue GetAttribute(Biota snapshot, PropertyAttribute attr)
         {
-            if (snapshot.PropertiesAttribute != null && snapshot.PropertiesAttribute.TryGetValue(attr, out var val))
+            if (snapshot.PropertiesAttribute == null) return new();
+            if (!snapshot.PropertiesAttribute.TryGetValue(attr, out PropertiesAttribute prop)) return new();
+            return new StatValue
             {
-                var baseVal = (int)(val.InitLevel + val.LevelFromCP);
-                return new { @base = baseVal, total = (int?)null, ranks = (int)val.LevelFromCP };
-            }
-            return new { @base = 0, total = (int?)null, ranks = 0 };
+                Innate = prop.InitLevel,
+                Ranks = prop.LevelFromCP,
+                Total = prop.InitLevel + prop.LevelFromCP
+            };
         }
 
-        private object GetVital(Biota snapshot, PropertyAttribute2nd vital)
+        private static StatValue GetVital(Biota snapshot, PropertyAttribute2nd vital)
         {
-            var baseVal = 0;
-            if (snapshot.PropertiesAttribute2nd != null && snapshot.PropertiesAttribute2nd.TryGetValue(vital, out var val))
-                baseVal = (int)val.InitLevel;
-
-            if (baseVal == 0)
+            if (snapshot.PropertiesAttribute2nd == null) return new();
+            if (!snapshot.PropertiesAttribute2nd.TryGetValue(vital, out PropertiesAttribute2nd prop)) return new();
+            return new StatValue
             {
-                // Use authoritative formula for base vitals
-                // This replaces the previous magic numbered fallback logic
-                baseVal = (int)AttributeFormula.GetFormula(snapshot, vital);
-            }
+                Innate = AttributeFormula.GetFormula(snapshot, vital),
+                Ranks = prop.LevelFromCP,
+                Total = prop.CurrentLevel
+            };
 
-            var ranks = (snapshot.PropertiesAttribute2nd != null && snapshot.PropertiesAttribute2nd.TryGetValue(vital, out var v) ? v.LevelFromCP : 0);
-            return new { @base = baseVal, total = (int?)null, ranks = (int)ranks };
         }
     }
 }

--- a/Source/ACE.Server/Entity/AttributeFormula.cs
+++ b/Source/ACE.Server/Entity/AttributeFormula.cs
@@ -50,6 +50,20 @@ namespace ACE.Server.Entity
         }
 
         /// <summary>
+        /// Returns the amount to add to a creature's current skill,
+        /// based on their primary attribute current values
+        /// </summary>
+        public static uint GetFormula(Biota creature, Skill skill)
+        {
+            var skillTable = DatManager.PortalDat.SkillTable;
+
+            if (!skillTable.SkillBaseHash.TryGetValue((uint)skill, out SkillBase skillBase))
+                return 0;
+
+            return GetFormula(creature, skillBase.Formula);
+        }
+
+        /// <summary>
         /// Returns the amount to add to a creature's current vital,
         /// based on their primary attribute current values
         /// </summary>

--- a/Source/ACE.Server/WorldObjects/Entity/CreatureSkill.cs
+++ b/Source/ACE.Server/WorldObjects/Entity/CreatureSkill.cs
@@ -137,16 +137,10 @@ namespace ACE.Server.WorldObjects.Entity
         {
             get
             {
-                uint total = 0;
-
-                if (IsUsable)
-                    total = AttributeFormula.GetFormula(creature, Skill, false);
-
-                total += InitLevel + Ranks;
-
-                if (creature is Player player)
-                    total += GetAugBonus_Base(player);
-
+                Player player = creature as Player;
+                uint total = InitLevel + Ranks;
+                if (IsUsable) total += AttributeFormula.GetFormula(creature, Skill, /*current=*/false);
+                if (player != null) total += GetAugBonus_Base(player);
                 return total;
             }
         }
@@ -155,18 +149,10 @@ namespace ACE.Server.WorldObjects.Entity
         {
             get
             {
-                uint total = 0;
-
-                if (IsUsable)
-                    total = AttributeFormula.GetFormula(creature, Skill);
-
-                total += InitLevel + Ranks;
-
-                var player = creature as Player;
-
-                // base gets scaled by vitae
-                if (player != null)
-                    total += GetAugBonus_Base(player);
+                Player player = creature as Player;
+                uint total = InitLevel + Ranks;
+                if (IsUsable) total += AttributeFormula.GetFormula(creature, Skill, /*current=*/true);
+                if (player != null) total += GetAugBonus_Base(player);
 
                 // apply multiplicative enchantments
                 var multiplier = creature.EnchantmentManager.GetSkillMod_Multiplier(Skill);

--- a/Source/ACE.Server/WorldObjects/Entity/CreatureVital.cs
+++ b/Source/ACE.Server/WorldObjects/Entity/CreatureVital.cs
@@ -105,14 +105,30 @@ namespace ACE.Server.WorldObjects.Entity
         {
             get
             {
-                var attr = AttributeFormula.GetFormula(creature, Vital, false);
+                return StartingValue
+                    + AttributeFormula.GetFormula(creature, Vital, /*current*/false)
+                    + EnlBonus
+                    + Ranks
+                    + GearBonus;
+            }
+        }
 
-                var total = StartingValue + Ranks + attr;
-
+        public uint EnlBonus
+        {
+            get {
                 if (creature is Player player && Vital == PropertyAttribute2nd.MaxHealth)
-                    total += (uint)(player.Enlightenment * 2 + player.GetGearMaxHealth());
+                    return (uint)player.Enlightenment * 2;
+                return 0;
+            }
+        }
 
-                return total;
+        public uint GearBonus
+        {
+            get
+            {
+                if (creature is Player player && Vital == PropertyAttribute2nd.MaxHealth)
+                    return (uint)player.GetGearMaxHealth();
+                return 0;
             }
         }
 
@@ -126,31 +142,18 @@ namespace ACE.Server.WorldObjects.Entity
 
         public uint GetMaxValue(bool enchanted)
         {
-            var attr = AttributeFormula.GetFormula(creature, Vital, true);
-
-            uint total = StartingValue + Ranks + attr;
-
-            var player = creature as Player;
-
-            if (player != null)
-            {
-                // Enlightenment and GearMaxHealth didn't work like other additives
-                // most additives (ie. from enchantments) were added in *after* multipliers,
-                // but Enlightenment and GearMaxHealth were an exception, and added in beforehand
-
-                // this means Enlightenment and GearMaxHealth would get scaled by multipliers,
-                // including Asheron's Benediction, and oddly enough, vitae as well
-
-                // it's also possible these were considered "base"
-                if (Vital == PropertyAttribute2nd.MaxHealth)
-                    total += (uint)(player.Enlightenment * 2 + player.GetGearMaxHealth());
-            }
+            uint total =
+                StartingValue
+                + AttributeFormula.GetFormula(creature, Vital, /*current*/true)
+                + EnlBonus
+                + Ranks
+                + GearBonus;
 
             // apply multiplicative enchantments first
             var multiplier = enchanted ? creature.EnchantmentManager.GetVitalMod_Multiplier(this) : 1.0f;
-
             var fTotal = total * multiplier;
 
+            var player = creature as Player;
             if (player != null)
             {
                 var vitae = player.Vitae;
@@ -161,7 +164,6 @@ namespace ACE.Server.WorldObjects.Entity
 
             // everything beyond this point does not get scaled by vitae
             var additives = enchanted ? creature.EnchantmentManager.GetVitalMod_Additives(this) : 0;
-
             var iTotal = (fTotal + additives).Round();
 
             // a creature cannot fall below 5 MaxVital from enchantments / vitae normally,

--- a/Source/ACE.WebPortal/ClientApp/src/components/CharacterDetail.tsx
+++ b/Source/ACE.WebPortal/ClientApp/src/components/CharacterDetail.tsx
@@ -11,8 +11,6 @@ import Modal from './common/Modal'
 import TabButton from './common/TabButton'
 
 interface CharacterDetailData extends Character {
-  enlightenment: number
-  augmentations: Record<string, number>
 }
 
 export default function CharacterDetail() {

--- a/Source/ACE.WebPortal/ClientApp/src/components/character/AttributeSection.tsx
+++ b/Source/ACE.WebPortal/ClientApp/src/components/character/AttributeSection.tsx
@@ -1,17 +1,25 @@
-import { Activity, Flame, Shield, Zap, Target, User } from 'lucide-react'
+import { Activity } from 'lucide-react'
 import { StatsData } from '../../types'
 import StatRow from './StatRow'
+
+const ATTRIBUTE_ICONS = {
+  strength: 0x060002C8,
+  endurance: 0x060002C4,
+  coordination: 0x060002C9,
+  quickness: 0x060002C6,
+  focus: 0x060002C5,
+  self: 0x060002C7,
+}
+
 
 interface AttributeSectionProps {
   attributes: StatsData['attributes']
 }
 
 export default function AttributeSection({ attributes }: AttributeSectionProps) {
-  const isOnline = attributes.strength.total !== null
-
   return (
     <div className="bg-neutral-950/50 border border-neutral-800 rounded-2xl p-6 shadow-xl relative overflow-hidden">
-      <div className="flex items-center justify-between mb-6 px-1">
+      <div className="flex items-center justify-between mb-4 px-1">
         <div className="flex items-center gap-2">
           <Activity className="w-4 h-4 text-orange-400" />
           <h3 className="text-xs font-bold uppercase tracking-[0.2em] text-neutral-400">Attributes</h3>
@@ -20,21 +28,17 @@ export default function AttributeSection({ attributes }: AttributeSectionProps) 
           <div className="w-14 text-center">Innate</div>
           <div className="w-px h-3 opacity-0" />
           <div className="w-14 text-center">Base</div>
-          {isOnline && (
-            <>
-              <div className="w-px h-3 opacity-0" />
-              <div className="w-14 text-center text-blue-400/80">Current</div>
-            </>
-          )}
+          <div className="w-px h-3 opacity-0" />
+          <div className="w-14 text-center text-blue-400/80">Current</div>
         </div>
       </div>
-      <div className="space-y-4">
-        <StatRow label="Strength" detail={attributes.strength} icon={<Flame className="w-3.5 h-3.5" />} />
-        <StatRow label="Endurance" detail={attributes.endurance} icon={<Shield className="w-3.5 h-3.5" />} />
-        <StatRow label="Coordination" detail={attributes.coordination} icon={<Activity className="w-3.5 h-3.5" />} />
-        <StatRow label="Quickness" detail={attributes.quickness} icon={<Zap className="w-3.5 h-3.5" />} />
-        <StatRow label="Focus" detail={attributes.focus} icon={<Target className="w-3.5 h-3.5" />} />
-        <StatRow label="Self" detail={attributes.self} icon={<User className="w-3.5 h-3.5" />} />
+      <div className="space-y-2">
+        <StatRow label="Strength" detail={attributes.strength} iconId={ATTRIBUTE_ICONS.strength} />
+        <StatRow label="Endurance" detail={attributes.endurance} iconId={ATTRIBUTE_ICONS.endurance} />
+        <StatRow label="Coordination" detail={attributes.coordination} iconId={ATTRIBUTE_ICONS.coordination} />
+        <StatRow label="Quickness" detail={attributes.quickness} iconId={ATTRIBUTE_ICONS.quickness} />
+        <StatRow label="Focus" detail={attributes.focus} iconId={ATTRIBUTE_ICONS.focus} />
+        <StatRow label="Self" detail={attributes.self} iconId={ATTRIBUTE_ICONS.self} />
       </div>
     </div>
   )

--- a/Source/ACE.WebPortal/ClientApp/src/components/character/AugmentationSection.tsx
+++ b/Source/ACE.WebPortal/ClientApp/src/components/character/AugmentationSection.tsx
@@ -11,7 +11,7 @@ export default function AugmentationSection({ augmentations }: AugmentationSecti
       <div className="absolute top-0 right-0 p-8 opacity-5">
         <TrendingUp className="w-24 h-24 text-purple-500" />
       </div>
-      <div className="flex items-center gap-2 mb-6 px-1">
+      <div className="flex items-center gap-2 mb-4 px-1">
         <TrendingUp className="w-4 h-4 text-purple-400" />
         <h3 className="text-xs font-bold uppercase tracking-[0.2em] text-neutral-400">Augmentations</h3>
       </div>

--- a/Source/ACE.WebPortal/ClientApp/src/components/character/InventoryItemCard.tsx
+++ b/Source/ACE.WebPortal/ClientApp/src/components/character/InventoryItemCard.tsx
@@ -14,7 +14,7 @@ export default function InventoryItemCard({ item, isHeader = false }: InventoryI
     : "text-xs font-medium text-neutral-400 group-hover:text-neutral-100"
 
   return (
-    <div className={`grid ${GRID_COLS} gap-4 px-5 py-2.5 items-center group transition-colors hover:bg-white/[0.02]`}>
+    <div className={`w-full grid ${GRID_COLS} gap-4 px-5 py-2.5 items-center group transition-colors hover:bg-white/[0.02]`}>
       <div className={`flex items-center gap-3 min-w-0 ${paddingLeft}`}>
         {item.iconId ? (
           <div className={`p-0.5 shrink-0 ${getIconBgClass(item)}`}>

--- a/Source/ACE.WebPortal/ClientApp/src/components/character/InventorySection.tsx
+++ b/Source/ACE.WebPortal/ClientApp/src/components/character/InventorySection.tsx
@@ -55,7 +55,7 @@ export default function InventorySection({
           {items.map(item => (
             <InventoryItemCard key={item.guid} item={item} />
           ))}
-          {items.length === 0 && (
+          {items.length === 0 && headerItem?.isContainer && (
             <div className="px-5 py-3 text-[10px] font-bold uppercase tracking-widest text-neutral-500 bg-neutral-950/10 flex items-center gap-3">
               <div className="pl-7 flex items-center gap-3">
                 <Package className="w-3.5 h-3.5 opacity-40" />

--- a/Source/ACE.WebPortal/ClientApp/src/components/character/ProgressionHeader.tsx
+++ b/Source/ACE.WebPortal/ClientApp/src/components/character/ProgressionHeader.tsx
@@ -8,19 +8,26 @@ interface ProgressionHeaderProps {
 export default function ProgressionHeader({ level, enlightenment }: ProgressionHeaderProps) {
   return (
     <div className="bg-neutral-950/50 border border-neutral-800 rounded-2xl p-6 shadow-xl relative overflow-hidden">
-      <div className="flex items-center justify-between px-1">
-        <div className="flex items-center gap-2">
+      <div className="flex flex-col gap-5">
+        <div className="flex items-center gap-2 px-1">
           <TrendingUp className="w-4 h-4 text-blue-400" />
           <h3 className="text-xs font-bold uppercase tracking-[0.2em] text-neutral-400">Progression</h3>
         </div>
-        <div className="flex items-center gap-4 text-[10px] font-bold uppercase tracking-[0.1em]">
-          <div className="flex items-center gap-1.5 bg-blue-600/10 px-3 py-1.5 rounded-full border border-blue-500/20">
-            <span className="text-neutral-500">Enlightenment</span>
-            <span className="text-blue-400 font-mono text-sm">{enlightenment}</span>
+        
+        <div className="grid grid-cols-3 gap-4 text-[10px] font-bold uppercase tracking-[0.1em]">
+          <div className="flex items-center justify-center gap-2 bg-red-600/10 py-2.5 rounded-xl border border-red-500/20 shadow-inner transition-all hover:bg-red-600/15">
+            <span className="text-neutral-500">Prestige</span>
+            <span className="text-red-400 font-mono text-sm tracking-tighter">-</span>
           </div>
-          <div className="flex items-center gap-1.5 bg-neutral-800/40 px-3 py-1.5 rounded-full border border-neutral-700/30">
+
+          <div className="flex items-center justify-center gap-2 bg-blue-600/10 py-2.5 rounded-xl border border-blue-500/20 shadow-inner transition-all hover:bg-blue-600/15">
+            <span className="text-neutral-500">Enlightenment</span>
+            <span className="text-blue-400 font-mono text-sm tracking-tighter">{enlightenment}</span>
+          </div>
+
+          <div className="flex items-center justify-center gap-2 bg-neutral-800/40 py-2.5 rounded-xl border border-neutral-700/30 shadow-inner transition-all hover:bg-neutral-800/60">
             <span className="text-neutral-500">Level</span>
-            <span className="text-white font-mono text-sm">{level.toLocaleString()}</span>
+            <span className="text-white font-mono text-sm tracking-tighter">{level.toLocaleString()}</span>
           </div>
         </div>
       </div>

--- a/Source/ACE.WebPortal/ClientApp/src/components/character/RatingSection.tsx
+++ b/Source/ACE.WebPortal/ClientApp/src/components/character/RatingSection.tsx
@@ -38,7 +38,7 @@ export default function RatingSection({ ratings }: RatingSectionProps) {
               <span className="text-[10px] font-bold uppercase tracking-wider text-neutral-500 group-hover:text-neutral-300 transition-colors">Effective Melee Defense</span>
             </div>
             <div className="text-sm font-mono font-bold text-neutral-300 group-hover:text-white transition-colors">
-              {ratings.emd?.toLocaleString() ?? ''}
+              {ratings.emd != null ? ratings.emd.toLocaleString() : '-'}
             </div>
           </div>
           <div className="h-px bg-neutral-800/50 mt-3" />
@@ -54,7 +54,7 @@ export default function RatingSection({ ratings }: RatingSectionProps) {
   )
 }
 
-function RatingStat({ label, value, icon }: { label: string, value: number, icon: React.ReactNode }) {
+function RatingStat({ label, value, icon }: { label: string, value: number | null, icon: React.ReactNode }) {
   return (
     <div className="flex items-center justify-between py-1 group">
       <div className="flex items-center gap-2">
@@ -64,7 +64,7 @@ function RatingStat({ label, value, icon }: { label: string, value: number, icon
         <span className="text-[10px] font-bold uppercase tracking-widest text-neutral-500 group-hover:text-neutral-400 transition-colors">{label}</span>
       </div>
       <div className="text-sm font-mono font-bold text-neutral-300 group-hover:text-white transition-colors">
-        {value}
+        {value != null ? value : '-'}
       </div>
     </div>
   )

--- a/Source/ACE.WebPortal/ClientApp/src/components/character/RatingSection.tsx
+++ b/Source/ACE.WebPortal/ClientApp/src/components/character/RatingSection.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { clsx } from 'clsx'
 import { Swords, Shield, TrendingUp, Crosshair } from 'lucide-react'
 import { StatsData } from '../../types'
 
@@ -7,38 +8,47 @@ interface RatingSectionProps {
 }
 
 export default function RatingSection({ ratings }: RatingSectionProps) {
+  const isOnline = ratings.emd !== null;
+
   return (
     <div className="bg-neutral-950/50 border border-neutral-800 rounded-2xl p-5 shadow-xl relative overflow-hidden">
-      <div className="flex items-center gap-2 mb-4 px-1">
-        <Swords className="w-4 h-4 text-blue-400" />
-        <h3 className="text-xs font-bold uppercase tracking-[0.2em] text-neutral-400">Combat Ratings</h3>
+      <div className="flex items-center justify-between mb-4 px-1">
+        <div className="flex items-center gap-2">
+          <Swords className="w-4 h-4 text-blue-400" />
+          <h3 className="text-xs font-bold uppercase tracking-[0.2em] text-neutral-400">Combat Ratings</h3>
+        </div>
+        {!isOnline && (
+          <div className="relative group/tooltip">
+            <div className="text-[9px] font-bold uppercase tracking-widest text-blue-400/80 bg-blue-500/5 px-2 py-0.5 rounded border border-blue-500/10 cursor-help transition-colors hover:border-blue-500/30">
+              Log in to view
+            </div>
+            {/* Tooltip */}
+            <div className="absolute bottom-full right-0 mb-2 px-2 py-1 bg-neutral-900 border border-neutral-800 rounded text-[10px] text-neutral-400 whitespace-nowrap opacity-0 group-hover/tooltip:opacity-100 transition-opacity pointer-events-none z-10 shadow-2xl">
+              Calculation requires live character data
+            </div>
+          </div>
+        )}
       </div>
       
-      <div className="mb-4">
-        <div className="flex items-center justify-between group">
-          <div className="flex items-center gap-2">
-            <Shield className="w-4 h-4 text-blue-400/50 group-hover:text-blue-400 transition-colors" />
-            <span className="text-[10px] font-bold uppercase tracking-wider text-neutral-500 group-hover:text-neutral-300 transition-colors">Effective Melee Defense</span>
+      <div className={clsx("transition-all duration-500", !isOnline && "opacity-50 grayscale pointer-events-none")}>
+        <div className="mb-4">
+          <div className="flex items-center justify-between group">
+            <div className="flex items-center gap-2">
+              <Shield className="w-4 h-4 text-blue-400/50 group-hover:text-blue-400 transition-colors" />
+              <span className="text-[10px] font-bold uppercase tracking-wider text-neutral-500 group-hover:text-neutral-300 transition-colors">Effective Melee Defense</span>
+            </div>
+            <div className="text-sm font-mono font-bold text-neutral-300 group-hover:text-white transition-colors">
+              {ratings.emd?.toLocaleString() ?? ''}
+            </div>
           </div>
-          <div className="flex flex-col items-end">
-            {ratings.emd !== null ? (
-              <div className="text-sm font-mono font-bold text-neutral-300 group-hover:text-white transition-colors">
-                {ratings.emd.toLocaleString()}
-              </div>
-            ) : (
-              <div className="text-[9px] font-bold uppercase tracking-tighter text-blue-400/60 bg-blue-500/5 px-2 py-0.5 rounded border border-blue-500/10">
-                Log in to see
-              </div>
-            )}
-          </div>
+          <div className="h-px bg-neutral-800/50 mt-3" />
         </div>
-        <div className="h-px bg-neutral-800/50 mt-3" />
-      </div>
-      <div className="grid grid-cols-2 gap-x-6 gap-y-1.5">
-        <RatingStat label="Damage (D)" value={ratings.damage} icon={<Swords />} />
-        <RatingStat label="Crit Damage (CD)" value={ratings.critDamage} icon={<TrendingUp />} />
-        <RatingStat label="Damage Resist (DR)" value={ratings.dr} icon={<Shield />} />
-        <RatingStat label="Crit Resist (CDR)" value={ratings.cdr} icon={<Crosshair />} />
+        <div className="grid grid-cols-2 gap-x-6 gap-y-1.5">
+          <RatingStat label="Damage (D)" value={ratings.damage} icon={<Swords />} />
+          <RatingStat label="Crit Damage (CD)" value={ratings.critDamage} icon={<TrendingUp />} />
+          <RatingStat label="Damage Resist (DR)" value={ratings.dr} icon={<Shield />} />
+          <RatingStat label="Crit Resist (CDR)" value={ratings.cdr} icon={<Crosshair />} />
+        </div>
       </div>
     </div>
   )

--- a/Source/ACE.WebPortal/ClientApp/src/components/character/StatRow.tsx
+++ b/Source/ACE.WebPortal/ClientApp/src/components/character/StatRow.tsx
@@ -37,7 +37,7 @@ export default function StatRow({ label, detail, iconId }: StatRowProps) {
 
         {/* Base Column */}
         <div className="flex flex-col items-center min-w-14">
-          <div className={`text-sm font-mono font-medium 'text-neutral-500' tabular-nums`}>
+          <div className="text-sm font-mono font-medium text-neutral-600 tabular-nums">
             {base?.toLocaleString()}
           </div>
         </div>

--- a/Source/ACE.WebPortal/ClientApp/src/components/character/StatRow.tsx
+++ b/Source/ACE.WebPortal/ClientApp/src/components/character/StatRow.tsx
@@ -1,29 +1,32 @@
-import React from 'react'
 import { StatDetail } from '../../types'
+import { getIconUrl } from '../../utils/icon'
 
 interface StatRowProps {
   label: string
   detail: StatDetail
-  icon: React.ReactNode
+  iconId: number
 }
 
-export default function StatRow({ label, detail, icon }: StatRowProps) {
+export default function StatRow({ label, detail, iconId }: StatRowProps) {
   const { innate, ranks, total } = detail
   const base = innate + ranks;
-  const isOnline = total !== null
   const mainColor = "text-white"
 
   return (
-    <div className="flex items-center justify-between group/row py-1 text-sm border-b border-neutral-800/10 last:border-0 hover:bg-white/[0.02] px-1 rounded-lg transition-colors">
-      <div className="flex items-center gap-3">
-        <div className="w-8 h-8 rounded-lg bg-neutral-900 border border-neutral-800 flex items-center justify-center text-neutral-500 group-hover/row:border-neutral-700/50 group-hover/row:text-neutral-300 transition-all shrink-0">
-          {icon}
+    <div className="flex items-center justify-between group/row pr-1 py-1 text-sm border-b border-neutral-800/10 last:border-0 hover:bg-white/[0.02] rounded-lg transition-colors">
+      <div className="flex items-center gap-5">
+        <div className="flex items-center justify-center text-neutral-500 group-hover/row:text-neutral-300 transition-all shrink-0">
+          <img 
+            src={getIconUrl({ iconId })} 
+            className="w-6 h-5 object-contain rounded-md shadow-sm grayscale-[0.3] group-hover/row:grayscale-0 transition-all duration-300" 
+            alt="" 
+          />
         </div>
         <span className="text-sm font-medium text-neutral-300 group-hover/row:text-white transition-colors">{label}</span>
       </div>
       <div className="flex items-center gap-3 pr-4">
         {/* Innate Column */}
-        <div className="flex flex-col items-center min-w-[3.5rem]">
+        <div className="flex flex-col items-center min-w-14">
           <div className="text-sm font-mono font-medium text-neutral-600 tabular-nums">
             {innate?.toLocaleString()}
           </div>
@@ -33,25 +36,21 @@ export default function StatRow({ label, detail, icon }: StatRowProps) {
         <div className="w-px h-6 bg-neutral-800/20 self-center" />
 
         {/* Base Column */}
-        <div className="flex flex-col items-center min-w-[3.5rem]">
-          <div className={`text-sm font-mono font-medium ${isOnline ? 'text-neutral-500' : 'text-neutral-200'} tabular-nums`}>
+        <div className="flex flex-col items-center min-w-14">
+          <div className={`text-sm font-mono font-medium 'text-neutral-500' tabular-nums`}>
             {base?.toLocaleString()}
           </div>
         </div>
 
-        {isOnline && (
-          <>
-            {/* Divider */}
-            <div className="w-px h-6 bg-neutral-800/30 self-center" />
+        {/* Divider */}
+        <div className="w-px h-6 bg-neutral-800/30 self-center" />
 
-            {/* Current Column */}
-            <div className="flex flex-col items-center min-w-[3.5rem]">
-              <div className={`font-mono font-bold text-base tracking-tight tabular-nums ${mainColor} brightness-110`}>
-                {total?.toLocaleString()}
-              </div>
-            </div>
-          </>
-        )}
+        {/* Current Column */}
+        <div className="flex flex-col items-center min-w-14">
+          <div className={`font-mono font-bold text-base tracking-tight tabular-nums ${mainColor} brightness-110`}>
+            {total?.toLocaleString()}
+          </div>
+        </div>
       </div>
     </div>
   )

--- a/Source/ACE.WebPortal/ClientApp/src/components/character/StatRow.tsx
+++ b/Source/ACE.WebPortal/ClientApp/src/components/character/StatRow.tsx
@@ -8,9 +8,9 @@ interface StatRowProps {
 }
 
 export default function StatRow({ label, detail, icon }: StatRowProps) {
-  const { total, base, ranks } = detail
+  const { innate, ranks, total } = detail
+  const base = innate + ranks;
   const isOnline = total !== null
-  const innate = base - ranks
   const mainColor = "text-white"
 
   return (
@@ -25,7 +25,7 @@ export default function StatRow({ label, detail, icon }: StatRowProps) {
         {/* Innate Column */}
         <div className="flex flex-col items-center min-w-[3.5rem]">
           <div className="text-sm font-mono font-medium text-neutral-600 tabular-nums">
-            {innate}
+            {innate?.toLocaleString()}
           </div>
         </div>
 
@@ -35,7 +35,7 @@ export default function StatRow({ label, detail, icon }: StatRowProps) {
         {/* Base Column */}
         <div className="flex flex-col items-center min-w-[3.5rem]">
           <div className={`text-sm font-mono font-medium ${isOnline ? 'text-neutral-500' : 'text-neutral-200'} tabular-nums`}>
-            {base}
+            {base?.toLocaleString()}
           </div>
         </div>
 
@@ -47,7 +47,7 @@ export default function StatRow({ label, detail, icon }: StatRowProps) {
             {/* Current Column */}
             <div className="flex flex-col items-center min-w-[3.5rem]">
               <div className={`font-mono font-bold text-base tracking-tight tabular-nums ${mainColor} brightness-110`}>
-                {total.toLocaleString()}
+                {total?.toLocaleString()}
               </div>
             </div>
           </>

--- a/Source/ACE.WebPortal/ClientApp/src/components/character/VitalSection.tsx
+++ b/Source/ACE.WebPortal/ClientApp/src/components/character/VitalSection.tsx
@@ -1,14 +1,19 @@
-import { Heart, Flame, Droplets } from 'lucide-react'
+import { Heart } from 'lucide-react'
 import { StatsData } from '../../types'
 import StatRow from './StatRow'
+
+const VITAL_ICONS = {
+  health: 0x06001D79,
+  stamina: 0x06001D7A,
+  mana: 0x06001D7B,
+}
+
 
 interface VitalSectionProps {
   vitals: StatsData['vitals']
 }
 
 export default function VitalSection({ vitals }: VitalSectionProps) {
-  const isOnline = vitals.health.total !== null
-
   return (
     <div className="bg-neutral-950/50 border border-neutral-800 rounded-2xl p-6 shadow-xl relative overflow-hidden">
       <div className="flex items-center justify-between mb-4 px-1">
@@ -20,18 +25,14 @@ export default function VitalSection({ vitals }: VitalSectionProps) {
           <div className="w-14 text-center">Innate</div>
           <div className="w-px h-3 opacity-0" />
           <div className="w-14 text-center">Base</div>
-          {isOnline && (
-            <>
-              <div className="w-px h-3 opacity-0" />
-              <div className="w-14 text-center text-red-400/80">Current</div>
-            </>
-          )}
+          <div className="w-px h-3 opacity-0" />
+          <div className="w-14 text-center text-blue-400/80">Current</div>
         </div>
       </div>
-      <div className="space-y-4">
-        <StatRow label="Health" detail={vitals.health} icon={<Heart className="w-3.5 h-3.5" />} />
-        <StatRow label="Stamina" detail={vitals.stamina} icon={<Flame className="w-3.5 h-3.5" />} />
-        <StatRow label="Mana" detail={vitals.mana} icon={<Droplets className="w-3.5 h-3.5" />} />
+      <div className="space-y-2">
+        <StatRow label="Health" detail={vitals.health} iconId={VITAL_ICONS.health} />
+        <StatRow label="Stamina" detail={vitals.stamina} iconId={VITAL_ICONS.stamina} />
+        <StatRow label="Mana" detail={vitals.mana} iconId={VITAL_ICONS.mana} />
       </div>
     </div>
   )

--- a/Source/ACE.WebPortal/ClientApp/src/types/index.ts
+++ b/Source/ACE.WebPortal/ClientApp/src/types/index.ts
@@ -4,8 +4,6 @@ export interface Character {
   guid: number;
   name: string;
   wcid: number;
-  level: number;
-  lastLogin: string;
   isOnline: boolean;
   isAdmin?: boolean;
 }

--- a/Source/ACE.WebPortal/ClientApp/src/types/index.ts
+++ b/Source/ACE.WebPortal/ClientApp/src/types/index.ts
@@ -38,10 +38,10 @@ export interface StatsData {
   };
   ratings: {
     emd: number | null;
-    dr: number;
-    cdr: number;
-    damage: number;
-    critDamage: number;
+    dr: number | null;
+    cdr: number | null;
+    damage: number | null;
+    critDamage: number | null;
   };
   augmentations: Record<string, number>;
   bank: Record<string, number>;

--- a/Source/ACE.WebPortal/ClientApp/src/types/index.ts
+++ b/Source/ACE.WebPortal/ClientApp/src/types/index.ts
@@ -19,9 +19,9 @@ export interface Player extends Character {
 // --- Stats & Progression ---
 
 export interface StatDetail {
-  base: number;
-  total: number | null;
+  innate: number;
   ranks: number;
+  total: number;
 }
 
 export interface StatsData {


### PR DESCRIPTION
Fix the skill and stats calculations for online and offline players in the web portal.  Also, add a little teaser.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added a Prestige pill; “Current” column always visible for stats and vitals.
  - Centralized icon IDs now power attribute and vital icons.

* **Bug Fixes**
  - Improved online/offline consistency: live totals shown when available; safer handling of missing/null values.
  - Ratings area shows a login hint and dims when offline.
  - Removed the offline search endpoint.

* **Style**
  - Tighter spacing, updated metric pill visuals, layout tweaks, and refined inventory empty-state logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->