### PR TITLE
Optimize and implement new ring spell damage parity, configuration, diagnostics, and classic isolation

### DIFF
--- a/Source/ACE.Server/Command/Handlers/ILTCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/ILTCommands.cs
@@ -42,7 +42,7 @@ namespace ACE.Server.Command.Handlers
 
         [CommandHandler("ilt", AccessLevel.Player, CommandHandlerFlag.RequiresWorld, 0,
             "ILT custom server commands and player preferences.",
-            "Usage: /ilt [help|features|dmgformat|showoverkill|levelskills|trainskills|xp level|train|ringmode|ringdebug]")]
+            "Usage: /ilt [help|features|dmgformat|showoverkill|levelskills|trainskills|xp level|train|ringmode|ringrange]")]
         public static void HandleILT(Session session, params string[] parameters)
         {
             var player = session.Player;
@@ -79,14 +79,6 @@ namespace ACE.Server.Command.Handlers
                     ? "Ring Spell Mode: Classic (physics collision \u2014 can multi-hit, rings may miss monsters)"
                     : "Ring Spell Mode: New (all targets in range guaranteed to hit once, no multi-hit)";
                 session.Network.EnqueueSend(new GameMessageSystemChat(msg, ChatMessageType.System));
-            }
-            else if (sub == "ringdebug")
-            {
-                player.RingAoeDebug = !player.RingAoeDebug;
-                var state = player.RingAoeDebug ? "ON" : "OFF";
-                session.Network.EnqueueSend(new GameMessageSystemChat(
-                    $"[RingAOE] Debug broadcast {state}. Cast any ring spell to see AOE stats.",
-                    ChatMessageType.System));
             }
             else if (sub == "dmgformat")
             {
@@ -261,16 +253,17 @@ namespace ACE.Server.Command.Handlers
             }
             else if (sub == "ringrange")
             {
-                // Admin-only diagnostic — not listed in player help.
-                if (session.AccessLevel < AccessLevel.Admin)
+                var isClassic = player.GetProperty(PropertyBool.ClassicRingAoe) ?? false;
+                if (isClassic)
                 {
-                    session.Network.EnqueueSend(new GameMessageSystemChat("[RingRange] Admin only.", ChatMessageType.System));
+                    session.Network.EnqueueSend(new GameMessageSystemChat("[RingRange] This diagnostic is only applicable in New ring mode. Classic mode operates entirely on standard projectile physics collisions with no custom server restraints.", ChatMessageType.System));
                     return;
                 }
 
                 // Scan for all known creatures within the player's ring AOE radius.
                 const float ringRadius = Player.DefaultRingAoeRadius;
                 var radius = ringRadius * (float)(player.GetProperty(PropertyFloat.AoeRangeMultiplier) ?? 1.0f);
+                var maxHeight = Player.RingAoeMaxHeightDelta;
 
                 if (player.Location == null)
                 {
@@ -282,7 +275,7 @@ namespace ACE.Server.Command.Handlers
                 var inRange = known
                     .Where(c => c != null && c != player && c.Location != null
                                 && c.IsAlive
-                                && Math.Abs(player.Location.PositionZ - c.Location.PositionZ) <= Player.RingAoeMaxHeightDelta
+                                && Math.Abs(player.Location.PositionZ - c.Location.PositionZ) <= maxHeight
                                 && player.Location.Distance2D(c.Location) <= radius
                                 && player.CanDamage(c)
                                 && player.CheckPKStatusVsTarget(c, null) == null)
@@ -290,7 +283,7 @@ namespace ACE.Server.Command.Handlers
                     .ToList();
 
                 session.Network.EnqueueSend(new GameMessageSystemChat(
-                    $"[RingRange] Radius: {radius:F1}m | Vertical: {Player.RingAoeMaxHeightDelta:F1}m | Creatures in range: {inRange.Count}",
+                    $"[RingRange] Radius: {radius:F1}m | Vertical: {maxHeight:F1}m | Creatures in range: {inRange.Count}",
                     ChatMessageType.System));
 
                 foreach (var c in inRange)
@@ -322,8 +315,8 @@ namespace ACE.Server.Command.Handlers
                 session.Network.EnqueueSend(new GameMessageSystemChat("      Train all affordable untrained skills using skill credits, in priority order.", ChatMessageType.System));
                 session.Network.EnqueueSend(new GameMessageSystemChat($"  /ilt ringmode", ChatMessageType.System));
                 session.Network.EnqueueSend(new GameMessageSystemChat($"      Toggle ring spell mode between New (guaranteed AOE) and Classic (physics multi-hit). (currently: {ringLabel})", ChatMessageType.System));
-                session.Network.EnqueueSend(new GameMessageSystemChat($"  /ilt ringdebug", ChatMessageType.System));
-                session.Network.EnqueueSend(new GameMessageSystemChat($"      Toggle ring AOE cast diagnostics broadcast for your character. Resets on relog.", ChatMessageType.System));
+                session.Network.EnqueueSend(new GameMessageSystemChat($"  /ilt ringrange", ChatMessageType.System));
+                session.Network.EnqueueSend(new GameMessageSystemChat($"      View all valid targets and parameters for your next ring spell.", ChatMessageType.System));
             }
         }
     }

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -1635,11 +1635,9 @@ namespace ACE.Server.WorldObjects
         }
 
         // ── Ring AOE radius (meters). Scaled by AoeRangeMultiplier charm (PropertyFloat 9048). ──
-        internal const float DefaultRingAoeRadius    =  5.0f;
+        internal const float DefaultRingAoeRadius    =  5.8f;
         // ── Max vertical delta (meters) — prevents hitting creatures on a different floor. ──
-        internal const float RingAoeMaxHeightDelta   =  4.0f;
-        // ── Per-player debug broadcast toggle (off by default). ──
-        public bool RingAoeDebug { get; set; } = false;
+        internal const float RingAoeMaxHeightDelta   =  7.0f;
 
         /// <summary>
         /// Applies one war-magic damage roll to every valid creature within the ring spell's
@@ -1665,6 +1663,12 @@ namespace ACE.Server.WorldObjects
             var attribBonus = 1.0f;
             attribBonus += SkillFormula.GetAttributeMod((int)Focus.Current) * SpellProjectile.DefaultSpellAttributeMult;
             attribBonus += SkillFormula.GetAttributeMod((int)Self.Current)  * SpellProjectile.DefaultSpellAttributeMult;
+
+            // Pre-calculate target-independent combat ratings for optimization.
+            var heritageMod = GetHeritageBonus(weapon) ? 1.05f : 1.0f;
+            var baseDamageRatingMod = Creature.GetPositiveRatingMod(GetDamageRating());
+            var critDamageRatingMod = Creature.GetPositiveRatingMod(GetCritDamageRating());
+            var pkDamageRatingMod = Creature.GetPositiveRatingMod(GetPKDamageRating());
 
             foreach (var creature in visibleCreatures)
             {
@@ -1761,6 +1765,37 @@ namespace ACE.Server.WorldObjects
                 var finalDamage = (baseDamage + critDamageBonus + skillBonus)
                                   * elementalMod * slayerMod * resistanceMod * absorbMod * attribBonus;
 
+                // Sneak attack & heritage mods (mirrors SpellProjectile.DamageTarget).
+                var sneakAttackMod = GetSneakAttackMod(creature);
+                var damageRatingMod = Creature.AdditiveCombine(baseDamageRatingMod, heritageMod, sneakAttackMod);
+
+                var damageResistRatingMod = creature.GetDamageResistRatingMod(CombatType.Magic);
+
+                if (criticalHit)
+                {
+                    var critDamageResistRatingMod = Creature.GetNegativeRatingMod(creature.GetCritDamageResistRating());
+
+                    damageRatingMod = Creature.AdditiveCombine(damageRatingMod, critDamageRatingMod);
+                    damageResistRatingMod = Creature.AdditiveCombine(damageResistRatingMod, critDamageResistRatingMod);
+                }
+
+                if (isPvP)
+                {
+                    var pkDamageResistRatingMod = Creature.GetNegativeRatingMod(creature.GetPKDamageResistRating());
+
+                    damageRatingMod = Creature.AdditiveCombine(damageRatingMod, pkDamageRatingMod);
+                    damageResistRatingMod = Creature.AdditiveCombine(damageResistRatingMod, pkDamageResistRatingMod);
+                }
+
+                finalDamage *= damageRatingMod * damageResistRatingMod;
+
+                // Apply enrage damage reduction for the defender.
+                if (creature.IsEnraged)
+                {
+                    var enrageReduction = creature.EnrageDamageReduction ?? 0.0f;
+                    finalDamage *= (1.0f - enrageReduction);
+                }
+
                 // CombatPet mitigation — extra spell-only damage reduction from owner's summon aug.
                 // Vanilla also gates this on pet_combat_summon_aug_spell_mitigation_players_only; since
                 // ring AOE is always cast by a Player, sourcePlayer != null is unconditionally true here.
@@ -1797,12 +1832,6 @@ namespace ACE.Server.WorldObjects
             // Intentionally outside the loop — ring spells should not award N ticks for N targets.
             if (dbgHit > 0)
                 Proficiency.OnSuccessUse(this, GetCreatureSkill(spell.School), spell.PowerMod);
-
-            // DEBUG — broadcast ring AOE summary to caster (only when RingAoeDebug is enabled via /ilt ringdebug)
-            if (RingAoeDebug)
-                Session?.Network.EnqueueSend(new GameMessageSystemChat(
-                    $"[RingAOE] inRange={dbgHit + dbgResist} resisted={dbgResist} hit={dbgHit} radius={radius:F1}m vertical={RingAoeMaxHeightDelta:F1}m",
-                    ACE.Entity.Enum.ChatMessageType.Broadcast));
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/WorldObject_Tick.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Tick.cs
@@ -373,7 +373,7 @@ namespace ACE.Server.WorldObjects
                         // For player ring spells, use our server-controlled radius so the visual
                         // matches the kill radius exactly.  Monster rings keep the DAT value.
                         float maxRange;
-                        if (spellProjectile.ProjectileSource is Player playerCaster)
+                        if (spellProjectile.ProjectileSource is Player playerCaster && !(playerCaster.GetProperty(PropertyBool.ClassicRingAoe) ?? false))
                         {
                             var multiplier = (float)(playerCaster.GetProperty(PropertyFloat.AoeRangeMultiplier) ?? 1.0f);
                             maxRange = Player.DefaultRingAoeRadius * multiplier;


### PR DESCRIPTION
🚀 Pull Request Overview: Ring Spell AOE Rework, Parity & Performance Optimizations
This pull request resolves the magic damage deficit for guaranteed-hit (New) ring spells, configures standard default radius/vertical dimensions, cleanly isolates Classic-mode visual physics, and refactors player diagnostic commands. It also introduces critical loop optimizations to ensure high-performance execution.

🛠️ Detailed List of Changes
1. Magic Damage Parity & Caching Optimization
File: Player_Magic.cs
Problem: In the new guaranteed-hit AOE mode, ring spells hit significantly weaker than standard single-target projectiles because they were completely missing critical damage rating adjustments, PvP scaling, sneak attack bonuses, weapon heritage bonuses, and defender-side enrage mitigations.
Solution: Integrated identical combat scaling algorithms from the core single-target pipeline (SpellProjectile.DamageTarget).

⚡ Performance Optimization (Hoisting): To prevent redundant calculations when hitting multiple targets in a single cast, all target-independent properties and rating calculations have been hoisted outside of the target loop:
Caster Heritage Weapon check (GetHeritageBonus)
Caster Base Magic Damage Rating (GetDamageRating)
Caster Critical Damage Rating (GetCritDamageRating)
Caster PvP/PK Damage Rating (GetPKDamageRating)
Result: Reduces lookup complexity from O(N) dynamic property/dictionary lookups on the player to O(1) per cast, saving computational time on high-density monster pulls.

2. Classic Visual Projectile Isolation
File: WorldObject_Tick.cs
Problem: Clamping visual ranges in physics updates caused Classic-mode projectiles (which depend on authentic client-side collision math) to disappear prematurely at 5.8m.
Solution: Restricted visual early-termination constraints exclusively to players using the New guaranteed-hit mode (!(playerCaster.GetProperty(PropertyBool.ClassicRingAoe) ?? false)). Classic-mode projectiles now correctly travel their standard client-side DAT distances.

3. Player Diagnostics Rework
File: ILTCommands.cs
Changes:
Elevated /ilt ringrange to a player-level diagnostic command (AccessLevel.Player).
Cleanly deprecated and removed the /ilt ringdebug diagnostics and its corresponding RingAoeDebug properties to keep command usage clean.
Added a safety check inside /ilt ringrange that intercepts Classic-mode players and gracefully explains that the command only applies to New mode.