### PR TITLE
Custom ally targeting (rebased on upstream master)

### DIFF
--- a/Database/Updates/World/2026-04-15-00-TargetingFlags-99999997.sql
+++ b/Database/Updates/World/2026-04-15-00-TargetingFlags-99999997.sql
@@ -1,0 +1,15 @@
+/* TargetingFlags refactor: test weenie 99999997 — remove UseCustomTargetingLists (9018), set PropertyInt.TargetingFlags (9041). */
+
+DELETE FROM `weenie_properties_bool` WHERE `object_Id` = 99999997 AND `type` = 9018;
+
+/* PropertyInt 9041 = TargetingFlags (FriendlyToQuestPlayer | HostileToAllPlayers = 8 + 16 = 24). Separate from PropertyBool 9041 in weenie_properties_bool. */
+DELETE FROM `weenie_properties_int` WHERE `object_Id` = 99999997 AND `type` = 9041;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (99999997, 9041, 24);
+
+UPDATE `weenie_properties_string` SET `value` = '11,18' WHERE `object_Id` = 99999997 AND `type` = 9014;
+
+DELETE FROM `weenie_properties_string` WHERE `object_Id` = 99999997 AND `type` = 9015;
+
+UPDATE `weenie_properties_bool` SET `value` = 1 WHERE `object_Id` = 99999997 AND `type` = 9042;

--- a/Source/ACE.Common/MasterConfiguration.cs
+++ b/Source/ACE.Common/MasterConfiguration.cs
@@ -10,7 +10,7 @@ namespace ACE.Common
 
         public OfflineConfiguration Offline { get; set; } = new OfflineConfiguration();
 
-        public ChatConfiguration Chat { get; set; }
+        public ChatConfiguration Chat { get; set; } = new ChatConfiguration();
 
         public DDDConfiguration DDD { get; set; } = new DDDConfiguration();
     }

--- a/Source/ACE.Entity/Enum/CreatureType.cs
+++ b/Source/ACE.Entity/Enum/CreatureType.cs
@@ -103,6 +103,51 @@ namespace ACE.Entity.Enum
         BlightedMoarsman,
         GearKnight,
         Gurog,
-        Anekshay
+        Anekshay,
+        /// <summary>
+        /// Pseudo creature type used by custom targeting lists to represent players that match a quest stamp.
+        /// </summary>
+        /// <remarks>
+        /// Prefer <see cref="CustomTargetingBehavior.FriendlyToQuestPlayer"/> on <see cref="T:ACE.Entity.Enum.Properties.PropertyInt.TargetingFlags"/> (9041).
+        /// Legacy: may appear in comma-separated <see cref="T:ACE.Entity.Enum.Properties.PropertyString.FriendTypeString"/> (9014) / <see cref="T:ACE.Entity.Enum.Properties.PropertyString.FoeTypeString"/> (9015).
+        ///
+        /// Quest matching is driven by <see cref="T:ACE.Entity.Enum.Properties.PropertyString.FriendlyQuestString"/> (9016): players are treated as matching
+        /// <c>QuestPlayer</c> when they currently have that quest stamp.
+        ///
+        /// Related behavior flags (not required for parsing the lists, but commonly used alongside them):
+        /// <see cref="T:ACE.Entity.Enum.Properties.PropertyBool.AllowFriendlyPlayerDamage"/> (9041) and
+        /// <see cref="T:ACE.Entity.Enum.Properties.PropertyBool.BreakPeaceOnHostileAction"/> (9042).
+        /// </remarks>
+        QuestPlayer = 996,
+        /// <summary>
+        /// Pseudo creature type used by custom targeting lists to represent all players (regardless of quest stamps).
+        /// </summary>
+        /// <remarks>
+        /// Prefer <see cref="CustomTargetingBehavior.FriendlyToPlayers"/> or <see cref="CustomTargetingBehavior.HostileToAllPlayers"/> on <see cref="T:ACE.Entity.Enum.Properties.PropertyInt.TargetingFlags"/> (9041).
+        /// Legacy: may appear in comma-separated friend/foe strings.
+        ///
+        /// Unlike <see cref="QuestPlayer"/>, this does not require <see cref="T:ACE.Entity.Enum.Properties.PropertyString.FriendlyQuestString"/> (9016) to take effect.
+        ///
+        /// Related behavior flags (not required for parsing the lists, but commonly used alongside them):
+        /// <see cref="T:ACE.Entity.Enum.Properties.PropertyBool.AllowFriendlyPlayerDamage"/> (9041) and
+        /// <see cref="T:ACE.Entity.Enum.Properties.PropertyBool.BreakPeaceOnHostileAction"/> (9042).
+        /// </remarks>
+        Player = 997,
+        AttackAll = 998,
+        /// <summary>
+        /// Pseudo creature type meaning “attack anything that is not the same concrete <see cref="CreatureType"/> as this creature”.
+        /// Hostile to outsiders + all players, but not automatically hostile to other mobs of my same <see cref="CreatureType"/>.
+        /// </summary>
+        /// <remarks>
+        /// Prefer <see cref="CustomTargetingBehavior.AttackNonSelf"/> on <see cref="T:ACE.Entity.Enum.Properties.PropertyInt.TargetingFlags"/> (9041).
+        /// Legacy: may appear in <see cref="T:ACE.Entity.Enum.Properties.PropertyString.FoeTypeString"/> (9015); retail may use <see cref="T:ACE.Entity.Enum.Properties.PropertyInt.FoeType"/> (73) only.
+        ///
+        /// Legacy databases may also represent this concept via <c>weenie_properties_int</c> <c>FoeType</c> (73) instead of string lists.
+        ///
+        /// Related behavior flags (not required for the pseudo-type itself, but commonly used alongside custom targeting):
+        /// <see cref="T:ACE.Entity.Enum.Properties.PropertyBool.AllowFriendlyPlayerDamage"/> (9041) and
+        /// <see cref="T:ACE.Entity.Enum.Properties.PropertyBool.BreakPeaceOnHostileAction"/> (9042).
+        /// </remarks>
+        AttackNonSelf = 999
     }
 }

--- a/Source/ACE.Entity/Enum/CustomTargetingBehavior.cs
+++ b/Source/ACE.Entity/Enum/CustomTargetingBehavior.cs
@@ -1,0 +1,27 @@
+namespace ACE.Entity.Enum
+{
+    /// <summary>
+    /// Bit flags for custom targeting (stored as <see cref="Properties.PropertyInt.TargetingFlags"/>).
+    /// Replaces embedding pseudo <see cref="CreatureType"/> values 996–999 in friend/foe strings.
+    /// </summary>
+    [System.Flags]
+    public enum CustomTargetingBehavior : int
+    {
+        None = 0,
+
+        /// <summary>Former pseudo-type 998 — hostile to all creature types.</summary>
+        AttackAll = 1 << 0,
+
+        /// <summary>Former pseudo-type 999 — hostile to outsiders and all players; not auto-hostile to same concrete <see cref="CreatureType"/>.</summary>
+        AttackNonSelf = 1 << 1,
+
+        /// <summary>Former pseudo-type 997 in friend lists — treat all players as friends.</summary>
+        FriendlyToPlayers = 1 << 2,
+
+        /// <summary>Former pseudo-type 996 in friend lists — quest-stamp friends (uses <see cref="Properties.PropertyString.FriendlyQuestString"/>).</summary>
+        FriendlyToQuestPlayer = 1 << 3,
+
+        /// <summary>Former pseudo-type 997 in foe lists — hostile to all players (unless explicitly made a friend).</summary>
+        HostileToAllPlayers = 1 << 4,
+    }
+}

--- a/Source/ACE.Entity/Enum/EmoteType.cs
+++ b/Source/ACE.Entity/Enum/EmoteType.cs
@@ -147,6 +147,7 @@ namespace ACE.Entity.Enum
         DecrementMyIntStat            = 138, //Custom - Decrement self's PropertyInt stat
         IncrementMyInt64Stat          = 139, //Custom - Increment self's PropertyInt64 stat
         DecrementMyInt64Stat          = 140, //Custom - Decrement self's PropertyInt64 stat
+        SetMyFloatStat                = 141, //Custom - Sets self's PropertyFloat stat
         RegisterPetSkin               = 150, //Custom - Pet Registry registration
         InqPetRegistryCount           = 151, //Custom - Check pet registry count (uses min/max)
         InqPetRegistryCreatureType    = 152, //Custom - Check if account has any pet of creature type (uses stat field)

--- a/Source/ACE.Entity/Enum/EmoteType.cs
+++ b/Source/ACE.Entity/Enum/EmoteType.cs
@@ -147,7 +147,6 @@ namespace ACE.Entity.Enum
         DecrementMyIntStat            = 138, //Custom - Decrement self's PropertyInt stat
         IncrementMyInt64Stat          = 139, //Custom - Increment self's PropertyInt64 stat
         DecrementMyInt64Stat          = 140, //Custom - Decrement self's PropertyInt64 stat
-        SetMyFloatStat                = 141, //Custom - Sets self's PropertyFloat stat
         RegisterPetSkin               = 150, //Custom - Pet Registry registration
         InqPetRegistryCount           = 151, //Custom - Check pet registry count (uses min/max)
         InqPetRegistryCreatureType    = 152, //Custom - Check if account has any pet of creature type (uses stat field)

--- a/Source/ACE.Entity/Enum/Properties/PropertyBool.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyBool.cs
@@ -190,12 +190,15 @@ namespace ACE.Entity.Enum.Properties
         CanGrapple                       = 9015,
         CanAOE                           = 9016,
         EnragedHotspot                   = 9017,
+        UseCustomTargetingLists          = 9018,
         [AssessmentProperty]
         SplitArrows                      = 9030,
         IsSplitArrow                     = 9031,
         IsSplitArrowKill                 = 9032,
         [AssessmentProperty]
         IsCharm                          = 9040,
+        AllowFriendlyPlayerDamage       = 9041,
+        BreakPeaceOnHostileAction       = 9042,
         /// <summary>
         /// If TRUE on a weapon, allows multi-strike hits to each roll a proc with decay
         /// </summary>

--- a/Source/ACE.Entity/Enum/Properties/PropertyInt.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyInt.cs
@@ -713,6 +713,11 @@ namespace ACE.Entity.Enum.Properties
 
         // Portal
         PortalUseCount                          = 9040, // Number of times a portal may be used before destroying itself
+
+        /// <summary>
+        /// Custom targeting behavior flags (<see cref="ACE.Entity.Enum.CustomTargetingBehavior"/>).
+        /// </summary>
+        TargetingFlags                          = 9041,
     }
 
     public static class PropertyIntExtensions
@@ -863,6 +868,9 @@ namespace ACE.Entity.Enum.Properties
 
                 case PropertyInt.HookGroup:
                     return System.Enum.GetName(typeof(HookGroupType), value);
+
+                case PropertyInt.TargetingFlags:
+                    return ((ACE.Entity.Enum.CustomTargetingBehavior)value).ToString();
 
                 //case PropertyInt.TypeOfAlteration:
                 //    return System.Enum.GetName(typeof(SkillAlterationType), value);

--- a/Source/ACE.Entity/Enum/Properties/PropertyString.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyString.cs
@@ -102,5 +102,8 @@ namespace ACE.Entity.Enum.Properties
         CapturedObjDescAnimParts = 9011,   // Serialized AnimPartChanges
         CapturedObjDescPalettes = 9012,    // Serialized SubPalettes
         CapturedObjDescTextures = 9013,    // Serialized TextureChanges
+        FriendTypeString = 9014,
+        FoeTypeString = 9015,
+        FriendlyQuestString = 9016,
     }
 }

--- a/Source/ACE.Server/Physics/Common/ObjectMaint.cs
+++ b/Source/ACE.Server/Physics/Common/ObjectMaint.cs
@@ -1063,11 +1063,20 @@ namespace ACE.Server.Physics.Common
                     (PhysicsObj.WeenieObj.FoeType == null || obj.WeenieObj.WorldObject != null && PhysicsObj.WeenieObj.FoeType != obj.WeenieObj.WorldObject.CreatureType))
                 {
                     obj.ObjMaint.AddVisibleTarget(PhysicsObj);
-                    return false;
+                    // Legacy: observer had no Int.73 foe — only the other mob tracked us.
+                    // Extended / custom targeting (9018 + lists / 999) still needs other monsters in *our*
+                    // VisibleTargets so Random / AI can pick them (e.g. Human weenie + FoeTypeString only).
+                    var selfCreatureInverse = PhysicsObj.WeenieObj.WorldObject as Creature;
+                    if (selfCreatureInverse == null || !selfCreatureInverse.UsesExtendedFoeTargeting)
+                        return false;
                 }
 
-                // only tracking players and combat pets
-                if (!obj.IsPlayer && !obj.WeenieObj.IsCombatPet && PhysicsObj.WeenieObj.FoeType == null)
+                // only tracking players and combat pets, unless this creature has legacy or extended foe targeting (Int.73 / 9015 / 999)
+                var selfCreature = PhysicsObj.WeenieObj.WorldObject as Creature;
+                var allowMonsterTargets = PhysicsObj.WeenieObj.FoeType != null
+                    || (selfCreature != null && selfCreature.UsesExtendedFoeTargeting);
+
+                if (!obj.IsPlayer && !obj.WeenieObj.IsCombatPet && !allowMonsterTargets)
                 {
                     log.Debug($"{PhysicsObj.Name}.ObjectMaint.AddVisibleTarget({obj.Name}): tried to add a non-player / non-combat pet");
                     return false;

--- a/Source/ACE.Server/Physics/Common/WeenieObject.cs
+++ b/Source/ACE.Server/Physics/Common/WeenieObject.cs
@@ -79,6 +79,9 @@ namespace ACE.Server.Physics.Common
 
         public bool PotentialFoe(PhysicsObj obj)
         {
+            if (WorldObject is Creature self && obj.WeenieObj.WorldObject is Creature target)
+                return self.PotentialFoe(target);
+
             return FoeType != null && FoeType == obj.WeenieObj.WorldObject?.CreatureType ||
                 obj.WeenieObj.FoeType != null && obj.WeenieObj.FoeType == WorldObject?.CreatureType;
         }

--- a/Source/ACE.Server/Program.cs
+++ b/Source/ACE.Server/Program.cs
@@ -306,7 +306,7 @@ namespace ACE.Server
             log.Info("Initializing GuidManager...");
             GuidManager.Initialize();
             
-            if (!string.IsNullOrEmpty(ConfigManager.Config.Chat.DiscordToken))
+            if (!string.IsNullOrEmpty(ConfigManager.Config.Chat?.DiscordToken))
             {
                 log.Info("Attempting to start Discord Client...");
                 DiscordChatManager.Initialize();

--- a/Source/ACE.Server/WorldObjects/Creature_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Combat.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 using ACE.Common;
@@ -17,6 +18,29 @@ namespace ACE.Server.WorldObjects
 {
     partial class Creature
     {
+        private HashSet<CreatureType> _cachedFriendTypes = new HashSet<CreatureType>();
+        private HashSet<CreatureType> _cachedFoeTypes = new HashSet<CreatureType>();
+        private bool _attackNonSelf;
+        private bool _attackAll;
+        private bool _targetingCacheInitialized;
+        private CustomTargetingBehavior _lastTargetingFlags;
+        private CreatureType? _lastFoeType;
+        private string _lastFriendTypeString;
+        private string _lastFoeTypeString;
+        private string _lastFriendlyQuestString;
+
+        /// <summary>
+        /// True when any custom targeting data is present (flags and/or friend/foe/quest strings).
+        /// </summary>
+        public bool IsUsingCustomTargetingLists =>
+            TargetingFlags != CustomTargetingBehavior.None ||
+            !string.IsNullOrEmpty(FriendTypeString) ||
+            !string.IsNullOrEmpty(FoeTypeString) ||
+            !string.IsNullOrEmpty(FriendlyQuestString);
+
+        private static bool IsPseudoTargetingCreatureType(ACE.Entity.Enum.CreatureType ct) =>
+            ct >= ACE.Entity.Enum.CreatureType.QuestPlayer && ct <= ACE.Entity.Enum.CreatureType.AttackNonSelf;
+
         const int OverpowerResistAdditionThreshold = 600;
         public enum DebugDamageType
         {
@@ -1057,10 +1081,16 @@ namespace ACE.Server.WorldObjects
 
         public virtual bool CanDamage(Creature target)
         {
+            if (target == null)
+                return false;
+
             if (target is Player player)
             {
                 // Skip players with CloakStatus.Creature - monsters should not attack them
                 if (player.CloakStatus == CloakStatus.Creature)
+                    return false;
+
+                if (BlocksFriendlyPlayerDamage(target))
                     return false;
 
                 // monster attacking player
@@ -1097,6 +1127,24 @@ namespace ACE.Server.WorldObjects
             }
         }
 
+        public bool BlocksFriendlyPlayerDamage(Creature target)
+        {
+            if (target == null)
+                return false;
+
+            if (this is Player && target is not Player)
+            {
+                return !target.AllowFriendlyPlayerDamage.GetValueOrDefault(false) && target.IsFriend(this);
+            }
+
+            if (this is not Player && target is Player)
+            {
+                return !AllowFriendlyPlayerDamage.GetValueOrDefault(false) && IsFriend(target);
+            }
+
+            return false;
+        }
+
         public static Skill GetDefenseSkill(CombatType combatType)
         {
             switch (combatType)
@@ -1115,7 +1163,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// If one of these fields is set, potential aggro from Player or CombatPet movement terminates immediately
         /// </summary>
-        protected static readonly Tolerance PlayerCombatPet_MoveExclude = Tolerance.NoAttack | Tolerance.Appraise | Tolerance.Provoke | Tolerance.Retaliate | Tolerance.Monster;
+        protected static readonly Tolerance PlayerCombatPet_MoveExclude = Tolerance.NoAttack | Tolerance.Appraise | Tolerance.Provoke | Tolerance.Retaliate;
 
         /// <summary>
         /// If one of these fields is set, potential aggro from other monster movement terminates immediately
@@ -1125,7 +1173,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// If one of these fields is set, potential aggro from Player or CombatPet attacks terminates immediately
         /// </summary>
-        protected static readonly Tolerance PlayerCombatPet_RetaliateExclude = Tolerance.NoAttack | Tolerance.Monster;
+        protected static readonly Tolerance PlayerCombatPet_RetaliateExclude = Tolerance.NoAttack;
 
         /// <summary>
         /// If one of these fields is set, potential aggro from monster alerts terminates immediately
@@ -1147,6 +1195,10 @@ namespace ACE.Server.WorldObjects
             if (this is Player player && player.CloakStatus == CloakStatus.Creature)
                 return false;
 
+            // Extended/custom targeting should not wake allies from player proximity.
+            if (this is Player && monster.UsesExtendedFoeTargeting && !monster.PotentialFoe(this))
+                return false;
+
             // non-attackable creatures do not get aggroed,
             // unless they have a TargetingTactic, such as the invisible archers in Oswald's Dirk Quest
             if (!monster.Attackable && monster.TargetingTactic == TargetingTactic.None)
@@ -1157,7 +1209,12 @@ namespace ACE.Server.WorldObjects
             // TODO: investigate usage for tolerance
             var tolerance = this is Player ? PlayerCombatPet_MoveExclude : Monster_MoveExclude;
 
-            if (monster.MonsterState != State.Idle || (monster.Tolerance & tolerance) != 0)
+            if (monster.MonsterState != State.Idle)
+                return false;
+
+            var blockingBits = monster.Tolerance & tolerance;
+
+            if (blockingBits != 0)
                 return false;
 
             // for faction mobs, ensure alerter doesn't belong to same faction
@@ -1374,12 +1431,221 @@ namespace ACE.Server.WorldObjects
         }
 
         /// <summary>
-        /// Returns TRUE is this creature has a FoeType that matches the input creature's CreatureType,
+        /// Returns TRUE if this creature has a FoeType that matches the input creature's CreatureType,
         /// or if the input creature has a FoeType that matches this creature's CreatureType
         /// </summary>
         public bool PotentialFoe(Creature creature)
         {
-            return FoeType != null && FoeType == creature.CreatureType || creature.FoeType != null && creature.FoeType == CreatureType;
+            EnsureTargetingCacheCurrent();
+
+            if (IsUsingCustomTargetingLists)
+            {
+                // Explicit player friendship should override custom hostility rules.
+                if (creature is Player player && IsExplicitlyFriendlyPlayer(player))
+                    return false;
+
+                // Explicit non-player friendship should also override custom hostility rules.
+                if (creature is not Player && creature.CreatureType is { } friendType && _cachedFriendTypes.Contains(friendType))
+                    return false;
+
+                // Attack All pseudo-type (998)
+                if (_attackAll) return true;
+
+                // Attack Non-Self (999)
+                if (_attackNonSelf && (creature is Player || creature.CreatureType != CreatureType)) return true;
+
+                // Explicitly designated foes (including pseudo-type Player 997)
+                if (creature is Player && _cachedFoeTypes.Contains(ACE.Entity.Enum.CreatureType.Player)) return true;
+                if (creature.CreatureType is { } creatureType && _cachedFoeTypes.Contains(creatureType)) return true;
+
+            }
+            else
+            {
+                // Legacy int properties
+                if (FoeType != null)
+                {
+                    if (FoeType == creature.CreatureType) return true;
+                    if (FoeType == ACE.Entity.Enum.CreatureType.AttackNonSelf && (creature is Player || creature.CreatureType != CreatureType)) return true;
+                }
+            }
+
+            // Reciprocal checking (does the target consider us a foe?)
+            creature.EnsureTargetingCacheCurrent();
+            if (creature.IsUsingCustomTargetingLists)
+            {
+                if (creature._attackAll) return true;
+                if (creature._attackNonSelf && (this is Player || CreatureType != creature.CreatureType)) return true;
+                if (this is Player && creature._cachedFoeTypes.Contains(ACE.Entity.Enum.CreatureType.Player)) return true;
+                if (CreatureType is { } selfType && creature._cachedFoeTypes.Contains(selfType)) return true;
+            }
+            else if (creature.FoeType != null)
+            {
+                if (creature.FoeType == CreatureType) return true;
+                if (creature.FoeType == ACE.Entity.Enum.CreatureType.AttackNonSelf && (this is Player || CreatureType != creature.CreatureType)) return true;
+            }
+
+            return false;
+        }
+
+        private bool IsExplicitlyFriendlyPlayer(Player player)
+        {
+            if (_cachedFriendTypes.Contains(ACE.Entity.Enum.CreatureType.Player))
+                return true;
+
+            if (_cachedFriendTypes.Contains(ACE.Entity.Enum.CreatureType.QuestPlayer) && MatchesQuestPlayerAffinity(player))
+                return true;
+
+            // FriendlyQuestString alone exempts players with that stamp (no need for QuestPlayer/996 in FriendTypeString)
+            if (!string.IsNullOrEmpty(FriendlyQuestString) && player.QuestManager.HasQuest(FriendlyQuestString))
+                return true;
+
+            return false;
+        }
+
+        private bool MatchesQuestPlayerAffinity(Player player)
+        {
+            if (player == null || string.IsNullOrEmpty(FriendlyQuestString))
+                return false;
+
+            return player.QuestManager.HasQuest(FriendlyQuestString);
+        }
+
+        private void EnsureTargetingCacheCurrent()
+        {
+            var tf = TargetingFlags;
+            var friendStr = FriendTypeString;
+            var foeStr = FoeTypeString;
+            var friendlyQuestStr = FriendlyQuestString;
+            var foeType = FoeType;
+
+            if (!_targetingCacheInitialized ||
+                _lastTargetingFlags != tf ||
+                _lastFoeType != foeType ||
+                !string.Equals(_lastFriendTypeString, friendStr, StringComparison.Ordinal) ||
+                !string.Equals(_lastFoeTypeString, foeStr, StringComparison.Ordinal) ||
+                !string.Equals(_lastFriendlyQuestString, friendlyQuestStr, StringComparison.Ordinal))
+            {
+                UpdateTargetingCache();
+            }
+        }
+
+        public override void OnPropertyStringChanged(PropertyString property, string value)
+        {
+            if (property == PropertyString.FriendTypeString || property == PropertyString.FoeTypeString || property == PropertyString.FriendlyQuestString)
+                UpdateTargetingCache();
+        }
+
+        public override void OnPropertyStringRemoved(PropertyString property)
+        {
+            if (property == PropertyString.FriendTypeString || property == PropertyString.FoeTypeString || property == PropertyString.FriendlyQuestString)
+                UpdateTargetingCache();
+        }
+
+        public void UpdateTargetingCache()
+        {
+            _cachedFriendTypes.Clear();
+            _cachedFoeTypes.Clear();
+
+            var tf = TargetingFlags;
+            _attackAll = tf.HasFlag(CustomTargetingBehavior.AttackAll);
+            _attackNonSelf = tf.HasFlag(CustomTargetingBehavior.AttackNonSelf);
+            if (IsUsingCustomTargetingLists && FoeType == ACE.Entity.Enum.CreatureType.AttackNonSelf)
+                _attackNonSelf = true;
+
+            if (tf.HasFlag(CustomTargetingBehavior.FriendlyToPlayers))
+                _cachedFriendTypes.Add(ACE.Entity.Enum.CreatureType.Player);
+            if (tf.HasFlag(CustomTargetingBehavior.FriendlyToQuestPlayer))
+                _cachedFriendTypes.Add(ACE.Entity.Enum.CreatureType.QuestPlayer);
+            if (tf.HasFlag(CustomTargetingBehavior.HostileToAllPlayers))
+                _cachedFoeTypes.Add(ACE.Entity.Enum.CreatureType.Player);
+
+            _targetingCacheInitialized = true;
+            _lastTargetingFlags = TargetingFlags;
+            _lastFoeType = FoeType;
+            _lastFriendTypeString = FriendTypeString;
+            _lastFoeTypeString = FoeTypeString;
+            _lastFriendlyQuestString = FriendlyQuestString;
+
+            if (!IsUsingCustomTargetingLists)
+                return;
+
+            var friendStr = FriendTypeString;
+            if (!string.IsNullOrEmpty(friendStr))
+            {
+                var types = friendStr.Split(',', StringSplitOptions.RemoveEmptyEntries);
+                foreach (var typeStr in types)
+                {
+                    if (uint.TryParse(typeStr.Trim(), out var typeId))
+                    {
+                        var ct = (CreatureType)typeId;
+                        if (IsPseudoTargetingCreatureType(ct))
+                            log.Warn($"{Name} ({Guid}): FriendTypeString contains pseudo CreatureType {(uint)ct}; use PropertyInt.TargetingFlags instead.");
+                        else
+                            _cachedFriendTypes.Add(ct);
+                    }
+                    else
+                        log.Error($"{Name} ({Guid}): Invalid CreatureType ID in FriendTypeString: {typeStr}");
+                }
+            }
+
+            var foeStr = FoeTypeString;
+            if (!string.IsNullOrEmpty(foeStr))
+            {
+                var types = foeStr.Split(',', StringSplitOptions.RemoveEmptyEntries);
+                foreach (var typeStr in types)
+                {
+                    if (uint.TryParse(typeStr.Trim(), out var typeId))
+                    {
+                        var foeCreatureType = (CreatureType)typeId;
+                        if (IsPseudoTargetingCreatureType(foeCreatureType))
+                            log.Warn($"{Name} ({Guid}): FoeTypeString contains pseudo CreatureType {(uint)foeCreatureType}; use PropertyInt.TargetingFlags instead.");
+                        else
+                            _cachedFoeTypes.Add(foeCreatureType);
+                    }
+                    else
+                        log.Error($"{Name} ({Guid}): Invalid CreatureType ID in FoeTypeString: {typeStr}");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns TRUE if the creature is considered a friend
+        /// </summary>
+        public bool IsFriend(Creature creature)
+        {
+            EnsureTargetingCacheCurrent();
+
+            if (IsUsingCustomTargetingLists)
+            {
+                // Explicitly designated friends override everything else.
+                // Handle pseudo-type Player (997)
+                if (creature is Player player && IsExplicitlyFriendlyPlayer(player))
+                    return true;
+
+                // Handle standard defined friends
+                if (creature is not Player && creature.CreatureType is { } friendCt && _cachedFriendTypes.Contains(friendCt))
+                    return true;
+
+                // If this creature wants to attack everything (998), no one else is a friend.
+                if (_attackAll)
+                    return false;
+
+                // Default behavior: same type is friendly unless target is a Player.
+                // Prevents Human monsters from treating Human players as friends.
+                if (CreatureType != null && CreatureType == creature.CreatureType && !(creature is Player))
+                    return true;
+            }
+            else
+            {
+                // Legacy system handling
+                if (creature is not Player && CreatureType != null && CreatureType == creature.CreatureType)
+                    return true;
+
+                if (creature is not Player && FriendType != null && FriendType == creature.CreatureType)
+                    return true;
+            }
+
+            return false;
         }
 
         public bool AllowFactionCombat(Creature creature)

--- a/Source/ACE.Server/WorldObjects/Creature_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Combat.cs
@@ -1473,6 +1473,9 @@ namespace ACE.Server.WorldObjects
             creature.EnsureTargetingCacheCurrent();
             if (creature.IsUsingCustomTargetingLists)
             {
+                if (creature.IsFriend(this))
+                    return false;
+
                 if (creature._attackAll) return true;
                 if (creature._attackNonSelf && (this is Player || CreatureType != creature.CreatureType)) return true;
                 if (this is Player && creature._cachedFoeTypes.Contains(ACE.Entity.Enum.CreatureType.Player)) return true;

--- a/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
@@ -543,21 +543,6 @@ namespace ACE.Server.WorldObjects.Managers
                     }
                     break;
 
-                /* sets self's PropertyFloat stat to a specific amount */
-                case EmoteType.SetMyFloatStat:
-
-                    if (WorldObject != null && emote.Stat != null)
-                    {
-                        var floatProperty = (PropertyFloat)emote.Stat;
-                        var newValue = emote.Percent ?? 1.0f; 
-                        
-                        WorldObject.SetProperty(floatProperty, newValue);
-
-                        if (WorldObject is Player selfPlayer)
-                            selfPlayer.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyFloat(selfPlayer, floatProperty, newValue));
-                    }
-                    break;
-
                 /* inq questbonus amount */
                 case EmoteType.QuestCompletionCount:
 

--- a/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
@@ -543,6 +543,21 @@ namespace ACE.Server.WorldObjects.Managers
                     }
                     break;
 
+                /* sets self's PropertyFloat stat to a specific amount */
+                case EmoteType.SetMyFloatStat:
+
+                    if (WorldObject != null && emote.Stat != null)
+                    {
+                        var floatProperty = (PropertyFloat)emote.Stat;
+                        var newValue = emote.Percent ?? 1.0f; 
+                        
+                        WorldObject.SetProperty(floatProperty, newValue);
+
+                        if (WorldObject is Player selfPlayer)
+                            selfPlayer.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyFloat(selfPlayer, floatProperty, newValue));
+                    }
+                    break;
+
                 /* inq questbonus amount */
                 case EmoteType.QuestCompletionCount:
 

--- a/Source/ACE.Server/WorldObjects/Monster.cs
+++ b/Source/ACE.Server/WorldObjects/Monster.cs
@@ -48,7 +48,11 @@ namespace ACE.Server.WorldObjects
 
             IsFactionMob = IsMonster && WeenieType != WeenieType.CombatPet && Faction1Bits != null;
 
-            HasFoeType = IsMonster && FoeType != null;
+            HasFoeType = IsMonster && (FoeType != null
+                || (TargetingFlags & (CustomTargetingBehavior.AttackNonSelf | CustomTargetingBehavior.AttackAll | CustomTargetingBehavior.HostileToAllPlayers)) != 0
+                || (IsUsingCustomTargetingLists && !string.IsNullOrEmpty(FoeTypeString)));
+
+            UpdateTargetingCache();
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Monster.cs
+++ b/Source/ACE.Server/WorldObjects/Monster.cs
@@ -15,7 +15,14 @@ namespace ACE.Server.WorldObjects
 
         public bool IsFactionMob { get; set; }
 
-        public bool HasFoeType { get; set; }
+        /// <summary>
+        /// True when this monster should run foe-based idle scans (classic FoeType, attack flags, or custom foe list).
+        /// Computed so it stays in sync when targeting properties change after <see cref="SetMonsterState"/>.
+        /// </summary>
+        public bool HasFoeType =>
+            IsMonster && (FoeType != null
+                || (TargetingFlags & (CustomTargetingBehavior.AttackNonSelf | CustomTargetingBehavior.AttackAll | CustomTargetingBehavior.HostileToAllPlayers)) != 0
+                || (IsUsingCustomTargetingLists && !string.IsNullOrEmpty(FoeTypeString)));
 
         /// <summary>
         /// The exclusive state of the monster
@@ -47,10 +54,6 @@ namespace ACE.Server.WorldObjects
             IsMonster = Attackable || TargetingTactic != TargetingTactic.None;
 
             IsFactionMob = IsMonster && WeenieType != WeenieType.CombatPet && Faction1Bits != null;
-
-            HasFoeType = IsMonster && (FoeType != null
-                || (TargetingFlags & (CustomTargetingBehavior.AttackNonSelf | CustomTargetingBehavior.AttackAll | CustomTargetingBehavior.HostileToAllPlayers)) != 0
-                || (IsUsingCustomTargetingLists && !string.IsNullOrEmpty(FoeTypeString)));
 
             UpdateTargetingCache();
         }

--- a/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
@@ -24,6 +24,27 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public bool IsAwake = false;
 
+        public bool HasTargetingOverride
+        {
+            get
+            {
+                EnsureTargetingCacheCurrent();
+                return FoeType != null || _attackNonSelf || _attackAll || _cachedFoeTypes.Count > 0;
+            }
+        }
+
+        /// <summary>
+        /// True when custom targeting is active (flags and/or friend/foe/quest strings).
+        /// </summary>
+        public bool UsesExtendedFoeTargeting
+        {
+            get
+            {
+                EnsureTargetingCacheCurrent();
+                return IsUsingCustomTargetingLists;
+            }
+        }
+
         /// <summary>
         /// Cache for visible targets to reduce expensive lookups
         /// </summary>
@@ -300,7 +321,7 @@ namespace ACE.Server.WorldObjects
                     case TargetingTactic.LastDamager:
 
                         var lastDamager = DamageHistory.LastDamager?.TryGetAttacker() as Creature;
-                        if (lastDamager != null)
+                        if (lastDamager != null && visibleTargets.Contains(lastDamager))
                         {
                             SetAttackTargetAndInvalidate(lastDamager);
                         }
@@ -309,7 +330,7 @@ namespace ACE.Server.WorldObjects
                     case TargetingTactic.TopDamager:
 
                         var topDamager = DamageHistory.TopDamager?.TryGetAttacker() as Creature;
-                        if (topDamager != null)
+                        if (topDamager != null && visibleTargets.Contains(topDamager))
                         {
                             SetAttackTargetAndInvalidate(topDamager);
                         }
@@ -412,9 +433,9 @@ namespace ACE.Server.WorldObjects
                     if (p.Hidden ?? false)
                         continue;
                 }
-                    
-                // Only apply TargetingTactic-based skip to non-players (players are excluded above)
-                if (creature.TargetingTactic == TargetingTactic.None && !(creature is Player))
+
+                // Retail: Int.67 Monster + Int.73-only foe = do not select players. Extended foe (9015 / 999 / multi-type) overrides.
+                if (Tolerance.HasFlag(Tolerance.Monster) && !UsesExtendedFoeTargeting && creature is Player)
                     continue;
                     
                 if (creature.Teleporting)
@@ -451,13 +472,44 @@ namespace ACE.Server.WorldObjects
                 if (Tolerance.HasFlag(Tolerance.Target) && creature != AttackTarget)
                     continue;
 
-                // can only target other monsters with Tolerance.Monster -- cannot target players or combat pets
-                if (Tolerance.HasFlag(Tolerance.Monster) && (creature is Player || creature is CombatPet))
+                if (!IsValidAttackCandidate(creature))
                     continue;
 
                 visibleTargets.Add(creature);
             }
             return visibleTargets;
+        }
+
+        /// <summary>
+        /// Determines whether a creature should be included in the attack-candidate list.
+        /// Keeps legacy player behavior while applying strict foe validation for custom targeting.
+        /// </summary>
+        private bool IsValidAttackCandidate(Creature creature)
+        {
+            // Preserve existing behavior for active target lock/switching paths.
+            if (creature == AttackTarget)
+                return true;
+
+            if (creature is Player)
+            {
+                // Under extended targeting, explicit friend/foe lists should decide if players are valid.
+                if (UsesExtendedFoeTargeting)
+                    return PotentialFoe(creature) || PhysicsObj.ObjMaint.RetaliateTargetsContainsKey(creature.Guid.Full);
+
+                // Legacy monster behavior remains unchanged for players.
+                return true;
+            }
+
+            // Passive NPC-like creatures should not be considered unless explicitly hostile.
+            if (creature.TargetingTactic == TargetingTactic.None && !PotentialFoe(creature))
+                return false;
+
+            // Primary hostility checks for non-player targets.
+            if (PotentialFoe(creature) || AllowFactionCombat(creature))
+                return true;
+
+            // Retaliate targets can be valid even when not classic foes.
+            return PhysicsObj.ObjMaint.RetaliateTargetsContainsKey(creature.Guid.Full);
         }
 
         /// <summary>
@@ -570,7 +622,14 @@ namespace ACE.Server.WorldObjects
                         continue;
                 }
 
-                if (Tolerance.HasFlag(Tolerance.Monster) && (creature is Player || creature is CombatPet))
+                if (Tolerance.HasFlag(Tolerance.Monster) && !UsesExtendedFoeTargeting && creature is Player)
+                    continue;
+
+                if (Tolerance.HasFlag(Tolerance.Monster) && creature is CombatPet)
+                    continue;
+
+                // Keep spawn-in target acquisition aligned with regular attack candidate filtering.
+                if (!IsValidAttackCandidate(creature))
                     continue;
 
                 //var distSq = Location.SquaredDistanceTo(creature.Location);
@@ -677,8 +736,7 @@ namespace ACE.Server.WorldObjects
                 if ((nearbyCreature.Tolerance & AlertExclude) != 0)
                     continue;
 
-                if (CreatureType != null && CreatureType == nearbyCreature.CreatureType ||
-                      FriendType != null && FriendType == nearbyCreature.CreatureType)
+                if (nearbyCreature.IsFriend(this))
                 {
                     //var distSq = Location.SquaredDistanceTo(nearbyCreature.Location);
                     var distSq = PhysicsObj.get_distance_sq_to_object(nearbyCreature.PhysicsObj, true);
@@ -731,8 +789,11 @@ namespace ACE.Server.WorldObjects
 
             foreach (var creature in creatures)
             {
-                // ensure type isn't already handled elsewhere
-                if (creature is Player || creature is CombatPet)
+                if (creature is CombatPet)
+                    continue;
+
+                // Retail monster+foe wake only from other mobs; extended foe (9015 / 999) also wakes from valid players
+                if (creature is Player && !UsesExtendedFoeTargeting)
                     continue;
 
                 // ensure valid/attackable
@@ -752,8 +813,47 @@ namespace ACE.Server.WorldObjects
                 if (PhysicsObj.get_distance_sq_to_object(creature.PhysicsObj, true) > VisualAwarenessRangeSq)
                     continue;
 
-                creature.AlertMonster(this);
-                break;
+                if (creature is Player player)
+                {
+                    if (player.CloakStatus == CloakStatus.Creature || (player.Hidden ?? false))
+                        continue;
+
+                    if (!PotentialFoe(player))
+                        continue;
+                    if (player.AlertMonster(this))
+                        break;
+                }
+                else
+                {
+                    if (creature.AlertMonster(this))
+                        break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Wakes this monster when a valid player is in range (idle tick). Legacy Int.73-only foes skip players entirely.
+        /// </summary>
+        public void ExtendedFoeWakeFromProximity()
+        {
+            if (MonsterState != State.Idle || IsAwake || !UsesExtendedFoeTargeting)
+                return;
+
+            foreach (var creature in PhysicsObj.ObjMaint.GetVisibleTargetsValuesOfTypeCreature())
+            {
+                if (creature is not Player player)
+                    continue;
+                if (player.CloakStatus == CloakStatus.Creature)
+                    continue;
+                if (!player.Attackable || player.Teleporting || (player.Hidden ?? false))
+                    continue;
+                if (PhysicsObj.get_distance_sq_to_object(creature.PhysicsObj, true) > VisualAwarenessRangeSq)
+                    continue;
+                if (!PotentialFoe(creature))
+                    continue;
+
+                if (player.AlertMonster(this))
+                    break;
             }
         }
     }

--- a/Source/ACE.Server/WorldObjects/Monster_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Melee.cs
@@ -104,6 +104,9 @@ namespace ACE.Server.WorldObjects
                     {
                         if (targetPlayer != null)
                         {
+                            if (!CanDamage(target))
+                                return;
+
                             // this is a player taking damage
                             targetPlayer.TakeDamage(this, damageEvent);
 
@@ -144,6 +147,9 @@ namespace ACE.Server.WorldObjects
                             
                             foreach (var cleaveHit in cleave)
                             {
+                                if (!CanDamage(cleaveHit))
+                                    continue;
+
                                 var cleaveDamageEvent = DamageEvent.CalculateDamage(this, cleaveHit, weapon, motionCommand, attackFrames[0].attackHook);
                                 
                                 if (cleaveDamageEvent.HasDamage)

--- a/Source/ACE.Server/WorldObjects/Monster_Tick.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Tick.cs
@@ -71,6 +71,10 @@ namespace ACE.Server.WorldObjects
                 if (IsFactionMob || HasFoeType)
                     FactionMob_CheckMonsters();
 
+                // FactionMob_CheckMonsters ignores players; extended foe mobs still need idle proximity wake when the player is standing still
+                if (HasFoeType && UsesExtendedFoeTargeting)
+                    ExtendedFoeWakeFromProximity();
+
                 return;
             }
 

--- a/Source/ACE.Server/WorldObjects/Player_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Combat.cs
@@ -897,7 +897,15 @@ namespace ACE.Server.WorldObjects
 
         public override bool CanDamage(Creature target)
         {
-            return target.Attackable && !target.Teleporting && !(target is CombatPet);
+            if (!target.Attackable || target.Teleporting || target is CombatPet)
+                return false;
+
+            // PropertyBool.AllowFriendlyPlayerDamage (9041): when explicitly false, friendly players cannot damage this creature.
+            // (Creature.BlocksFriendlyPlayerDamage's player→creature branch is never invoked from Creature.CanDamage; this is the live check for melee/missile/magic.)
+            if (target.AllowFriendlyPlayerDamage == false && target.IsFriend(this))
+                return false;
+
+            return true;
         }
 
         // http://acpedia.org/wiki/Announcements_-_2002/04_-_Betrayal

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -1112,7 +1112,7 @@ namespace ACE.Server.WorldObjects
                     if (!spell.IsProjectile)
                     {
                         if (targetPlayer == null)
-                            OnAttackMonster(targetCreature);
+                            OnAttackMonster(targetCreature, spell.IsHarmful);
 
                         if (TryResistSpell(target, spell, itemCaster))
                             break;

--- a/Source/ACE.Server/WorldObjects/Player_Monster.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Monster.cs
@@ -37,13 +37,28 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Called when this player attacks a monster
         /// </summary>
-        public void OnAttackMonster(Creature monster)
+        public void OnAttackMonster(Creature monster, bool hostileAction = true)
         {
             if (monster == null || !Attackable) return;
 
             /*Console.WriteLine($"{Name}.OnAttackMonster({monster.Name})");
             Console.WriteLine($"Attackable: {monster.Attackable}");
             Console.WriteLine($"Tolerance: {monster.Tolerance}");*/
+
+            if (monster.IsUsingCustomTargetingLists && monster.IsFriend(this))
+            {
+                var breakPeace = hostileAction && monster.BreakPeaceOnHostileAction.GetValueOrDefault(false);
+                if (!breakPeace)
+                    return;
+
+                // Force explicit retaliation target even if the monster is already awake.
+                monster.AddRetaliateTarget(this);
+                monster.AttackTarget = this;
+                if (monster.MonsterState != State.Awake)
+                    monster.WakeUp();
+
+                return;
+            }
 
             // faction mobs will retaliate against players belonging to the same faction
             if (SameFaction(monster))

--- a/Source/ACE.Server/WorldObjects/ProjectileCollisionHelper.cs
+++ b/Source/ACE.Server/WorldObjects/ProjectileCollisionHelper.cs
@@ -80,51 +80,59 @@ namespace ACE.Server.WorldObjects
                 }
                 else if (sourceCreature != null && sourceCreature.AttackTarget != null)
                 {
-                    // todo: clean this up
-                    var targetPlayer = sourceCreature.AttackTarget as Player;
-
-                    damageEvent = DamageEvent.CalculateDamage(sourceCreature, targetCreature, worldObject);
-
-                    if (targetPlayer != null)
+                    if (!sourceCreature.CanDamage(targetCreature))
                     {
-                        // monster damage player
-                        if (damageEvent.HasDamage)
-                        {
-                            targetPlayer.TakeDamage(sourceCreature, damageEvent);
-
-                            // blood splatter?
-
-                            if (damageEvent.ShieldMod != 1.0f)
-                            {
-                                var shieldSkill = targetPlayer.GetCreatureSkill(Skill.Shield);
-                                Proficiency.OnSuccessUse(targetPlayer, shieldSkill, shieldSkill.Current);   // ??
-                            }
-
-                            // handle Dirty Fighting
-                            if (sourceCreature.GetCreatureSkill(Skill.DirtyFighting).AdvancementClass >= SkillAdvancementClass.Trained)
-                                sourceCreature.FightDirty(targetPlayer, damageEvent.Weapon);
-                        }
-                        else
-                            targetPlayer.OnEvade(sourceCreature, CombatType.Missile);
+                        // Blocked by targeting rules; do not apply damage,
+                        // but still continue to shared projectile cleanup below.
                     }
                     else
                     {
-                        // monster damage pet
-                        if (damageEvent.HasDamage)
+                        // todo: clean this up
+                        var targetPlayer = sourceCreature.AttackTarget as Player;
+
+                        damageEvent = DamageEvent.CalculateDamage(sourceCreature, targetCreature, worldObject);
+
+                        if (targetPlayer != null)
                         {
-                            targetCreature.TakeDamage(sourceCreature, damageEvent.DamageType, damageEvent.Damage);
+                            // monster damage player
+                            if (damageEvent.HasDamage)
+                            {
+                                targetPlayer.TakeDamage(sourceCreature, damageEvent);
 
-                            // blood splatter?
+                                // blood splatter?
 
-                            // handle Dirty Fighting
-                            if (sourceCreature.GetCreatureSkill(Skill.DirtyFighting).AdvancementClass >= SkillAdvancementClass.Trained)
-                                sourceCreature.FightDirty(targetCreature, damageEvent.Weapon);
+                                if (damageEvent.ShieldMod != 1.0f)
+                                {
+                                    var shieldSkill = targetPlayer.GetCreatureSkill(Skill.Shield);
+                                    Proficiency.OnSuccessUse(targetPlayer, shieldSkill, shieldSkill.Current);   // ??
+                                }
+
+                                // handle Dirty Fighting
+                                if (sourceCreature.GetCreatureSkill(Skill.DirtyFighting).AdvancementClass >= SkillAdvancementClass.Trained)
+                                    sourceCreature.FightDirty(targetPlayer, damageEvent.Weapon);
+                            }
+                            else
+                                targetPlayer.OnEvade(sourceCreature, CombatType.Missile);
                         }
-
-                        if (!(targetCreature is CombatPet))
+                        else
                         {
-                            // faction mobs and foetype
-                            sourceCreature.MonsterOnAttackMonster(targetCreature);
+                            // monster damage pet
+                            if (damageEvent.HasDamage)
+                            {
+                                targetCreature.TakeDamage(sourceCreature, damageEvent.DamageType, damageEvent.Damage);
+
+                                // blood splatter?
+
+                                // handle Dirty Fighting
+                                if (sourceCreature.GetCreatureSkill(Skill.DirtyFighting).AdvancementClass >= SkillAdvancementClass.Trained)
+                                    sourceCreature.FightDirty(targetCreature, damageEvent.Weapon);
+                            }
+
+                            if (!(targetCreature is CombatPet))
+                            {
+                                // faction mobs and foetype
+                                sourceCreature.MonsterOnAttackMonster(targetCreature);
+                            }
                         }
                     }
                 }

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -374,7 +374,7 @@ namespace ACE.Server.WorldObjects
 
             // also called on resist
             if (player != null && targetPlayer == null)
-                player.OnAttackMonster(creatureTarget);
+                player.OnAttackMonster(creatureTarget, Spell.IsHarmful);
 
             if (player == null && targetPlayer == null)
             {

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -205,9 +205,15 @@ namespace ACE.Server.WorldObjects
                 Biota.SetProperty(property, value, BiotaDatabaseLock, out var changed);
 
                 if (changed)
+                {
                     ChangesDetected = true;
+                    OnPropertyStringChanged(property, value);
+                }
             }
         }
+
+        public virtual void OnPropertyStringChanged(PropertyString property, string value) { }
+        public virtual void OnPropertyStringRemoved(PropertyString property) { }
         #endregion
 
         #region RemoveProperty Functions
@@ -299,7 +305,10 @@ namespace ACE.Server.WorldObjects
             else
             {
                 if (Biota.TryRemoveProperty(property, BiotaDatabaseLock))
+                {
                     ChangesDetected = true;
+                    OnPropertyStringRemoved(property);
+                }
             }
         }
         #endregion
@@ -2031,6 +2040,58 @@ namespace ACE.Server.WorldObjects
         {
             get => (CreatureType?)GetProperty(PropertyInt.FoeType);
             set { if (!value.HasValue) RemoveProperty(PropertyInt.FoeType); else SetProperty(PropertyInt.FoeType, (int)value.Value); }
+        }
+
+        /// <summary>
+        /// Custom targeting pseudo-types (AttackAll, AttackNonSelf, friend/foe player modes) as flags.
+        /// </summary>
+        public CustomTargetingBehavior TargetingFlags
+        {
+            get => (CustomTargetingBehavior)(GetProperty(PropertyInt.TargetingFlags) ?? 0);
+            set
+            {
+                if (value == CustomTargetingBehavior.None)
+                    RemoveProperty(PropertyInt.TargetingFlags);
+                else
+                    SetProperty(PropertyInt.TargetingFlags, (int)value);
+            }
+        }
+
+        public string FriendTypeString
+        {
+            get => GetProperty(PropertyString.FriendTypeString);
+            set { if (string.IsNullOrEmpty(value)) RemoveProperty(PropertyString.FriendTypeString); else SetProperty(PropertyString.FriendTypeString, value); }
+        }
+
+        public string FoeTypeString
+        {
+            get => GetProperty(PropertyString.FoeTypeString);
+            set { if (string.IsNullOrEmpty(value)) RemoveProperty(PropertyString.FoeTypeString); else SetProperty(PropertyString.FoeTypeString, value); }
+        }
+
+        public string FriendlyQuestString
+        {
+            get => GetProperty(PropertyString.FriendlyQuestString);
+            set { if (string.IsNullOrEmpty(value)) RemoveProperty(PropertyString.FriendlyQuestString); else SetProperty(PropertyString.FriendlyQuestString, value); }
+        }
+
+        [Obsolete("Custom targeting is implied by TargetingFlags and/or friend/foe/quest strings.")]
+        public bool? UseCustomTargetingLists
+        {
+            get => GetProperty(PropertyBool.UseCustomTargetingLists);
+            set { if (!value.HasValue) RemoveProperty(PropertyBool.UseCustomTargetingLists); else SetProperty(PropertyBool.UseCustomTargetingLists, value.Value); }
+        }
+
+        public bool? AllowFriendlyPlayerDamage
+        {
+            get => GetProperty(PropertyBool.AllowFriendlyPlayerDamage);
+            set { if (!value.HasValue) RemoveProperty(PropertyBool.AllowFriendlyPlayerDamage); else SetProperty(PropertyBool.AllowFriendlyPlayerDamage, value.Value); }
+        }
+
+        public bool? BreakPeaceOnHostileAction
+        {
+            get => GetProperty(PropertyBool.BreakPeaceOnHostileAction);
+            set { if (!value.HasValue) RemoveProperty(PropertyBool.BreakPeaceOnHostileAction); else SetProperty(PropertyBool.BreakPeaceOnHostileAction, value.Value); }
         }
 
         public string LongDesc


### PR DESCRIPTION
Friend/Foe string lists, FriendlyQuestString, UseCustomTargetingLists, AllowFriendlyPlayerDamage; aggro/retaliate/damage gating for friends. Excludes clothing mod, ReceiveDamage emote schema, and unrelated fork commits.

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom targeting lists and extended foe-targeting modes added (quest-player, player, attack-all, attack-non-self) plus a new bitflag-based targeting setting and public hooks/properties to configure friend/foe strings and behaviors.
  * Friendly-fire controls to allow or block player-on-player damage and to control peace-breaking on hostile actions.

* **Bug Fixes / Improvements**
  * Stricter target validation across melee, projectiles, spells and wake/proximity to prevent unintended damage or alerts.
  * Property-change hooks and safer defaults to keep targeting caches current and avoid null-reference issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->