### PR TITLE
feat: self-service @unstuck command for stuck characters

### DIFF
--- a/Source/ACE.Server/Command/Handlers/AccountCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AccountCommands.cs
@@ -227,99 +227,189 @@ namespace ACE.Server.Command.Handlers
             CommandHandlerHelper.WriteOutputInfo(session, "Account password successfully changed.", ChatMessageType.Broadcast);
         }
 
-        // Add a cooldown dictionary to track last unstuck usage per session
-        private static readonly Dictionary<uint, DateTime> UnstuckCooldowns = new Dictionary<uint, DateTime>();
+        // -----------------------------------------------------------------------
+        // PREVIOUS /unstuck IMPLEMENTATION (preserved, no longer active)
+        // Issues: AccessLevel.Developer (players couldn't use it), required account
+        // name as argument, used IP matching as security gate (broke on VPN/NAT),
+        // and called NetworkManager.RemoveSession() manually after Terminate() which
+        // is redundant and unsafe. Replaced below with a corrected version.
+        // -----------------------------------------------------------------------
+        //
+        // // Add a cooldown dictionary to track last unstuck usage per session
+        // private static readonly Dictionary<uint, DateTime> UnstuckCooldowns = new Dictionary<uint, DateTime>();
+        //
+        // [CommandHandler("unstuck", AccessLevel.Developer, CommandHandlerFlag.None, 1,
+        //     "Kicks all online players for the specified account if the IP matches the command issuer.",
+        //     "accountname")]
+        // public static void HandleUnstuck(Session session, params string[] parameters)
+        // {
+        //     // Cooldown check
+        //     var now = DateTime.UtcNow;
+        //     var sessionId = session?.Player?.Guid.Full ?? 0;
+        //     lock (UnstuckCooldowns)
+        //     {
+        //         if (UnstuckCooldowns.TryGetValue(sessionId, out var lastUsed))
+        //         {
+        //             if ((now - lastUsed).TotalSeconds < 15)
+        //             {
+        //                 CommandHandlerHelper.WriteOutputInfo(session, $"/unstuck is on cooldown. Please wait {15 - (int)(now - lastUsed).TotalSeconds} seconds.", ChatMessageType.Broadcast);
+        //                 return;
+        //             }
+        //         }
+        //         UnstuckCooldowns[sessionId] = now;
+        //     }
+        //
+        //     string accountName = parameters[0].ToLower();
+        //
+        //     var account = DatabaseManager.Authentication.GetAccountByName(accountName);
+        //     if (account == null)
+        //     {
+        //         CommandHandlerHelper.WriteOutputInfo(session, "Account does not exist.", ChatMessageType.Broadcast);
+        //         return;
+        //     }
+        //
+        //     // Only target sessions for the account that are NOT the issuer's session
+        //     var playersToKick = PlayerManager.GetAllOnline()
+        //         .Where(p => p.Account != null
+        //             && p.Account.AccountId == account.AccountId
+        //             && p.Session != session) // Exclude the issuer's session
+        //         .ToList();
+        //
+        //     if (playersToKick.Count == 0)
+        //     {
+        //         CommandHandlerHelper.WriteOutputInfo(session, "Account is not online.", ChatMessageType.Broadcast);
+        //         return;
+        //     }
+        //
+        //     // Check if the IP of the command issuer matches the IP of the target account's online session(s)
+        //     var issuerIP = session?.EndPoint?.Address;
+        //     var targetIPs = playersToKick.Select(p => p.Session?.EndPoint?.Address).Distinct().ToList();
+        //     if (!targetIPs.Contains(issuerIP))
+        //     {
+        //         CommandHandlerHelper.WriteOutputInfo(session, "IP mismatch - failed to kick.", ChatMessageType.Broadcast);
+        //         return;
+        //     }
+        //
+        //     foreach (var player in playersToKick)
+        //     {
+        //         player.Session.Terminate(
+        //             ACE.Server.Network.Enum.SessionTerminationReason.AccountBooted,
+        //             new ACE.Server.Network.GameMessages.Messages.GameMessageBootAccount("! You have been kicked by /unstuck command."));
+        //     }
+        //
+        //     // Capture the sessions to remove
+        //     var sessionsToRemove = playersToKick.Select(p => p.Session).ToList();
+        //
+        //     System.Threading.Tasks.Task.Run(async () =>
+        //     {
+        //         await System.Threading.Tasks.Task.Delay(3000);
+        //         foreach (var sessionToRemove in sessionsToRemove)
+        //         {
+        //             if (sessionToRemove != null)
+        //             {
+        //                 try
+        //                 {
+        //                     ACE.Server.Network.Managers.NetworkManager.RemoveSession(sessionToRemove);
+        //                 }
+        //                 catch (Exception ex)
+        //                 {
+        //                     // Log error but do not freeze server
+        //                     log.Error($"Error removing session in /unstuck: {ex.Message}", ex);
+        //                 }
+        //             }
+        //         }
+        //     });
+        //
+        //     // Write to Audit channel
+        //     if (session?.Player != null)
+        //     {
+        //         PlayerManager.BroadcastToAuditChannel(session.Player, $"{session.Player.Name} has issued a stuck command for {accountName} - Verified by IP - KICKING");
+        //     }
+        //
+        //     var kickedNames = string.Join(", ", playersToKick.Select(p => p.Name));
+        //     CommandHandlerHelper.WriteOutputInfo(session, $"Unstuck: {playersToKick.Count} player(s) on account '{accountName}' have been kicked: {kickedNames}", ChatMessageType.Broadcast);
+        // }
+        // -----------------------------------------------------------------------
 
-        [CommandHandler("unstuck", AccessLevel.Developer, CommandHandlerFlag.None, 1,
-            "Kicks all online players for the specified account if the IP matches the command issuer.",
-            "accountname")]
+        /// <summary>
+        /// Per-account cooldown tracker for /unstuck. Keyed by AccountId.
+        /// ConcurrentDictionary avoids the lock overhead of the previous implementation.
+        /// </summary>
+        private static readonly System.Collections.Concurrent.ConcurrentDictionary<uint, DateTime> _unstuckCooldowns
+            = new System.Collections.Concurrent.ConcurrentDictionary<uint, DateTime>();
+
+        private static readonly TimeSpan UnstuckCooldownDuration = TimeSpan.FromMinutes(5);
+
+        [CommandHandler("unstuck", AccessLevel.Player, CommandHandlerFlag.RequiresWorld, 0,
+            "Boots any other stuck characters on your account so you can log back in to them.",
+            "Usage: @unstuck\n" +
+            "If another character on your account is stuck and preventing you from logging in,\n" +
+            "log in to any other character and type @unstuck. The stuck character will be\n" +
+            "disconnected and you will be able to log back in to them normally.\n" +
+            "This command has a 5-minute cooldown.")]
         public static void HandleUnstuck(Session session, params string[] parameters)
         {
-            // Cooldown check
+            var accountId = session.AccountId;
             var now = DateTime.UtcNow;
-            var sessionId = session?.Player?.Guid.Full ?? 0;
-            lock (UnstuckCooldowns)
+
+            // --- Cooldown check ---
+            if (_unstuckCooldowns.TryGetValue(accountId, out var lastUsed))
             {
-                if (UnstuckCooldowns.TryGetValue(sessionId, out var lastUsed))
+                var elapsed = now - lastUsed;
+                if (elapsed < UnstuckCooldownDuration)
                 {
-                    if ((now - lastUsed).TotalSeconds < 15)
-                    {
-                        CommandHandlerHelper.WriteOutputInfo(session, $"/unstuck is on cooldown. Please wait {15 - (int)(now - lastUsed).TotalSeconds} seconds.", ChatMessageType.Broadcast);
-                        return;
-                    }
+                    var remaining = (int)(UnstuckCooldownDuration - elapsed).TotalSeconds;
+                    CommandHandlerHelper.WriteOutputInfo(session,
+                        $"Silas the Unsticker whispers: \"Easy there — I just helped you. Give it another {remaining} second{(remaining == 1 ? "" : "s")} before asking again.\"",
+                        ChatMessageType.Broadcast);
+                    return;
                 }
-                UnstuckCooldowns[sessionId] = now;
             }
 
-            string accountName = parameters[0].ToLower();
-
-            var account = DatabaseManager.Authentication.GetAccountByName(accountName);
-            if (account == null)
-            {
-                CommandHandlerHelper.WriteOutputInfo(session, "Account does not exist.", ChatMessageType.Broadcast);
-                return;
-            }
-
-            // Only target sessions for the account that are NOT the issuer's session
-            var playersToKick = PlayerManager.GetAllOnline()
+            // --- Find other stuck characters on this account ---
+            // Scoped strictly to the caller's AccountId — no IP matching, no account name argument.
+            // A player can only ever unstuck their own account.
+            var stuckPlayers = PlayerManager.GetAllOnline()
                 .Where(p => p.Account != null
-                    && p.Account.AccountId == account.AccountId
-                    && p.Session != session) // Exclude the issuer's session
+                    && p.Account.AccountId == accountId
+                    && p.Session != session)
                 .ToList();
 
-            if (playersToKick.Count == 0)
+            if (stuckPlayers.Count == 0)
             {
-                CommandHandlerHelper.WriteOutputInfo(session, "Account is not online.", ChatMessageType.Broadcast);
+                CommandHandlerHelper.WriteOutputInfo(session,
+                    "Silas the Unsticker whispers: \"Hmm... I don't see any other characters from your account stuck out there. You look fine to me!\"",
+                    ChatMessageType.Broadcast);
                 return;
             }
 
-            // Check if the IP of the command issuer matches the IP of the target account's online session(s)
-            var issuerIP = session?.EndPoint?.Address;
-            var targetIPs = playersToKick.Select(p => p.Session?.EndPoint?.Address).Distinct().ToList();
-            if (!targetIPs.Contains(issuerIP))
+            // --- Boot each stuck character ---
+            var kickedNames = new System.Collections.Generic.List<string>();
+            foreach (var stuck in stuckPlayers)
             {
-                CommandHandlerHelper.WriteOutputInfo(session, "IP mismatch - failed to kick.", ChatMessageType.Broadcast);
-                return;
-            }
+                var stuckName = stuck.Name;
+                log.Info($"[Unstuck] Booting stuck character '{stuckName}' (Account: {session.Account}, AccountId: {accountId}) requested by '{session.Player.Name}'.");
 
-            foreach (var player in playersToKick)
-            {
-                player.Session.Terminate(
+                stuck.Session?.Terminate(
                     ACE.Server.Network.Enum.SessionTerminationReason.AccountBooted,
-                    new ACE.Server.Network.GameMessages.Messages.GameMessageBootAccount("! You have been kicked by /unstuck command."));
+                    new ACE.Server.Network.GameMessages.Messages.GameMessageBootAccount(
+                        " - Freed by Silas the Unsticker at your request."));
+
+                kickedNames.Add(stuckName);
             }
 
-            // Capture the sessions to remove
-            var sessionsToRemove = playersToKick.Select(p => p.Session).ToList();
+            // --- Apply cooldown ---
+            _unstuckCooldowns[accountId] = now;
 
-            System.Threading.Tasks.Task.Run(async () =>
-            {
-                await System.Threading.Tasks.Task.Delay(3000);
-                foreach (var sessionToRemove in sessionsToRemove)
-                {
-                    if (sessionToRemove != null)
-                    {
-                        try
-                        {
-                            ACE.Server.Network.Managers.NetworkManager.RemoveSession(sessionToRemove);
-                        }
-                        catch (Exception ex)
-                        {
-                            // Log error but do not freeze server
-                            log.Error($"Error removing session in /unstuck: {ex.Message}", ex);
-                        }
-                    }
-                }
-            });
+            // --- Audit log ---
+            PlayerManager.BroadcastToAuditChannel(session.Player,
+                $"[Unstuck] {session.Player.Name} used @unstuck — booted {kickedNames.Count} stuck character(s) on account '{session.Account}': {string.Join(", ", kickedNames)}");
 
-            // Write to Audit channel
-            if (session?.Player != null)
-            {
-                PlayerManager.BroadcastToAuditChannel(session.Player, $"{session.Player.Name} has issued a stuck command for {accountName} - Verified by IP - KICKING");
-            }
-
-            var kickedNames = string.Join(", ", playersToKick.Select(p => p.Name));
-            CommandHandlerHelper.WriteOutputInfo(session, $"Unstuck: {playersToKick.Count} player(s) on account '{accountName}' have been kicked: {kickedNames}", ChatMessageType.Broadcast);
+            // --- Confirmation to the player ---
+            var names = string.Join(", ", kickedNames);
+            CommandHandlerHelper.WriteOutputInfo(session,
+                $"Silas the Unsticker whispers: \"Consider it done! I've sent {names} packing. They should be free to log back in now.\"",
+                ChatMessageType.Broadcast);
         }
     }
 }

--- a/Source/ACE.Server/Command/Handlers/AccountCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AccountCommands.cs
@@ -394,7 +394,7 @@ namespace ACE.Server.Command.Handlers
             {
                 // s.Player may be null for zombie sessions — fall back to account info.
                 var charName = s.Player?.Name ?? $"[session:{s.AccountId}]";
-                log.Info($"[Unstuck] Booting session for '{charName}' (Account: {session.Account}, AccountId: {accountId}) requested by '{callerName}'.");
+                log.Info($"[Unstuck] Booting session for '{charName}' (Account: {session.Account ?? "[unknown]"}, AccountId: {accountId}) requested by '{callerName}'.");
 
                 s.Terminate(
                     ACE.Server.Network.Enum.SessionTerminationReason.AccountBooted,
@@ -417,7 +417,7 @@ namespace ACE.Server.Command.Handlers
 
             // --- Audit log ---
             PlayerManager.BroadcastToAuditChannel(session.Player,
-                $"[Unstuck] {callerName} used @unstuck — booted {kickedNames.Count} session(s) on account '{session.Account}': {string.Join(", ", kickedNames)}");
+                $"[Unstuck] {callerName} used @unstuck — booted {kickedNames.Count} session(s) on account '{session.Account ?? "[unknown]"}': {string.Join(", ", kickedNames)}");
 
             // --- Confirmation to the player ---
             var names = string.Join(", ", kickedNames);

--- a/Source/ACE.Server/Command/Handlers/AccountCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AccountCommands.cs
@@ -366,6 +366,10 @@ namespace ACE.Server.Command.Handlers
                 }
             }
 
+            // --- Stamp cooldown on every invocation (not just on success) ---
+            // Prevents spam on the "nothing found" path as well as the boot path.
+            _unstuckCooldowns[accountId] = now;
+
             // --- Find other stuck characters on this account ---
             // Scoped strictly to the caller's AccountId — no IP matching, no account name argument.
             // A player can only ever unstuck their own account.
@@ -397,9 +401,6 @@ namespace ACE.Server.Command.Handlers
 
                 kickedNames.Add(stuckName);
             }
-
-            // --- Apply cooldown ---
-            _unstuckCooldowns[accountId] = now;
 
             // --- Audit log ---
             PlayerManager.BroadcastToAuditChannel(session.Player,

--- a/Source/ACE.Server/Command/Handlers/AccountCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AccountCommands.cs
@@ -389,7 +389,7 @@ namespace ACE.Server.Command.Handlers
             // session.Player is guaranteed non-null by CommandHandlerFlag.RequiresWorld.
             var callerName = session.Player.Name;
 
-            var kickedNames = new System.Collections.Generic.List<string>();
+            var kickedNames = new List<string>();
             foreach (var s in sessionsToKick)
             {
                 // s.Player may be null for zombie sessions — fall back to account info.

--- a/Source/ACE.Server/Command/Handlers/AccountCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AccountCommands.cs
@@ -346,7 +346,7 @@ namespace ACE.Server.Command.Handlers
             "If another character on your account is stuck and preventing you from logging in,\n" +
             "log in to any other character and type @unstuck. The stuck character will be\n" +
             "disconnected and you will be able to log back in to them normally.\n" +
-            "This command has a 5-minute cooldown.")]
+            "A 5-minute cooldown applies after a successful boot. Checking when nothing is stuck is always free.")]
         public static void HandleUnstuck(Session session, params string[] parameters)
         {
             var accountId = session.AccountId;
@@ -389,14 +389,14 @@ namespace ACE.Server.Command.Handlers
             // session.Player is guaranteed non-null by CommandHandlerFlag.RequiresWorld.
             var callerName = session.Player.Name;
 
-            var kickedNames = new List<string>();
-            foreach (var s in sessionsToKick)
+            var kickedNames = new List<string>(sessionsToKick.Count);
+            foreach (var stuckSession in sessionsToKick)
             {
-                // s.Player may be null for zombie sessions — fall back to account info.
-                var charName = s.Player?.Name ?? $"[session:{s.AccountId}]";
+                // stuckSession.Player may be null for zombie sessions — fall back to account info.
+                var charName = stuckSession.Player?.Name ?? $"[session:{stuckSession.AccountId}]";
                 log.Info($"[Unstuck] Booting session for '{charName}' (Account: {session.Account ?? "[unknown]"}, AccountId: {accountId}) requested by '{callerName}'.");
 
-                s.Terminate(
+                stuckSession.Terminate(
                     ACE.Server.Network.Enum.SessionTerminationReason.AccountBooted,
                     new ACE.Server.Network.GameMessages.Messages.GameMessageBootAccount(
                         " - Freed by Silas the Unsticker at your request."));

--- a/Source/ACE.Server/Command/Handlers/AccountCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AccountCommands.cs
@@ -370,18 +370,18 @@ namespace ACE.Server.Command.Handlers
             // Prevents spam on the "nothing found" path as well as the boot path.
             _unstuckCooldowns[accountId] = now;
 
-            // --- Find all sessions on this account ---
+            // --- Find all OTHER sessions on this account ---
             // Uses NetworkManager.FindAllByAccount() instead of PlayerManager.GetAllOnline()
             // so that zombie/stuck sessions (no attached Player object) are also caught.
-            // NOTE: For testing, this includes the caller's own session so the boot
-            // mechanism can be verified by self-kicking. Re-add the exclusion after testing:
-            //   .Where(s => s != session)
-            var sessionsToKick = ACE.Server.Network.Managers.NetworkManager.FindAllByAccount(accountId);
+            // The caller's own session is excluded — only other sessions on the account are booted.
+            var sessionsToKick = ACE.Server.Network.Managers.NetworkManager.FindAllByAccount(accountId)
+                .Where(s => s != session)
+                .ToList();
 
             if (sessionsToKick.Count == 0)
             {
                 CommandHandlerHelper.WriteOutputInfo(session,
-                    "Silas the Unsticker whispers: \"Hmm... I don't see any sessions from your account out there. You look fine to me!\"",
+                    "Silas the Unsticker whispers: \"Hmm... I don't see any other characters from your account stuck out there. You look fine to me!\"",
                     ChatMessageType.Broadcast);
                 return;
             }

--- a/Source/ACE.Server/Command/Handlers/AccountCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AccountCommands.cs
@@ -366,9 +366,9 @@ namespace ACE.Server.Command.Handlers
                 }
             }
 
-            // --- Stamp cooldown on every invocation (not just on success) ---
-            // Prevents spam on the "nothing found" path as well as the boot path.
-            _unstuckCooldowns[accountId] = now;
+            // NOTE: Cooldown is stamped ONLY after a real boot (below).
+            // The "nothing found" path is a read-only no-op with negligible cost
+            // and no reason to penalise the player for checking.
 
             // --- Find all OTHER sessions on this account ---
             // Uses NetworkManager.FindAllByAccount() instead of PlayerManager.GetAllOnline()
@@ -386,7 +386,10 @@ namespace ACE.Server.Command.Handlers
                 return;
             }
 
-            // --- Boot each session ---
+            // --- Boot each session and stamp cooldown ---
+            // Cooldown is applied here — only when a real boot actually occurs.
+            _unstuckCooldowns[accountId] = now;
+
             var kickedNames = new System.Collections.Generic.List<string>();
             foreach (var s in sessionsToKick)
             {

--- a/Source/ACE.Server/Command/Handlers/AccountCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AccountCommands.cs
@@ -386,15 +386,15 @@ namespace ACE.Server.Command.Handlers
                 return;
             }
 
-            // --- Boot each session and stamp cooldown ---
-            // Cooldown is applied here — only when a real boot actually occurs.
-            _unstuckCooldowns[accountId] = now;
+            // session.Player is guaranteed non-null by CommandHandlerFlag.RequiresWorld.
+            var callerName = session.Player.Name;
 
             var kickedNames = new System.Collections.Generic.List<string>();
             foreach (var s in sessionsToKick)
             {
+                // s.Player may be null for zombie sessions — fall back to account info.
                 var charName = s.Player?.Name ?? $"[session:{s.AccountId}]";
-                log.Info($"[Unstuck] Booting session for '{charName}' (Account: {session.Account}, AccountId: {accountId}) requested by '{session.Player?.Name}'.");
+                log.Info($"[Unstuck] Booting session for '{charName}' (Account: {session.Account}, AccountId: {accountId}) requested by '{callerName}'.");
 
                 s.Terminate(
                     ACE.Server.Network.Enum.SessionTerminationReason.AccountBooted,
@@ -404,9 +404,21 @@ namespace ACE.Server.Command.Handlers
                 kickedNames.Add(charName);
             }
 
+            // --- Stamp cooldown after all boots complete ---
+            // Stamped after the loop so a mid-loop exception doesn't lock the player
+            // out of a 5-minute cooldown when boots may not have fully fired.
+            // Prune entries older than the cooldown window to keep the dictionary
+            // bounded over long server uptimes (avoids unbounded growth).
+            foreach (var staleKey in _unstuckCooldowns.Keys)
+            {
+                if (_unstuckCooldowns.TryGetValue(staleKey, out var ts) && (now - ts) > UnstuckCooldownDuration)
+                    _unstuckCooldowns.TryRemove(staleKey, out _);
+            }
+            _unstuckCooldowns[accountId] = now;
+
             // --- Audit log ---
             PlayerManager.BroadcastToAuditChannel(session.Player,
-                $"[Unstuck] {session.Player?.Name} used @unstuck — booted {kickedNames.Count} session(s) on account '{session.Account}': {string.Join(", ", kickedNames)}");
+                $"[Unstuck] {callerName} used @unstuck — booted {kickedNames.Count} session(s) on account '{session.Account}': {string.Join(", ", kickedNames)}");
 
             // --- Confirmation to the player ---
             var names = string.Join(", ", kickedNames);

--- a/Source/ACE.Server/Command/Handlers/AccountCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AccountCommands.cs
@@ -358,7 +358,7 @@ namespace ACE.Server.Command.Handlers
                 var elapsed = now - lastUsed;
                 if (elapsed < UnstuckCooldownDuration)
                 {
-                    var remaining = (int)(UnstuckCooldownDuration - elapsed).TotalSeconds;
+                    var remaining = Math.Max(1, (int)(UnstuckCooldownDuration - elapsed).TotalSeconds);
                     CommandHandlerHelper.WriteOutputInfo(session,
                         $"Silas the Unsticker whispers: \"Easy there — I just helped you. Give it another {remaining} second{(remaining == 1 ? "" : "s")} before asking again.\"",
                         ChatMessageType.Broadcast);
@@ -404,16 +404,15 @@ namespace ACE.Server.Command.Handlers
                 kickedNames.Add(charName);
             }
 
-            // --- Stamp cooldown after all boots complete ---
-            // Stamped after the loop so a mid-loop exception doesn't lock the player
-            // out of a 5-minute cooldown when boots may not have fully fired.
             // Prune entries older than the cooldown window to keep the dictionary
-            // bounded over long server uptimes (avoids unbounded growth).
-            foreach (var staleKey in _unstuckCooldowns.Keys)
-            {
-                if (_unstuckCooldowns.TryGetValue(staleKey, out var ts) && (now - ts) > UnstuckCooldownDuration)
-                    _unstuckCooldowns.TryRemove(staleKey, out _);
-            }
+            // bounded over long server uptimes. Filter first, then remove — avoids
+            // a redundant TryGetValue inside the loop.
+            var staleKeys = _unstuckCooldowns
+                .Where(kvp => (now - kvp.Value) > UnstuckCooldownDuration)
+                .Select(kvp => kvp.Key)
+                .ToList();
+            foreach (var staleKey in staleKeys)
+                _unstuckCooldowns.TryRemove(staleKey, out _);
             _unstuckCooldowns[accountId] = now;
 
             // --- Audit log ---

--- a/Source/ACE.Server/Command/Handlers/AccountCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AccountCommands.cs
@@ -370,41 +370,40 @@ namespace ACE.Server.Command.Handlers
             // Prevents spam on the "nothing found" path as well as the boot path.
             _unstuckCooldowns[accountId] = now;
 
-            // --- Find other stuck characters on this account ---
-            // Scoped strictly to the caller's AccountId — no IP matching, no account name argument.
-            // A player can only ever unstuck their own account.
-            var stuckPlayers = PlayerManager.GetAllOnline()
-                .Where(p => p.Account != null
-                    && p.Account.AccountId == accountId
-                    && p.Session != session)
-                .ToList();
+            // --- Find all sessions on this account ---
+            // Uses NetworkManager.FindAllByAccount() instead of PlayerManager.GetAllOnline()
+            // so that zombie/stuck sessions (no attached Player object) are also caught.
+            // NOTE: For testing, this includes the caller's own session so the boot
+            // mechanism can be verified by self-kicking. Re-add the exclusion after testing:
+            //   .Where(s => s != session)
+            var sessionsToKick = ACE.Server.Network.Managers.NetworkManager.FindAllByAccount(accountId);
 
-            if (stuckPlayers.Count == 0)
+            if (sessionsToKick.Count == 0)
             {
                 CommandHandlerHelper.WriteOutputInfo(session,
-                    "Silas the Unsticker whispers: \"Hmm... I don't see any other characters from your account stuck out there. You look fine to me!\"",
+                    "Silas the Unsticker whispers: \"Hmm... I don't see any sessions from your account out there. You look fine to me!\"",
                     ChatMessageType.Broadcast);
                 return;
             }
 
-            // --- Boot each stuck character ---
+            // --- Boot each session ---
             var kickedNames = new System.Collections.Generic.List<string>();
-            foreach (var stuck in stuckPlayers)
+            foreach (var s in sessionsToKick)
             {
-                var stuckName = stuck.Name;
-                log.Info($"[Unstuck] Booting stuck character '{stuckName}' (Account: {session.Account}, AccountId: {accountId}) requested by '{session.Player.Name}'.");
+                var charName = s.Player?.Name ?? $"[session:{s.AccountId}]";
+                log.Info($"[Unstuck] Booting session for '{charName}' (Account: {session.Account}, AccountId: {accountId}) requested by '{session.Player?.Name}'.");
 
-                stuck.Session?.Terminate(
+                s.Terminate(
                     ACE.Server.Network.Enum.SessionTerminationReason.AccountBooted,
                     new ACE.Server.Network.GameMessages.Messages.GameMessageBootAccount(
                         " - Freed by Silas the Unsticker at your request."));
 
-                kickedNames.Add(stuckName);
+                kickedNames.Add(charName);
             }
 
             // --- Audit log ---
             PlayerManager.BroadcastToAuditChannel(session.Player,
-                $"[Unstuck] {session.Player.Name} used @unstuck — booted {kickedNames.Count} stuck character(s) on account '{session.Account}': {string.Join(", ", kickedNames)}");
+                $"[Unstuck] {session.Player?.Name} used @unstuck — booted {kickedNames.Count} session(s) on account '{session.Account}': {string.Join(", ", kickedNames)}");
 
             // --- Confirmation to the player ---
             var names = string.Join(", ", kickedNames);

--- a/Source/ACE.Server/Command/Handlers/AccountCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AccountCommands.cs
@@ -332,11 +332,17 @@ namespace ACE.Server.Command.Handlers
         // -----------------------------------------------------------------------
 
         /// <summary>
-        /// Per-account cooldown tracker for /unstuck. Keyed by AccountId.
-        /// ConcurrentDictionary avoids the lock overhead of the previous implementation.
+        /// Per-account cooldown tracker for @unstuck. Keyed by AccountId.
         /// </summary>
         private static readonly System.Collections.Concurrent.ConcurrentDictionary<uint, DateTime> _unstuckCooldowns
             = new System.Collections.Concurrent.ConcurrentDictionary<uint, DateTime>();
+
+        /// <summary>
+        /// Per-account lock gates for @unstuck. Ensures the cooldown check, boot, and stamp
+        /// are serialized per account so two concurrent calls cannot both pass the cooldown check.
+        /// </summary>
+        private static readonly System.Collections.Concurrent.ConcurrentDictionary<uint, object> _unstuckLocks
+            = new System.Collections.Concurrent.ConcurrentDictionary<uint, object>();
 
         private static readonly TimeSpan UnstuckCooldownDuration = TimeSpan.FromMinutes(5);
 
@@ -350,80 +356,88 @@ namespace ACE.Server.Command.Handlers
         public static void HandleUnstuck(Session session, params string[] parameters)
         {
             var accountId = session.AccountId;
-            var now = DateTime.UtcNow;
 
-            // --- Cooldown check ---
-            if (_unstuckCooldowns.TryGetValue(accountId, out var lastUsed))
+            // Acquire a per-account gate so the cooldown check → boot → stamp sequence
+            // is atomic. Without this, two concurrent @unstuck calls on the same account
+            // could both pass the cooldown check before either stamps it.
+            var gate = _unstuckLocks.GetOrAdd(accountId, _ => new object());
+            lock (gate)
             {
-                var elapsed = now - lastUsed;
-                if (elapsed < UnstuckCooldownDuration)
+                var now = DateTime.UtcNow;
+
+                // --- Cooldown check ---
+                if (_unstuckCooldowns.TryGetValue(accountId, out var lastUsed))
                 {
-                    var remaining = Math.Max(1, (int)(UnstuckCooldownDuration - elapsed).TotalSeconds);
+                    var elapsed = now - lastUsed;
+                    if (elapsed < UnstuckCooldownDuration)
+                    {
+                        var remaining = Math.Max(1, (int)(UnstuckCooldownDuration - elapsed).TotalSeconds);
+                        CommandHandlerHelper.WriteOutputInfo(session,
+                            $"Silas the Unsticker whispers: \"Easy there — I just helped you. Give it another {remaining} second{(remaining == 1 ? "" : "s")} before asking again.\"",
+                            ChatMessageType.Broadcast);
+                        return;
+                    }
+                }
+
+                // NOTE: Cooldown is stamped ONLY after a real boot (below).
+                // The "nothing found" path is a read-only no-op with negligible cost
+                // and no reason to penalise the player for checking.
+
+                // --- Find all OTHER sessions on this account ---
+                // Uses NetworkManager.FindAllByAccount() instead of PlayerManager.GetAllOnline()
+                // so that zombie/stuck sessions (no attached Player object) are also caught.
+                // The caller's own session is excluded — only other sessions on the account are booted.
+                var sessionsToKick = ACE.Server.Network.Managers.NetworkManager.FindAllByAccount(accountId)
+                    .Where(s => s != session)
+                    .ToList();
+
+                if (sessionsToKick.Count == 0)
+                {
                     CommandHandlerHelper.WriteOutputInfo(session,
-                        $"Silas the Unsticker whispers: \"Easy there — I just helped you. Give it another {remaining} second{(remaining == 1 ? "" : "s")} before asking again.\"",
+                        "Silas the Unsticker whispers: \"Hmm... I don't see any other characters from your account stuck out there. You look fine to me!\"",
                         ChatMessageType.Broadcast);
                     return;
                 }
-            }
 
-            // NOTE: Cooldown is stamped ONLY after a real boot (below).
-            // The "nothing found" path is a read-only no-op with negligible cost
-            // and no reason to penalise the player for checking.
+                // session.Player is guaranteed non-null by CommandHandlerFlag.RequiresWorld.
+                var callerName = session.Player.Name;
 
-            // --- Find all OTHER sessions on this account ---
-            // Uses NetworkManager.FindAllByAccount() instead of PlayerManager.GetAllOnline()
-            // so that zombie/stuck sessions (no attached Player object) are also caught.
-            // The caller's own session is excluded — only other sessions on the account are booted.
-            var sessionsToKick = ACE.Server.Network.Managers.NetworkManager.FindAllByAccount(accountId)
-                .Where(s => s != session)
-                .ToList();
+                var kickedNames = new List<string>(sessionsToKick.Count);
+                foreach (var stuckSession in sessionsToKick)
+                {
+                    // stuckSession.Player may be null for zombie sessions — fall back to account info.
+                    var charName = stuckSession.Player?.Name ?? $"[session:{stuckSession.AccountId}]";
+                    log.Info($"[Unstuck] Booting session for '{charName}' (Account: {session.Account ?? "[unknown]"}, AccountId: {accountId}) requested by '{callerName}'.");
 
-            if (sessionsToKick.Count == 0)
-            {
+                    stuckSession.Terminate(
+                        ACE.Server.Network.Enum.SessionTerminationReason.AccountBooted,
+                        new ACE.Server.Network.GameMessages.Messages.GameMessageBootAccount(
+                            " - Freed by Silas the Unsticker at your request."));
+
+                    kickedNames.Add(charName);
+                }
+
+                // Prune entries older than the cooldown window to keep the dictionary
+                // bounded over long server uptimes. Filter first, then remove — avoids
+                // a redundant TryGetValue inside the loop.
+                var staleKeys = _unstuckCooldowns
+                    .Where(kvp => (now - kvp.Value) > UnstuckCooldownDuration)
+                    .Select(kvp => kvp.Key)
+                    .ToList();
+                foreach (var staleKey in staleKeys)
+                    _unstuckCooldowns.TryRemove(staleKey, out _);
+                _unstuckCooldowns[accountId] = now;
+
+                // --- Audit log ---
+                PlayerManager.BroadcastToAuditChannel(session.Player,
+                    $"[Unstuck] {callerName} used @unstuck — booted {kickedNames.Count} session(s) on account '{session.Account ?? "[unknown]"}': {string.Join(", ", kickedNames)}");
+
+                // --- Confirmation to the player ---
+                var names = string.Join(", ", kickedNames);
                 CommandHandlerHelper.WriteOutputInfo(session,
-                    "Silas the Unsticker whispers: \"Hmm... I don't see any other characters from your account stuck out there. You look fine to me!\"",
+                    $"Silas the Unsticker whispers: \"Consider it done! I've sent {names} packing. They should be free to log back in now.\"",
                     ChatMessageType.Broadcast);
-                return;
             }
-
-            // session.Player is guaranteed non-null by CommandHandlerFlag.RequiresWorld.
-            var callerName = session.Player.Name;
-
-            var kickedNames = new List<string>(sessionsToKick.Count);
-            foreach (var stuckSession in sessionsToKick)
-            {
-                // stuckSession.Player may be null for zombie sessions — fall back to account info.
-                var charName = stuckSession.Player?.Name ?? $"[session:{stuckSession.AccountId}]";
-                log.Info($"[Unstuck] Booting session for '{charName}' (Account: {session.Account ?? "[unknown]"}, AccountId: {accountId}) requested by '{callerName}'.");
-
-                stuckSession.Terminate(
-                    ACE.Server.Network.Enum.SessionTerminationReason.AccountBooted,
-                    new ACE.Server.Network.GameMessages.Messages.GameMessageBootAccount(
-                        " - Freed by Silas the Unsticker at your request."));
-
-                kickedNames.Add(charName);
-            }
-
-            // Prune entries older than the cooldown window to keep the dictionary
-            // bounded over long server uptimes. Filter first, then remove — avoids
-            // a redundant TryGetValue inside the loop.
-            var staleKeys = _unstuckCooldowns
-                .Where(kvp => (now - kvp.Value) > UnstuckCooldownDuration)
-                .Select(kvp => kvp.Key)
-                .ToList();
-            foreach (var staleKey in staleKeys)
-                _unstuckCooldowns.TryRemove(staleKey, out _);
-            _unstuckCooldowns[accountId] = now;
-
-            // --- Audit log ---
-            PlayerManager.BroadcastToAuditChannel(session.Player,
-                $"[Unstuck] {callerName} used @unstuck — booted {kickedNames.Count} session(s) on account '{session.Account ?? "[unknown]"}': {string.Join(", ", kickedNames)}");
-
-            // --- Confirmation to the player ---
-            var names = string.Join(", ", kickedNames);
-            CommandHandlerHelper.WriteOutputInfo(session,
-                $"Silas the Unsticker whispers: \"Consider it done! I've sent {names} packing. They should be free to log back in now.\"",
-                ChatMessageType.Broadcast);
         }
     }
 }

--- a/Source/ACE.Server/Network/Managers/NetworkManager.cs
+++ b/Source/ACE.Server/Network/Managers/NetworkManager.cs
@@ -345,6 +345,25 @@ namespace ACE.Server.Network.Managers
         }
 
         /// <summary>
+        /// Returns all active sessions belonging to the given account ID.
+        /// Unlike Find(uint accountId) which uses SingleOrDefault, this handles
+        /// the stuck-character scenario where two sessions share the same AccountId
+        /// (one zombie/stuck, one newly connected). Safe to call with any account.
+        /// </summary>
+        public static List<Session> FindAllByAccount(uint accountId)
+        {
+            sessionLock.EnterReadLock();
+            try
+            {
+                return sessionMap.Where(s => s != null && s.AccountId == accountId).ToList();
+            }
+            finally
+            {
+                sessionLock.ExitReadLock();
+            }
+        }
+
+        /// <summary>
         /// Removes a session, network client and network endpoint from the various tracker objects.
         /// </summary>
         public static void RemoveSession(Session session)


### PR DESCRIPTION
## Summary
Adds a player-accessible @unstuck command that allows players to boot other stuck sessions on their own account without admin intervention.

## Problem
When a character's session becomes stuck server-side (zombie session), the player cannot log back in to that character. Previously this required an admin to manually run /boot.

## Solution
- New @unstuck command at AccessLevel.Player with RequiresWorld flag
- - Automatically finds and terminates all other sessions on the caller's account via NetworkManager.FindAllByAccount() - catches zombie sessions that PlayerManager.GetAllOnline() would miss
- - 5-minute cooldown per account, stamped only on successful boot
- - Full audit channel + server log entry on every successful boot
- - Silas the Unsticker flavor messaging
## Files Changed
- AccountCommands.cs - new command handler, previous broken attempt preserved as comments
- - NetworkManager.cs - new FindAllByAccount(uint accountId) method
## Security
- Strictly account-scoped - no parameters, cannot target other accounts
- - Caller's own session excluded via reference comparison
- - All usage audited

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * `/unstuck` command now accessible to all players (previously developer-only)
  * Enhanced behavior: disconnects all active sessions on the account
  * Added 5-minute cooldown tracking per account
  * Improved audit logging and confirmation notifications

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rkroska/ACECustom/pull/448)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->