### PR TITLE
Expand 9014/9015 mob ally/foe idle reacquisition

### DIFF
--- a/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
@@ -824,6 +824,7 @@ namespace ACE.Server.WorldObjects
             if (MonsterState != State.Idle) return;
 
             var creatures = PhysicsObj.ObjMaint.GetVisibleTargetsValuesOfTypeCreature();
+            var woke = false;
 
             foreach (var creature in creatures)
             {
@@ -839,16 +840,23 @@ namespace ACE.Server.WorldObjects
                     continue;
                 if (!creature.Attackable)
                     continue;
-                // Don't skip players based on TargetingTactic - that's for monster behavior, not target validity
-                if (creature.TargetingTactic == TargetingTactic.None && !(creature is Player))
+
+                // Keep idle foe wake logic consistent with spawn-time/regular candidate filtering.
+                // This allows hostile non-player targets with TargetingTactic.None (e.g. spawned test creatures)
+                // to be detected when they match foe/faction rules.
+                if (!IsValidAttackCandidate(creature))
                     continue;
 
                 // ensure another faction
                 if (SameFaction(creature) && !PotentialFoe(creature))
                     continue;
 
-                // ensure within detection range
-                if (PhysicsObj.get_distance_sq_to_object(creature.PhysicsObj, true) > VisualAwarenessRangeSq)
+                var distSq = PhysicsObj.get_distance_sq_to_object(creature.PhysicsObj, true);
+                var wakeRangeSq = VisualAwarenessRangeSq;
+                if (UsesExtendedFoeTargeting && creature is not Player)
+                    wakeRangeSq = Math.Max(VisualAwarenessRangeSq, MaxChaseRangeSq);
+
+                if (distSq > wakeRangeSq)
                     continue;
 
                 if (creature is Player player)
@@ -858,15 +866,69 @@ namespace ACE.Server.WorldObjects
 
                     if (!PotentialFoe(player))
                         continue;
+
                     if (player.AlertMonster(this))
+                    {
+                        woke = true;
                         break;
+                    }
                 }
                 else
                 {
+                    // Ensure target persistence across the next monster tick:
+                    // Monster_Tick drops AttackTarget when it's not in VisibleTargets.
+                    // Retaliate entries are mirrored into VisibleTargets in ObjMaint.
+                    if (UsesExtendedFoeTargeting)
+                        AddRetaliateTarget(creature);
+
                     if (creature.AlertMonster(this))
+                    {
+                        woke = true;
                         break;
+                    }
                 }
             }
+
+            // Visibility lists can lag briefly after spawns. For custom mob-to-mob targeting, do a
+            // lightweight landblock fallback pass so newly spawned foes are still detected while idle.
+            if (!woke && UsesExtendedFoeTargeting)
+                TryWakeFromLandblockCustomFoes();
+        }
+
+        private bool TryWakeFromLandblockCustomFoes()
+        {
+            if (CurrentLandblock == null)
+                return false;
+
+            var maxFallbackRangeSq = Math.Max(VisualAwarenessRangeSq, MaxChaseRangeSq);
+
+            foreach (var wo in CurrentLandblock.GetWorldObjectsForPhysicsHandling())
+            {
+                if (wo is not Creature creature || creature == this)
+                    continue;
+                if (creature is Player || creature is CombatPet)
+                    continue;
+                if (creature.IsDead || creature.Teleporting || !creature.Attackable || creature.PhysicsObj == null)
+                    continue;
+                if (!IsValidAttackCandidate(creature))
+                    continue;
+                if (SameFaction(creature) && !PotentialFoe(creature))
+                    continue;
+
+                var distSq = PhysicsObj.get_distance_sq_to_object(creature.PhysicsObj, true);
+                if (distSq > maxFallbackRangeSq)
+                    continue;
+
+                // Keep fallback-acquired foe in our retaliate/visible tables so attack doesn't
+                // get dropped immediately by the next IsVisibleTarget gate.
+                AddRetaliateTarget(creature);
+
+                var alerted = creature.AlertMonster(this);
+                if (alerted)
+                    return true;
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/Monster_Tick.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Tick.cs
@@ -133,10 +133,24 @@ namespace ACE.Server.WorldObjects
                 return;
             }
 
-            if (creatureTarget != null && (creatureTarget.IsDead || (combatPet == null && !IsVisibleTarget(creatureTarget))))
+            if (creatureTarget != null && creatureTarget.IsDead)
             {
                 FindNextTarget();
                 return;
+            }
+
+            // Custom mob-to-mob targeting can briefly lag visibility table updates after spawn/idle transitions.
+            // If the current non-player foe is valid, pin it via retaliate so we don't bounce Awake<->Idle.
+            if (creatureTarget != null && combatPet == null && !IsVisibleTarget(creatureTarget))
+            {
+                if (UsesExtendedFoeTargeting && creatureTarget is not Player && PotentialFoe(creatureTarget))
+                    AddRetaliateTarget(creatureTarget);
+
+                if (!IsVisibleTarget(creatureTarget))
+                {
+                    FindNextTarget();
+                    return;
+                }
             }
 
             if (firstUpdate)

--- a/Source/ACE.Server/WorldObjects/Monster_Tick.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Tick.cs
@@ -147,7 +147,9 @@ namespace ACE.Server.WorldObjects
             // If the current non-player foe is valid, pin it via retaliate so we don't bounce Awake<->Idle.
             if (creatureTarget != null && combatPet == null && !IsVisibleTarget(creatureTarget))
             {
-                if (UsesExtendedFoeTargeting && creatureTarget is not Player && PotentialFoe(creatureTarget))
+                if (UsesExtendedFoeTargeting
+                    && creatureTarget is not Player
+                    && (PotentialFoe(creatureTarget) || AllowFactionCombat(creatureTarget)))
                     AddRetaliateTarget(creatureTarget);
 
                 if (!IsVisibleTarget(creatureTarget))

--- a/Source/ACE.Server/WorldObjects/Monster_Tick.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Tick.cs
@@ -135,6 +135,10 @@ namespace ACE.Server.WorldObjects
 
             if (creatureTarget != null && creatureTarget.IsDead)
             {
+                if (HasRetaliateTarget(creatureTarget))
+                    RemoveRetaliateTarget(creatureTarget);
+                AttackTarget = null;
+                InvalidateTargetCaches();
                 FindNextTarget();
                 return;
             }


### PR DESCRIPTION
## Summary
- align idle foe wake candidate filtering with the same custom 9014/9015 hostility checks used in normal targeting paths
- stabilize mob-to-mob wake/retarget behavior by keeping valid foes in retaliate/visible tables during visibility update lag
- add bounded wake range handling (`max(visual, chase)`) plus landblock fallback scan so newly spawned valid foes are reacquired without requiring a second helper mob

## Test plan
- [x] Spawn `99999991` and then spawn Auroch (`20`): mob should acquire and attack without spawning a second helper mob
- [x] Spawn `99999992` and then spawn Tusker (`11`): mob should acquire and attack while avoiding repeated combat/peace flicker
- [x] Verify friendly/non-hostile player behavior remains unchanged for these custom mobs

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved monster wake and awareness logic to better detect and engage valid non-player targets.
  * Enhanced extended foe targeting so non-player foes are retained (pinned) to reduce target churn.
  * Adjusted engagement distance checks for more reliable non-player detection.
  * Added a nearby-object fallback scan to catch newly spawned or briefly unseen entities.
  * Ensured explicit re-acquisition of targets when visibility checks fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->