### PR TITLE
feat: support monster healing in /heal command

### DIFF
--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -5937,7 +5937,11 @@ namespace ACE.Server.Command.Handlers
 
                 if (!(creature is Player))
                 {
-                    session.Network.EnqueueSend(new GameMessageSystemChat($"Healed {creature.Name} to full vitals (+{hpHealed} HP, +{stamHealed} Stam, +{manaHealed} Mana).", ChatMessageType.Broadcast));
+                    var hpFormatted = Creature.FormatDamage(hpHealed, session.Player.DamageNumberFormat);
+                    var stamFormatted = Creature.FormatDamage(stamHealed, session.Player.DamageNumberFormat);
+                    var manaFormatted = Creature.FormatDamage(manaHealed, session.Player.DamageNumberFormat);
+
+                    session.Network.EnqueueSend(new GameMessageSystemChat($"Healed {creature.Name} to full vitals (+{hpFormatted} HP, +{stamFormatted} Stam, +{manaFormatted} Mana).", ChatMessageType.Broadcast));
                 }
             }
             else

--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -5937,9 +5937,9 @@ namespace ACE.Server.Command.Handlers
 
                 if (!(creature is Player))
                 {
-                    var hpFormatted = Creature.FormatDamage(hpHealed, session.Player.DamageNumberFormat);
-                    var stamFormatted = Creature.FormatDamage(stamHealed, session.Player.DamageNumberFormat);
-                    var manaFormatted = Creature.FormatDamage(manaHealed, session.Player.DamageNumberFormat);
+                    var hpFormatted = Creature.FormatDamage(hpHealed, 2);
+                    var stamFormatted = Creature.FormatDamage(stamHealed, 2);
+                    var manaFormatted = Creature.FormatDamage(manaHealed, 2);
 
                     session.Network.EnqueueSend(new GameMessageSystemChat($"Healed {creature.Name} to full vitals (+{hpFormatted} HP, +{stamFormatted} Stam, +{manaFormatted} Mana).", ChatMessageType.Broadcast));
                 }

--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -5927,13 +5927,22 @@ namespace ACE.Server.Command.Handlers
             {
                 session.Network.EnqueueSend(new GameMessageSystemChat($"Unable to locate what you have selected.", ChatMessageType.Broadcast));
             }
-            else if (wo is Player player)
+            else if (wo is Creature creature)
             {
-                player.SetMaxVitals();
+                var hpHealed = creature.Health.Missing;
+                var stamHealed = creature.Stamina.Missing;
+                var manaHealed = creature.Mana.Missing;
+
+                creature.SetMaxVitals();
+
+                if (!(creature is Player))
+                {
+                    session.Network.EnqueueSend(new GameMessageSystemChat($"Healed {creature.Name} to full vitals (+{hpHealed} HP, +{stamHealed} Stam, +{manaHealed} Mana).", ChatMessageType.Broadcast));
+                }
             }
             else
             {
-                session.Network.EnqueueSend(new GameMessageSystemChat($"You cannot heal {wo.Name} because it is not a player.", ChatMessageType.Broadcast));
+                session.Network.EnqueueSend(new GameMessageSystemChat($"You cannot heal {wo.Name} because it is not a creature.", ChatMessageType.Broadcast));
             }
         }
 

--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -5935,14 +5935,11 @@ namespace ACE.Server.Command.Handlers
 
                 creature.SetMaxVitals();
 
-                if (!(creature is Player))
-                {
-                    var hpFormatted = Creature.FormatDamage(hpHealed, 2);
-                    var stamFormatted = Creature.FormatDamage(stamHealed, 2);
-                    var manaFormatted = Creature.FormatDamage(manaHealed, 2);
+                var hpFormatted = Creature.FormatDamage(hpHealed, 2);
+                var stamFormatted = Creature.FormatDamage(stamHealed, 2);
+                var manaFormatted = Creature.FormatDamage(manaHealed, 2);
 
-                    session.Network.EnqueueSend(new GameMessageSystemChat($"Healed {creature.Name} to full vitals (+{hpFormatted} HP, +{stamFormatted} Stam, +{manaFormatted} Mana).", ChatMessageType.Broadcast));
-                }
+                session.Network.EnqueueSend(new GameMessageSystemChat($"Healed {creature.Name} to full vitals (+{hpFormatted} HP, +{stamFormatted} Stam, +{manaFormatted} Mana).", ChatMessageType.Broadcast));
             }
             else
             {


### PR DESCRIPTION
Allows GMs/admins to use the `/heal` command on monsters, pets, and NPCs (any `Creature` in the game world).

### Changes
- Casts targeted `WorldObject` to `Creature` instead of restricting to `Player`.
- Pre-calculates the exact amount of health, stamina, and mana restored and formats using the short damage format (mode `2`).
- Prints a yellow system broadcast chat message to the admin: `Healed [Name] to full vitals (+X HP, +Y Stam, +Z Mana).`
- Returns a friendly error message for non-creature targets (e.g. doors, chests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The heal admin command now works on creatures in addition to players, with broadcast notifications when healing non-player creatures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rkroska/ACECustom/pull/458?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->