### PR TITLE
Feature/random teleport

### DIFF
--- a/Source/ACE.Database/Models/Auth/AuthDbContext.cs
+++ b/Source/ACE.Database/Models/Auth/AuthDbContext.cs
@@ -29,7 +29,7 @@ public partial class AuthDbContext : DbContext
         {
             var config = Common.ConfigManager.Config.MySql.Authentication;
 
-            var connectionString = $"server={config.Host};port={config.Port};user={config.Username};password={config.Password};database={config.Database};TreatTinyAsBoolean=False;SslMode=None;AllowPublicKeyRetrieval=true;ApplicationName=ACEmulator";
+            var connectionString = $"server={config.Host};port={config.Port};user={config.Username};password={config.Password};database={config.Database};TreatTinyAsBoolean=False;SslMode=Disabled;AllowPublicKeyRetrieval=true;ApplicationName=ACEmulator";
 
             optionsBuilder.UseMySql(connectionString, ServerVersion.AutoDetect(connectionString), builder =>
             {

--- a/Source/ACE.Database/Models/Shard/ShardDbContext.cs
+++ b/Source/ACE.Database/Models/Shard/ShardDbContext.cs
@@ -78,7 +78,7 @@ namespace ACE.Database.Models.Shard
             {
                 var config = Common.ConfigManager.Config.MySql.Shard;
 
-                var connectionString = $"server={config.Host};port={config.Port};user={config.Username};password={config.Password};database={config.Database};TreatTinyAsBoolean=False;SslMode=None;AllowPublicKeyRetrieval=true;ApplicationName=ACEmulator;MaximumPoolSize=200;MinimumPoolSize=10;ConnectionLifetime=300";
+                var connectionString = $"server={config.Host};port={config.Port};user={config.Username};password={config.Password};database={config.Database};TreatTinyAsBoolean=False;SslMode=Disabled;AllowPublicKeyRetrieval=true;ApplicationName=ACEmulator;MaximumPoolSize=200;MinimumPoolSize=10;ConnectionLifetime=300";
 
                 optionsBuilder.UseMySql(connectionString, ServerVersion.AutoDetect(connectionString), builder =>
                 {

--- a/Source/ACE.Database/Models/World/WorldDbContext.cs
+++ b/Source/ACE.Database/Models/World/WorldDbContext.cs
@@ -78,7 +78,7 @@ namespace ACE.Database.Models.World
             {
                 var config = Common.ConfigManager.Config.MySql.World;
 
-                var connectionString = $"server={config.Host};port={config.Port};user={config.Username};password={config.Password};database={config.Database};TreatTinyAsBoolean=False;SslMode=None;AllowPublicKeyRetrieval=true;ApplicationName=ACEmulator";
+                var connectionString = $"server={config.Host};port={config.Port};user={config.Username};password={config.Password};database={config.Database};TreatTinyAsBoolean=False;SslMode=Disabled;AllowPublicKeyRetrieval=true;ApplicationName=ACEmulator";
 
                 optionsBuilder.UseMySql(connectionString, ServerVersion.AutoDetect(connectionString), builder =>
                 {

--- a/Source/ACE.Server/Command/Handlers/TeleportCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/TeleportCommands.cs
@@ -10,6 +10,7 @@ using ACE.Server.Network.GameMessages.Messages;
 using ACE.Server.Physics.Common;
 using ACE.Server.Entity;
 using ACE.Server.WorldObjects;
+using ACE.Common;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -774,7 +775,7 @@ namespace ACE.Server.Command.Handlers
             "Teleport yourself to a random valid location anywhere in the world (outdoor or dungeon).")]
         public static void HandleTeleRandom(Session session, params string[] parameters)
         {
-            if (new Random().Next(2) == 0)
+            if (ThreadSafeRandom.Next(0, 1) == 0)
                 TeleportToRandomOutdoor(session);
             else
                 TeleportToRandomDungeon(session);
@@ -794,14 +795,13 @@ namespace ACE.Server.Command.Handlers
 
         private static void TeleportToRandomOutdoor(Session session)
         {
-            var rng = new Random();
             const int MaxAttempts = 15;
 
             for (int attempt = 0; attempt < MaxAttempts; attempt++)
             {
                 // Full Dereth grid: 0x01-0xFE on both axes
-                byte lbX = (byte)rng.Next(0x01, 0xFF);
-                byte lbY = (byte)rng.Next(0x01, 0xFF);
+                byte lbX = (byte)ThreadSafeRandom.Next(0x01, 0xFE);
+                byte lbY = (byte)ThreadSafeRandom.Next(0x01, 0xFE);
                 uint cellId = ((uint)lbX << 24) | ((uint)lbY << 16) | 0x0001;
 
                 var lb = LScape.get_landblock(cellId, null);
@@ -832,7 +832,6 @@ namespace ACE.Server.Command.Handlers
 
         private static void TeleportToRandomDungeon(Session session)
         {
-            var rng = new Random();
             const int MaxDungeonAttempts = 5;
 
             // --- Step 1: Build accessible dungeon list from the world DB ---
@@ -876,7 +875,7 @@ namespace ACE.Server.Command.Handlers
             // --- Steps 2–4: Pick dungeon, find deep creature spawn positions ---
             for (int attempt = 0; attempt < MaxDungeonAttempts; attempt++)
             {
-                var chosen = accessibleDungeons[rng.Next(accessibleDungeons.Count)];
+                var chosen = accessibleDungeons[ThreadSafeRandom.Next(0, accessibleDungeons.Count - 1)];
                 uint blockStart  = chosen.DungeonLandblock << 16;
                 uint blockEnd    = blockStart | 0xFFFFu;
                 uint deepCellMin = blockStart | 0x0100u;  // skip outdoor cell, EnvCells only
@@ -932,7 +931,7 @@ namespace ACE.Server.Command.Handlers
                     .ToList();
 
                 int deepCount = Math.Max(1, sortedByDepth.Count / 3);
-                var dest = sortedByDepth[rng.Next(deepCount)].Pos;
+                var dest = sortedByDepth[ThreadSafeRandom.Next(0, deepCount - 1)].Pos;
 
                 session.Player.SetPosition(PositionType.TeleportedCharacter, new Position(session.Player.Location));
                 session.Player.Teleport(dest);

--- a/Source/ACE.Server/Command/Handlers/TeleportCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/TeleportCommands.cs
@@ -881,24 +881,32 @@ namespace ACE.Server.Command.Handlers
                 uint blockEnd    = blockStart | 0xFFFFu;
                 uint deepCellMin = blockStart | 0x0100u;  // skip outdoor cell, EnvCells only
 
-                // Query creature spawn positions inside this dungeon's cells
+                // Query creature spawn positions inside this dungeon's cells.
+                // Project to anonymous type first (EF-safe), then construct Position in memory.
                 List<Position> spawnPositions;
                 using (var ctx = new WorldDbContext())
                 {
-                    var spawnQuery = from weenie in ctx.Weenie
-                                     join wpos in ctx.WeeniePropertiesPosition on weenie.ClassId equals wpos.ObjectId
-                                     where weenie.Type == (int)WeenieType.Creature
-                                        && wpos.PositionType == (int)PositionType.Location
-                                        && wpos.ObjCellId   >= deepCellMin
-                                        && wpos.ObjCellId   <= blockEnd
-                                     select new Position(
-                                         wpos.ObjCellId,
-                                         wpos.OriginX, wpos.OriginY, wpos.OriginZ,
-                                         wpos.AnglesX, wpos.AnglesY, wpos.AnglesZ,
-                                         wpos.AnglesW, false, wpos.VariationId);
+                    var rawRows = (from weenie in ctx.Weenie
+                                   join wpos in ctx.WeeniePropertiesPosition on weenie.ClassId equals wpos.ObjectId
+                                   where weenie.Type == (int)WeenieType.Creature
+                                      && wpos.PositionType == (int)PositionType.Location
+                                      && wpos.ObjCellId   >= deepCellMin
+                                      && wpos.ObjCellId   <= blockEnd
+                                   select new
+                                   {
+                                       wpos.ObjCellId,
+                                       wpos.OriginX, wpos.OriginY, wpos.OriginZ,
+                                       wpos.AnglesX, wpos.AnglesY, wpos.AnglesZ,
+                                       wpos.AnglesW, wpos.VariationId
+                                   }).ToList();
 
-                    spawnPositions = spawnQuery.ToList();
+                    spawnPositions = rawRows.Select(r => new Position(
+                        r.ObjCellId,
+                        r.OriginX, r.OriginY, r.OriginZ,
+                        r.AnglesX, r.AnglesY, r.AnglesZ,
+                        r.AnglesW, false, r.VariationId)).ToList();
                 }
+
 
                 // No creature data — retry with a different dungeon unless this is the last attempt,
                 // in which case use the portal entrance so we still land somewhere valid.

--- a/Source/ACE.Server/Command/Handlers/TeleportCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/TeleportCommands.cs
@@ -823,8 +823,6 @@ namespace ACE.Server.Command.Handlers
                 var coords = dest.GetMapCoordStr();
                 session.Network.EnqueueSend(new GameMessageSystemChat(
                     $"Teleporting to random outdoor location: {coords}", ChatMessageType.System));
-                PlayerManager.BroadcastToAuditChannel(session.Player,
-                    $"Admin {session.Player.Name} used /telerandomoutside — landed at {coords}.");
                 return;
             }
 
@@ -928,8 +926,6 @@ namespace ACE.Server.Command.Handlers
                 session.Network.EnqueueSend(new GameMessageSystemChat(
                     $"Teleporting deep into: {chosen.Name} (landblock 0x{chosen.DungeonLandblock:X4})",
                     ChatMessageType.System));
-                PlayerManager.BroadcastToAuditChannel(session.Player,
-                    $"Admin {session.Player.Name} used /telerandomdungeon — landed in {chosen.Name} at {dest}.");
                 return;
             }
 

--- a/Source/ACE.Server/Command/Handlers/TeleportCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/TeleportCommands.cs
@@ -881,7 +881,7 @@ namespace ACE.Server.Command.Handlers
                 uint blockEnd    = blockStart | 0xFFFFu;
                 uint deepCellMin = blockStart | 0x0100u;  // skip outdoor cell, EnvCells only
 
-                // Query creature/generator spawn positions inside this dungeon's cells
+                // Query creature spawn positions inside this dungeon's cells
                 List<Position> spawnPositions;
                 using (var ctx = new WorldDbContext())
                 {
@@ -900,24 +900,31 @@ namespace ACE.Server.Command.Handlers
                     spawnPositions = spawnQuery.ToList();
                 }
 
-                Position dest;
+                // No creature data — retry with a different dungeon unless this is the last attempt,
+                // in which case use the portal entrance so we still land somewhere valid.
                 if (spawnPositions.Count == 0)
                 {
-                    // No creature data for this dungeon — fall back to entrance and try again next loop
-                    dest = chosen.Entrance;
-                }
-                else
-                {
-                    // Sort all spawn positions by distance from entrance (descending),
-                    // take the furthest 33%, and pick one at random — this lands us deep inside.
-                    var sortedByDepth = spawnPositions
-                        .Select(p => (Pos: p, DistSq: DungeonDistanceSq(p, chosen.Entrance)))
-                        .OrderByDescending(x => x.DistSq)
-                        .ToList();
+                    if (attempt < MaxDungeonAttempts - 1)
+                        continue;
 
-                    int deepCount = Math.Max(1, sortedByDepth.Count / 3);
-                    dest = sortedByDepth[rng.Next(deepCount)].Pos;
+                    session.Player.SetPosition(PositionType.TeleportedCharacter, new Position(session.Player.Location));
+                    session.Player.Teleport(chosen.Entrance);
+                    session.Player.OnTeleportComplete();
+                    session.Network.EnqueueSend(new GameMessageSystemChat(
+                        $"Teleporting to entrance of: {chosen.Name} (landblock 0x{chosen.DungeonLandblock:X4})",
+                        ChatMessageType.System));
+                    return;
                 }
+
+                // Sort all spawn positions by distance from entrance (descending),
+                // take the furthest 33%, and pick one at random — this lands us deep inside.
+                var sortedByDepth = spawnPositions
+                    .Select(p => (Pos: p, DistSq: DungeonDistanceSq(p, chosen.Entrance)))
+                    .OrderByDescending(x => x.DistSq)
+                    .ToList();
+
+                int deepCount = Math.Max(1, sortedByDepth.Count / 3);
+                var dest = sortedByDepth[rng.Next(deepCount)].Pos;
 
                 session.Player.SetPosition(PositionType.TeleportedCharacter, new Position(session.Player.Location));
                 session.Player.Teleport(dest);
@@ -928,6 +935,7 @@ namespace ACE.Server.Command.Handlers
                     ChatMessageType.System));
                 return;
             }
+
 
             session.Network.EnqueueSend(new GameMessageSystemChat(
                 "Could not find a valid dungeon after several attempts. Try again.", ChatMessageType.System));

--- a/Source/ACE.Server/Command/Handlers/TeleportCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/TeleportCommands.cs
@@ -8,6 +8,7 @@ using ACE.Server.Managers;
 using ACE.Server.Network;
 using ACE.Server.Network.GameMessages.Messages;
 using ACE.Server.Physics.Common;
+using ACE.Server.Entity;
 using ACE.Server.WorldObjects;
 using System;
 using System.Collections.Generic;
@@ -752,6 +753,200 @@ namespace ACE.Server.Command.Handlers
             }
             if (!suppressErrors) session.Network.EnqueueSend(new GameMessageSystemChat($"Couldn't find POI {name}", ChatMessageType.System));
             return false;
+        }
+
+
+        // ==========================================================================================
+        // RANDOM TELEPORT COMMANDS
+        // ==========================================================================================
+
+        /// <summary>
+        /// Portal names containing these strings are excluded from random dungeon selection
+        /// (housing, private instances, dev/test areas).
+        /// </summary>
+        private static readonly HashSet<string> DungeonNameExclusions = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "House", "Apartment", "Mansion", "Cottage", "Villa", "Penthouse",
+            "Hovel", "Test", "Admin", "Dev", "Instance"
+        };
+
+        [CommandHandler("telerandom", AccessLevel.Admin, CommandHandlerFlag.RequiresWorld, 0,
+            "Teleport yourself to a random valid location anywhere in the world (outdoor or dungeon).")]
+        public static void HandleTeleRandom(Session session, params string[] parameters)
+        {
+            if (new Random().Next(2) == 0)
+                TeleportToRandomOutdoor(session);
+            else
+                TeleportToRandomDungeon(session);
+        }
+
+        [CommandHandler("telerandomoutside", AccessLevel.Admin, CommandHandlerFlag.RequiresWorld, 0,
+            "Teleport yourself to a random outdoor location anywhere in Dereth.")]
+        public static void HandleTeleRandomOutside(Session session, params string[] parameters)
+            => TeleportToRandomOutdoor(session);
+
+        [CommandHandler("telerandomdungeon", AccessLevel.Admin, CommandHandlerFlag.RequiresWorld, 0,
+            "Teleport yourself deep inside a random accessible dungeon.")]
+        public static void HandleTeleRandomDungeon(Session session, params string[] parameters)
+            => TeleportToRandomDungeon(session);
+
+        // ------------------------------------------------------------------------------------------
+
+        private static void TeleportToRandomOutdoor(Session session)
+        {
+            var rng = new Random();
+            const int MaxAttempts = 15;
+
+            for (int attempt = 0; attempt < MaxAttempts; attempt++)
+            {
+                // Full Dereth grid: 0x01-0xFE on both axes
+                byte lbX = (byte)rng.Next(0x01, 0xFF);
+                byte lbY = (byte)rng.Next(0x01, 0xFF);
+                uint cellId = ((uint)lbX << 24) | ((uint)lbY << 16) | 0x0001;
+
+                var lb = LScape.get_landblock(cellId, null);
+                if (lb == null) continue;
+                if (lb.WaterType == LandDefs.WaterType.EntirelyWater) continue;
+                if (lb.IsDungeon) continue;
+
+                // Sample terrain height at the center of the landblock
+                float localX = 96.0f, localY = 96.0f;
+                float z = lb.GetZ(new System.Numerics.Vector3(localX, localY, 0f)) + 1.0f;
+
+                var dest = new Position(cellId, localX, localY, z, 0f, 0f, 0f, 1f);
+                if (!ValidateDestination(session, dest)) continue;
+
+                session.Player.SetPosition(PositionType.TeleportedCharacter, new Position(session.Player.Location));
+                session.Player.Teleport(dest);
+                session.Player.OnTeleportComplete();
+
+                var coords = dest.GetMapCoordStr();
+                session.Network.EnqueueSend(new GameMessageSystemChat(
+                    $"Teleporting to random outdoor location: {coords}", ChatMessageType.System));
+                PlayerManager.BroadcastToAuditChannel(session.Player,
+                    $"Admin {session.Player.Name} used /telerandomoutside — landed at {coords}.");
+                return;
+            }
+
+            session.Network.EnqueueSend(new GameMessageSystemChat(
+                "Could not find a valid outdoor location after several attempts. Try again.", ChatMessageType.System));
+        }
+
+        private static void TeleportToRandomDungeon(Session session)
+        {
+            var rng = new Random();
+            const int MaxDungeonAttempts = 5;
+
+            // --- Step 1: Build accessible dungeon list from the world DB ---
+            // We pull all portal Destination positions that land inside an EnvCell (dungeon interior),
+            // then filter out housing/private portals by name.
+            List<(string Name, uint DungeonLandblock, Position Entrance)> accessibleDungeons;
+            using (var ctx = new WorldDbContext())
+            {
+                var query = from weenie in ctx.Weenie
+                            join wstr in ctx.WeeniePropertiesString   on weenie.ClassId equals wstr.ObjectId
+                            join wpos in ctx.WeeniePropertiesPosition on weenie.ClassId equals wpos.ObjectId
+                            where weenie.Type        == (int)WeenieType.Portal
+                               && wstr.Type         == (int)PropertyString.Name
+                               && wpos.PositionType == (int)PositionType.Destination
+                               && (wpos.ObjCellId & 0x0000FFFFu) >= 0x0100u  // EnvCell = dungeon interior
+                            select new { wstr.Value, wpos };
+
+                accessibleDungeons = query
+                    .AsEnumerable()
+                    .Where(r => !DungeonNameExclusions.Any(ex =>
+                        r.Value.Contains(ex, StringComparison.OrdinalIgnoreCase)))
+                    .Select(r => (
+                        Name:             r.Value,
+                        DungeonLandblock: r.wpos.ObjCellId >> 16,
+                        Entrance:         new Position(
+                                              r.wpos.ObjCellId,
+                                              r.wpos.OriginX, r.wpos.OriginY, r.wpos.OriginZ,
+                                              r.wpos.AnglesX, r.wpos.AnglesY, r.wpos.AnglesZ,
+                                              r.wpos.AnglesW, false, r.wpos.VariationId)
+                    ))
+                    .ToList();
+            }
+
+            if (accessibleDungeons.Count == 0)
+            {
+                session.Network.EnqueueSend(new GameMessageSystemChat(
+                    "No accessible dungeons found in the database.", ChatMessageType.System));
+                return;
+            }
+
+            // --- Steps 2–4: Pick dungeon, find deep creature spawn positions ---
+            for (int attempt = 0; attempt < MaxDungeonAttempts; attempt++)
+            {
+                var chosen = accessibleDungeons[rng.Next(accessibleDungeons.Count)];
+                uint blockStart  = chosen.DungeonLandblock << 16;
+                uint blockEnd    = blockStart | 0xFFFFu;
+                uint deepCellMin = blockStart | 0x0100u;  // skip outdoor cell, EnvCells only
+
+                // Query creature/generator spawn positions inside this dungeon's cells
+                List<Position> spawnPositions;
+                using (var ctx = new WorldDbContext())
+                {
+                    var spawnQuery = from weenie in ctx.Weenie
+                                     join wpos in ctx.WeeniePropertiesPosition on weenie.ClassId equals wpos.ObjectId
+                                     where weenie.Type == (int)WeenieType.Creature
+                                        && wpos.PositionType == (int)PositionType.Location
+                                        && wpos.ObjCellId   >= deepCellMin
+                                        && wpos.ObjCellId   <= blockEnd
+                                     select new Position(
+                                         wpos.ObjCellId,
+                                         wpos.OriginX, wpos.OriginY, wpos.OriginZ,
+                                         wpos.AnglesX, wpos.AnglesY, wpos.AnglesZ,
+                                         wpos.AnglesW, false, wpos.VariationId);
+
+                    spawnPositions = spawnQuery.ToList();
+                }
+
+                Position dest;
+                if (spawnPositions.Count == 0)
+                {
+                    // No creature data for this dungeon — fall back to entrance and try again next loop
+                    dest = chosen.Entrance;
+                }
+                else
+                {
+                    // Sort all spawn positions by distance from entrance (descending),
+                    // take the furthest 33%, and pick one at random — this lands us deep inside.
+                    var sortedByDepth = spawnPositions
+                        .Select(p => (Pos: p, DistSq: DungeonDistanceSq(p, chosen.Entrance)))
+                        .OrderByDescending(x => x.DistSq)
+                        .ToList();
+
+                    int deepCount = Math.Max(1, sortedByDepth.Count / 3);
+                    dest = sortedByDepth[rng.Next(deepCount)].Pos;
+                }
+
+                session.Player.SetPosition(PositionType.TeleportedCharacter, new Position(session.Player.Location));
+                session.Player.Teleport(dest);
+                session.Player.OnTeleportComplete();
+
+                session.Network.EnqueueSend(new GameMessageSystemChat(
+                    $"Teleporting deep into: {chosen.Name} (landblock 0x{chosen.DungeonLandblock:X4})",
+                    ChatMessageType.System));
+                PlayerManager.BroadcastToAuditChannel(session.Player,
+                    $"Admin {session.Player.Name} used /telerandomdungeon — landed in {chosen.Name} at {dest}.");
+                return;
+            }
+
+            session.Network.EnqueueSend(new GameMessageSystemChat(
+                "Could not find a valid dungeon after several attempts. Try again.", ChatMessageType.System));
+        }
+
+        /// <summary>
+        /// Squared XYZ distance between two positions within the same dungeon landblock.
+        /// Using squared distance avoids sqrt and is sufficient for relative ordering.
+        /// </summary>
+        private static float DungeonDistanceSq(Position a, Position b)
+        {
+            float dx = a.Pos.X - b.Pos.X;
+            float dy = a.Pos.Y - b.Pos.Y;
+            float dz = a.Pos.Z - b.Pos.Z;
+            return dx * dx + dy * dy + dz * dz;
         }
 
     }

--- a/Source/ACE.Server/Command/Handlers/TeleportCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/TeleportCommands.cs
@@ -802,7 +802,7 @@ namespace ACE.Server.Command.Handlers
                 // Full Dereth grid: 0x01-0xFE on both axes
                 byte lbX = (byte)ThreadSafeRandom.Next(0x01, 0xFE);
                 byte lbY = (byte)ThreadSafeRandom.Next(0x01, 0xFE);
-                uint cellId = ((uint)lbX << 24) | ((uint)lbY << 16) | 0x0001;
+                uint cellId = ((uint)lbX << 24) | ((uint)lbY << 16) | 0x0000;
 
                 var lb = LScape.get_landblock(cellId, null);
                 if (lb == null) continue;

--- a/Source/ACE.Server/Program_DbUpdates.cs
+++ b/Source/ACE.Server/Program_DbUpdates.cs
@@ -116,7 +116,7 @@ namespace ACE.Server
             Console.Write($"Importing {sqlFile} into SQL server at {ConfigManager.Config.MySql.World.Host}:{ConfigManager.Config.MySql.World.Port} (This will take a while, please be patient) .... ");
             using (var sr = File.OpenText(sqlFile))
             {
-                var sqlConnect = new MySql.Data.MySqlClient.MySqlConnection($"server={ConfigManager.Config.MySql.World.Host};port={ConfigManager.Config.MySql.World.Port};user={ConfigManager.Config.MySql.World.Username};password={ConfigManager.Config.MySql.World.Password};DefaultCommandTimeout=120;SslMode=None;AllowPublicKeyRetrieval=true");
+                var sqlConnect = new MySql.Data.MySqlClient.MySqlConnection($"server={ConfigManager.Config.MySql.World.Host};port={ConfigManager.Config.MySql.World.Port};user={ConfigManager.Config.MySql.World.Username};password={ConfigManager.Config.MySql.World.Password};DefaultCommandTimeout=120;SslMode=Disabled;AllowPublicKeyRetrieval=true");
 
                 var line = string.Empty;
                 var completeSQLline = string.Empty;
@@ -156,7 +156,7 @@ namespace ACE.Server
 
         private static string GetContentFolder()
         {
-            var sqlConnect = new MySql.Data.MySqlClient.MySqlConnection($"server={ConfigManager.Config.MySql.Shard.Host};port={ConfigManager.Config.MySql.Shard.Port};user={ConfigManager.Config.MySql.Shard.Username};password={ConfigManager.Config.MySql.Shard.Password};database={ConfigManager.Config.MySql.Shard.Database};DefaultCommandTimeout=120;SslMode=None;AllowPublicKeyRetrieval=true");
+            var sqlConnect = new MySql.Data.MySqlClient.MySqlConnection($"server={ConfigManager.Config.MySql.Shard.Host};port={ConfigManager.Config.MySql.Shard.Port};user={ConfigManager.Config.MySql.Shard.Username};password={ConfigManager.Config.MySql.Shard.Password};database={ConfigManager.Config.MySql.Shard.Database};DefaultCommandTimeout=120;SslMode=Disabled;AllowPublicKeyRetrieval=true");
             var sqlQuery = "SELECT `value` FROM config_properties_string WHERE `key` = 'content_folder';";
             var sqlCommand = new MySql.Data.MySqlClient.MySqlCommand(sqlQuery, sqlConnect);
 
@@ -209,7 +209,7 @@ namespace ACE.Server
                     {
                         Console.Write($"Found {file.FullName} .... ");
                         var sqlDBFile = File.ReadAllText(file.FullName);
-                        var sqlConnect = new MySql.Data.MySqlClient.MySqlConnection($"server={ConfigManager.Config.MySql.World.Host};port={ConfigManager.Config.MySql.World.Port};user={ConfigManager.Config.MySql.World.Username};password={ConfigManager.Config.MySql.World.Password};database={ConfigManager.Config.MySql.World.Database};DefaultCommandTimeout=120;SslMode=None;AllowPublicKeyRetrieval=true");
+                        var sqlConnect = new MySql.Data.MySqlClient.MySqlConnection($"server={ConfigManager.Config.MySql.World.Host};port={ConfigManager.Config.MySql.World.Port};user={ConfigManager.Config.MySql.World.Username};password={ConfigManager.Config.MySql.World.Password};database={ConfigManager.Config.MySql.World.Database};DefaultCommandTimeout=120;SslMode=Disabled;AllowPublicKeyRetrieval=true");
                         sqlDBFile = sqlDBFile.Replace("ace_world", ConfigManager.Config.MySql.World.Database);
                         var script = new MySql.Data.MySqlClient.MySqlScript(sqlConnect, sqlDBFile);
 
@@ -303,7 +303,7 @@ namespace ACE.Server
                         database = worldDB;
                         break;
                 }
-                var sqlConnect = new MySql.Data.MySqlClient.MySqlConnection($"server={host};port={port};user={username};password={password};database={database};DefaultCommandTimeout=120;SslMode=None;AllowPublicKeyRetrieval=true");
+                var sqlConnect = new MySql.Data.MySqlClient.MySqlConnection($"server={host};port={port};user={username};password={password};database={database};DefaultCommandTimeout=120;SslMode=Disabled;AllowPublicKeyRetrieval=true");
                 sqlDBFile = sqlDBFile.Replace("ace_auth", authDB);
                 sqlDBFile = sqlDBFile.Replace("ace_shard", shardDB);
                 sqlDBFile = sqlDBFile.Replace("ace_world", worldDB);


### PR DESCRIPTION
## Summary
Adds three new admin-level teleport commands designed to support hide-and-seek events or other gameplay scenarios requiring placement at random, valid world locations.

## New Commands

| Command | Behavior |
|---|---|
| `/telerandom` | Teleports to a random valid location — 50/50 chance of outdoor or dungeon |
| `/telerandomoutside` | Teleports to a random outdoor location anywhere across full Dereth |
| `/telerandomdungeon` | Teleports deep inside a random accessible dungeon |

All commands require `AccessLevel.Admin`.

## Implementation Details

**Outdoor (`/telerandomoutside`)**
- Samples random landblocks across the full Dereth grid (0x01–0xFE on both axes)
- Skips entirely-water and dungeon landblocks
- Uses `LScape.get_landblock` + `GetZ` for valid terrain height placement
- Retries up to 15 times on invalid positions

**Dungeon (`/telerandomdungeon`)**
- Queries the world DB for all portal destinations that resolve to dungeon interiors (EnvCells)
- Filters out housing, apartments, and private/dev areas by portal name
- Queries creature spawn positions within the dungeon and picks randomly from the furthest 33% — landing deep inside rather than near the entrance
- Falls back to the portal entrance if no creature spawn data exists

**Safety**
- Saves previous location via `PositionType.TeleportedCharacter` so `/tele return` works
- No audit channel broadcasts by design (covert event use)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three admin teleport commands: /telerandom, /telerandomoutside, and /telerandomdungeon to teleport players to randomized outdoor or dungeon locations with intelligent selection, retries, and failover.

* **Chores**
  * Adjusted database connection SSL/TLS settings across authentication, shard, and world database contexts and related tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->