### PR TITLE
New Emote - SingleLocalBroadcast + minor code adjustment for special mob targeting

### DIFF
--- a/Source/ACE.Entity/Enum/EmoteType.cs
+++ b/Source/ACE.Entity/Enum/EmoteType.cs
@@ -156,6 +156,7 @@ namespace ACE.Entity.Enum
         InqPetRegistryCount           = 151, //Custom - Check pet registry count (uses min/max)
         InqPetRegistryCreatureType    = 152, //Custom - Check if account has any pet of creature type (uses stat field)
         JailPlayer                    = 153, //Custom - Jails (amount=1) or releases (amount=0) a player
+        SingleLocalBroadcast          = 154, //Custom - LocalBroadcast that emits once per awake cycle
 
         // Unknown Id Emotes & Custom Emotes
         Enlightenment                 = 9001

--- a/Source/ACE.Entity/Enum/Properties/PropertyBool.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyBool.cs
@@ -240,6 +240,10 @@ namespace ACE.Entity.Enum.Properties
         /// Single-use, extremely rare item obtained by exchanging 5000 Flawed Siphon Lenses.
         /// </summary>
         IsGuaranteedCaptureLens           = 9042,
+        /// <summary>
+        /// If TRUE, this world object suppresses configured spell schools even when not awake/aggro.
+        /// </summary>
+        IsPassiveSpellSuppressor          = 9045,
     }
 }
 

--- a/Source/ACE.Entity/Enum/Properties/PropertyFloat.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyFloat.cs
@@ -268,5 +268,9 @@ namespace ACE.Entity.Enum.Properties
         /// </summary>
         [AssessmentProperty]
         DamageCapMultiplier = 9045,
+        /// <summary>
+        /// Optional radius for spell suppression zones. When <= 0 or unset, creatures fall back to VisualAwarenessRange.
+        /// </summary>
+        SpellSuppressionRadius = 9046,
     }
 }

--- a/Source/ACE.Entity/Enum/Properties/PropertyInt.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyInt.cs
@@ -742,6 +742,10 @@ namespace ACE.Entity.Enum.Properties
         /// Custom targeting behavior flags (<see cref="ACE.Entity.Enum.CustomTargetingBehavior"/>).
         /// </summary>
         TargetingFlags                          = 9046,
+        /// <summary>
+        /// Bitmask of magic schools this creature suppresses for nearby players (see SpellSuppressionSchools).
+        /// </summary>
+        SpellSuppressionSchools                 = 9047,
     }
 
     public static class PropertyIntExtensions
@@ -889,6 +893,9 @@ namespace ACE.Entity.Enum.Properties
                 case PropertyInt.UseRequiresSkillSpec:
                 case PropertyInt.SkillToBeAltered:
                     return System.Enum.GetName(typeof(Skill), value);
+
+                case PropertyInt.SpellSuppressionSchools:
+                    return System.Enum.GetName(typeof(SpellSuppressionSchools), value);
 
                 case PropertyInt.HookGroup:
                     return System.Enum.GetName(typeof(HookGroupType), value);

--- a/Source/ACE.Entity/Enum/Properties/PropertyString.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyString.cs
@@ -105,5 +105,10 @@ namespace ACE.Entity.Enum.Properties
         FriendTypeString = 9014,
         FoeTypeString = 9015,
         FriendlyQuestString = 9016,
+        /// <summary>
+        /// Optional custom message sent when a cast is blocked by nearby spell suppression.
+        /// Supports {school} and {source} placeholders.
+        /// </summary>
+        SpellSuppressionMessage = 9017,
     }
 }

--- a/Source/ACE.Entity/Enum/SpellSuppressionSchools.cs
+++ b/Source/ACE.Entity/Enum/SpellSuppressionSchools.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace ACE.Entity.Enum
+{
+    [Flags]
+    public enum SpellSuppressionSchools
+    {
+        None = 0,
+        WarMagic = 1 << 0,
+        LifeMagic = 1 << 1,
+        ItemEnchantment = 1 << 2,
+        CreatureEnchantment = 1 << 3,
+        VoidMagic = 1 << 4,
+
+        All = WarMagic | LifeMagic | ItemEnchantment | CreatureEnchantment | VoidMagic,
+    }
+}

--- a/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
@@ -3849,10 +3849,9 @@ namespace ACE.Server.WorldObjects.Managers
 
         private bool TryMarkSingleLocalBroadcastSent(PropertiesEmote emoteSet, PropertiesEmoteAction emote)
         {
-            if (emote.DatabaseRecordId.HasValue)
-                return _singleLocalBroadcastsSent.Add($"db:{emote.DatabaseRecordId.Value}");
-
-            var key = $"fallback:{emoteSet.Category}:{emoteSet.WeenieClassId}:{emoteSet.Quest}:{emote.Type}:{emote.Delay}:{emote.Message}";
+            // Use per-instance references to avoid collisions from reused DatabaseRecordId values
+            // in dynamic emotes (action ids commonly start at 1 for each dynamic emote set).
+            var key = $"instance:{RuntimeHelpers.GetHashCode(emoteSet)}:{RuntimeHelpers.GetHashCode(emote)}";
             return _singleLocalBroadcastsSent.Add(key);
         }
 

--- a/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
@@ -49,6 +49,7 @@ namespace ACE.Server.WorldObjects.Managers
         public int Nested { get; set; }
 
         public bool Debug = false;
+        private readonly HashSet<string> _singleLocalBroadcastsSent = new HashSet<string>();
 
         public EmoteManager(WorldObject worldObject)
         {
@@ -1136,6 +1137,15 @@ namespace ACE.Server.WorldObjects.Managers
 
                     message = Replace(emote.Message, WorldObject, targetObject, emoteSet.Quest);
                     WorldObject.EnqueueBroadcast(new GameMessageSystemChat(message, ChatMessageType.Broadcast));
+                    break;
+
+                case EmoteType.SingleLocalBroadcast:
+
+                    if (TryMarkSingleLocalBroadcastSent(emoteSet, emote))
+                    {
+                        message = Replace(emote.Message, WorldObject, targetObject, emoteSet.Quest);
+                        WorldObject.EnqueueBroadcast(new GameMessageSystemChat(message, ChatMessageType.Broadcast));
+                    }
                     break;
 
                 case EmoteType.LocalSignal:
@@ -3648,6 +3658,7 @@ namespace ACE.Server.WorldObjects.Managers
         /// </summary>
         public void OnWakeUp(Creature target)
         {
+            ResetSingleLocalBroadcasts();
             ExecuteEmoteSet(EmoteCategory.Scream, null, target);
         }
 
@@ -3829,6 +3840,20 @@ namespace ACE.Server.WorldObjects.Managers
         public void OnHomeSick(WorldObject attackTarget)
         {
             ExecuteEmoteSet(EmoteCategory.Homesick, null, attackTarget);
+        }
+
+        public void ResetSingleLocalBroadcasts()
+        {
+            _singleLocalBroadcastsSent.Clear();
+        }
+
+        private bool TryMarkSingleLocalBroadcastSent(PropertiesEmote emoteSet, PropertiesEmoteAction emote)
+        {
+            if (emote.DatabaseRecordId.HasValue)
+                return _singleLocalBroadcastsSent.Add($"db:{emote.DatabaseRecordId.Value}");
+
+            var key = $"fallback:{emoteSet.Category}:{emoteSet.WeenieClassId}:{emoteSet.Quest}:{emote.Type}:{emote.Delay}:{emote.Message}";
+            return _singleLocalBroadcastsSent.Add(key);
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
@@ -142,6 +142,7 @@ namespace ACE.Server.WorldObjects
             CurrentAttack = null;
             firstUpdate = true;
             AttackTarget = null;
+            EmoteManager.ResetSingleLocalBroadcasts();
             IsAwake = false;
             IsMoving = false;
             MonsterState = State.Idle;

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -394,6 +394,126 @@ namespace ACE.Server.WorldObjects
             return true;
         }
 
+        private static SpellSuppressionSchools ToSuppressionSchool(MagicSchool school)
+        {
+            return school switch
+            {
+                MagicSchool.WarMagic => SpellSuppressionSchools.WarMagic,
+                MagicSchool.LifeMagic => SpellSuppressionSchools.LifeMagic,
+                MagicSchool.ItemEnchantment => SpellSuppressionSchools.ItemEnchantment,
+                MagicSchool.CreatureEnchantment => SpellSuppressionSchools.CreatureEnchantment,
+                MagicSchool.VoidMagic => SpellSuppressionSchools.VoidMagic,
+                _ => SpellSuppressionSchools.None
+            };
+        }
+
+        private static string GetSuppressionSchoolName(SpellSuppressionSchools school)
+        {
+            return school switch
+            {
+                SpellSuppressionSchools.WarMagic => "War Magic",
+                SpellSuppressionSchools.LifeMagic => "Life Magic",
+                SpellSuppressionSchools.ItemEnchantment => "Item Enchantment",
+                SpellSuppressionSchools.CreatureEnchantment => "Creature Enchantment",
+                SpellSuppressionSchools.VoidMagic => "Void Magic",
+                _ => "Magic"
+            };
+        }
+
+        private static double GetSpellSuppressionRadiusSq(WorldObject source)
+        {
+            var configuredRadius = source.SpellSuppressionRadius;
+            if (configuredRadius.HasValue && configuredRadius.Value > 0)
+                return configuredRadius.Value * configuredRadius.Value;
+
+            if (source is Creature creature && creature.VisualAwarenessRange > 0)
+                return creature.VisualAwarenessRangeSq;
+
+            return 0;
+        }
+
+        private static bool IsActiveSpellSuppressor(WorldObject source)
+        {
+            if (source == null || source.PhysicsObj == null)
+                return false;
+
+            if (source is Creature creature)
+            {
+                if (creature.IsDead)
+                    return false;
+
+                if (creature.IsAwake)
+                    return true;
+            }
+
+            return source.IsPassiveSpellSuppressor == true;
+        }
+
+        private bool TryGetActiveSpellSuppressor(SpellSuppressionSchools schoolFlag, out WorldObject suppressor)
+        {
+            suppressor = null;
+
+            if (schoolFlag == SpellSuppressionSchools.None || PhysicsObj?.ObjMaint == null)
+                return false;
+
+            var visibleObjects = PhysicsObj.ObjMaint.GetVisibleObjectsValuesWhere(o => o?.WeenieObj?.WorldObject != null);
+            var nearestDistSq = double.MaxValue;
+
+            foreach (var visibleObject in visibleObjects)
+            {
+                var source = visibleObject.WeenieObj.WorldObject;
+                if (source == null || source == this)
+                    continue;
+
+                if ((source.SpellSuppressionSchools & schoolFlag) == 0)
+                    continue;
+
+                if (!IsActiveSpellSuppressor(source))
+                    continue;
+
+                var suppressionRadiusSq = GetSpellSuppressionRadiusSq(source);
+                if (suppressionRadiusSq <= 0)
+                    continue;
+
+                var distSq = PhysicsObj.get_distance_sq_to_object(source.PhysicsObj, true);
+                if (distSq > suppressionRadiusSq)
+                    continue;
+
+                if (distSq < nearestDistSq)
+                {
+                    nearestDistSq = distSq;
+                    suppressor = source;
+                }
+            }
+
+            return suppressor != null;
+        }
+
+        private bool VerifySpellSchoolSuppression(Spell spell)
+        {
+            var schoolFlag = ToSuppressionSchool(spell.School);
+            if (schoolFlag == SpellSuppressionSchools.None)
+                return true;
+
+            if (!TryGetActiveSpellSuppressor(schoolFlag, out var suppressor))
+                return true;
+
+            var schoolName = GetSuppressionSchoolName(schoolFlag);
+            var msg = suppressor.SpellSuppressionMessage;
+
+            if (string.IsNullOrWhiteSpace(msg))
+                msg = $"{schoolName} is being suppressed by {suppressor.Name}.";
+            else
+            {
+                msg = msg.Replace("{school}", schoolName, StringComparison.OrdinalIgnoreCase);
+                msg = msg.Replace("{source}", suppressor.Name, StringComparison.OrdinalIgnoreCase);
+            }
+
+            Session.Network.EnqueueSend(new GameMessageSystemChat(msg, ChatMessageType.Magic));
+            SendUseDoneEvent(WeenieError.None);
+            return false;
+        }
+
         public bool IsValidSpell(Spell spell, bool isWeaponSpell = false)
         {
             if (spell.NotFound)
@@ -1017,6 +1137,9 @@ namespace ACE.Server.WorldObjects
             if (!IsValidSpell(spell, casterItem != null))
                 return false;
 
+            if (!VerifySpellSchoolSuppression(spell))
+                return false;
+
             if (!VerifySpellTarget(spell, target))
                 return false;
 
@@ -1154,6 +1277,9 @@ namespace ACE.Server.WorldObjects
         private bool CreatePlayerSpell(Spell spell)
         {
             if (!IsValidSpell(spell))
+                return false;
+
+            if (!VerifySpellSchoolSuppression(spell))
                 return false;
 
             // get player's current magic skill

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -2075,6 +2075,59 @@ namespace ACE.Server.WorldObjects
             set { if (string.IsNullOrEmpty(value)) RemoveProperty(PropertyString.FriendlyQuestString); else SetProperty(PropertyString.FriendlyQuestString, value); }
         }
 
+        /// <summary>
+        /// Bitmask of spell schools this creature suppresses for nearby players.
+        /// </summary>
+        public SpellSuppressionSchools SpellSuppressionSchools
+        {
+            get => (SpellSuppressionSchools)(GetProperty(PropertyInt.SpellSuppressionSchools) ?? 0);
+            set { if (value == SpellSuppressionSchools.None) RemoveProperty(PropertyInt.SpellSuppressionSchools); else SetProperty(PropertyInt.SpellSuppressionSchools, (int)value); }
+        }
+
+        /// <summary>
+        /// If TRUE, this source suppresses configured spell schools even when not awake/aggro.
+        /// </summary>
+        public bool? IsPassiveSpellSuppressor
+        {
+            get => GetProperty(PropertyBool.IsPassiveSpellSuppressor);
+            set { if (!value.HasValue) RemoveProperty(PropertyBool.IsPassiveSpellSuppressor); else SetProperty(PropertyBool.IsPassiveSpellSuppressor, value.Value); }
+        }
+
+        /// <summary>
+        /// Optional suppression radius for this source. For creatures, unset or non-positive falls back to VisualAwarenessRange.
+        /// </summary>
+        public double? SpellSuppressionRadius
+        {
+            get => GetProperty(PropertyFloat.SpellSuppressionRadius);
+            set
+            {
+                if (!value.HasValue || value.Value <= 0 || double.IsNaN(value.Value) || double.IsInfinity(value.Value))
+                    RemoveProperty(PropertyFloat.SpellSuppressionRadius);
+                else
+                    SetProperty(PropertyFloat.SpellSuppressionRadius, value.Value);
+            }
+        }
+
+        /// <summary>
+        /// Optional custom message shown to players when a nearby suppression source blocks a spell cast.
+        /// Supports {school} and {source} placeholders.
+        /// </summary>
+        public string SpellSuppressionMessage
+        {
+            get
+            {
+                var v = GetProperty(PropertyString.SpellSuppressionMessage);
+                return string.IsNullOrWhiteSpace(v) ? null : v.Trim();
+            }
+            set
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                    RemoveProperty(PropertyString.SpellSuppressionMessage);
+                else
+                    SetProperty(PropertyString.SpellSuppressionMessage, value.Trim());
+            }
+        }
+
         public bool? AllowFriendlyPlayerDamage
         {
             get => GetProperty(PropertyBool.AllowFriendlyPlayerDamage);


### PR DESCRIPTION
## Summary
- Add a new `SingleLocalBroadcast` emote action that mirrors `LocalBroadcast` messaging behavior.
- Ensure `SingleLocalBroadcast` emits only once while a creature remains active/awake.
- Reset the one-time emission state when the creature returns to idle (including homesick return flow).
- Also some slight modification to PR 427 code to update edge case for special mob targeting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added spell suppression system allowing world objects to restrict spell casting within a configured radius.
  * Players receive custom messages when spells are blocked, with customizable text and dynamic placeholders.
  * Suppressors can target specific spell schools individually (War Magic, Life Magic, Item Enchantment, Creature Enchantment, Void Magic).
  * Passive suppressors now block spells even when dormant.
  * Added new single-broadcast emote type for controlled spell announcements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->