### PR TITLE
Fix/bank transfer

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Bank.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Bank.cs
@@ -1670,6 +1670,13 @@ namespace ACE.Server.WorldObjects
                 return false;
             }
             
+            if (string.Equals(tarplayer.Name, this.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                LogTransfer("TransferPyreals", "Pyreals", Amount, CharacterDestination, false, "Self-transfer attempted");
+                Session.Network.EnqueueSend(new GameMessageSystemChat("You cannot transfer currency to yourself.", ChatMessageType.System));
+                return false;
+            }
+            
             log.Info($"[BANK_DEBUG] Player: {Name} | Target player found | Name: {tarplayer.Name} | Type: {(tarplayer is OfflinePlayer ? "Offline" : "Online")}");
             
             long oldBalance = BankedPyreals ?? 0;
@@ -1799,6 +1806,12 @@ namespace ACE.Server.WorldObjects
                 Session.Network.EnqueueSend(new GameMessageSystemChat($"Character '{CharacterDestination}' not found.", ChatMessageType.System));
                 return false;
             }
+            
+            if (string.Equals(tarplayer.Name, this.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                Session.Network.EnqueueSend(new GameMessageSystemChat("You cannot transfer currency to yourself.", ChatMessageType.System));
+                return false;
+            }
             else
             {
                 if (tarplayer is OfflinePlayer)
@@ -1878,6 +1891,12 @@ namespace ACE.Server.WorldObjects
             if (tarplayer == null)
             {
                 Session.Network.EnqueueSend(new GameMessageSystemChat($"Character '{CharacterDestination}' not found.", ChatMessageType.System));
+                return false;
+            }
+            
+            if (string.Equals(tarplayer.Name, this.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                Session.Network.EnqueueSend(new GameMessageSystemChat("You cannot transfer currency to yourself.", ChatMessageType.System));
                 return false;
             }
             else
@@ -1969,6 +1988,12 @@ namespace ACE.Server.WorldObjects
             if (tarplayer == null)
             {
                 Session.Network.EnqueueSend(new GameMessageSystemChat($"Character '{CharacterDestination}' not found.", ChatMessageType.System));
+                return false;
+            }
+            
+            if (string.Equals(tarplayer.Name, this.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                Session.Network.EnqueueSend(new GameMessageSystemChat("You cannot transfer currency to yourself.", ChatMessageType.System));
                 return false;
             }
             
@@ -2074,6 +2099,12 @@ namespace ACE.Server.WorldObjects
                 Session.Network.EnqueueSend(new GameMessageSystemChat($"Character '{CharacterDestination}' not found.", ChatMessageType.System));
                 return false;
             }
+            
+            if (string.Equals(tarplayer.Name, this.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                Session.Network.EnqueueSend(new GameMessageSystemChat("You cannot transfer currency to yourself.", ChatMessageType.System));
+                return false;
+            }
             else
             {
                 if (tarplayer is OfflinePlayer)
@@ -2162,6 +2193,12 @@ namespace ACE.Server.WorldObjects
             if (tarplayer == null)
             {
                 Session.Network.EnqueueSend(new GameMessageSystemChat($"Character '{CharacterDestination}' not found.", ChatMessageType.System));
+                return false;
+            }
+            
+            if (string.Equals(tarplayer.Name, this.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                Session.Network.EnqueueSend(new GameMessageSystemChat("You cannot transfer currency to yourself.", ChatMessageType.System));
                 return false;
             }
             else


### PR DESCRIPTION
# Bug Report: Bank Self-Transfer Currency Duplication

**Branch:** `fix/bank-self-transfer`  
**Commit:** `25ebe10f1`  
**File:** `Source/ACE.Server/WorldObjects/Player_Bank.cs`  
**Severity:** Critical Active currency duplication exploit  
**Status:** Fixed, deployed, pushed

---

## Summary

Players were able to transfer banked currency to themselves using the `/bank transfer` (or `/b t`) command by supplying their own character name as the destination. In the case of pyreals and MMD-equivalent note transfers, this resulted in the transferred amount being **added to the player's balance without any corresponding deduction** â€” effectively creating currency from nothing on every command invocation.

---

## Root Cause Analysis

### Missing Self-Transfer Guard

All six `Transfer*` methods in `Player_Bank.cs` used `PlayerManager.FindByName(name)` to resolve the target player, but **none of them checked whether the resolved target was the same player as the sender** before executing the transfer.

`PlayerManager.FindByName` will successfully return the calling player's own `IPlayer` record when their own character name is supplied. The code then proceeded directly into the transfer logic.

---

### Why Pyreals Actively Duped (Online Path)

The `TransferPyreals` online path captured **both** the source and destination balances into local variables **before** performing any mutation.

```csharp
// Both snapshots captured first same object, same value
long srcOldBalance = this.BankedPyreals ?? 0;         // e.g. 125,390,992
long dstOldBalance = onlinePlayer.BankedPyreals ?? 0; // e.g. 125,390,992 (same object!)

// Mutation step 1: subtract from sender
this.BankedPyreals = srcOldBalance - Amount;           //  122,890,992

// Mutation step 2: add to receiver using PRE-SUBTRACTION snapshot
onlinePlayer.BankedPyreals = dstOldBalance + Amount;  //  127,890,992
//                             dstOldBalance was frozen at 125,390,992
//                              BEFORE step 1 modified the shared object
```

Because `this` and `onlinePlayer` are the **same object in memory**, step 2 overwrites the result of step 1 using a stale pre-mutation snapshot. The subtraction is silently discarded. The player's final balance is their original balance **plus** the transfer amount.

**Net effect per transfer: `+Amount` gained from nothing.**

This is a classic read-modify-write hazard on a shared mutable reference where snapshot ordering is incorrect.

---

### Why Luminance / Keys / Coins Did Not Dupe (But Were Still Broken)

The other five transfer methods used a different mutation pattern â€” compound assignment operators or inline reads rather than pre-captured snapshots:

```csharp
// TransferLuminance, TransferEnlightenedCoins, etc.
this.BankedLuminance -= Amount;                                          // step 1: now old - Amount
onlinePlayer.BankedLuminance = (onlinePlayer.BankedLuminance ?? 0) + Amount; // step 2: reads CURRENT value
//                               â†‘ reads (old - Amount), then +Amount â†’ back to old
```

Because step 2 reads the **live, already-modified** value rather than a frozen snapshot, the subtraction and addition cancel each other out. The net result is a **silent no-op** â€” balance is unchanged, no error is shown, no currency is created or lost.

These methods were still logically incorrect (a self-transfer should be explicitly rejected), but they did not produce free currency.

---

### Affected Methods

| Method | Self-Transfer Behavior | Exploit |
|---|---|---|
| `TransferPyreals` | Balance increases by Amount | **Active dupe** |
| `TransferLuminance` | Silent no-op | No dupe |
| `TransferLegendaryKeys` | Silent no-op | No dupe |
| `TransferMythicalKeys` | Silent no-op | No dupe |
| `TransferEnlightenedCoins` | Silent no-op | No dupe |
| `TransferWeaklyEnlightenedCoins` | Silent no-op | No dupe |

---

## The Fix

A self-identity check was added to all six `Transfer*` methods immediately after the `tarplayer == null` null check, before any balance mutation is performed:

```csharp
if (string.Equals(tarplayer.Name, this.Name, StringComparison.OrdinalIgnoreCase))
{
    Session.Network.EnqueueSend(new GameMessageSystemChat(
        "You cannot transfer currency to yourself.", ChatMessageType.System));
    return false;
}
```

The check uses `OrdinalIgnoreCase` to be robust against any case variation in the name the player types.

For `TransferPyreals` specifically, the log call was also included for audit trail purposes:
```csharp
LogTransfer("TransferPyreals", "Pyreals", Amount, CharacterDestination, false, "Self-transfer attempted");
```

This guard fires before either player's balance is read or modified, so there is no window for the snapshot-ordering bug to execute.

---

## Testing

| Test | Result |
|---|---|
| `/b t n mmd 10 Grumpy` (self) | "You cannot transfer currency to yourself." â€” balance unchanged âœ… |
| `/b t p 500000 Grumpy` (self) | "You cannot transfer currency to yourself." â€” balance unchanged âœ… |
| Legitimate transfer to another player | Transfers correctly, unaffected âœ… |

Luminance, legendary keys, mythical keys, enlightened coins, and weakly enlightened coins could not be tested in-game due to zero balances, but the guard code is identical across all six methods.

---

## Timeline

| Time | Event |
|---|---|
| 23:09 | Exploit reported players sending themselves pyreals/MMDs |
| 23:12 | Exploit confirmed in-game: +2,500,000 pyreals via self-transfer |
| 23:18 | Branch `fix/bank-self-transfer` created, guard added to all 6 methods |
| 23:19 | Build succeeded (0 errors) |
| 23:21 | DLL deployed to `C:\ACE\ACEBuild` |
| 23:23 | Fix verified in-game for pyreals |
| 23:24 | Pushed to `origin/fix/bank-self-transfer` |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to bank currency transfer methods to prevent transfers to oneself. Attempted self-transfers now display a system message and are blocked.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rkroska/ACECustom/pull/445)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->