### PR TITLE
Feat/ring spell aoe rework

### DIFF
--- a/Source/ACE.Entity/Enum/Properties/PropertyBool.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyBool.cs
@@ -298,6 +298,9 @@ namespace ACE.Entity.Enum.Properties
         /// <summary>ILT Skill #20: Tectonic Rifts I is redirected to Ring of Unspeakable Agony while charm is active (requires Agony learned). Rocky Shrapnel takes priority if both charms are active.</summary>
         HasAgonyCharm    = 50033,
 
+        /// <summary>ILT Player Pref: Use classic physics-collision ring spell behavior (can multi-hit through positioning). Default OFF = new guaranteed AOE system.</summary>
+        ClassicRingAoe   = 50034,
+
         // -- ILT Player UI Preferences -> see PropertyInt.DamageNumberFormat (50101) --
     }
 }

--- a/Source/ACE.Entity/Enum/Properties/PropertyFloat.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyFloat.cs
@@ -276,5 +276,10 @@ namespace ACE.Entity.Enum.Properties
         /// Monster capture: ObjScale normalized to ~1.5m physical height for combat pet summons (parallel to CapturedScale at ~0.75m).
         /// </summary>
         CapturedScaleCombatPet = 9047,
+        /// <summary>
+        /// Multiplier applied to the effective radius of player ring AOE spells (SpreadAngle == 360).
+        /// Used by ring-specific charms to increase coverage. Defaults to 1.0 if not set.
+        /// </summary>
+        AoeRangeMultiplier = 9048,
     }
 }

--- a/Source/ACE.Server/Command/Handlers/ILTCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/ILTCommands.cs
@@ -42,7 +42,7 @@ namespace ACE.Server.Command.Handlers
 
         [CommandHandler("ilt", AccessLevel.Player, CommandHandlerFlag.RequiresWorld, 0,
             "ILT custom server commands and player preferences.",
-            "Usage: /ilt [help|features|dmgformat|showoverkill|levelskills|trainskills|xp level|train|ringmode]")]
+            "Usage: /ilt [help|features|dmgformat|showoverkill|levelskills|trainskills|xp level|train|ringmode|ringdebug]")]
         public static void HandleILT(Session session, params string[] parameters)
         {
             var player = session.Player;
@@ -322,6 +322,8 @@ namespace ACE.Server.Command.Handlers
                 session.Network.EnqueueSend(new GameMessageSystemChat("      Train all affordable untrained skills using skill credits, in priority order.", ChatMessageType.System));
                 session.Network.EnqueueSend(new GameMessageSystemChat($"  /ilt ringmode", ChatMessageType.System));
                 session.Network.EnqueueSend(new GameMessageSystemChat($"      Toggle ring spell mode between New (guaranteed AOE) and Classic (physics multi-hit). (currently: {ringLabel})", ChatMessageType.System));
+                session.Network.EnqueueSend(new GameMessageSystemChat($"  /ilt ringdebug", ChatMessageType.System));
+                session.Network.EnqueueSend(new GameMessageSystemChat($"      Toggle ring AOE cast diagnostics broadcast for your character. Resets on relog.", ChatMessageType.System));
             }
         }
     }

--- a/Source/ACE.Server/Command/Handlers/ILTCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/ILTCommands.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using ACE.DatLoader;
+using ACE.Entity;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
 using ACE.Server.Command;
@@ -40,7 +42,7 @@ namespace ACE.Server.Command.Handlers
 
         [CommandHandler("ilt", AccessLevel.Player, CommandHandlerFlag.RequiresWorld, 0,
             "ILT custom server commands and player preferences.",
-            "Usage: /ilt [help|features|dmgformat|showoverkill|levelskills|trainskills|xp level|train]")]
+            "Usage: /ilt [help|features|dmgformat|showoverkill|levelskills|trainskills|xp level|train|ringmode]")]
         public static void HandleILT(Session session, params string[] parameters)
         {
             var player = session.Player;
@@ -60,6 +62,26 @@ namespace ACE.Server.Command.Handlers
             {
                 session.Network.EnqueueSend(new GameMessageSystemChat("=== ILT Custom Features ===", ChatMessageType.System));
                 session.Network.EnqueueSend(new GameMessageSystemChat("  Coming Soon", ChatMessageType.System));
+            }
+            else if (sub == "ringmode")
+            {
+                var classic = player.GetProperty(PropertyBool.ClassicRingAoe) ?? false;
+                classic = !classic;  // toggle
+                player.SetProperty(PropertyBool.ClassicRingAoe, classic);
+                player.SaveBiotaToDatabase();
+
+                var msg = classic
+                    ? "Ring Spell Mode: Classic (physics collision \u2014 can multi-hit, rings may miss monsters)"
+                    : "Ring Spell Mode: New (all targets in range guaranteed to hit once, no multi-hit)";
+                session.Network.EnqueueSend(new GameMessageSystemChat(msg, ChatMessageType.System));
+            }
+            else if (sub == "ringdebug")
+            {
+                player.RingAoeDebug = !player.RingAoeDebug;
+                var state = player.RingAoeDebug ? "ON" : "OFF";
+                session.Network.EnqueueSend(new GameMessageSystemChat(
+                    $"[RingAOE] Debug broadcast {state}. Cast any ring spell to see AOE stats.",
+                    ChatMessageType.System));
             }
             else if (sub == "dmgformat")
             {
@@ -232,10 +254,54 @@ namespace ACE.Server.Command.Handlers
                         "No skills were trained — not enough credits for the next skill in the priority list.",
                         ChatMessageType.System));
             }
+            else if (sub == "ringrange")
+            {
+                // Admin-only diagnostic — not listed in player help.
+                if (session.AccessLevel < AccessLevel.Admin)
+                {
+                    session.Network.EnqueueSend(new GameMessageSystemChat("[RingRange] Admin only.", ChatMessageType.System));
+                    return;
+                }
+
+                // Scan for all known creatures within the player's ring AOE radius.
+                const float ringRadius = Player.DefaultRingAoeRadius;
+                var radius = ringRadius * (float)(player.GetProperty(PropertyFloat.AoeRangeMultiplier) ?? 1.0f);
+
+                if (player.Location == null)
+                {
+                    session.Network.EnqueueSend(new GameMessageSystemChat("[RingRange] Player location unavailable.", ChatMessageType.System));
+                    return;
+                }
+
+                var known = player.PhysicsObj.ObjMaint.GetKnownObjectsValuesAsCreature();
+                var inRange = known
+                    .Where(c => c != null && c != player && c.Location != null
+                                && Math.Abs(player.Location.PositionZ - c.Location.PositionZ) <= Player.RingAoeMaxHeightDelta
+                                && player.Location.Distance2D(c.Location) <= radius
+                                && player.CanDamage(c))
+                    .OrderBy(c => player.Location.Distance2D(c.Location))
+                    .ToList();
+
+                session.Network.EnqueueSend(new GameMessageSystemChat(
+                    $"[RingRange] Radius: {radius:F1}m | Vertical: {Player.RingAoeMaxHeightDelta:F1}m | Creatures in range: {inRange.Count}",
+                    ChatMessageType.System));
+
+                foreach (var c in inRange)
+                {
+                    var dist = player.Location.Distance2D(c.Location);
+                    session.Network.EnqueueSend(new GameMessageSystemChat(
+                        $"  {c.Name}  ({dist:F1}m)",
+                        ChatMessageType.System));
+                }
+
+                if (inRange.Count == 0)
+                    session.Network.EnqueueSend(new GameMessageSystemChat("  None found.", ChatMessageType.System));
+            }
             else
             {
-                var dmgLabel = player.DamageNumberFormat switch { 1 => "commas", 2 => "short", _ => "default" };
-                var okLabel  = player.ShowOverkill ? "ON" : "OFF";
+                var dmgLabel  = player.DamageNumberFormat switch { 1 => "commas", 2 => "short", _ => "default" };
+                var okLabel   = player.ShowOverkill ? "ON" : "OFF";
+                var ringLabel = (player.GetProperty(PropertyBool.ClassicRingAoe) ?? false) ? "Classic" : "New";
                 session.Network.EnqueueSend(new GameMessageSystemChat("=== ILT Custom Commands ===", ChatMessageType.System));
                 session.Network.EnqueueSend(new GameMessageSystemChat("  /ilt features", ChatMessageType.System));
                 session.Network.EnqueueSend(new GameMessageSystemChat("      View a list of custom ILT server features.", ChatMessageType.System));
@@ -247,6 +313,8 @@ namespace ACE.Server.Command.Handlers
                 session.Network.EnqueueSend(new GameMessageSystemChat("      Spend all available XP into trained and specialized skills, in priority order.", ChatMessageType.System));
                 session.Network.EnqueueSend(new GameMessageSystemChat("  /ilt trainskills  |  /ilt train", ChatMessageType.System));
                 session.Network.EnqueueSend(new GameMessageSystemChat("      Train all affordable untrained skills using skill credits, in priority order.", ChatMessageType.System));
+                session.Network.EnqueueSend(new GameMessageSystemChat($"  /ilt ringmode", ChatMessageType.System));
+                session.Network.EnqueueSend(new GameMessageSystemChat($"      Toggle ring spell mode between New (guaranteed AOE) and Classic (physics multi-hit). (currently: {ringLabel})", ChatMessageType.System));
             }
         }
     }

--- a/Source/ACE.Server/Command/Handlers/ILTCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/ILTCommands.cs
@@ -276,9 +276,11 @@ namespace ACE.Server.Command.Handlers
                 var known = player.PhysicsObj.ObjMaint.GetKnownObjectsValuesAsCreature();
                 var inRange = known
                     .Where(c => c != null && c != player && c.Location != null
+                                && c.IsAlive
                                 && Math.Abs(player.Location.PositionZ - c.Location.PositionZ) <= Player.RingAoeMaxHeightDelta
                                 && player.Location.Distance2D(c.Location) <= radius
-                                && player.CanDamage(c))
+                                && player.CanDamage(c)
+                                && player.CheckPKStatusVsTarget(c, null) == null)
                     .OrderBy(c => player.Location.Distance2D(c.Location))
                     .ToList();
 

--- a/Source/ACE.Server/Command/Handlers/ILTCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/ILTCommands.cs
@@ -67,8 +67,13 @@ namespace ACE.Server.Command.Handlers
             {
                 var classic = player.GetProperty(PropertyBool.ClassicRingAoe) ?? false;
                 classic = !classic;  // toggle
-                player.SetProperty(PropertyBool.ClassicRingAoe, classic);
-                player.SaveBiotaToDatabase();
+
+                if (classic)
+                    player.SetProperty(PropertyBool.ClassicRingAoe, true);
+                else
+                    player.RemoveProperty(PropertyBool.ClassicRingAoe);  // absent = New mode (default)
+
+                player.SaveBiotaToDatabase(enqueueSave: true);
 
                 var msg = classic
                     ? "Ring Spell Mode: Classic (physics collision \u2014 can multi-hit, rings may miss monsters)"

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -6,6 +6,7 @@ using ACE.Common;
 using ACE.DatLoader;
 using ACE.Entity;
 using ACE.Entity.Enum;
+using ACE.Entity.Enum.Properties;
 using ACE.Server.Entity;
 using ACE.Server.Entity.Actions;
 using ACE.Server.Managers;
@@ -1631,6 +1632,130 @@ namespace ACE.Server.WorldObjects
 
             if (!SquelchManager.Squelches.Contains(source, msgType))
                 Session.Network.EnqueueSend(new GameMessageSystemChat(msg, msgType));
+        }
+
+        // ── Ring AOE radius (meters). Scaled by AoeRangeMultiplier charm (PropertyFloat 9048). ──
+        internal const float DefaultRingAoeRadius    =  5.0f;
+        // ── Max vertical delta (meters) — prevents hitting creatures on a different floor. ──
+        internal const float RingAoeMaxHeightDelta   =  4.0f;
+        // ── Per-player debug broadcast toggle (off by default). ──
+        public bool RingAoeDebug { get; set; } = false;
+
+        /// <summary>
+        /// Applies one war-magic damage roll to every valid creature within the ring spell's
+        /// effective radius.  Called immediately after the visual ring projectiles are spawned;
+        /// the projectiles themselves are made non-damaging in SpellProjectile.OnCollideObject.
+        /// </summary>
+        internal void ApplyRingSpellAreaDamage(Spell spell)
+        {
+            if (Location == null) return;
+
+            // Ring radius — scaled by the future AoeRangeMultiplier charm.
+            var radius = DefaultRingAoeRadius * (float)(GetProperty(PropertyFloat.AoeRangeMultiplier) ?? 1.0f);
+
+            var magicSkill    = GetCreatureSkill(spell.School).Current;
+            var resistanceType = Creature.GetResistanceType(spell.DamageType);
+            var weapon        = GetEquippedWand();
+
+            var visibleCreatures = PhysicsObj.ObjMaint.GetKnownObjectsValuesAsCreature();
+            var dbgHit = 0; var dbgResist = 0;
+
+            // Compute attribute bonus once — Focus/Self don't change mid-cast.
+            var attribBonus = 1.0f;
+            attribBonus += SkillFormula.GetAttributeMod((int)Focus.Current) * SpellProjectile.DefaultSpellAttributeMult;
+            attribBonus += SkillFormula.GetAttributeMod((int)Self.Current)  * SpellProjectile.DefaultSpellAttributeMult;
+
+            foreach (var creature in visibleCreatures)
+            {
+                if (creature == null || creature == this) continue;
+                if (creature.Location == null)            continue;
+
+                // Distance gate: horizontal ring radius (2D) + vertical height cap.
+                // 2D keeps creatures on uneven terrain / slight slopes within range.
+                // Height cap prevents hitting creatures on a completely different floor.
+                var dz = Math.Abs(Location.PositionZ - creature.Location.PositionZ);
+                if (dz > RingAoeMaxHeightDelta) continue;
+                if (Location.Distance2D(creature.Location) > radius) continue;
+
+                if (!CanDamage(creature)) continue;
+
+                // PK status check (mirrors SpellProjectile.OnCollideObject).
+                var pkError = CheckPKStatusVsTarget(creature, spell);
+                if (pkError != null) continue;
+
+                // Resist check — sends the resist message automatically.
+                var resisted = TryResistSpell(creature, spell, null, true);
+
+                // Notify the creature that it was attacked (triggers aggro) whether or not it resisted.
+                if (creature is not Player)
+                    OnAttackMonster(creature, spell.IsHarmful);
+
+                if (resisted) { dbgResist++; continue; }
+
+                // ── War-magic damage calculation (mirrors SpellProjectile.CalculateDamage) ──
+                var criticalHit      = false;
+                var critDamageBonus  = 0.0f;
+                var skillBonus       = 0.0f;
+
+                // 2% base crit chance (no weapon for ring spells).
+                if (ThreadSafeRandom.Next(0.0f, 1.0f) < 0.02f)
+                {
+                    criticalHit     = true;
+                    critDamageBonus = spell.MaxDamage * 0.5f; // PvE: 50% of max damage
+                }
+
+                // Skill-based damage bonus.
+                if (magicSkill > spell.Power)
+                    skillBonus = spell.MinDamage * (magicSkill - spell.Power) / 1000.0f;
+
+                long baseDamage = ThreadSafeRandom.Next(spell.MinDamage, spell.MaxDamage);
+
+                // Luminance War augment.
+                if (LuminanceAugmentWarCount.HasValue && LuminanceAugmentWarCount >= 1)
+                    baseDamage += LuminanceAugmentWarCount.Value;
+
+                // Elemental modifier (wand-centric, no separate weapon for ring spells).
+                var elementalMod  = GetCasterElementalDamageModifier(weapon, this as Creature, creature, spell.DamageType);
+
+                // Target resistance.
+                var resistanceMod = (float)Math.Max(0.0f, creature.GetResistanceMod(resistanceType, null, null, 1.0f));
+
+                // Attribute bonus (Focus + Self) — pre-computed before the loop.
+                var finalDamage = (baseDamage + critDamageBonus + skillBonus) * elementalMod * resistanceMod * attribBonus;
+
+                if (finalDamage <= 0) continue;
+
+                creature.TakeDamage(this, spell.DamageType, finalDamage, criticalHit);
+
+                // Only send "You hit X for Y" if the target survived — mirrors SpellProjectile.DamageTarget
+                // which gates the attacker message on target.IsAlive (line 920).
+                // On a kill, TakeDamage already sent the quest counter and overkill message.
+                if (creature.IsAlive)
+                {
+                    var displayAmt  = (uint)Math.Round(finalDamage);
+                    var amtStr      = Creature.FormatDamage(displayAmt, DamageNumberFormat);
+                    var percent     = (float)displayAmt / creature.Health.MaxValue;
+                    string verb = null, plural = null;
+                    Strings.GetAttackVerb(spell.DamageType, percent, ref verb, ref plural);
+                    var critMsg     = criticalHit ? "Critical hit! " : "";
+                    var attackerMsg = $"{critMsg}You {verb} {creature.Name} for {amtStr} points with {spell.Name}.";
+                    if (!SquelchManager.Squelches.Contains(creature, ACE.Entity.Enum.ChatMessageType.Magic))
+                        Session?.Network.EnqueueSend(new GameMessageSystemChat(attackerMsg, ACE.Entity.Enum.ChatMessageType.Magic));
+                }
+
+                dbgHit++;
+            }
+
+            // Award one proficiency tick for the cast if at least one target was hit.
+            // Intentionally outside the loop — ring spells should not award N ticks for N targets.
+            if (dbgHit > 0)
+                Proficiency.OnSuccessUse(this, GetCreatureSkill(spell.School), spell.PowerMod);
+
+            // DEBUG — broadcast ring AOE summary to caster (only when RingAoeDebug is enabled via /ilt ringdebug)
+            if (RingAoeDebug)
+                Session?.Network.EnqueueSend(new GameMessageSystemChat(
+                    $"[RingAOE] inRange={dbgHit + dbgResist} resisted={dbgResist} hit={dbgHit} radius={radius:F1}m vertical={RingAoeMaxHeightDelta:F1}m",
+                    ACE.Entity.Enum.ChatMessageType.Broadcast));
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -1762,7 +1762,9 @@ namespace ACE.Server.WorldObjects
                                   * elementalMod * slayerMod * resistanceMod * absorbMod * attribBonus;
 
                 // CombatPet mitigation — extra spell-only damage reduction from owner's summon aug.
-                if (finalDamage > 0 && spell.IsHarmful && creature is CombatPet combatPet)
+                // Condition mirrors SpellProjectile.CalculateDamage; sourcePlayer != null is always true here.
+                if (finalDamage > 0 && spell.IsHarmful && creature is CombatPet combatPet
+                    && (!ServerConfig.pet_combat_summon_aug_spell_mitigation_players_only.Value || true))
                 {
                     var petMit = combatPet.GetSpellProjectileDamageTakenMultiplier();
                     if (petMit < 1.0f) finalDamage *= petMit;
@@ -1771,7 +1773,6 @@ namespace ACE.Server.WorldObjects
                 if (finalDamage <= 0) continue;
 
                 creature.TakeDamage(this, spell.DamageType, finalDamage, criticalHit);
-
 
                 // Only send "You hit X for Y" if the target survived — mirrors SpellProjectile.DamageTarget
                 // which gates the attacker message on target.IsAlive (line 920).

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -1653,7 +1653,8 @@ namespace ACE.Server.WorldObjects
             // Ring radius — scaled by the future AoeRangeMultiplier charm.
             var radius = DefaultRingAoeRadius * (float)(GetProperty(PropertyFloat.AoeRangeMultiplier) ?? 1.0f);
 
-            var magicSkill    = GetCreatureSkill(spell.School).Current;
+            var attackSkill   = GetCreatureSkill(spell.School);
+            var magicSkill    = attackSkill.Current;
             var resistanceType = Creature.GetResistanceType(spell.DamageType);
             var weapon        = GetEquippedWand();
 
@@ -1668,6 +1669,7 @@ namespace ACE.Server.WorldObjects
             foreach (var creature in visibleCreatures)
             {
                 if (creature == null || creature == this) continue;
+                if (!creature.IsAlive)                    continue;  // skip corpses from this or prior casts
                 if (creature.Location == null)            continue;
 
                 // Distance gate: horizontal ring radius (2D) + vertical height cap.
@@ -1697,11 +1699,15 @@ namespace ACE.Server.WorldObjects
                 var critDamageBonus  = 0.0f;
                 var skillBonus       = 0.0f;
 
-                // 2% base crit chance (no weapon for ring spells).
-                if (ThreadSafeRandom.Next(0.0f, 1.0f) < 0.02f)
+                // Use the full crit pipeline: 5% base + player crit rating, mitigated by target resist rating.
+                // Mirrors GetWeaponMagicCritFrequency — weapon == null returns defaultMagicCritFrequency (5%).
+                var critChance = GetWeaponMagicCritFrequency(weapon, this as Creature, attackSkill, creature);
+                if (ThreadSafeRandom.Next(0.0f, 1.0f) < critChance)
                 {
                     criticalHit     = true;
-                    critDamageBonus = spell.MaxDamage * 0.5f; // PvE: 50% of max damage
+                    // Use crit damage multiplier (accounts for Crippling Blow imbues on wand).
+                    var critDamageMult = GetWeaponCritDamageMod(weapon, this as Creature, attackSkill, creature);
+                    critDamageBonus = spell.MaxDamage * critDamageMult;
                 }
 
                 // Skill-based damage bonus.

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -1762,9 +1762,9 @@ namespace ACE.Server.WorldObjects
                                   * elementalMod * slayerMod * resistanceMod * absorbMod * attribBonus;
 
                 // CombatPet mitigation — extra spell-only damage reduction from owner's summon aug.
-                // Condition mirrors SpellProjectile.CalculateDamage; sourcePlayer != null is always true here.
-                if (finalDamage > 0 && spell.IsHarmful && creature is CombatPet combatPet
-                    && (!ServerConfig.pet_combat_summon_aug_spell_mitigation_players_only.Value || true))
+                // Vanilla also gates this on pet_combat_summon_aug_spell_mitigation_players_only; since
+                // ring AOE is always cast by a Player, sourcePlayer != null is unconditionally true here.
+                if (finalDamage > 0 && spell.IsHarmful && creature is CombatPet combatPet)
                 {
                     var petMit = combatPet.GetSpellProjectileDamageTakenMultiplier();
                     if (petMit < 1.0f) finalDamage *= petMit;

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -1694,20 +1694,32 @@ namespace ACE.Server.WorldObjects
 
                 if (resisted) { dbgResist++; continue; }
 
-                // ── War-magic damage calculation (mirrors SpellProjectile.CalculateDamage) ──
+                // ── War-magic damage calculation (exact parity with SpellProjectile.CalculateDamage) ──
                 var criticalHit      = false;
                 var critDamageBonus  = 0.0f;
                 var skillBonus       = 0.0f;
+                var isPvP            = creature is Player;
 
-                // Use the full crit pipeline: 5% base + player crit rating, mitigated by target resist rating.
-                // Mirrors GetWeaponMagicCritFrequency — weapon == null returns defaultMagicCritFrequency (5%).
+                // Crit chance — 5% base + player crit rating, mitigated by target resist rating.
                 var critChance = GetWeaponMagicCritFrequency(weapon, this as Creature, attackSkill, creature);
                 if (ThreadSafeRandom.Next(0.0f, 1.0f) < critChance)
                 {
-                    criticalHit     = true;
-                    // Use crit damage multiplier (accounts for Crippling Blow imbues on wand).
-                    var critDamageMult = GetWeaponCritDamageMod(weapon, this as Creature, attackSkill, creature);
-                    critDamageBonus = spell.MaxDamage * critDamageMult;
+                    // AugmentationCriticalDefense check (PvP only — 5% per aug rank vs player attacker).
+                    var critDefended = false;
+                    if (creature is Player tgtPlayer && tgtPlayer.AugmentationCriticalDefense > 0)
+                    {
+                        var critDefChance = tgtPlayer.AugmentationCriticalDefense * 0.05f; // sourcePlayer != null → 5%
+                        if (critDefChance > ThreadSafeRandom.Next(0.0f, 1.0f))
+                            critDefended = true;
+                    }
+
+                    if (!critDefended)
+                    {
+                        criticalHit = true;
+                        // PvE: +50% of MaxDamage.  PvP: +50% of MinDamage.
+                        critDamageBonus  = isPvP ? spell.MinDamage * 0.5f : spell.MaxDamage * 0.5f;
+                        critDamageBonus *= GetWeaponCritDamageMod(weapon, this as Creature, attackSkill, creature);
+                    }
                 }
 
                 // Skill-based damage bonus.
@@ -1720,18 +1732,46 @@ namespace ACE.Server.WorldObjects
                 if (LuminanceAugmentWarCount.HasValue && LuminanceAugmentWarCount >= 1)
                     baseDamage += LuminanceAugmentWarCount.Value;
 
-                // Elemental modifier (wand-centric, no separate weapon for ring spells).
-                var elementalMod  = GetCasterElementalDamageModifier(weapon, this as Creature, creature, spell.DamageType);
+                // Elemental modifier (wand element vs target).
+                var elementalMod = GetCasterElementalDamageModifier(weapon, this as Creature, creature, spell.DamageType);
 
-                // Target resistance.
-                var resistanceMod = (float)Math.Max(0.0f, creature.GetResistanceMod(resistanceType, null, null, 1.0f));
+                // Slayer modifier — respects wand/creature slayer properties.
+                var slayerMod = GetWeaponCreatureSlayerModifier(weapon, this as Creature, creature);
+
+                // Weapon resistance mod — applies rending on wand to target resistance.
+                var weaponResistanceMod = GetWeaponResistanceModifier(weapon, this as Creature, attackSkill, spell.DamageType);
+                var resistanceMod = (float)Math.Max(0.0f, creature.GetResistanceMod(resistanceType, null, null, weaponResistanceMod));
+
+                // Void PvP modifier (matches SpellProjectile line ~602).
+                if (isPvP && spell.DamageType == DamageType.Nether)
+                    resistanceMod *= (float)ServerConfig.void_pvp_modifier.Value;
+
+                // Absorb mod — Aegis shield / magic-absorbing items on target.
+                // Uses caster position as directional source (ring radiates from caster).
+                var absorbMod = SpellProjectile.GetAbsorbMod(this, creature);
+                if (isPvP && (creature.CombatMode == CombatMode.Melee || creature.CombatMode == CombatMode.Missile))
+                {
+                    // Aegis is 72% effective in PvP (Forces of Nature patch).
+                    absorbMod  = 1 - absorbMod;
+                    absorbMod *= 0.72f;
+                    absorbMod  = 1 - absorbMod;
+                }
 
                 // Attribute bonus (Focus + Self) — pre-computed before the loop.
-                var finalDamage = (baseDamage + critDamageBonus + skillBonus) * elementalMod * resistanceMod * attribBonus;
+                var finalDamage = (baseDamage + critDamageBonus + skillBonus)
+                                  * elementalMod * slayerMod * resistanceMod * absorbMod * attribBonus;
+
+                // CombatPet mitigation — extra spell-only damage reduction from owner's summon aug.
+                if (finalDamage > 0 && spell.IsHarmful && creature is CombatPet combatPet)
+                {
+                    var petMit = combatPet.GetSpellProjectileDamageTakenMultiplier();
+                    if (petMit < 1.0f) finalDamage *= petMit;
+                }
 
                 if (finalDamage <= 0) continue;
 
                 creature.TakeDamage(this, spell.DamageType, finalDamage, criticalHit);
+
 
                 // Only send "You hit X for Y" if the target survived — mirrors SpellProjectile.DamageTarget
                 // which gates the attacker message on target.IsAlive (line 920).

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -1168,6 +1168,14 @@ namespace ACE.Server.WorldObjects
 
             spell = TryRedirectTectonicRifts(spell);
 
+            // Ring of Agony and Shrapnel fire a 360° ring from the caster.  If cast through the
+            // targeted path the selected enemy is passed down to CreateSpellProjectiles, causing
+            // all ring projectiles to converge on that single creature instead of radiating
+            // outward.  Route through the untargeted overload so target = null and the ring hits
+            // everything in range as intended.
+            if (spell.Id == SpellId_RingOfAgony || spell.Id == SpellId_RockyShrapnel)
+                return CreatePlayerSpell(spell);
+
             if (!IsValidSpell(spell, casterItem != null))
                 return false;
 

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -698,47 +698,22 @@ namespace ACE.Server.WorldObjects
         }
 
         /// <summary>
-        /// Shield absorb calculation using a WorldObject as the directional source (for AOE paths).
-        /// Mirrors GetShieldMod but replaces 'this' with the provided attacker.
-        /// NOTE: keep in sync with GetShieldMod if that method is ever updated.
+        /// Core shield magic absorb calculation given a pre-computed angle.
+        /// Single source of truth for both projectile and AOE code paths.
         /// </summary>
-        private static float GetShieldAbsorbMod(WorldObject attacker, Creature target, WorldObject shield)
+        /// <param name="angle">Angle in degrees from the incoming source to the target's facing.</param>
+        private static float CalculateShieldAbsorb(Creature target, WorldObject shield, float angle)
         {
-            var effectiveAngle = 180.0f;
-            var angle = target.GetAngle(attacker);
-            if (Math.Abs(angle) > effectiveAngle / 2.0f)
-                return 1.0f;
-
-            var shieldSkill = target.GetCreatureSkill(Skill.Shield);
-            if (shieldSkill.AdvancementClass < SkillAdvancementClass.Trained || shieldSkill.Base < 100)
-                return 1.0f;
-
-            var baseSkill = Math.Min(shieldSkill.Base, 433);
-            var specMod = shieldSkill.AdvancementClass == SkillAdvancementClass.Specialized ? 1.0f : 0.8f;
-            var cap = (float)(shield.GetAbsorbMagicDamage() ?? 0.0f);
-
-            var reduction = (cap * specMod * baseSkill * 0.003f) - (cap * specMod * 0.3f);
-            return Math.Min(1.0f, 1.0f - reduction);
-        }
-
-        /// <summary>
-        /// Calculates the amount of damage a shield absorbs from magic projectile
-        /// </summary>
-        public float GetShieldMod(Creature target, WorldObject shield)
-        {
-            // is spell projectile in front of creature target,
-            // within shield effectiveness area?
-            var effectiveAngle = 180.0f;
-            var angle = target.GetAngle(this);
-            if (Math.Abs(angle) > effectiveAngle / 2.0f)
-                return 1.0f;
-
             // https://asheron.fandom.com/wiki/Shield
             // The formula to determine magic absorption for shields is:
             // Reduction Percent = (cap * specMod * baseSkill * 0.003f) - (cap * specMod * 0.3f)
             // Cap = Maximum reduction
             // SpecMod = 1.0 for spec, 0.8 for trained
             // BaseSkill = 100 to 433 (above 433 base shield you always achieve the maximum %)
+
+            var effectiveAngle = 180.0f;
+            if (Math.Abs(angle) > effectiveAngle / 2.0f)
+                return 1.0f;
 
             var shieldSkill = target.GetCreatureSkill(Skill.Shield);
             // ensure trained?
@@ -759,9 +734,26 @@ namespace ACE.Server.WorldObjects
             // trained, 433 skill = 80%
 
             var reduction = (cap * specMod * baseSkill * 0.003f) - (cap * specMod * 0.3f);
+            return Math.Min(1.0f, 1.0f - reduction);
+        }
 
-            var shieldMod = Math.Min(1.0f, 1.0f - reduction);
-            return shieldMod;
+        /// <summary>
+        /// Shield absorb calculation using a WorldObject as the directional source (for AOE paths).
+        /// Ring spells radiate from the caster, so the caster's position substitutes for projectile position.
+        /// </summary>
+        private static float GetShieldAbsorbMod(WorldObject attacker, Creature target, WorldObject shield)
+        {
+            return CalculateShieldAbsorb(target, shield, target.GetAngle(attacker));
+        }
+
+        /// <summary>
+        /// Calculates the amount of damage a shield absorbs from magic projectile
+        /// </summary>
+        public float GetShieldMod(Creature target, WorldObject shield)
+        {
+            // is spell projectile in front of creature target,
+            // within shield effectiveness area?
+            return CalculateShieldAbsorb(target, shield, target.GetAngle(this));
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -668,6 +668,59 @@ namespace ACE.Server.WorldObjects
         }
 
         /// <summary>
+        /// Static overload for use in server-side AOE paths (e.g. ring spells) where there is no
+        /// physical projectile. Uses the attacker WorldObject as the directional source instead of
+        /// the projectile position — ring spells radiate from the caster, so this is the correct substitute.
+        /// </summary>
+        internal static float GetAbsorbMod(WorldObject attacker, Creature target)
+        {
+            switch (target.CombatMode)
+            {
+                case CombatMode.Melee:
+                    var shield = target.GetEquippedShield();
+                    if (shield != null && shield.GetAbsorbMagicDamage() != null)
+                        return GetShieldAbsorbMod(attacker, target, shield);
+                    break;
+
+                case CombatMode.Missile:
+                    var missileLauncherOrShield = target.GetEquippedMissileLauncher() ?? target.GetEquippedShield();
+                    if (missileLauncherOrShield != null && missileLauncherOrShield.GetAbsorbMagicDamage() != null)
+                        return AbsorbMagic(target, missileLauncherOrShield);
+                    break;
+
+                case CombatMode.Magic:
+                    var caster = target.GetEquippedWand();
+                    if (caster != null && caster.GetAbsorbMagicDamage() != null)
+                        return AbsorbMagic(target, caster);
+                    break;
+            }
+            return 1.0f;
+        }
+
+        /// <summary>
+        /// Shield absorb calculation using a WorldObject as the directional source (for AOE paths).
+        /// Mirrors GetShieldMod but replaces 'this' with the provided attacker.
+        /// </summary>
+        private static float GetShieldAbsorbMod(WorldObject attacker, Creature target, WorldObject shield)
+        {
+            var effectiveAngle = 180.0f;
+            var angle = target.GetAngle(attacker);
+            if (Math.Abs(angle) > effectiveAngle / 2.0f)
+                return 1.0f;
+
+            var shieldSkill = target.GetCreatureSkill(Skill.Shield);
+            if (shieldSkill.AdvancementClass < SkillAdvancementClass.Trained || shieldSkill.Base < 100)
+                return 1.0f;
+
+            var baseSkill = Math.Min(shieldSkill.Base, 433);
+            var specMod = shieldSkill.AdvancementClass == SkillAdvancementClass.Specialized ? 1.0f : 0.8f;
+            var cap = (float)(shield.GetAbsorbMagicDamage() ?? 0.0f);
+
+            var reduction = (cap * specMod * baseSkill * 0.003f) - (cap * specMod * 0.3f);
+            return Math.Min(1.0f, 1.0f - reduction);
+        }
+
+        /// <summary>
         /// Calculates the amount of damage a shield absorbs from magic projectile
         /// </summary>
         public float GetShieldMod(Creature target, WorldObject shield)

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -700,6 +700,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Shield absorb calculation using a WorldObject as the directional source (for AOE paths).
         /// Mirrors GetShieldMod but replaces 'this' with the provided attacker.
+        /// NOTE: keep in sync with GetShieldMod if that method is ever updated.
         /// </summary>
         private static float GetShieldAbsorbMod(WorldObject attacker, Creature target, WorldObject shield)
         {

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -276,7 +276,18 @@ namespace ACE.Server.WorldObjects
                 player.Session.Network.EnqueueSend(new GameMessageSystemChat(Info.ToString(), ChatMessageType.Broadcast));
             }
 
+            // ProjectileImpact() is intentionally called first so the projectile sets NoDraw,
+            // deactivates physics, and cleans itself up — even though no damage will be dealt.
             ProjectileImpact();
+
+            // Ring spells cast by a player use server-side radius-based area damage
+            // (Player.ApplyRingSpellAreaDamage).  The projectiles are visual-only so that
+            // every enemy within range is guaranteed one hit regardless of angular gaps.
+            // Exception: if the player has opted into Classic mode, allow physics damage through.
+            if (SpellType == ProjectileSpellType.Ring
+                && ProjectileSource is Player ringSourcePlayer
+                && !(ringSourcePlayer.GetProperty(PropertyBool.ClassicRingAoe) ?? false))
+                return;
 
             // ensure valid creature target
             var creatureTarget = target as Creature;

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -1090,6 +1090,13 @@ namespace ACE.Server.WorldObjects
 
             CreateSpellProjectiles(spell, target, weapon, isWeaponSpell, fromProc, damage);
 
+            // For ring spells cast by a player, apply guaranteed radius-based area damage
+            // unless the player has opted into Classic mode (physics collision / multi-hit).
+            if (SpellProjectile.GetProjectileSpellType(spell.Id) == ProjectileSpellType.Ring
+                && this is Player ringPlayer
+                && !(ringPlayer.GetProperty(PropertyBool.ClassicRingAoe) ?? false))
+                ringPlayer.ApplyRingSpellAreaDamage(spell);
+
             if (spell.School == MagicSchool.LifeMagic)
             {
                 if (caster.Health.Current <= 0)
@@ -1971,6 +1978,7 @@ namespace ACE.Server.WorldObjects
                 sp.SpawnPos = new Position(sp.Location);
 
                 sp.LifeProjectileDamage = lifeProjectileDamage;
+
 
                 if (!LandblockManager.AddObject(sp))
                 {

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -1979,7 +1979,6 @@ namespace ACE.Server.WorldObjects
 
                 sp.LifeProjectileDamage = lifeProjectileDamage;
 
-
                 if (!LandblockManager.AddObject(sp))
                 {
                     sp.Destroy();

--- a/Source/ACE.Server/WorldObjects/WorldObject_Tick.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Tick.cs
@@ -369,8 +369,18 @@ namespace ACE.Server.WorldObjects
                     if (spellProjectile.SpellType == ProjectileSpellType.Ring)
                     {
                         var dist = spellProjectile.SpawnPos.DistanceTo(Location);
-                        var maxRange = spellProjectile.Spell.BaseRangeConstant;
-                        //Console.WriteLine("Max range: " + maxRange);
+
+                        // For player ring spells, use our server-controlled radius so the visual
+                        // matches the kill radius exactly.  Monster rings keep the DAT value.
+                        float maxRange;
+                        if (spellProjectile.ProjectileSource is Player playerCaster)
+                        {
+                            var multiplier = (float)(playerCaster.GetProperty(PropertyFloat.AoeRangeMultiplier) ?? 1.0f);
+                            maxRange = Player.DefaultRingAoeRadius * multiplier;
+                        }
+                        else
+                            maxRange = spellProjectile.Spell.BaseRangeConstant;
+
                         if (dist > maxRange)
                         {
                             PhysicsObj.set_active(false);


### PR DESCRIPTION
**Summary**
This branch replaces the physics-collision ring spell system with a deterministic server-side radial scan for player casters, addressing two core problems with the retail implementation: angular gaps that left creatures between projectile paths unhit, and overlapping projectiles that could strike the same target multiple times.

The new system fires a single server-authoritative scan at cast time, guaranteeing every valid creature within the configured radius receives exactly one damage roll. The visual ring projectiles are preserved for client fidelity but made non-damaging in New mode. Classic physics behavior is retained as an opt-in player toggle.

**Solution**
New mode (default): When a player casts a ring spell, HandleCastSpell_Projectile calls Player.ApplyRingSpellAreaDamage immediately after spawning the visual projectiles. The projectiles call ProjectileImpact() for visual cleanup then return early — no physics damage is dealt. All damage comes from the server-side scan.

Classic mode (opt-in): The early return is bypassed and the original physics-collision behavior is restored in full.

**Damage Pipeline**
ApplyRingSpellAreaDamage mirrors SpellProjectile.CalculateDamage exactly for war magic:

Crit chance — GetWeaponMagicCritFrequency (5% base + player crit rating − target crit resist)
Crit damage — Spell.MaxDamage × 0.5 × critDamageMod (PvE) / Spell.MinDamage × 0.5 × critDamageMod (PvP)
Crit defense — AugmentationCriticalDefense check applied vs player targets
Skill bonus — (warSkill − spell.Power) / 1000 × MinDamage
Luminance War augment — added to base damage roll
Elemental modifier — GetCasterElementalDamageModifier
Slayer modifier — GetWeaponCreatureSlayerModifier
Weapon rending — GetWeaponResistanceModifier passed into GetResistanceMod
Absorb mod — SpellProjectile.GetAbsorbMod (Aegis / magic-absorbing items); 72% effective in PvP per the Forces of Nature patch
Void PvP modifier — applied when both parties are players casting Nether damage
Attribute bonus — Focus + Self pre-computed once before the loop
CombatPet mitigation — GetSpellProjectileDamageTakenMultiplier
Aggro (OnAttackMonster) is triggered before the resist check, matching standard projectile behavior. One proficiency tick is awarded per cast regardless of target count.

**AOE Filters**
Each creature in the scan must pass all of the following:

creature.IsAlive
|ΔZ| ≤ 4m                          (prevents cross-floor hits)
2D distance ≤ radius                (DefaultRingAoeRadius × AoeRangeMultiplier)
CanDamage(creature)
CheckPKStatusVsTarget(creature, spell) == null

**Visual Parity**
Player ring projectiles decay at DefaultRingAoeRadius × AoeRangeMultiplier instead of the DAT BaseRangeConstant, keeping the visual ring synchronized with the actual server-side kill radius.


**Player Commands (/ilt)**
/ilt ringmode — Player Toggle ring spell mode between New (guaranteed AOE, 1 hit per creature) and Classic (physics multi-hit). Persisted. Current mode shown on toggle.

/ilt ringdebug — Player In-memory debug toggle. After each ring cast displays: [RingAOE] inRange=X resisted=X hit=X radius=Xm. Resets on relog — intentional, diagnostic tool only.

/ilt ringrange — Admin only Lists every creature currently within AOE range from your position with distances. Applies the exact same filter as the damage loop.

**New Properties**
PropertyBool.ClassicRingAoe (50034) — Player mode preference. Absent = New mode (default). Set = Classic mode.
PropertyFloat.AoeRangeMultiplier (9048) — Per-player radius scalar. Hook for future ring-range charms.

**Files Changed**
Player_Magic.cs — ApplyRingSpellAreaDamage: full radial scan and damage pipeline
SpellProjectile.cs — Visual-only early return for player ring casts; GetAbsorbMod static overload
WorldObject_Magic.cs — Hook calling ApplyRingSpellAreaDamage after projectile creation
WorldObject_Tick.cs — Visual decay radius tied to server-controlled kill radius
ILTCommands.cs — ringmode, ringdebug, ringrange sub-commands
PropertyBool.cs — ClassicRingAoe = 50034
PropertyFloat.cs — AoeRangeMultiplier = 9048

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Players can now toggle between ring spell area-of-effect behavior modes via in-game commands.
  * Ring spell coverage range is now adjustable through a configurable multiplier, providing greater control over spell effects.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rkroska/ACECustom/pull/451?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->