### PR TITLE
Fix indoor dungeon NPC floating after visibility changes

### DIFF
--- a/NETWORK_MASS_SPAWN_MITIGATIONS.md
+++ b/NETWORK_MASS_SPAWN_MITIGATIONS.md
@@ -27,7 +27,7 @@ These apply to **all** outbound message types in a bundle, not CreateObject alon
 
 ## Suggested values for mass spawns (500+ mobs)
 
-```
+```bash
 /modifylong net_max_packets_per_tick 30
 /modifylong net_min_bundle_interval_ms 10
 /modifylong monster_tick_throttle_limit 50

--- a/NETWORK_MASS_SPAWN_MITIGATIONS.md
+++ b/NETWORK_MASS_SPAWN_MITIGATIONS.md
@@ -1,0 +1,54 @@
+# Network & Mass Spawn Mitigations
+
+Live-tunable server properties for client/server load near large spawns (e.g. 500+ mobs). Use `/showprops` to list all names.
+
+---
+
+## Network pacing (implemented)
+
+| Property | Default | Description | Live command |
+|----------|---------|-------------|--------------|
+| `net_max_packets_per_tick` | 50 | Max UDP packets sent to one client per server tick | `/modifylong net_max_packets_per_tick 30` |
+| `net_min_bundle_interval_ms` | 5 | Min ms between outbound bundle flushes per session | `/modifylong net_min_bundle_interval_ms 10` |
+| `net_retransmit_warn_threshold` | 75 | Log RETRANSMIT when ACK prunes more than N cached packets | `/modifylong net_retransmit_warn_threshold 20` |
+
+These apply to **all** outbound message types in a bundle, not CreateObject alone.
+
+---
+
+## Server-side throttles (implemented)
+
+| Property | Default | Description | Live command |
+|----------|---------|-------------|--------------|
+| `monster_tick_throttle_limit` | 75 | Monsters processed per tick per landblock | `/modifylong monster_tick_throttle_limit 50` |
+| `action_queue_throttle_limit` | 300 | Actions processed per tick | `/modifylong action_queue_throttle_limit 150` |
+
+---
+
+## Suggested values for mass spawns (500+ mobs)
+
+```
+/modifylong net_max_packets_per_tick 30
+/modifylong net_min_bundle_interval_ms 10
+/modifylong monster_tick_throttle_limit 50
+/modifylong action_queue_throttle_limit 150
+```
+
+---
+
+## Not implemented (do not use — no ServerConfig entry)
+
+The following were design notes only; they are **not** wired in `PropertyManager` or `NetworkSession`:
+
+- `network_create_object_max_per_tick`
+- `network_update_position_max_per_tick`
+- `network_movement_dedupe_window_ms`
+- `network_telemetry_log_interval_seconds`
+- `network_packet_pacing_enabled` / `network_priority_drain_enabled`
+
+---
+
+## Related files
+
+- `Source/ACE.Server/Network/NetworkSession.cs` — packet pacing
+- `Source/ACE.Server/Managers/PropertyManager.cs` — `net_*`, `monster_tick_throttle_limit`, `action_queue_throttle_limit`

--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -328,12 +328,6 @@ namespace ACE.Server.Entity
 
             actionQueue.EnqueueAction(new ActionEventDelegate(ActionType.Landblock_CreateWorldObjects, () =>
             {
-                if (PhysicsLandblock.HasDungeon)
-                {
-                    foreach (var envCell in PhysicsLandblock.get_envcells())
-                        envCell.EnsureVisibleCellsBuilt();
-                }
-
                 // for mansion linking
                 var houses = new List<House>();
                 foreach (var fo in factoryObjects)
@@ -373,54 +367,8 @@ namespace ACE.Server.Entity
                 // Spawn prestige boundary markers after normal objects
                 SpawnPrestigeBoundaryMarkers();
 
-                if (PhysicsLandblock.HasDungeon && (players.Count > 0 || pendingAdditions.Values.Any(v => v is Player)))
-                    RefreshIndoorStationaryCreaturesForViewers();
-
                 PhysicsLandblock.SortObjects();
             }, ActionPriority.Low));
-        }
-
-        /// <summary>
-        /// Dungeon NPCs persist on the landblock across player relog. Refresh physics and re-send CreateObject
-        /// so clients do not reuse a stale ObjMaint "already known" entry without grounded vendor state.
-        /// </summary>
-        /// <summary>
-        /// Queued after player add/teleport; skip if the player left this landblock before the callback runs.
-        /// </summary>
-        private void TryRefreshIndoorStationaryCreaturesForPlayer(Player player)
-        {
-            if (player?.CurrentLandblock != this)
-                return;
-
-            RefreshIndoorStationaryCreaturesForViewers(player);
-        }
-
-        private void RefreshIndoorStationaryCreaturesForViewers(Player viewer = null)
-        {
-            var viewers = new List<Player>();
-            if (viewer != null)
-                viewers.Add(viewer);
-            else
-            {
-                viewers.AddRange(players);
-                foreach (var kvp in pendingAdditions)
-                {
-                    if (kvp.Value is Player pendingPlayer && !viewers.Contains(pendingPlayer))
-                        viewers.Add(pendingPlayer);
-                }
-            }
-
-            if (viewers.Count == 0)
-                return;
-
-            foreach (var wo in worldObjects.Values.Union(pendingAdditions.Values))
-            {
-                if (wo is not WorldObject worldObject)
-                    continue;
-
-                foreach (var p in viewers)
-                    worldObject.RefreshIndoorStationarySpawnPhysics(p);
-            }
         }
 
         /// <summary>
@@ -1375,29 +1323,6 @@ namespace ACE.Server.Entity
 
             if (wo is Player player)
             {
-                if (PhysicsLandblock.HasDungeon)
-                {
-                    foreach (var envCell in PhysicsLandblock.get_envcells())
-                        envCell.EnsureVisibleCellsBuilt();
-
-                    if (CreateWorldObjectsCompleted)
-                    {
-                        if (DateTime.UtcNow - player.LastTeleportTime < PhysicsObj.TeleportCreateObjectDelay)
-                        {
-                            var actionChain = new ActionChain();
-                            actionChain.AddDelaySeconds(PhysicsObj.TeleportCreateObjectDelay.TotalSeconds);
-                            actionChain.AddAction(player, ActionType.Landblock_CreateWorldObjects, () =>
-                                TryRefreshIndoorStationaryCreaturesForPlayer(player));
-                            actionChain.EnqueueChain();
-                        }
-                        else
-                        {
-                            actionQueue.EnqueueAction(new ActionEventDelegate(ActionType.Landblock_CreateWorldObjects, () =>
-                                TryRefreshIndoorStationaryCreaturesForPlayer(player)));
-                        }
-                    }
-                }
-
                 if (ServerConfig.prestige_interaction_diag_verbose.Value)
                 {
                     // Helpful when one player can't see another: shows whether physics/ObjMaint is even populated yet.

--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -22,6 +22,7 @@ using ACE.Entity.Models;
 using ACE.Server.Entity.Actions;
 using ACE.Server.Factories;
 using ACE.Server.Managers;
+using ACE.Server.Physics;
 using ACE.Server.Physics.Common;
 using ACE.Server.Network.GameMessages;
 using ACE.Server.WorldObjects;
@@ -327,6 +328,12 @@ namespace ACE.Server.Entity
 
             actionQueue.EnqueueAction(new ActionEventDelegate(ActionType.Landblock_CreateWorldObjects, () =>
             {
+                if (PhysicsLandblock.HasDungeon)
+                {
+                    foreach (var envCell in PhysicsLandblock.get_envcells())
+                        envCell.EnsureVisibleCellsBuilt();
+                }
+
                 // for mansion linking
                 var houses = new List<House>();
                 foreach (var fo in factoryObjects)
@@ -366,8 +373,43 @@ namespace ACE.Server.Entity
                 // Spawn prestige boundary markers after normal objects
                 SpawnPrestigeBoundaryMarkers();
 
+                if (PhysicsLandblock.HasDungeon && (players.Count > 0 || pendingAdditions.Values.Any(v => v is Player)))
+                    RefreshIndoorStationaryCreaturesForViewers();
+
                 PhysicsLandblock.SortObjects();
             }, ActionPriority.Low));
+        }
+
+        /// <summary>
+        /// Dungeon NPCs persist on the landblock across player relog. Refresh physics and re-send CreateObject
+        /// so clients do not reuse a stale ObjMaint "already known" entry without grounded vendor state.
+        /// </summary>
+        private void RefreshIndoorStationaryCreaturesForViewers(Player viewer = null)
+        {
+            var viewers = new List<Player>();
+            if (viewer != null)
+                viewers.Add(viewer);
+            else
+            {
+                viewers.AddRange(players);
+                foreach (var kvp in pendingAdditions)
+                {
+                    if (kvp.Value is Player pendingPlayer && !viewers.Contains(pendingPlayer))
+                        viewers.Add(pendingPlayer);
+                }
+            }
+
+            if (viewers.Count == 0)
+                return;
+
+            foreach (var wo in worldObjects.Values.Union(pendingAdditions.Values))
+            {
+                if (wo is not WorldObject worldObject)
+                    continue;
+
+                foreach (var p in viewers)
+                    worldObject.RefreshIndoorStationarySpawnPhysics(p);
+            }
         }
 
         /// <summary>
@@ -1322,6 +1364,29 @@ namespace ACE.Server.Entity
 
             if (wo is Player player)
             {
+                if (PhysicsLandblock.HasDungeon)
+                {
+                    foreach (var envCell in PhysicsLandblock.get_envcells())
+                        envCell.EnsureVisibleCellsBuilt();
+
+                    if (CreateWorldObjectsCompleted)
+                    {
+                        if (DateTime.UtcNow - player.LastTeleportTime < PhysicsObj.TeleportCreateObjectDelay)
+                        {
+                            var actionChain = new ActionChain();
+                            actionChain.AddDelaySeconds(PhysicsObj.TeleportCreateObjectDelay.TotalSeconds);
+                            actionChain.AddAction(player, ActionType.Landblock_CreateWorldObjects, () =>
+                                RefreshIndoorStationaryCreaturesForViewers(player));
+                            actionChain.EnqueueChain();
+                        }
+                        else
+                        {
+                            actionQueue.EnqueueAction(new ActionEventDelegate(ActionType.Landblock_CreateWorldObjects, () =>
+                                RefreshIndoorStationaryCreaturesForViewers(player)));
+                        }
+                    }
+                }
+
                 if (ServerConfig.prestige_interaction_diag_verbose.Value)
                 {
                     // Helpful when one player can't see another: shows whether physics/ObjMaint is even populated yet.

--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -384,6 +384,17 @@ namespace ACE.Server.Entity
         /// Dungeon NPCs persist on the landblock across player relog. Refresh physics and re-send CreateObject
         /// so clients do not reuse a stale ObjMaint "already known" entry without grounded vendor state.
         /// </summary>
+        /// <summary>
+        /// Queued after player add/teleport; skip if the player left this landblock before the callback runs.
+        /// </summary>
+        private void TryRefreshIndoorStationaryCreaturesForPlayer(Player player)
+        {
+            if (player?.CurrentLandblock != this)
+                return;
+
+            RefreshIndoorStationaryCreaturesForViewers(player);
+        }
+
         private void RefreshIndoorStationaryCreaturesForViewers(Player viewer = null)
         {
             var viewers = new List<Player>();
@@ -1376,13 +1387,13 @@ namespace ACE.Server.Entity
                             var actionChain = new ActionChain();
                             actionChain.AddDelaySeconds(PhysicsObj.TeleportCreateObjectDelay.TotalSeconds);
                             actionChain.AddAction(player, ActionType.Landblock_CreateWorldObjects, () =>
-                                RefreshIndoorStationaryCreaturesForViewers(player));
+                                TryRefreshIndoorStationaryCreaturesForPlayer(player));
                             actionChain.EnqueueChain();
                         }
                         else
                         {
                             actionQueue.EnqueueAction(new ActionEventDelegate(ActionType.Landblock_CreateWorldObjects, () =>
-                                RefreshIndoorStationaryCreaturesForViewers(player)));
+                                TryRefreshIndoorStationaryCreaturesForPlayer(player)));
                         }
                     }
                 }

--- a/Source/ACE.Server/Physics/Common/EnvCell.cs
+++ b/Source/ACE.Server/Physics/Common/EnvCell.cs
@@ -75,7 +75,14 @@ namespace ACE.Server.Physics.Common
             if (Environment?.Cells != null && Environment.Cells.TryGetValue(CellStructureID, out var cellStruct))
                 CellStructure = new CellStruct(cellStruct);
             else
+            {
                 Console.WriteLine("CellStructureID {0} not found in Environment {1}", CellStructureID, EnvironmentID);
+                CellStructure = new CellStruct
+                {
+                    Polygons = new Dictionary<ushort, Polygon>(),
+                    Portals = new List<Polygon>()
+                };
+            }
 
             //NumSurfaces = envCell.Surfaces.Count;
         }
@@ -129,7 +136,8 @@ namespace ACE.Server.Physics.Common
             {
                 var blockCellID = ID & 0xFFFF0000 | visibleCellID;
                 var cell = (EnvCell)LScape.get_landcell(blockCellID, this.Pos.Variation);
-                VisibleCells.TryAdd(visibleCellID, cell);
+                if (cell != null)
+                    VisibleCells.TryAdd(visibleCellID, cell);
             }
             //Parallel.ForEach(VisibleCellIDs, ConfigManager.Config.Server.Threading.LandblockManagerParallelOptions, visibleCellID =>
             //{

--- a/Source/ACE.Server/Physics/Common/EnvCell.cs
+++ b/Source/ACE.Server/Physics/Common/EnvCell.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 
-using log4net;
-
 using ACE.Entity.Enum;
 using ACE.Server.Physics.BSP;
 using ACE.Server.Physics.Animation;
@@ -13,27 +11,11 @@ using ACE.Server.Physics.Extensions;
 using System.Collections.Concurrent;
 using System.Threading.Tasks;
 using ACE.Common;
-using ACE.Server.Physics.Util;
 
 namespace ACE.Server.Physics.Common
 {
     public class EnvCell: ObjCell, IEquatable<EnvCell>
     {
-        private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
-
-        /// <summary>True while a root <see cref="build_visible_cells"/> is running (nested loads defer instead of recursing).</summary>
-        [ThreadStatic]
-        private static bool _buildingVisibleCells;
-
-        /// <summary>Cells whose neighbor load triggered <see cref="build_visible_cells"/> during an outer build.</summary>
-        [ThreadStatic]
-        private static List<EnvCell> _deferredVisibleBuilds;
-
-        /// <summary>Cells fully built in the current root build (avoids duplicate work and dat cycles).</summary>
-        [ThreadStatic]
-        private static HashSet<uint> _builtVisibleCellIds;
-
-        private const int MaxDeferredVisibleBuilds = 4096;
         //public int NumSurfaces;
         //public List<Surface> Surfaces;
         public CellStruct CellStructure;
@@ -93,52 +75,15 @@ namespace ACE.Server.Physics.Common
             if (Environment?.Cells != null && Environment.Cells.TryGetValue(CellStructureID, out var cellStruct))
                 CellStructure = new CellStruct(cellStruct);
             else
-            {
-                PhysicsLogGates.MissingCellStructure.Warn(
-                    () =>
-                        $"[PHYSICS] EnvCell CellStructureID 0x{CellStructureID:X8} not found in Environment 0x{EnvironmentID:X8} (cell 0x{ID:X8} variation={Variation?.ToString() ?? "null"}). CellStructure left null; physics for this cell will be skipped until cell.dat is repaired.",
-                    10_000);
-            }
+                Console.WriteLine("CellStructureID {0} not found in Environment {1}", CellStructureID, EnvironmentID);
+
             //NumSurfaces = envCell.Surfaces.Count;
-            // PostInit may skip before build_visible_cells runs; never leave VisibleCells null (GetVisible / add_visible_cell).
-            VisibleCells = new ConcurrentDictionary<uint, EnvCell>();
         }
 
         public void PostInit(int? variation)
         {
-            if (ID == 0)
-            {
-                PhysicsLogGates.PostInitSkipped.Warn(
-                    () => $"[PHYSICS] EnvCell.PostInit skipped: cell Id is 0 (invalid). variation={variation?.ToString() ?? "null"}",
-                    10_000);
-                return;
-            }
-
-            if (CellStructure == null)
-            {
-                PhysicsLogGates.PostInitSkipped.Warn(
-                    () =>
-                        $"[PHYSICS] EnvCell.PostInit skipped: CellStructure is null for cell 0x{ID:X8} env=0x{EnvironmentID:X8} cellStructId=0x{CellStructureID:X8} variation={variation?.ToString() ?? "null"}. Skipping visible-cell build and statics.",
-                    10_000);
-                return;
-            }
-
-            EnsureVisibleCellsBuilt();
-            init_static_objects(variation);
-        }
-
-        /// <summary>
-        /// Populates <see cref="VisibleCells"/> when still empty (e.g. deferred build or first PVS use).
-        /// </summary>
-        public void EnsureVisibleCellsBuilt()
-        {
-            if (CellStructure == null || VisibleCellIDs == null || VisibleCellIDs.Count == 0)
-                return;
-
-            if (VisibleCells != null && VisibleCells.Count > 0)
-                return;
-
             build_visible_cells();
+            init_static_objects(variation);
         }
 
         public override TransitionState FindEnvCollisions(Transition transition)
@@ -175,131 +120,16 @@ namespace ACE.Server.Physics.Common
 
         public void build_visible_cells()
         {
-            build_visible_cells(fromDeferDrain: false);
-        }
-
-        /// <param name="fromDeferDrain">When true, run even if an outer build is in progress (avoids re-deferring the drain queue).</param>
-        private void build_visible_cells(bool fromDeferDrain)
-        {
-            if (CellStructure == null || VisibleCellIDs == null)
-                return;
-
-            _builtVisibleCellIds ??= new HashSet<uint>();
-
-            if (_builtVisibleCellIds.Contains(ID))
-                return;
-
-            if (_buildingVisibleCells && !fromDeferDrain)
-            {
-                _deferredVisibleBuilds ??= new List<EnvCell>();
-                if (_deferredVisibleBuilds.Count >= MaxDeferredVisibleBuilds)
-                {
-                    PhysicsLogGates.BuildVisibleDepth.Warn(
-                        () =>
-                            $"[PHYSICS] build_visible_cells deferred queue exceeded {MaxDeferredVisibleBuilds} (likely cyclic visible-cell graph). cell=0x{ID:X8} variation={Pos.Variation?.ToString() ?? "null"}",
-                        10_000);
-                    return;
-                }
-
-                for (var i = 0; i < _deferredVisibleBuilds.Count; i++)
-                {
-                    if (_deferredVisibleBuilds[i].ID == ID)
-                        return;
-                }
-
-                _deferredVisibleBuilds.Add(this);
-                return;
-            }
-
-            var isRoot = !fromDeferDrain;
-            if (isRoot)
-                _buildingVisibleCells = true;
-
-            try
-            {
-                BuildVisibleCellsCore();
-                _builtVisibleCellIds.Add(ID);
-
-                if (isRoot)
-                    DrainDeferredVisibleBuilds();
-            }
-            finally
-            {
-                if (isRoot)
-                {
-                    _buildingVisibleCells = false;
-                    _builtVisibleCellIds = null;
-                    _deferredVisibleBuilds = null;
-                }
-            }
-        }
-
-        private static void DrainDeferredVisibleBuilds()
-        {
-            while (_deferredVisibleBuilds != null && _deferredVisibleBuilds.Count > 0)
-            {
-                var batch = _deferredVisibleBuilds;
-                _deferredVisibleBuilds = null;
-
-                foreach (var cell in batch)
-                    cell.build_visible_cells(fromDeferDrain: true);
-            }
-        }
-
-        private void BuildVisibleCellsCore()
-        {
+            //if (VisibleCells != null && VisibleCellIDs != null && VisibleCells.Count == VisibleCellIDs.Count)
+            //{
+            //    return; // already built
+            //}
             VisibleCells ??= new ConcurrentDictionary<uint, EnvCell>();
-            if (VisibleCellIDs == null)
-                return;
-
-            var diagDebug = IndoorPlacementDiagLogging.IsColo(ID) && log.IsDebugEnabled;
-            var diagCfg = IndoorPlacementDiagLogging.Enabled && IndoorPlacementDiagLogging.IsColo(ID);
-            var visibleListCount = VisibleCellIDs?.Count ?? 0;
-            var failedVisibleLoads = 0;
-            var tryAddFailed = 0;
             foreach (var visibleCellID in VisibleCellIDs)
             {
-                var blockCellID = (ID & 0xFFFF0000) | visibleCellID;
+                var blockCellID = ID & 0xFFFF0000 | visibleCellID;
                 var cell = (EnvCell)LScape.get_landcell(blockCellID, this.Pos.Variation);
-                if (cell == null)
-                {
-                    if (diagDebug || diagCfg)
-                        log.Debug($"[DEBUG-VIS] EnvCell {ID:X8} (Var:{this.Pos.Variation}): Failed to load VisibleCell {blockCellID:X8} (requestedVar:{this.Pos.Variation})");
-                    failedVisibleLoads++;
-                }
-                else if (!VisibleCells.TryAdd(visibleCellID, cell))
-                    tryAddFailed++;// duplicate key — expected rarely when multiple paths register the same stub
-            }
-            if (diagDebug || diagCfg)
-            {
-                var keyMismatch = 0;
-                foreach (var kv in VisibleCells)
-                {
-                    if (kv.Value == null) continue;
-                    if (kv.Key != (kv.Value.ID & 0xFFFF))
-                        keyMismatch++;
-                }
-                var loaded = VisibleCells.Values.Where(v => v != null).ToList();
-                var distinctInstances = 0;
-                for (var i = 0; i < loaded.Count; i++)
-                {
-                    var isNew = true;
-                    for (var j = 0; j < i; j++)
-                    {
-                        if (ReferenceEquals(loaded[i], loaded[j])) { isNew = false; break; }
-                    }
-                    if (isNew) distinctInstances++;
-                }
-                var distinctFullIds = loaded.Select(v => v.ID).Distinct().Count();
-                var distinctOrigins = loaded
-                    .Select(v => $"{v.Pos.Frame.Origin.X:F1},{v.Pos.Frame.Origin.Y:F1},{v.Pos.Frame.Origin.Z:F1}")
-                    .Distinct()
-                    .Count();
-                var msg = $"build_visible_cells: root={ID:X8} posVar={Pos.Variation} visibleIdListCount={visibleListCount} visibleDictCount={VisibleCells.Count} failedLoads={failedVisibleLoads} tryAddDup={tryAddFailed} keyVsValueIdMismatch={keyMismatch} distinctVisibleInstances={distinctInstances} distinctVisibleFullIds={distinctFullIds} distinctVisibleOrigins={distinctOrigins} cellStructNull={CellStructure == null}";
-                if (diagCfg)
-                    log.Info($"[IndoorPlaceDiag] {msg}");
-                if (diagDebug)
-                    log.Debug($"[SpawnDiag] {msg}");
+                VisibleCells.TryAdd(visibleCellID, cell);
             }
             //Parallel.ForEach(VisibleCellIDs, ConfigManager.Config.Server.Threading.LandblockManagerParallelOptions, visibleCellID =>
             //{
@@ -315,8 +145,6 @@ namespace ACE.Server.Physics.Common
         {
             //if (portalId == 0) return;
             if (portalId == ushort.MaxValue) return;
-            if (CellStructure == null)
-                return;
 
             foreach (var sphere in spheres)
             {
@@ -335,9 +163,6 @@ namespace ACE.Server.Physics.Common
         {
             //if (portalId == 0) return;
             if (portalId == ushort.MaxValue) return;
-            if (CellStructure == null || Portals == null || CellStructure.Portals == null
-                || portalId < 0 || portalId >= Portals.Count || portalId >= CellStructure.Portals.Count)
-                return;
 
             var portal = Portals[portalId];
             var portalPoly = CellStructure.Portals[portalId];
@@ -389,24 +214,13 @@ namespace ACE.Server.Physics.Common
 
             if (searchCells)
             {
-                if (VisibleCells == null)
-                {
-                    if (IndoorPlacementDiagLogging.Enabled && IndoorPlacementDiagLogging.IsColo(ID))
-                        log.Info($"[IndoorPlaceDiag] find_visible_child_cell: VisibleCells is null (searchCells). root={ID:X8} posVar={Pos.Variation}");
-                    if (IndoorPlacementDiagLogging.IsColo(ID) && log.IsDebugEnabled)
-                        log.Debug($"[SpawnDiag] find_visible_child_cell: VisibleCells is null (searchCells). root={ID:X8} posVar={Pos.Variation}");
-                    return null;
-                }
-
-                // Use the EnvCell instances already stored in VisibleCells. Re-fetching via GetVisible(visibleCell.ID & 0xFFFF)
-                // can miss when dictionary keys ever diverge from (cell.ID & 0xFFFF) after variant-cache refactors (PR #391+),
-                // which would skip point_in_cell tests entirely and break indoor spawns.
                 foreach (var visibleCell in VisibleCells.Values)
                 {
                     if (visibleCell == null) continue;
 
-                    if (visibleCell.point_in_cell(origin))
-                        return visibleCell;
+                    var envCell = GetVisible(visibleCell.ID & 0xFFFF);
+                    if (envCell != null && envCell.point_in_cell(origin))
+                        return envCell;
                 }
             }
             else
@@ -418,61 +232,11 @@ namespace ACE.Server.Physics.Common
                         return envCell;
                 }
             }
-
-            var diagFindDebug = IndoorPlacementDiagLogging.IsColo(ID) && log.IsDebugEnabled;
-            var diagFindCfg = IndoorPlacementDiagLogging.Enabled && IndoorPlacementDiagLogging.IsColo(ID);
-            if (diagFindDebug || diagFindCfg)
-            {
-                var rootIn = point_in_cell(origin);
-                var rootOwnOriginInCell = CellStructure != null && point_in_cell(Pos.Frame.Origin);
-                var childHits = 0;
-                var childStructNull = 0;
-                var ownOriginHits = 0;
-                var ownOriginChecked = 0;
-                if (VisibleCells != null)
-                {
-                    foreach (var vc in VisibleCells.Values)
-                    {
-                        if (vc == null) { childStructNull++; continue; }
-                        if (vc.CellStructure == null) childStructNull++;
-                        else if (vc.point_in_cell(origin)) childHits++;
-
-                        if (vc?.CellStructure != null)
-                        {
-                            ownOriginChecked++;
-                            if (vc.point_in_cell(vc.Pos.Frame.Origin))
-                                ownOriginHits++;
-                        }
-                    }
-                }
-                var lbVar = CurLandblock?.VariationId;
-                uint? adjustCellId = null;
-                string adjustCellOrigin = null;
-                if (diagFindCfg)
-                {
-                    var dungeonId = ID >> 16;
-                    var v = Pos.Variation ?? CurLandblock?.VariationId;
-                    adjustCellId = AdjustCell.Get(dungeonId, v)?.GetCell(origin);
-                    if (adjustCellId != null)
-                    {
-                        var hit = (EnvCell)LScape.get_landcell(adjustCellId.Value, v);
-                        adjustCellOrigin = hit?.Pos.Frame.Origin.ToString();
-                    }
-                }
-                var tail = $"adjustCellGetCell={adjustCellId?.ToString("X8") ?? "n/a"} adjustCellResolvedOrigin={adjustCellOrigin ?? "n/a"}";
-                var body = $"find_visible_child_cell null: root={ID:X8} env={EnvironmentID:X8} cellStruct={CellStructureID} posVar={Pos.Variation} physLandblockVar={lbVar} rootOrigin={Pos.Frame.Origin} origin={origin} distRootOriginToSample={Vector3.Distance(Pos.Frame.Origin, origin)} SeenOutside={SeenOutside} searchCells={searchCells} rootPointInCell={rootIn} rootOwnOriginInCell={rootOwnOriginInCell} rootCellStructNull={CellStructure == null} visibleDict={VisibleCells?.Count} visibleIdList={VisibleCellIDs?.Count} childPointHits={childHits} childOrStructNull={childStructNull} visibleOwnOriginHits={ownOriginHits}/{ownOriginChecked} {tail}";
-                if (diagFindCfg)
-                    log.Info($"[IndoorPlaceDiag] {body}");
-                if (diagFindDebug)
-                    log.Debug($"[SpawnDiag] {body}");
-            }
             return null;
         }
 
         public EnvCell GetVisible(uint cellID)
         {
-            if (VisibleCells == null)
-                return null;
             VisibleCells.TryGetValue(cellID, out EnvCell envCell);
             return envCell;
         }
@@ -486,41 +250,24 @@ namespace ACE.Server.Physics.Common
             VisibleCells = new ConcurrentDictionary<uint, EnvCell>();
         }
 
-        public EnvCell? add_visible_cell(uint cellID, int? Variation)
+        public EnvCell add_visible_cell(uint cellID, int? Variation)
         {
-            // VisibleCells keys are low 16 bits (same as BuildVisibleCellsCore / GetVisible(portal.OtherCellId) / IsVisibleIndoors).
-            var loadCellId = (cellID & 0xFFFF0000) != 0 ? cellID : (uint)((ID & 0xFFFF0000) | (cellID & 0xFFFF));
-            var key = loadCellId & 0xFFFFU;
-
-            var envCell = DBObj.GetEnvCell(loadCellId, Variation);
-            if (envCell == null)
-            {
-                PhysicsLogGates.AddVisibleCellNull.Warn(
-                    () => $"[PHYSICS] add_visible_cell: DBObj.GetEnvCell returned null for loadCellId=0x{loadCellId:X8} (arg cellID=0x{cellID:X8}) variation={Variation?.ToString() ?? "null"} (parent 0x{ID:X8})",
-                    10_000);
-                return null;
-            }
-            VisibleCells ??= new ConcurrentDictionary<uint, EnvCell>();
-            VisibleCells.TryAdd(key, envCell);
+            var envCell = DBObj.GetEnvCell(cellID, Variation);
+            VisibleCells.TryAdd(cellID, envCell);
             return envCell;
         }
 
         public override void find_transit_cells(int numParts, List<PhysicsPart> parts, CellArray cellArray)
         {
-            if (CellStructure == null || Portals == null)
-                return;
-
             var checkOutside = false;
 
             foreach (var portal in Portals)
             {
-                if (portal == null || CellStructure.Polygons == null
-                    || !CellStructure.Polygons.TryGetValue(portal.PolygonId, out var portalPoly))
-                    continue;
+                var portalPoly = CellStructure.Polygons[portal.PolygonId];
 
                 foreach (var part in parts)
                 {
-                    if (part == null || part.GfxObj == null) continue;
+                    if (part == null) continue;
                     var sphere = part.GfxObj.PhysicsSphere;
                     if (sphere == null)
                         sphere = part.GfxObj.DrawingSphere;
@@ -563,9 +310,6 @@ namespace ACE.Server.Physics.Common
                         break;
                     }
 
-                    if (otherCell.CellStructure == null)
-                        continue;
-
                     var cellBox = new BBox();
                     cellBox.LocalToLocal(bbox, part.Pos, otherCell.Pos);
                     if (otherCell.CellStructure.box_intersects_cell(cellBox))
@@ -581,16 +325,11 @@ namespace ACE.Server.Physics.Common
 
         public override void find_transit_cells(Position position, int numSphere, List<Sphere> spheres, CellArray cellArray, SpherePath path)
         {
-            if (CellStructure == null || Portals == null)
-                return;
-
             var checkOutside = false;
 
             foreach (var portal in Portals)
             {
-                if (portal == null || CellStructure.Polygons == null
-                    || !CellStructure.Polygons.TryGetValue(portal.PolygonId, out var portalPoly))
-                    continue;
+                var portalPoly = CellStructure.Polygons[portal.PolygonId];
 
                 if (portal.OtherCellId == ushort.MaxValue)
                 {
@@ -610,7 +349,7 @@ namespace ACE.Server.Physics.Common
                 else
                 {
                     var otherCell = GetVisible(portal.OtherCellId);
-                    if (otherCell != null && otherCell.CellStructure != null)
+                    if (otherCell != null)
                     {
                         foreach (var sphere in spheres)
                         {
@@ -625,7 +364,7 @@ namespace ACE.Server.Physics.Common
                             }
                         }
                     }
-                    else if (otherCell == null)
+                    else
                     {
                         foreach (var sphere in spheres)
                         {
@@ -662,7 +401,7 @@ namespace ACE.Server.Physics.Common
 
                 for (var i = 0; i < NumStaticObjects; i++)
                 {
-                    var staticObj = PhysicsObj.makeObject(StaticObjectIDs[i], 0, false, variation);
+                    var staticObj = PhysicsObj.makeObject(StaticObjectIDs[i], 0, false);
                     staticObj.DatObject = true;
                     staticObj.add_obj_to_cell(this, StaticObjectFrames[i], variation);
                     if (staticObj.CurCell == null)
@@ -682,9 +421,7 @@ namespace ACE.Server.Physics.Common
         public static ObjCell get_visible(uint cellID, int? variationId)
         {
             var cell = (EnvCell)LScape.get_landcell(cellID, variationId);
-            if (cell?.VisibleCells == null || cell.VisibleCells.Count == 0)
-                return null;
-            return cell.VisibleCells.Values.FirstOrDefault();
+            return cell.VisibleCells.Values.First();
         }
 
         //public void grab_visible(List<uint> stabs)
@@ -729,8 +466,6 @@ namespace ACE.Server.Physics.Common
 
         public bool IsVisibleIndoors(ObjCell cell)
         {
-            EnsureVisibleCellsBuilt();
-
             var blockDist = PhysicsObj.GetBlockDist(ID, cell.ID);
 
             // if landblocks equal

--- a/Source/ACE.Server/Physics/Common/ObjectMaint.cs
+++ b/Source/ACE.Server/Physics/Common/ObjectMaint.cs
@@ -24,6 +24,24 @@ namespace ACE.Server.Physics.Common
         /// </summary>
         public static readonly float DestructionTime = 25.0f;
 
+        /// <summary>
+        /// Aligns physics ObjMaint checks with <see cref="Player_Tracking"/> / <see cref="PrestigeManager"/> networking gates.
+        /// </summary>
+        private static int? GetVariationForVisibility(PhysicsObj obj, int? variationOverride = null)
+        {
+            if (variationOverride.HasValue)
+                return variationOverride;
+
+            return PrestigeManager.GetEffectiveVariationForVisibility(obj?.WeenieObj?.WorldObject) ?? obj?.Position?.Variation;
+        }
+
+        private static bool SameVariationForVisibility(PhysicsObj a, PhysicsObj b, int? aOverride = null, int? bOverride = null)
+        {
+            return PrestigeManager.SameVariationForVisibility(
+                GetVariationForVisibility(a, aOverride),
+                GetVariationForVisibility(b, bOverride));
+        }
+
         private readonly ReaderWriterLockSlim rwLock = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
 
         /// <summary>
@@ -198,16 +216,8 @@ namespace ACE.Server.Physics.Common
         public bool AddKnownObject(PhysicsObj obj)
         {
             // Initial sanity checks (no lock needed yet)
-            // Must match networking (Player_Tracking / PrestigeManager): retail null vs 0 is one bucket; prestige is exact.
-            if (!PrestigeManager.SameVariationForVisibility(this.PhysicsObj.Position.Variation, obj.Position.Variation))
-            {
-                if (ServerConfig.prestige_interaction_diag_verbose.Value)
-                {
-                    log.Warn($"[PrestigeInteraction] ObjMaint.AddKnownObject blocked: viewer={PhysicsObj?.Name}({PhysicsObj?.ID:X8}) v={PhysicsObj?.Position?.Variation?.ToString() ?? "null"} " +
-                             $"target={obj?.Name}({obj?.ID:X8}) v={obj?.Position?.Variation?.ToString() ?? "null"}");
-                }
+            if (!SameVariationForVisibility(PhysicsObj, obj))
                 return false;
-            }
 
             // Check if already known (optimistic read to avoid write lock overhead)
             bool alreadyKnown = false;
@@ -402,12 +412,10 @@ namespace ACE.Server.Physics.Common
                 // and envcells seen from outside (all buildings)
                 var visibleObjs = PhysicsObj.CurLandblock.GetServerObjects(true);
 
-                var results = ApplyFilter(visibleObjs, type).Where(i => i.ID != PhysicsObj.ID && (i.CurCell is not EnvCell indoors || indoors.SeenOutside));
-
-                int targetVar = VariationId ?? PhysicsObj.Position.Variation ?? 0;
-                results = results.Where(i => (i.Position.Variation ?? 0) == targetVar);
-
-                return results.ToList();
+                return ApplyFilter(visibleObjs, type)
+                    .Where(i => i.ID != PhysicsObj.ID && (i.CurCell is not EnvCell indoors || indoors.SeenOutside))
+                    .Where(i => SameVariationForVisibility(PhysicsObj, i, VariationId, null))
+                    .ToList();
             }
             finally
             {
@@ -420,8 +428,6 @@ namespace ACE.Server.Physics.Common
         /// </summary>
         private List<PhysicsObj> GetVisibleObjects(EnvCell cell, VisibleObjectType type, int? VariationId = null)
         {
-            cell.EnsureVisibleCellsBuilt();
-
             var visibleObjs = new List<PhysicsObj>();
 
             // add objects from current cell
@@ -442,10 +448,11 @@ namespace ACE.Server.Physics.Common
                 visibleObjs.AddRange(outsideObjs);
             }
 
-            int targetVar = VariationId ?? PhysicsObj.Position.Variation ?? 0;
-            var results = ApplyFilter(visibleObjs, type).Where(i => i.ID != PhysicsObj.ID && !i.DatObject);
-
-            return results.Where(i => (i.Position.Variation ?? 0) == targetVar).Distinct().ToList();
+            return ApplyFilter(visibleObjs, type)
+                .Where(i => !i.DatObject && i.ID != PhysicsObj.ID)
+                .Where(i => SameVariationForVisibility(PhysicsObj, i, VariationId, null))
+                .Distinct()
+                .ToList();
         }
 
         public enum VisibleObjectType
@@ -493,15 +500,9 @@ namespace ACE.Server.Physics.Common
             rwLock.EnterWriteLock();
             try
             {
-                if (!PrestigeManager.SameVariationForVisibility(PhysicsObj.Position.Variation, obj.Position.Variation))
-                {
-                    if (ServerConfig.prestige_interaction_diag_verbose.Value)
-                    {
-                        log.Warn($"[PrestigeInteraction] ObjMaint.AddVisibleObject blocked: viewer={PhysicsObj?.Name}({PhysicsObj?.ID:X8}) v={PhysicsObj?.Position?.Variation?.ToString() ?? "null"} " +
-                                 $"target={obj?.Name}({obj?.ID:X8}) v={obj?.Position?.Variation?.ToString() ?? "null"}");
-                    }
+                if (!SameVariationForVisibility(PhysicsObj, obj))
                     return false;
-                }
+
                 if (VisibleObjects.ContainsKey(obj.ID))
                     return false;
 
@@ -546,13 +547,7 @@ namespace ACE.Server.Physics.Common
 
                 RemoveObjectsToBeDestroyed(objs);
 
-                var newlyKnown = AddKnownObjects(visibleAdded);
-                if (ServerConfig.prestige_interaction_diag_verbose.Value && PhysicsObj?.IsPlayer == true)
-                {
-                    log.Warn($"[PrestigeInteraction] ObjMaint.AddVisibleObjects: viewer={PhysicsObj.Name}({PhysicsObj.ID:X8}) v={PhysicsObj.Position?.Variation?.ToString() ?? "null"} " +
-                             $"candidates={objs?.Count.ToString() ?? "null"} newlyVisible={visibleAdded.Count} newlyKnown={newlyKnown?.Count.ToString() ?? "null"}");
-                }
-                return newlyKnown;
+                return AddKnownObjects(visibleAdded);
             }
             finally
             {
@@ -868,7 +863,7 @@ namespace ACE.Server.Physics.Common
                 log.Debug($"{PhysicsObj.Name}.ObjectMaint.AddKnownPlayer({obj.Name}): tried to add player for dat object");
                 return false;
             }
-            if (!PrestigeManager.SameVariationForVisibility(obj.Position.Variation, PhysicsObj.Position.Variation))
+            if (!SameVariationForVisibility(PhysicsObj, obj))
             {
                 log.Debug($"{PhysicsObj.Name}.ObjectMaint.AddKnownPlayer({obj.Name}): tried to add player in a different Variation");
                 return false;
@@ -898,12 +893,6 @@ namespace ACE.Server.Physics.Common
                         newObjs.Add(obj);
                 }
 
-                if (ServerConfig.prestige_interaction_diag_verbose.Value && PhysicsObj?.IsPlayer == true)
-                {
-                    var list = objs as ICollection<PhysicsObj>;
-                    log.Warn($"[PrestigeInteraction] ObjMaint.AddKnownPlayers: owner={PhysicsObj.Name}({PhysicsObj.ID:X8}) v={PhysicsObj.Position?.Variation?.ToString() ?? "null"} " +
-                             $"candidates={(list?.Count.ToString() ?? "?" )} added={newObjs.Count} totalKnownPlayers={KnownPlayers.Count}");
-                }
                 return newObjs;
             }
             finally
@@ -1094,21 +1083,11 @@ namespace ACE.Server.Physics.Common
                     (PhysicsObj.WeenieObj.FoeType == null || obj.WeenieObj.WorldObject != null && PhysicsObj.WeenieObj.FoeType != obj.WeenieObj.WorldObject.CreatureType))
                 {
                     obj.ObjMaint.AddVisibleTarget(PhysicsObj);
-                    // Legacy: observer had no Int.73 foe — only the other mob tracked us.
-                    // Custom targeting should only include other monsters in *our* VisibleTargets when the
-                    // config actually targets non-players (not player-only modes such as HostileToAllPlayers).
-                    var selfCreatureInverse = PhysicsObj.WeenieObj.WorldObject as Creature;
-                    if (selfCreatureInverse == null || !selfCreatureInverse.AllowsCustomMonsterTargets)
-                        return false;
+                    return false;
                 }
 
-                // only tracking players and combat pets, unless this creature has legacy foe targeting
-                // or custom targeting that explicitly includes non-player foes.
-                var selfCreature = PhysicsObj.WeenieObj.WorldObject as Creature;
-                var allowMonsterTargets = PhysicsObj.WeenieObj.FoeType != null
-                    || (selfCreature != null && selfCreature.AllowsCustomMonsterTargets);
-
-                if (!obj.IsPlayer && !obj.WeenieObj.IsCombatPet && !allowMonsterTargets)
+                // only tracking players and combat pets
+                if (!obj.IsPlayer && !obj.WeenieObj.IsCombatPet && PhysicsObj.WeenieObj.FoeType == null)
                 {
                     log.Debug($"{PhysicsObj.Name}.ObjectMaint.AddVisibleTarget({obj.Name}): tried to add a non-player / non-combat pet");
                     return false;
@@ -1266,18 +1245,12 @@ namespace ACE.Server.Physics.Common
                 rwLock.ExitWriteLock();
             }
         }
+
         public bool RemoveRetaliateTarget(PhysicsObj obj)
         {
-            rwLock.EnterWriteLock();
-            try
-            {
-                return RetaliateTargets.Remove(obj.ID);
-            }
-            finally
-            {
-                rwLock.ExitWriteLock();
-            }
+            return RetaliateTargets.Remove(obj.ID);
         }
+
         /// <summary>
         /// Clears all of the ObjMaint tables for an object
         /// </summary>

--- a/Source/ACE.Server/Physics/Common/ObjectMaint.cs
+++ b/Source/ACE.Server/Physics/Common/ObjectMaint.cs
@@ -1248,7 +1248,15 @@ namespace ACE.Server.Physics.Common
 
         public bool RemoveRetaliateTarget(PhysicsObj obj)
         {
-            return RetaliateTargets.Remove(obj.ID);
+            rwLock.EnterWriteLock();
+            try
+            {
+                return RetaliateTargets.Remove(obj.ID);
+            }
+            finally
+            {
+                rwLock.ExitWriteLock();
+            }
         }
 
         /// <summary>

--- a/Source/ACE.Server/Physics/PhysicsObj.cs
+++ b/Source/ACE.Server/Physics/PhysicsObj.cs
@@ -1985,10 +1985,18 @@ namespace ACE.Server.Physics
         }
 
         /// <summary>
-        /// This is to mitigate possible decal crashes w/ CO messages being sent
-        /// for objects when the client landblock is very early in the loading state
+        /// Mitigate decal crashes when CreateObject is sent while the client landblock is still loading.
+        /// Landblock indoor-NPC refresh should use the same delay after a player teleport.
         /// </summary>
-        private static TimeSpan TeleportCreateObjectDelay = TimeSpan.FromSeconds(1);
+        internal static TimeSpan TeleportCreateObjectDelay = TimeSpan.FromSeconds(1);
+
+        private static void TrackOrRefreshVisibleWorldObject(Player player, WorldObject wo)
+        {
+            if (wo.TryRefreshIndoorStationarySpawnForViewer(player))
+                return;
+
+            player.TrackObject(wo);
+        }
 
         public void enqueue_objs(IEnumerable<PhysicsObj> newlyVisible)
         {
@@ -2004,8 +2012,8 @@ namespace ACE.Server.Physics
                     foreach (var obj in newlyVisible)
                     {
                         var wo = obj.WeenieObj.WorldObject;
-                        if (wo != null && (wo.Location.Variation ?? 0) == (player.Location.Variation ?? 0))
-                            player.TrackObject(wo, true);
+                        if (wo != null && PrestigeManager.SameVariationForVisibility(wo.Location.Variation, player.Location.Variation))
+                            TrackOrRefreshVisibleWorldObject(player, wo);
                     }
                 });
                 actionChain.EnqueueChain();
@@ -2019,7 +2027,7 @@ namespace ACE.Server.Physics
                     if (wo == null)
                         continue;
 
-                    if ((wo.Location.Variation ?? 0) != (player.Location.Variation ?? 0))
+                    if (!PrestigeManager.SameVariationForVisibility(wo.Location.Variation, player.Location.Variation))
                         continue;
 
                     if (wo.Teleporting)
@@ -2027,11 +2035,11 @@ namespace ACE.Server.Physics
                         // ensure post-teleport position is sent
                         var actionChain = new ActionChain();
                         actionChain.AddDelayForOneTick();
-                        actionChain.AddAction(player, ActionType.PhysicsObj_TrackObject, () => player.TrackObject(wo));
+                        actionChain.AddAction(player, ActionType.PhysicsObj_TrackObject, () => TrackOrRefreshVisibleWorldObject(player, wo));
                         actionChain.EnqueueChain();
                     }
                     else
-                        player.TrackObject(wo);
+                        TrackOrRefreshVisibleWorldObject(player, wo);
                 }
             }
         }
@@ -2045,14 +2053,14 @@ namespace ACE.Server.Physics
             if (wo == null)
                 return;
 
-            if ((wo.Location.Variation ?? 0) != (player.Location.Variation ?? 0))
+            if (!PrestigeManager.SameVariationForVisibility(wo.Location.Variation, player.Location.Variation))
                 return;
 
             if (DateTime.UtcNow - player.LastTeleportTime < TeleportCreateObjectDelay)
             {
                 var actionChain = new ActionChain();
                 actionChain.AddDelaySeconds(TeleportCreateObjectDelay.TotalSeconds);
-                actionChain.AddAction(player, ActionType.PhysicsObj_TrackObject, () => player.TrackObject(wo, true));
+                actionChain.AddAction(player, ActionType.PhysicsObj_TrackObject, () => TrackOrRefreshVisibleWorldObject(player, wo));
                 actionChain.EnqueueChain();
             }
             else
@@ -2062,11 +2070,11 @@ namespace ACE.Server.Physics
                     // ensure post-teleport position is sent
                     var actionChain = new ActionChain();
                     actionChain.AddDelayForOneTick();
-                    actionChain.AddAction(player, ActionType.PhysicsObj_TrackObject, () => player.TrackObject(wo));
+                    actionChain.AddAction(player, ActionType.PhysicsObj_TrackObject, () => TrackOrRefreshVisibleWorldObject(player, wo));
                     actionChain.EnqueueChain();
                 }
                 else
-                    player.TrackObject(wo);
+                    TrackOrRefreshVisibleWorldObject(player, wo);
             }
         }
 
@@ -2137,7 +2145,7 @@ namespace ACE.Server.Physics
             entering_world = true;
 
             store_position(pos);
-            bool slide = ProjectileTarget == null || WeenieObj.WorldObject is SpellProjectile;
+            var slide = ProjectileTarget == null || WeenieObj.WorldObject is SpellProjectile;
             var result = enter_world(slide, pos);
 
             entering_world = false;

--- a/Source/ACE.Server/Physics/PhysicsObj.cs
+++ b/Source/ACE.Server/Physics/PhysicsObj.cs
@@ -2983,6 +2983,7 @@ namespace ACE.Server.Physics
 
             set_cell_id(pos.ObjCellID);
             set_frame(pos.Frame);
+            Position.Variation = pos.Variation;
         }
 
 

--- a/Source/ACE.Server/Physics/PhysicsObj.cs
+++ b/Source/ACE.Server/Physics/PhysicsObj.cs
@@ -707,6 +707,89 @@ namespace ACE.Server.Physics
             return SetPositionError.OK;
         }
 
+        private bool IsIndoorStationarySpawnPosition(Position pos)
+        {
+            if ((pos.ObjCellID & 0xFFFF) < 0x100)
+                return false;
+
+            if (WeenieObj?.WorldObject is not Creature creature)
+                return false;
+
+            if (creature is Player || creature is CombatPet)
+                return false;
+
+            return creature.IsNPC;
+        }
+
+        private bool ShouldForceIndoorSpawnPlacement(ObjCell newCell, Position pos)
+        {
+            if (!entering_world || newCell == null)
+                return false;
+
+            return IsIndoorStationarySpawnPosition(pos);
+        }
+
+        /// <summary>
+        /// Stay in the spawn env cell; step down only within that cell to find the platform floor.
+        /// Prevents unrestricted slide from dropping into a lower overlapping cell (e.g. under buildings).
+        /// </summary>
+        private SetPositionError PlaceIndoorStationarySpawn(ObjCell newCell, Position pos, Transition transition, SetPosition setPos)
+        {
+            transition.InitPath(newCell, null, pos);
+            transition.RestrictPlacementToCheckCell = true;
+            transition.PlacementMinOriginZ = pos.Frame.Origin.Z - 2.0f;
+            transition.SpherePath.PlacementAllowsSliding = false;
+
+            var placed = transition.FindValidPosition();
+            transition.RestrictPlacementToCheckCell = false;
+            transition.PlacementMinOriginZ = null;
+
+            if (!placed || transition.SpherePath.CurCell == null || transition.SpherePath.CurPos.ObjCellID != newCell.ID)
+                return ForceIntoCell(newCell, pos);
+
+            if (entering_world && transition.SpherePath.CurPos.Landblock != pos.Landblock)
+                return SetPositionError.NoValidPosition;
+
+            if (!SetPositionInternal(transition))
+                return SetPositionError.GeneralFailure;
+
+            return SetPositionError.OK;
+        }
+
+        /// <summary>
+        /// Re-snap persisted indoor vendors after relog (landblock keeps NPCs; unrestricted slide may have left bad Z).
+        /// </summary>
+        internal bool TryReconcileIndoorStationarySpawnPlacement(Position nominalPos)
+        {
+            if (entering_world)
+                return false;
+
+            if (!IsIndoorStationarySpawnPosition(nominalPos))
+                return false;
+
+            var newCell = CurCell ?? LScape.get_landcell(nominalPos.ObjCellID, nominalPos.Variation);
+            if (newCell == null)
+                return false;
+
+            var transition = Transition.MakeTransition();
+            if (transition == null)
+                return false;
+
+            transition.InitObject(this, ObjectInfoState.Default);
+
+            if (PartArray != null && PartArray.GetNumSphere() != 0)
+                transition.InitSphere(PartArray.GetNumSphere(), PartArray.GetSphere(), Scale);
+            else
+                transition.InitSphere(1, PhysicsGlobals.DummySphere, 1.0f);
+
+            transition.VariationId = nominalPos.Variation;
+            var setPos = new SetPosition { Pos = nominalPos, Flags = SetPositionFlags.Placement };
+
+            var result = PlaceIndoorStationarySpawn(newCell, nominalPos, transition, setPos) == SetPositionError.OK;
+            transition.CleanupTransition();
+            return result;
+        }
+
         public double GetAutonomyBlipDistance()
         {
             if ((Position.ObjCellID & 0xFFFF) < 0x100) return 100.0f;
@@ -1233,6 +1316,9 @@ namespace ACE.Server.Physics
                 set_active(false);
                 return SetPositionError.OK;
             }
+
+            if (WeenieObj != null && ShouldForceIndoorSpawnPlacement(newCell, pos))
+                return PlaceIndoorStationarySpawn(newCell, pos, transition, setPos);
 
             if (WeenieObj != null && (WeenieObj.IsStorage || WeenieObj.IsCorpse))
                 return ForceIntoCell(newCell, pos);

--- a/Source/ACE.Server/Physics/PhysicsObj.cs
+++ b/Source/ACE.Server/Physics/PhysicsObj.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
@@ -15,7 +14,6 @@ using ACE.Server.Physics.Combat;
 using ACE.Server.Physics.Common;
 using ACE.Server.Physics.Hooks;
 using ACE.Server.Physics.Managers;
-using ACE.Server.Physics.Util;
 using ACE.Server.WorldObjects;
 
 using log4net;
@@ -31,41 +29,6 @@ namespace ACE.Server.Physics
     public class PhysicsObj
     {
         private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
-
-        private static readonly ConcurrentDictionary<long, long> _prestigeVisDiagLastLogMs = new();
-        private static readonly ConcurrentDictionary<string, double> _petPlayerCollisionDebugLastLog = new();
-
-        private const double PetPlayerCollisionDebugThrottleSec = 0.35;
-
-        /// <summary> Trim stale throttle keys so long-running servers do not grow this map without bound. </summary>
-        private static void PrestigeVisDiagMaybePrune(long nowMs)
-        {
-            const int maxEntries = 4096;
-            const long staleMs = 120_000;
-            if (_prestigeVisDiagLastLogMs.Count < maxEntries)
-                return;
-
-            foreach (var kv in _prestigeVisDiagLastLogMs.ToArray())
-            {
-                var age = nowMs - kv.Value;
-                if (age > staleMs || age < -staleMs)
-                    _prestigeVisDiagLastLogMs.TryRemove(kv.Key, out _);
-            }
-        }
-
-        /// <summary> Drop pet/player collision debug throttle entries past the log interval so pair keys do not accumulate forever. </summary>
-        private static void PetPlayerCollisionDebugMaybePrune(double now)
-        {
-            if (_petPlayerCollisionDebugLastLog.Count == 0)
-                return;
-
-            foreach (var kv in _petPlayerCollisionDebugLastLog.ToArray())
-            {
-                var age = now - kv.Value;
-                if (age > PetPlayerCollisionDebugThrottleSec || age < -PetPlayerCollisionDebugThrottleSec)
-                    _petPlayerCollisionDebugLastLog.TryRemove(kv.Key, out _);
-            }
-        }
 
         public uint ID;
         public ObjectGuid ObjID;
@@ -222,95 +185,35 @@ namespace ACE.Server.Physics
             }
         }
 
-        private ObjCell AdjustPosition(Position position, Vector3 low_pt, bool searchCells)
+        private static ObjCell AdjustPosition(Position position, Vector3 low_pt, bool searchCells)
         {
             var cellID = position.ObjCellID & 0xFFFF;
             //Console.WriteLine("AdjustPosition variation: {0:X4}", position.Variation);
             if ((cellID < 1 || cellID > 0x40) && (cellID < 0x100 || cellID > 0xFFFD) && cellID != 0xFFFF)
-            {
-                if (log.IsDebugEnabled)
-                    log.Debug($"[SpawnDiag] AdjustPosition: rejected ObjCellID (local cell {cellID:X4} out of valid ranges). physicsObj={Name} ({ID:X8}) full={position.ObjCellID:X8} v={position.Variation} origin={position.Frame.Origin}");
                 return null;
-            }
 
             if (cellID < 0x100)
             {
-                var originalID = position.ObjCellID;
-                var originalLoc = position.Frame.Origin;
                 LandDefs.AdjustToOutside(position);
-                var cell = ObjCell.GetVisible(position.ObjCellID, position.Variation);
-
-#if DEBUG
-                if (cell == null && (position.ObjCellID & 0xFFFF0000) == 0xDA550000)
-                {
-                    Console.WriteLine($"[DEBUG-PHYS] AdjustPosition ({originalID:X8}) -> ({position.ObjCellID:X8}) - Loc: {originalLoc} -> {position.Frame.Origin} - GetVisible returned NULL (Var: {position.Variation})");
-                }
-#endif
-                if (cell == null && log.IsDebugEnabled)
-                    log.Debug($"[SpawnDiag] AdjustPosition(outdoor): GetVisible null after AdjustToOutside. physicsObj={Name} ({ID:X8}) was={originalID:X8} now={position.ObjCellID:X8} v={position.Variation} loc {originalLoc} -> {position.Frame.Origin}");
-                return cell;
+                return ObjCell.GetVisible(position.ObjCellID, position.Variation);
             }
 
             var visibleCell = (EnvCell)ObjCell.GetVisible(position.ObjCellID, position.Variation);
-            if (visibleCell == null)
-            {
-                if (IndoorPlacementDiagLogging.Enabled && IndoorPlacementDiagLogging.IsColo(position.ObjCellID))
-                    log.Info($"[IndoorPlaceDiag] AdjustPosition(indoor) GetVisible null physicsObj={Name} ({ID:X8}) cell={position.ObjCellID:X8} v={position.Variation} origin={position.Frame.Origin}");
-                if (log.IsDebugEnabled)
-                    log.Debug($"[SpawnDiag] AdjustPosition(indoor): GetVisible null — no landcell for this cell id + variation (check dat/instance variation). physicsObj={Name} ({ID:X8}) cell={position.ObjCellID:X8} v={position.Variation} origin={position.Frame.Origin}");
-                return null;
-            }
+            if (visibleCell == null) return null;
 
             var point = position.LocalToGlobal(low_pt);
-            if (IndoorPlacementDiagLogging.Enabled && IndoorPlacementDiagLogging.IsColo(position.ObjCellID))
-                log.Info($"[IndoorPlaceDiag] AdjustPosition(indoor) probe physicsObj={Name} ({ID:X8}) wcid={WeenieObj?.WorldObject?.WeenieClassId} nominalCell={position.ObjCellID:X8} posV={position.Variation} lbV={visibleCell.CurLandblock?.VariationId} rootEnv={visibleCell.ID:X8} SeenOutside={visibleCell.SeenOutside} frameOrigin={position.Frame.Origin} sampleWorldPoint={point} sphereLocal={low_pt} searchCells={searchCells}");
             var child = visibleCell.find_visible_child_cell(point, searchCells);
             if (child != null)
             {
-                if (IndoorPlacementDiagLogging.Enabled && IndoorPlacementDiagLogging.IsColo(position.ObjCellID))
-                    log.Info($"[IndoorPlaceDiag] AdjustPosition(indoor) find_visible_child_cell hit -> child={child.ID:X8} physicsObj={Name}");
                 position.ObjCellID = child.ID;
                 return child;
             }
 
             if (!visibleCell.SeenOutside)
-            {
-                // VisibleCells from the nominal ObjCellID may not list every stub that contains this
-                // world point (e.g. long colosseum-style shells). LandblockInfo enumeration + point_in_cell
-                // matches placement to the correct env cell when the visibility graph alone is incomplete.
-                var dungeonId = position.ObjCellID >> 16;
-                var v = position.Variation ?? visibleCell.CurLandblock?.VariationId;
-                var resolvedId = AdjustCell.Get(dungeonId, v)?.GetCell(point);
-                if (resolvedId != null)
-                {
-                    var env = (EnvCell)LScape.get_landcell(resolvedId.Value, v);
-                    if (env != null)
-                    {
-                        if (IndoorPlacementDiagLogging.Enabled && IndoorPlacementDiagLogging.IsColo(position.ObjCellID))
-                            log.Info($"[IndoorPlaceDiag] AdjustPosition(indoor) AdjustCell fallback resolved nominal={position.ObjCellID:X8} -> {env.ID:X8} probeV={v?.ToString() ?? "null"} physicsObj={Name}");
-                        position.ObjCellID = env.ID;
-                        return env;
-                    }
-                }
-
-                if (IndoorPlacementDiagLogging.Enabled && IndoorPlacementDiagLogging.IsColo(position.ObjCellID))
-                {
-                    var lbV = visibleCell.CurLandblock?.VariationId;
-                    log.Info($"[IndoorPlaceDiag] AdjustPosition(indoor) FAILED after fallback physicsObj={Name} ({ID:X8}) rootEnv={visibleCell.ID:X8} posV={position.Variation} physLandblockVar={lbV} frameOrigin={position.Frame.Origin} sampleWorldPoint={point} AdjustCellGetCell={resolvedId?.ToString("X8") ?? "null"}");
-                }
-                if (log.IsDebugEnabled)
-                {
-                    var lbV = visibleCell.CurLandblock?.VariationId;
-                    log.Debug($"[SpawnDiag] AdjustPosition(indoor): find_visible_child_cell returned null and SeenOutside=false — origin is outside any child BSP for this env shell (wrong coords vs variation, wrong env/cellStruct for dat, or bad CellBSP). physicsObj={Name} ({ID:X8}) rootEnv={visibleCell.ID:X8} posV={position.Variation} physLandblockVar={lbV} frameOrigin={position.Frame.Origin} sampleWorldPoint={point} localSphereOffset={low_pt}");
-                }
                 return null;
-            }
 
             position.adjust_to_outside();
-            var afterOutside = ObjCell.GetVisible(position.ObjCellID, position.Variation);
-            if (afterOutside == null && log.IsDebugEnabled)
-                log.Debug($"[SpawnDiag] AdjustPosition(indoor): after adjust_to_outside, GetVisible null. physicsObj={Name} ({ID:X8}) cell={position.ObjCellID:X8} v={position.Variation} origin={position.Frame.Origin}");
-            return afterOutside;
+            return ObjCell.GetVisible(position.ObjCellID, position.Variation);
         }
 
         public bool CacheHasPhysicsBSP()
@@ -436,13 +339,6 @@ namespace ACE.Server.Physics
                             var intersects = cylSpheres[i].IntersectsSphere(Position, Scale, transition);
                             if (intersects != TransitionState.OK)
                             {
-                                if (ServerConfig.pet_player_collision_debug_console.Value
-                                    && LooksLikePetPlayerCollision(this, transition.ObjectInfo.Object)
-                                    && !IsPetVsPlayerCollision(this, transition.ObjectInfo.Object))
-                                {
-                                    TracePetPlayerCollision("FindObjCollisions.cylHit.pairFailed", this, transition.ObjectInfo.Object, transition, intersects, ethereal, isCreature, suppressed: false);
-                                }
-
                                 return FindObjCollisions_Inner(transition, intersects, ethereal, isCreature);
                             }
                         }
@@ -460,124 +356,8 @@ namespace ACE.Server.Physics
             return TransitionState.OK;
         }
 
-        /// <summary>
-        /// True when one collision participant is a summon <see cref="Pet"/> (passive or <see cref="CombatPet"/>)
-        /// and the other is any <see cref="Player"/>. Used with replicated <see cref="PhysicsState.Ethereal"/> on pets for client walk-through.
-        /// </summary>
-        private static bool IsPetVsPlayerCollision(PhysicsObj self, PhysicsObj? other)
-        {
-            if (self?.WeenieObj?.WorldObject == null || other?.WeenieObj?.WorldObject == null)
-                return false;
-            var a = self.WeenieObj.WorldObject;
-            var b = other.WeenieObj.WorldObject;
-            if (a is Pet && b is Player)
-                return true;
-            if (b is Pet && a is Player)
-                return true;
-            return false;
-        }
-
-        /// <summary>
-        /// Pets use <see cref="PhysicsState.Ethereal"/> for client player walk-through. On the server, still block pet movement
-        /// vs doors, monsters, and other non-player objects (not <see cref="IgnoreCollisions"/> — that would skip env/object checks entirely).
-        /// </summary>
-        private static bool IsPetMustBlockNonPlayerCollision(PhysicsObj obstacle, PhysicsObj mover)
-        {
-            var involvesPet = obstacle.WeenieObj?.WorldObject is Pet || mover.WeenieObj?.WorldObject is Pet;
-            if (!involvesPet)
-                return false;
-
-            if (IsPetVsPlayerCollision(obstacle, mover))
-                return false;
-
-            return true;
-        }
-
-        private static bool TryGetPetPlayerPair(PhysicsObj? a, PhysicsObj? b, out Pet? pet, out Player? player)
-        {
-            pet = null;
-            player = null;
-            if (a?.WeenieObj?.WorldObject == null || b?.WeenieObj?.WorldObject == null)
-                return false;
-
-            var wa = a.WeenieObj.WorldObject;
-            var wb = b.WeenieObj.WorldObject;
-            if (wa is Pet p && wb is Player pl)
-            {
-                pet = p;
-                player = pl;
-                return true;
-            }
-            if (wb is Pet p2 && wa is Player pl2)
-            {
-                pet = p2;
-                player = pl2;
-                return true;
-            }
-            return false;
-        }
-
-        private static bool LooksLikePetPlayerCollision(PhysicsObj? a, PhysicsObj? b)
-        {
-            if (a?.WeenieObj == null || b?.WeenieObj == null)
-                return false;
-            var petSide = (a.WeenieObj.IsCreature && !a.WeenieObj.IsPlayer && a.WeenieObj.WorldObject is Pet)
-                || (b.WeenieObj.IsCreature && !b.WeenieObj.IsPlayer && b.WeenieObj.WorldObject is Pet);
-            var playerSide = a.WeenieObj.IsPlayer || b.WeenieObj.IsPlayer;
-            return petSide && playerSide;
-        }
-
-        private static string FormatPhysicsCollisionFlags(PhysicsObj obj)
-        {
-            if (obj == null)
-                return "null";
-            var s = obj.State;
-            return $"Ethereal={s.HasFlag(PhysicsState.Ethereal)} IgnoreColl={s.HasFlag(PhysicsState.IgnoreCollisions)} Static={s.HasFlag(PhysicsState.Static)} ReportColl={s.HasFlag(PhysicsState.ReportCollisions)}";
-        }
-
-        private static void TracePetPlayerCollision(string stage, PhysicsObj obstacle, PhysicsObj mover, Transition? transition, TransitionState result, bool ethereal, bool isCreature, bool suppressed)
-        {
-            if (!ServerConfig.pet_player_collision_debug_console.Value)
-                return;
-
-            if (!LooksLikePetPlayerCollision(obstacle, mover) && !IsPetVsPlayerCollision(obstacle, mover))
-                return;
-
-            var now = PhysicsTimer.CurrentTime;
-            PetPlayerCollisionDebugMaybePrune(now);
-            var key = $"{Math.Min(obstacle.ID, mover.ID):X8}:{Math.Max(obstacle.ID, mover.ID):X8}";
-            if (_petPlayerCollisionDebugLastLog.TryGetValue(key, out var last) && now - last < PetPlayerCollisionDebugThrottleSec)
-                return;
-            _petPlayerCollisionDebugLastLog[key] = now;
-
-            TryGetPetPlayerPair(obstacle, mover, out var pet, out var player);
-            var petWo = pet ?? obstacle.WeenieObj?.WorldObject as Pet ?? mover.WeenieObj?.WorldObject as Pet;
-            var playerWo = player ?? obstacle.WeenieObj?.WorldObject as Player ?? mover.WeenieObj?.WorldObject as Player;
-            var petName = petWo?.Name ?? "?";
-            var playerName = playerWo?.Name ?? "?";
-            var pairOk = IsPetVsPlayerCollision(obstacle, mover);
-            var woNull = obstacle.WeenieObj?.WorldObject == null || mover.WeenieObj?.WorldObject == null;
-            var pathDetail = transition?.SpherePath != null
-                ? $"path StepDown={transition.SpherePath.StepDown} Collide={transition.SpherePath.Collide} CheckWalkable={transition.SpherePath.CheckWalkable} ObstructionEthereal={transition.SpherePath.ObstructionEthereal}"
-                : "path n/a";
-
-            Console.WriteLine(
-                $"[PetPlayerColl] {stage} {(suppressed ? "SUPPRESSED" : "HARD")} result={result} pairOk={pairOk} woNull={woNull} " +
-                $"pet={petName} player={playerName} obs={obstacle.ID:X8} mover={mover.ID:X8} {pathDetail} " +
-                $"inner ethereal={ethereal} isCreature={isCreature} | obs({FormatPhysicsCollisionFlags(obstacle)}) mover({FormatPhysicsCollisionFlags(mover)}) " +
-                $"propEthereal pet={petWo?.Ethereal} player={playerWo?.Ethereal} | client blocks on PhysicsState.Ethereal from CreateObject, not server IsPetVsPlayer");
-        }
-
         public TransitionState FindObjCollisions_Inner(Transition transition, TransitionState result, bool ethereal, bool isCreature)
         {
-            var mover = transition.ObjectInfo.Object;
-            var looksPetPlayer = LooksLikePetPlayerCollision(this, mover) || IsPetVsPlayerCollision(this, mover);
-            var petMustBlock = IsPetMustBlockNonPlayerCollision(this, mover);
-            var allowPassThrough = !petMustBlock
-                && (ethereal
-                    || IsPetVsPlayerCollision(this, transition.ObjectInfo.Object)
-                    || isCreature && transition.ObjectInfo.State.HasFlag(ObjectInfoState.IgnoreCreatures));
-
             if (!transition.SpherePath.StepDown)
             {
                 if (State.HasFlag(PhysicsState.Static))
@@ -585,40 +365,15 @@ namespace ACE.Server.Physics
                     if (!transition.ObjectInfo.State.HasFlag(ObjectInfoState.Contact))
                         transition.CollisionInfo.CollidedWithEnvironment = true;
                 }
-                else if (allowPassThrough)
+                else if (ethereal || isCreature && transition.ObjectInfo.State.HasFlag(ObjectInfoState.IgnoreCreatures))
                 {
-                    if (looksPetPlayer)
-                        TracePetPlayerCollision("FindObjCollisions_Inner", this, mover, transition, result, ethereal, isCreature, suppressed: true);
-
                     result = TransitionState.OK;
                     transition.CollisionInfo.CollisionNormalValid = false;
                     transition.CollisionInfo.AddObject(this, TransitionState.OK);
                 }
                 else
-                {
-                    if (looksPetPlayer || (petMustBlock && ServerConfig.pet_player_collision_debug_console.Value))
-                        TracePetPlayerCollision(petMustBlock ? "FindObjCollisions_Inner.petMustBlock" : "FindObjCollisions_Inner", this, mover, transition, result, ethereal, isCreature, suppressed: false);
-
                     transition.CollisionInfo.AddObject(this, result);
-                }
             }
-            else if (allowPassThrough)
-            {
-                if (looksPetPlayer)
-                    TracePetPlayerCollision("FindObjCollisions_Inner.StepDown", this, mover, transition, result, ethereal, isCreature, suppressed: true);
-
-                result = TransitionState.OK;
-                transition.CollisionInfo.CollisionNormalValid = false;
-                transition.CollisionInfo.AddObject(this, TransitionState.OK);
-            }
-            else
-            {
-                if (looksPetPlayer || (petMustBlock && ServerConfig.pet_player_collision_debug_console.Value))
-                    TracePetPlayerCollision(petMustBlock ? "FindObjCollisions_Inner.StepDown.petMustBlock" : "FindObjCollisions_Inner.StepDown", this, mover, transition, result, ethereal, isCreature, suppressed: false);
-
-                transition.CollisionInfo.AddObject(this, result);
-            }
-
             transition.SpherePath.ObstructionEthereal = false;
             return result;
         }
@@ -705,89 +460,6 @@ namespace ACE.Server.Physics
                 calc_cross_cells(pos.Variation);
             }
             return SetPositionError.OK;
-        }
-
-        private bool IsIndoorStationarySpawnPosition(Position pos)
-        {
-            if ((pos.ObjCellID & 0xFFFF) < 0x100)
-                return false;
-
-            if (WeenieObj?.WorldObject is not Creature creature)
-                return false;
-
-            if (creature is Player || creature is CombatPet)
-                return false;
-
-            return creature.IsNPC;
-        }
-
-        private bool ShouldForceIndoorSpawnPlacement(ObjCell newCell, Position pos)
-        {
-            if (!entering_world || newCell == null)
-                return false;
-
-            return IsIndoorStationarySpawnPosition(pos);
-        }
-
-        /// <summary>
-        /// Stay in the spawn env cell; step down only within that cell to find the platform floor.
-        /// Prevents unrestricted slide from dropping into a lower overlapping cell (e.g. under buildings).
-        /// </summary>
-        private SetPositionError PlaceIndoorStationarySpawn(ObjCell newCell, Position pos, Transition transition, SetPosition setPos)
-        {
-            transition.InitPath(newCell, null, pos);
-            transition.RestrictPlacementToCheckCell = true;
-            transition.PlacementMinOriginZ = pos.Frame.Origin.Z - 2.0f;
-            transition.SpherePath.PlacementAllowsSliding = false;
-
-            var placed = transition.FindValidPosition();
-            transition.RestrictPlacementToCheckCell = false;
-            transition.PlacementMinOriginZ = null;
-
-            if (!placed || transition.SpherePath.CurCell == null || transition.SpherePath.CurPos.ObjCellID != newCell.ID)
-                return ForceIntoCell(newCell, pos);
-
-            if (entering_world && transition.SpherePath.CurPos.Landblock != pos.Landblock)
-                return SetPositionError.NoValidPosition;
-
-            if (!SetPositionInternal(transition))
-                return SetPositionError.GeneralFailure;
-
-            return SetPositionError.OK;
-        }
-
-        /// <summary>
-        /// Re-snap persisted indoor vendors after relog (landblock keeps NPCs; unrestricted slide may have left bad Z).
-        /// </summary>
-        internal bool TryReconcileIndoorStationarySpawnPlacement(Position nominalPos)
-        {
-            if (entering_world)
-                return false;
-
-            if (!IsIndoorStationarySpawnPosition(nominalPos))
-                return false;
-
-            var newCell = CurCell ?? LScape.get_landcell(nominalPos.ObjCellID, nominalPos.Variation);
-            if (newCell == null)
-                return false;
-
-            var transition = Transition.MakeTransition();
-            if (transition == null)
-                return false;
-
-            transition.InitObject(this, ObjectInfoState.Default);
-
-            if (PartArray != null && PartArray.GetNumSphere() != 0)
-                transition.InitSphere(PartArray.GetNumSphere(), PartArray.GetSphere(), Scale);
-            else
-                transition.InitSphere(1, PhysicsGlobals.DummySphere, 1.0f);
-
-            transition.VariationId = nominalPos.Variation;
-            var setPos = new SetPosition { Pos = nominalPos, Flags = SetPositionFlags.Placement };
-
-            var result = PlaceIndoorStationarySpawn(newCell, nominalPos, transition, setPos) == SetPositionError.OK;
-            transition.CleanupTransition();
-            return result;
         }
 
         public double GetAutonomyBlipDistance()
@@ -1296,29 +968,16 @@ namespace ACE.Server.Physics
         {
             if (CurCell == null) prepare_to_enter_world();
 
-#if DEBUG
-            if ((pos.ObjCellID & 0xFFFF0000) == 0xDA550000)
-                Console.WriteLine($"[DEBUG-PHYS] SetPositionInternal ENTRY: pos.ObjCellID={pos.ObjCellID:X8} before AdjustPosition");
-#endif
-
             var newCell = AdjustPosition(pos, transition.SpherePath.LocalSphere[0].Center, true);
 
             if (newCell == null)
             {
-                if (log.IsDebugEnabled)
-                {
-                    var wcid = WeenieObj?.WorldObject?.WeenieClassId;
-                    log.Debug($"[SpawnDiag] SetPositionInternal: AdjustPosition returned null (physics still returns OK; CurCell stays null). physicsObj={Name} ({ID:X8}) wcid={wcid} posCell={pos.ObjCellID:X8} posVar={pos.Variation} transitionVar={transition.VariationId} origin={pos.Frame.Origin} enteringWorld={entering_world}");
-                }
                 prepare_to_leave_visibility();
                 store_position(pos);
                 //ObjMaint.GotoLostCell(this, Position.ObjCellID);
                 set_active(false);
                 return SetPositionError.OK;
             }
-
-            if (WeenieObj != null && ShouldForceIndoorSpawnPlacement(newCell, pos))
-                return PlaceIndoorStationarySpawn(newCell, pos, transition, setPos);
 
             if (WeenieObj != null && (WeenieObj.IsStorage || WeenieObj.IsCorpse))
                 return ForceIntoCell(newCell, pos);
@@ -1327,23 +986,10 @@ namespace ACE.Server.Physics
             //transition.CellArray.DoNotLoadCells = true;
 
             if (!CheckPositionInternal(newCell, pos, transition, setPos))
-            {
-                 bool success = handle_all_collisions(transition.CollisionInfo, false, false);
-#if DEBUG
-                 if ((pos.ObjCellID & 0xFFFF0000) == 0xDA550000)
-                     Console.WriteLine($"[DEBUG-PHYS] SetPositionInternal DA55: CheckPositionInternal FAILED. HandleAllCollisions={success}. Transition.CollisionInfo: {transition.CollisionInfo.CollideObject.Count} objs.");
-#endif
-                 return success ? SetPositionError.Collided : SetPositionError.NoValidPosition;
-            }
+                return handle_all_collisions(transition.CollisionInfo, false, false) ?
+                    SetPositionError.Collided : SetPositionError.NoValidPosition;
 
-            if (transition.SpherePath.CurCell == null) 
-            {
-#if DEBUG
-                if ((pos.ObjCellID & 0xFFFF0000) == 0xDA550000)
-                    Console.WriteLine($"[DEBUG-PHYS] SetPositionInternal DA55: Transition.SpherePath.CurCell is NULL after CheckPositionInternal! NewCell was: {newCell?.ID:X8}");
-#endif
-                return SetPositionError.NoCell;
-            }
+            if (transition.SpherePath.CurCell == null) return SetPositionError.NoCell;
 
             // custom:
             // test for non-ethereal spell projectile collision on world entry
@@ -1693,6 +1339,8 @@ namespace ACE.Server.Physics
                     {
                         if (IsPlayer)
                             log.Debug($"{Name} ({ID:X8}).UpdateObjectInternal({quantum}) - failed transition from {Position} to {newPos}");
+                        else if (transit != null && transit.SpherePath.CurCell == null)
+                            log.Warn($"{Name} ({ID:X8}).UpdateObjectInternal({quantum}) - avoided CurCell=null from {Position} to {newPos}");
 
                         newPos.Frame.Origin = Position.Frame.Origin;
                         set_initial_frame(newPos.Frame);
@@ -2071,23 +1719,17 @@ namespace ACE.Server.Physics
         }
 
         /// <summary>
-        /// Mitigate decal crashes when CreateObject is sent while the client landblock is still loading.
-        /// Landblock indoor-NPC refresh should use the same delay after a player teleport.
+        /// This is to mitigate possible decal crashes w/ CO messages being sent
+        /// for objects when the client landblock is very early in the loading state
         /// </summary>
-        internal static TimeSpan TeleportCreateObjectDelay = TimeSpan.FromSeconds(1);
-
-        private static void TrackOrRefreshVisibleWorldObject(Player player, WorldObject wo)
-        {
-            if (wo.TryRefreshIndoorStationarySpawnForViewer(player))
-                return;
-
-            player.TrackObject(wo);
-        }
+        private static TimeSpan TeleportCreateObjectDelay = TimeSpan.FromSeconds(1);
 
         public void enqueue_objs(IEnumerable<PhysicsObj> newlyVisible)
         {
             if (!IsPlayer || WeenieObj.WorldObject is not Player player)
                 return;
+
+            var playerVar = PrestigeManager.GetEffectiveVariationForVisibility(player);
 
             if (DateTime.UtcNow - player.LastTeleportTime < TeleportCreateObjectDelay)
             {
@@ -2098,8 +1740,13 @@ namespace ACE.Server.Physics
                     foreach (var obj in newlyVisible)
                     {
                         var wo = obj.WeenieObj.WorldObject;
-                        if (wo != null && PrestigeManager.SameVariationForVisibility(wo.Location.Variation, player.Location.Variation))
-                            TrackOrRefreshVisibleWorldObject(player, wo);
+                        if (wo == null)
+                            continue;
+
+                        if (!PrestigeManager.SameVariationForVisibility(playerVar, PrestigeManager.GetEffectiveVariationForVisibility(wo)))
+                            continue;
+
+                        player.TrackObject(wo, true);
                     }
                 });
                 actionChain.EnqueueChain();
@@ -2113,7 +1760,7 @@ namespace ACE.Server.Physics
                     if (wo == null)
                         continue;
 
-                    if (!PrestigeManager.SameVariationForVisibility(wo.Location.Variation, player.Location.Variation))
+                    if (!PrestigeManager.SameVariationForVisibility(playerVar, PrestigeManager.GetEffectiveVariationForVisibility(wo)))
                         continue;
 
                     if (wo.Teleporting)
@@ -2121,11 +1768,11 @@ namespace ACE.Server.Physics
                         // ensure post-teleport position is sent
                         var actionChain = new ActionChain();
                         actionChain.AddDelayForOneTick();
-                        actionChain.AddAction(player, ActionType.PhysicsObj_TrackObject, () => TrackOrRefreshVisibleWorldObject(player, wo));
+                        actionChain.AddAction(player, ActionType.PhysicsObj_TrackObject, () => player.TrackObject(wo));
                         actionChain.EnqueueChain();
                     }
                     else
-                        TrackOrRefreshVisibleWorldObject(player, wo);
+                        player.TrackObject(wo);
                 }
             }
         }
@@ -2139,14 +1786,16 @@ namespace ACE.Server.Physics
             if (wo == null)
                 return;
 
-            if (!PrestigeManager.SameVariationForVisibility(wo.Location.Variation, player.Location.Variation))
+            if (!PrestigeManager.SameVariationForVisibility(
+                    PrestigeManager.GetEffectiveVariationForVisibility(player),
+                    PrestigeManager.GetEffectiveVariationForVisibility(wo)))
                 return;
 
             if (DateTime.UtcNow - player.LastTeleportTime < TeleportCreateObjectDelay)
             {
                 var actionChain = new ActionChain();
                 actionChain.AddDelaySeconds(TeleportCreateObjectDelay.TotalSeconds);
-                actionChain.AddAction(player, ActionType.PhysicsObj_TrackObject, () => TrackOrRefreshVisibleWorldObject(player, wo));
+                actionChain.AddAction(player, ActionType.PhysicsObj_TrackObject, () => player.TrackObject(wo, true));
                 actionChain.EnqueueChain();
             }
             else
@@ -2156,30 +1805,23 @@ namespace ACE.Server.Physics
                     // ensure post-teleport position is sent
                     var actionChain = new ActionChain();
                     actionChain.AddDelayForOneTick();
-                    actionChain.AddAction(player, ActionType.PhysicsObj_TrackObject, () => TrackOrRefreshVisibleWorldObject(player, wo));
+                    actionChain.AddAction(player, ActionType.PhysicsObj_TrackObject, () => player.TrackObject(wo));
                     actionChain.EnqueueChain();
                 }
                 else
-                    TrackOrRefreshVisibleWorldObject(player, wo);
+                    player.TrackObject(wo);
             }
         }
 
         public void enter_cell(ObjCell newCell)
         {
-            if (PartArray == null)
-            {
-                if (WeenieObj?.WorldObject?.WeenieClassId == 720 || WeenieObj?.WorldObject?.WeenieClassId == 835) // Door or Vendor
-                    Console.WriteLine($"[DEBUG-PHYS] enter_cell failed: PartArray is null for {Name} ({ID:X8})");
-                return;
-            }
+            if (PartArray == null) return;
             newCell.AddObject(this);
             foreach (var child in Children.Objects)
                 child.enter_cell(newCell);
 
             CurCell = newCell;
             Position.ObjCellID = newCell.ID;        // warning: Position will be in an inconsistent state here, until set_frame() is run!
-            // Note: Do NOT sync Position.Variation here - variation should be preserved during movement
-            // and only set during world entry via SyncLocation()
             if (PartArray != null && !State.HasFlag(PhysicsState.ParticleEmitter))
                 PartArray.SetCellID(newCell.ID);
 
@@ -2197,7 +1839,6 @@ namespace ACE.Server.Physics
 
             enter_cell(newCell);
             RequestPos.ObjCellID = newCell.ID;      // document this control flow better
-            // Note: Do NOT sync RequestPos.Variation here - variation should be preserved during movement
 
             // sync location for initial CO
             if (entering_world)
@@ -2231,7 +1872,7 @@ namespace ACE.Server.Physics
             entering_world = true;
 
             store_position(pos);
-            var slide = ProjectileTarget == null || WeenieObj.WorldObject is SpellProjectile;
+            bool slide = ProjectileTarget == null || WeenieObj.WorldObject is SpellProjectile;
             var result = enter_world(slide, pos);
 
             entering_world = false;
@@ -2594,50 +2235,12 @@ namespace ACE.Server.Physics
             }
 
             var isVisible = CurCell.IsVisible(obj.CurCell);
-            if (isVisible && !PrestigeManager.SameVariationForVisibility(obj.Position.Variation, this.Position.Variation))
+            if (isVisible)
             {
-                if (ServerConfig.prestige_interaction_diag_verbose.Value && this.IsPlayer && obj.IsPlayer)
-                {
-                    var key = ((long)ID << 32) | obj.ID;
-                    var nowMs = System.Environment.TickCount64;
-                    var lastMs = _prestigeVisDiagLastLogMs.GetOrAdd(key, 0);
-                    if (nowMs - lastMs >= 5000)
-                    {
-                        _prestigeVisDiagLastLogMs[key] = nowMs;
-                        PrestigeVisDiagMaybePrune(nowMs);
-                        log.Warn($"[PrestigeInteraction] PhysicsObj.handle_visible_obj variation blocked: viewer={Name}({ID:X8}) v={Position?.Variation?.ToString() ?? "null"} " +
-                                 $"target={obj.Name}({obj.ID:X8}) v={obj.Position?.Variation?.ToString() ?? "null"}");
-                    }
-                }
-                isVisible = false;
-            }
-            else if (!isVisible && ServerConfig.prestige_interaction_diag_verbose.Value && this.IsPlayer && obj.IsPlayer)
-            {
-                // If players are close and in the same visibility domain, but IsVisible is false, this strongly suggests a
-                // visible-cell graph / EnvCell load issue rather than prestige variation logic.
-                var sameVisDomain = PrestigeManager.SameVariationForVisibility(obj.Position.Variation, this.Position.Variation);
-                if (sameVisDomain)
-                {
-                    var dx = (double)(Position.Frame.Origin.X - obj.Position.Frame.Origin.X);
-                    var dy = (double)(Position.Frame.Origin.Y - obj.Position.Frame.Origin.Y);
-                    var distSq = dx * dx + dy * dy;
-
-                    // Only log when "nearby" to avoid spam during normal occlusion at distance.
-                    if (distSq <= 50.0 * 50.0)
-                    {
-                        // Throttle per viewer-target pair.
-                        var key = ((long)ID << 32) | obj.ID;
-                        var nowMs = System.Environment.TickCount64;
-                        var lastMs = _prestigeVisDiagLastLogMs.GetOrAdd(key, 0);
-                        if (nowMs - lastMs >= 5000)
-                        {
-                            _prestigeVisDiagLastLogMs[key] = nowMs;
-                            PrestigeVisDiagMaybePrune(nowMs);
-                            log.Warn($"[PrestigeInteraction] PhysicsObj.handle_visible_obj IsVisible=false (nearby): viewer={Name}({ID:X8}) cell={CurCell?.ID:X8} v={Position?.Variation?.ToString() ?? "null"} " +
-                                     $"target={obj.Name}({obj.ID:X8}) cell={obj.CurCell?.ID:X8} v={obj.Position?.Variation?.ToString() ?? "null"} dist2d={Math.Sqrt(distSq):0.00}");
-                        }
-                    }
-                }
+                var myVar = PrestigeManager.GetEffectiveVariationForVisibility(WeenieObj?.WorldObject);
+                var objVar = PrestigeManager.GetEffectiveVariationForVisibility(obj.WeenieObj?.WorldObject);
+                if (!PrestigeManager.SameVariationForVisibility(myVar, objVar))
+                    isVisible = false;
             }
 
             if (isVisible)
@@ -2997,13 +2600,6 @@ namespace ACE.Server.Physics
 
         public bool report_object_collision(PhysicsObj obj, bool prev_has_contact)
         {
-            if (ServerConfig.pet_player_collision_debug_console.Value
-                && (IsPetVsPlayerCollision(this, obj) || LooksLikePetPlayerCollision(this, obj)))
-            {
-                TracePetPlayerCollision("report_object_collision.enter", this, obj, null, TransitionState.OK, false, false,
-                    suppressed: false);
-            }
-
             if (obj.State.HasFlag(PhysicsState.ReportCollisionsAsEnvironment))
                 return report_environment_collision(prev_has_contact);
 
@@ -3387,9 +2983,6 @@ namespace ACE.Server.Physics
 
             set_cell_id(pos.ObjCellID);
             set_frame(pos.Frame);
-            
-            // Sync variation to ensure visibility filtering works correctly
-            Position.Variation = pos.Variation;
         }
 
 

--- a/Source/ACE.Server/Physics/Transition.cs
+++ b/Source/ACE.Server/Physics/Transition.cs
@@ -28,6 +28,13 @@ namespace ACE.Server.Physics.Animation
         public CollisionInfo CollisionInfo;
         public CellArray CellArray;
         public int? VariationId;
+        /// <summary>
+        /// When set, placement/step-down only resolves against <see cref="SpherePath.CheckCell"/>,
+        /// avoiding transitions into lower overlapping env cells (dungeon vendor spawns).
+        /// </summary>
+        public bool RestrictPlacementToCheckCell;
+        /// <summary>When <see cref="RestrictPlacementToCheckCell"/> is set, step-down will not lower origin below this Z.</summary>
+        public float? PlacementMinOriginZ;
         //public ObjCell NewCellPtr;
 
         // Reusable objects to reduce allocations
@@ -161,6 +168,9 @@ namespace ACE.Server.Physics.Animation
 
         public TransitionState CheckOtherCells(ObjCell currCell)
         {
+            if (RestrictPlacementToCheckCell)
+                return TransitionState.OK;
+
             var result = TransitionState.OK;
 
             //SpherePath.CellArrayValid = true;
@@ -755,6 +765,9 @@ namespace ACE.Server.Physics.Animation
 
             var transitionState = TransitionalInsert(3); //was 5
             SpherePath.StepDown = false;
+
+            if (RestrictPlacementToCheckCell && PlacementMinOriginZ.HasValue && SpherePath.CheckPos.Frame.Origin.Z < PlacementMinOriginZ.Value)
+                return false;
 
             if (transitionState == TransitionState.OK && CollisionInfo.ContactPlaneValid && CollisionInfo.ContactPlane.Normal.Z >= zVal &&
                 ((ObjectInfo.State & ObjectInfoState.EdgeSlide) == 0 || SpherePath.StepUp || CheckWalkable(zVal)))

--- a/Source/ACE.Server/Physics/Transition.cs
+++ b/Source/ACE.Server/Physics/Transition.cs
@@ -28,13 +28,6 @@ namespace ACE.Server.Physics.Animation
         public CollisionInfo CollisionInfo;
         public CellArray CellArray;
         public int? VariationId;
-        /// <summary>
-        /// When set, placement/step-down only resolves against <see cref="SpherePath.CheckCell"/>,
-        /// avoiding transitions into lower overlapping env cells (dungeon vendor spawns).
-        /// </summary>
-        public bool RestrictPlacementToCheckCell;
-        /// <summary>When <see cref="RestrictPlacementToCheckCell"/> is set, step-down will not lower origin below this Z.</summary>
-        public float? PlacementMinOriginZ;
         //public ObjCell NewCellPtr;
 
         // Reusable objects to reduce allocations
@@ -160,17 +153,11 @@ namespace ACE.Server.Physics.Animation
             SpherePath.InsertType = InsertType.Placement;
             SpherePath.SetCheckPos(SpherePath.CurPos, SpherePath.CurCell);
 
-            var result = obj.FindObjCollisions(this) != TransitionState.OK;
-            if (result && (SpherePath.CheckPos.ObjCellID & 0xFFFF0000) == 0xDA550000)
-                 Console.WriteLine($"[DEBUG-PHYS] CheckCollisions FAILED for DA55 obj. Collided with: {obj.Name} ({obj.ID:X8})");
-            return result;
+            return obj.FindObjCollisions(this) != TransitionState.OK;
         }
 
         public TransitionState CheckOtherCells(ObjCell currCell)
         {
-            if (RestrictPlacementToCheckCell)
-                return TransitionState.OK;
-
             var result = TransitionState.OK;
 
             //SpherePath.CellArrayValid = true;
@@ -375,14 +362,7 @@ namespace ACE.Server.Physics.Animation
                 return true;
 
             if (!SpherePath.PlacementAllowsSliding)
-            {
-                if ((SpherePath.CheckPos.ObjCellID & 0xFFFF0000) == 0xDA550000)
-                     Console.WriteLine($"[DEBUG-PHYS] FindPlacementPos: Initial validation FAILED (State: {transitionState}), PlacementAllowsSliding=FALSE. Aborting.");
                 return false;
-            }
-
-            if ((SpherePath.CheckPos.ObjCellID & 0xFFFF0000) == 0xDA550000)
-                 Console.WriteLine($"[DEBUG-PHYS] FindPlacementPos: Initial validation FAILED (State: {transitionState}). Attempting sliding search. PlacementAllowsSliding=TRUE.");
 
             var adjustDist = 4.0f;
             var adjustRad = adjustDist;
@@ -451,8 +431,6 @@ namespace ACE.Server.Physics.Animation
                     }
                 }
             }
-            if ((SpherePath.CheckPos.ObjCellID & 0xFFFF0000) == 0xDA550000)
-                 Console.WriteLine($"[DEBUG-PHYS] FindPlacementPos: Sliding search exhausted all positions. No valid position found.");
             return false;
         }
 
@@ -472,24 +450,12 @@ namespace ACE.Server.Physics.Animation
             else
                 transitionState = TransitionState.Collided;
 
-            if (transitionState != TransitionState.OK && (SpherePath.CheckPos.ObjCellID & 0xFFFF0000) == 0xDA550000)
-                 Console.WriteLine($"[DEBUG-PHYS] FindPlacementPosition: InsertIntoCell/CheckOtherCells FAILED. State: {transitionState}. CheckCell: {SpherePath.CheckCell?.ID:X8}");
-
             var result = ValidatePlacement(transitionState, true);
             if (result != TransitionState.OK)
-            {
-                if ((SpherePath.CheckPos.ObjCellID & 0xFFFF0000) == 0xDA550000)
-                     Console.WriteLine($"[DEBUG-PHYS] FindPlacementPosition: ValidatePlacement (Initial) FAILED. Result: {result}");
                 return false;
-            }
 
             SpherePath.InsertType = InsertType.Placement;
-            if (!FindPlacementPos())
-            {
-                 if ((SpherePath.CheckPos.ObjCellID & 0xFFFF0000) == 0xDA550000)
-                     Console.WriteLine($"[DEBUG-PHYS] FindPlacementPosition: FindPlacementPos (Sliding/Search) FAILED.");
-                 return false;
-            }
+            if (!FindPlacementPos()) return false;
 
             if (!ObjectInfo.StepDown)
             {
@@ -640,12 +606,7 @@ namespace ACE.Server.Physics.Animation
             if (SpherePath.InsertType == InsertType.Transition)
                 return FindTransitionalPosition();
             else
-            {
-                var result = FindPlacementPosition();
-                if (!result && (SpherePath.CheckPos.ObjCellID & 0xFFFF0000) == 0xDA550000)
-                    Console.WriteLine($"[DEBUG-PHYS] FindValidPosition (Placement) FAILED for DA55 obj. CheckCell: {SpherePath.CheckCell?.ID:X8}");
-                return result;
-            }
+                return FindPlacementPosition();
         }
 
         public void InitContactPlane(uint cellID, Plane contactPlane, bool isWater)
@@ -765,9 +726,6 @@ namespace ACE.Server.Physics.Animation
 
             var transitionState = TransitionalInsert(3); //was 5
             SpherePath.StepDown = false;
-
-            if (RestrictPlacementToCheckCell && PlacementMinOriginZ.HasValue && SpherePath.CheckPos.Frame.Origin.Z < PlacementMinOriginZ.Value)
-                return false;
 
             if (transitionState == TransitionState.OK && CollisionInfo.ContactPlaneValid && CollisionInfo.ContactPlane.Normal.Z >= zVal &&
                 ((ObjectInfo.State & ObjectInfoState.EdgeSlide) == 0 || SpherePath.StepUp || CheckWalkable(zVal)))

--- a/Source/ACE.Server/Physics/Util/AdjustCell.cs
+++ b/Source/ACE.Server/Physics/Util/AdjustCell.cs
@@ -4,14 +4,11 @@ using System.Numerics;
 using ACE.DatLoader;
 using ACE.DatLoader.FileTypes;
 using ACE.Common;
-using ACE.Server.Physics.Common;
-using log4net;
 
 namespace ACE.Server.Physics.Util
 {
     public class AdjustCell
     {
-        private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
         public readonly List<Common.EnvCell> EnvCells = [];
         public static readonly ConcurrentDictionary<VariantCacheId, AdjustCell> AdjustCells = new();
 
@@ -42,21 +39,14 @@ namespace ACE.Server.Physics.Util
 
         public static AdjustCell Get(uint dungeonID, int? variationId)
         {            
-            VariantCacheId cacheKey = new() { Landblock = (ushort)dungeonID, Variant = variationId };
-            if (AdjustCells.TryGetValue(cacheKey, out var cached) && cached != null)
-                return cached;
-
-            var created = new AdjustCell(dungeonID, variationId);
-            if (!AdjustCells.TryAdd(cacheKey, created))
+            VariantCacheId cacheKey = new() { Landblock = (ushort)dungeonID, Variant = variationId ?? 0};
+            AdjustCells.TryGetValue(cacheKey, out AdjustCell adjustCell);
+            if (adjustCell == null)
             {
-                if (AdjustCells.TryGetValue(cacheKey, out var winner) && winner != null)
-                    return winner;
-                return created;
+                adjustCell = new AdjustCell(dungeonID, variationId);
+                AdjustCells.TryAdd(cacheKey, adjustCell);
             }
-
-            if (IndoorPlacementDiagLogging.Enabled && IndoorPlacementDiagLogging.IsColo(dungeonID << 16 | 0x100))
-                log.Info($"[IndoorPlaceDiag] AdjustCell.Get new cache entry dungeon=0x{dungeonID:X4} variationId={variationId?.ToString() ?? "null"} envCellsLoaded={created.EnvCells.Count}");
-            return created;
+            return adjustCell;
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Creature_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Death.cs
@@ -34,7 +34,7 @@ namespace ACE.Server.WorldObjects
         public virtual DeathMessage OnDeath(DamageHistoryInfo lastDamager, DamageType damageType, bool criticalHit = false)
         {
             if (onDeathEntered)
-                return Strings.GetDeathMessage(damageType, criticalHit); // re-entry: return without sending killer notification
+                return GetDeathMessage(lastDamager, damageType, criticalHit);
 
             onDeathEntered = true;
 
@@ -82,15 +82,6 @@ namespace ACE.Server.WorldObjects
 
             var deathMessage = Strings.GetDeathMessage(damageType, criticalHit);
 
-            // ILT: always clear split arrow tracking — killer may not be a player
-            var lastHitWasSplitArrow = GetProperty(PropertyBool.LastHitWasSplitArrow) is true;
-            if (lastHitWasSplitArrow)
-            {
-                RemoveProperty(PropertyBool.LastHitWasSplitArrow);
-                RemoveProperty(PropertyInstanceId.LastSplitArrowProjectile);
-                RemoveProperty(PropertyInstanceId.LastSplitArrowShooter);
-            }
-
             // if killed by a player, send them a message
             if (lastDamagerInfo.IsPlayer)
             {
@@ -100,17 +91,7 @@ namespace ACE.Server.WorldObjects
                 var killerMsg = string.Format(deathMessage.Killer, Name);
 
                 if (lastDamager is Player playerKiller && playerKiller.Session != null)
-                {
-                    // ILT: build overkill suffix — applied AFTER split arrow text transformation
-                    // inside GameEventKillerNotification, so [Overkill: N] is always last.
-                    var overkillSuffix = (playerKiller.ShowOverkill && lastDamagerInfo.OverkillAmount > 0)
-                        ? $" [Overkill: {Creature.FormatDamage(lastDamagerInfo.OverkillAmount, playerKiller.DamageNumberFormat)}]"
-                        : "";
-
-                    playerKiller.Session.Network.EnqueueSend(
-                        new GameEventKillerNotification(playerKiller.Session, killerMsg, lastHitWasSplitArrow, overkillSuffix));
-                }
-
+                    playerKiller.Session.Network.EnqueueSend(new GameEventKillerNotification(playerKiller.Session, killerMsg, GetProperty(PropertyBool.IsSplitArrowKill) == true));
             }
             return deathMessage;
         }
@@ -166,8 +147,7 @@ namespace ACE.Server.WorldObjects
             var deathAnimLength = ExecuteMotion(motionDeath);
 
             // Try to generate Siphon Lens before death emotes (which might destroy the creature)
-            if (!(this is Pet))
-                GenerateSiphonLens(topDamager);
+            GenerateSiphonLens(topDamager);
 
             if (EmoteManager != null)
             {
@@ -226,115 +206,31 @@ namespace ACE.Server.WorldObjects
             if (totalHealth == 0)
                 return;
 
-            var monsterTier = PrestigeManager.GetKillScalingMonsterTier(this);
-
-            var baseXp = (long)(XpOverride ?? 0);
-
-            // One EarnXP / EarnLuminance per player: combine direct hits + all of that player's combat pets.
-            // Avoids duplicate fellowship splits and matches "your kill bonuses apply to the full credit you earned on the mob."
-            var xpCreditByPlayer = new Dictionary<uint, float>();
             foreach (var kvp in DamageHistory.TotalDamage)
             {
-                var info = kvp.Value;
-                if (info.TotalDamage <= 0)
+                var damager = kvp.Value.TryGetAttacker();
+
+                var playerDamager = damager as Player;
+
+                if (playerDamager == null && kvp.Value.PetOwner != null)
+                    playerDamager = kvp.Value.TryGetPetOwner();
+
+                if (playerDamager == null)
                     continue;
 
-                var damager = info.TryGetAttacker();
-                Player creditPlayer = damager as Player;
-                if (creditPlayer == null && info.PetOwner != null)
-                    creditPlayer = info.TryGetPetOwner();
+                var totalDamage = kvp.Value.TotalDamage;
 
-                if (creditPlayer == null)
-                    continue;
+                var damagePercent = totalDamage / totalHealth;
 
-                var id = creditPlayer.Guid.Full;
-                if (xpCreditByPlayer.TryGetValue(id, out var acc))
-                    xpCreditByPlayer[id] = acc + info.TotalDamage;
-                else
-                    xpCreditByPlayer[id] = info.TotalDamage;
-            }
+                var totalXP = (XpOverride ?? 0) * damagePercent;
 
-            foreach (var kv in xpCreditByPlayer)
-            {
-                var player = PlayerManager.GetOnlinePlayer(new ObjectGuid(kv.Key));
-                if (player == null)
-                    continue;
+                playerDamager.EarnXP((long)Math.Round(totalXP), XpType.Kill);
 
-                var damagePercent = kv.Value / totalHealth;
-                if (damagePercent <= 0)
-                    continue;
-
-                if (baseXp > 0)
-                {
-                    var totalXP = baseXp * damagePercent;
-                    player.EarnXP((long)Math.Round(totalXP), XpType.Kill, ShareType.All, monsterTier);
-                }
-
+                // handle luminance
                 if (LuminanceAward != null)
                 {
-                    var totalLuminance = LuminanceAward.Value * damagePercent;
-                    player.EarnLuminance((long)Math.Round(totalLuminance), XpType.Kill, ShareType.All, monsterTier);
-                }
-            }
-
-            // Pet Bonding System - bond XP scales with pet damage share and the owner's kill XP modifier stack (same profile as EarnXP).
-            // Accumulate per summoning device so TryAwardBondXp (save + network) runs once per device per kill.
-            if (ServerConfig.pet_bond_enabled.Value && baseXp > 0)
-            {
-                var bondXpByDevice = new Dictionary<uint, (Player Owner, long Xp)>();
-
-                foreach (var kvp in DamageHistory.TotalDamage)
-                {
-                    var info = kvp.Value;
-                    if (info.TotalDamage <= 0)
-                        continue;
-
-                    var damager = info.TryGetAttacker();
-                    if (damager is not CombatPet combatPet || info.PetOwner == null)
-                        continue;
-
-                    var playerDamager = info.TryGetPetOwner();
-                    if (playerDamager == null)
-                        continue;
-
-                    var damagePercent = info.TotalDamage / totalHealth;
-                    if (damagePercent <= 0)
-                        continue;
-
-                    var bondXp = (long)Math.Round(baseXp * damagePercent * ServerConfig.pet_bond_xp_multiplier.Value * playerDamager.GetKillXpModifierProduct());
-                    var minAward = ServerConfig.pet_bond_xp_min_award.Value;
-                    if (bondXp < minAward) bondXp = minAward;
-
-                    PetDevice device = combatPet.TryGetSummoningDevice();
-                    if (device == null)
-                    {
-                        var devGuid = combatPet.SummoningDeviceGuid;
-                        if (devGuid != ObjectGuid.Invalid)
-                        {
-                            device = playerDamager.FindObject(devGuid.Full, Player.SearchLocations.MyInventory | Player.SearchLocations.MyEquippedItems) as PetDevice;
-                        }
-                    }
-
-                    if (device == null)
-                        continue;
-
-                    var key = device.Guid.Full;
-                    if (bondXpByDevice.TryGetValue(key, out var acc))
-                        bondXpByDevice[key] = (playerDamager, acc.Xp + bondXp);
-                    else
-                        bondXpByDevice[key] = (playerDamager, bondXp);
-                }
-
-                foreach (var kv in bondXpByDevice)
-                {
-                    var (owner, xp) = kv.Value;
-                    var device = owner.FindObject(kv.Key, Player.SearchLocations.MyInventory | Player.SearchLocations.MyEquippedItems) as PetDevice;
-                    if (device == null)
-                        continue;
-
-                    var awarded = device.TryAwardBondXp(owner, xp, out var leveledUp);
-                    if (awarded && leveledUp)
-                        owner.SendMessage($"Your bond with {device.GetBondMessageDisplayName()} deepens. (Bond Level {device.PetBondLevel:N0})");
+                    var totalLuminance = (long)Math.Round(LuminanceAward.Value * damagePercent);
+                    playerDamager.EarnLuminance(totalLuminance, XpType.Kill);
                 }
             }
         }
@@ -573,10 +469,6 @@ namespace ACE.Server.WorldObjects
             {
                 if (killer != null && killer.IsOlthoiPlayer) return;
 
-                // PetDevice summons (Pet / CombatPet): no death treasure or ground drops (DeathTreasure, createlist, siphon lens)
-                if (this is Pet)
-                    return;
-
                 var loot = GenerateTreasure(killer, null);
 
                 foreach(var item in loot)
@@ -637,6 +529,8 @@ namespace ACE.Server.WorldObjects
             // use the physics location for accuracy,
             // especially while jumping
             corpse.Location = PhysicsObj.Position.ACEPosition();
+            if (!corpse.Location.Variation.HasValue && Location.Variation.HasValue)
+                corpse.Location.Variation = Location.Variation;
 
             corpse.VictimId = Guid.Full;
             corpse.Name = $"{prefix} of {Name}";
@@ -652,10 +546,12 @@ namespace ACE.Server.WorldObjects
 
                     corpse.KillerId = killer.Guid.Full;
 
-                    if (killer.TryGetPetOwner() is Player petLootPlayer)
-                        corpse.KillerId = petLootPlayer.Guid.Full;
-                    else if (killer.TryGetAttacker() is CombatPet killerPet && killerPet.P_PetOwner != null)
-                        corpse.KillerId = killerPet.P_PetOwner.Guid.Full;
+                    if (killer.PetOwner != null)
+                    {
+                        var petOwner = killer.TryGetPetOwner();
+                        if (petOwner != null)
+                            corpse.KillerId = petOwner.Guid.Full;
+                    }
                 }
             }
 
@@ -880,18 +776,13 @@ namespace ACE.Server.WorldObjects
         private List<WorldObject> GenerateTreasure(DamageHistoryInfo killer, Corpse corpse)
         {
             var droppedItems = new List<WorldObject>();
-            var tier = PrestigeManager.GetKillScalingMonsterTier(this);
 
             // create death treasure from loot generation factory
             if (DeathTreasure != null)
             {
                 List<WorldObject> items = LootGenerationFactory.CreateRandomLootObjects(DeathTreasure);
-
                 foreach (WorldObject wo in items)
                 {
-                    if (tier > 0)
-                        PrestigeManager.ApplyLootScaling(wo, tier);
-
                     if (corpse != null)
                         corpse.TryAddToInventory(wo);
                     else
@@ -950,9 +841,6 @@ namespace ACE.Server.WorldObjects
 
                     if (wo != null)
                     {
-                        if (tier > 0)
-                            PrestigeManager.ApplyLootScaling(wo, tier);
-
                         if (corpse != null)
                             corpse.TryAddToInventory(wo);
                         else

--- a/Source/ACE.Server/WorldObjects/Creature_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Death.cs
@@ -34,7 +34,15 @@ namespace ACE.Server.WorldObjects
         public virtual DeathMessage OnDeath(DamageHistoryInfo lastDamager, DamageType damageType, bool criticalHit = false)
         {
             if (onDeathEntered)
-                return GetDeathMessage(lastDamager, damageType, criticalHit);
+            {
+                if (lastDamager == null || lastDamager.Guid == Guid || lastDamager.TryGetAttacker() is Hotspot)
+                    return Strings.General[1];
+
+                var deathMessage = Strings.GetDeathMessage(damageType, criticalHit);
+                if (criticalHit && this is Player)
+                    deathMessage = Strings.PKCritical[0];
+                return deathMessage;
+            }
 
             onDeathEntered = true;
 

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -237,6 +237,10 @@ namespace ACE.Server.WorldObjects
 
             FirstEnterWorldDone = false;
 
+            // Treat login/relog the same as a teleport so dungeon NPC CreateObject messages
+            // are held for 1 second, giving the client time to load geometry before NPCs drop in.
+            LastTeleportTime = DateTime.UtcNow;
+
             SetStance(MotionStance.NonCombat, false);
 
             // radius for object updates

--- a/Source/ACE.Server/WorldObjects/Player_Tracking.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Tracking.cs
@@ -267,7 +267,7 @@ namespace ACE.Server.WorldObjects
             // disabled by default
             if (fixLevel < 1) return;
 
-            if (Location.Cell == newPosition.Cell)
+            if (Location.Cell == newPosition.Cell && Location.Variation == newPosition.Variation)
                 return;
 
             var knownObjs = GetKnownObjects();

--- a/Source/ACE.Server/WorldObjects/Player_Tracking.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Tracking.cs
@@ -33,14 +33,6 @@ namespace ACE.Server.WorldObjects
         public Dictionary<int, DateTime> LastUseTracker { get; set; }
 
         /// <summary>
-        /// ObjMaint can mark another Player as known before NotifyPlayers runs; we resend CreateObject from that reconcile path.
-        /// Without throttling, every Landblock/physics re-notify would enqueue duplicate CreateObject messages.
-        /// </summary>
-        private readonly Dictionary<uint, long> _lastDuplicateKnownPlayerTrackMs = new();
-
-        private const int DuplicateKnownPlayerTrackDebounceMs = 750;
-
-        /// <summary>
         /// The link to this player's Object Maintenance
         /// This is the system from client physics that tracks known objects, visible objects,
         /// and objects that have been occluded for less than 25s that are pending destruction
@@ -69,18 +61,13 @@ namespace ACE.Server.WorldObjects
             if (worldObject == null || worldObject.Guid == Guid)
                 return;
 
-            // VARIATION CHECK (Network Boundary)
-            // This ensures we never tell the client to create an object from another variation.
-            var myVar = PrestigeManager.GetEffectiveVariationForVisibility(this);
-            var objVar = PrestigeManager.GetEffectiveVariationForVisibility(worldObject);
-            if (!PrestigeManager.SameVariationForVisibility(myVar, objVar))
-            {
-                log.Error($"{Name} (eff v:{myVar?.ToString() ?? "null"}) tried to TrackObject {worldObject.Name} (eff v:{objVar?.ToString() ?? "null"}) - BLOCKED network message to prevent client contamination.");
-                return;
-            }
-
             // If Visibility is true, do not send object to client, object is meant for server side only, unless Adminvision is true.
             if (worldObject.Visibility && !Adminvision)
+                return;
+
+            if (!PrestigeManager.SameVariationForVisibility(
+                    PrestigeManager.GetEffectiveVariationForVisibility(this),
+                    PrestigeManager.GetEffectiveVariationForVisibility(worldObject)))
                 return;
 
             Session.Network.EnqueueSend(new GameMessageCreateObject(worldObject, Adminvision, Adminvision));
@@ -104,73 +91,16 @@ namespace ACE.Server.WorldObjects
             if (worldObject?.PhysicsObj == null || PhysicsObj == null)
                 return false;
 
-            var myVar = PrestigeManager.GetEffectiveVariationForVisibility(this);
-            var objVar = PrestigeManager.GetEffectiveVariationForVisibility(worldObject);
-
-            // ObjMaint can still list the other PhysicsObj from before a variation / visibility-domain change.
-            // The old early-out here skipped TrackObject entirely, so clients never got DO+CO and stayed wrong.
+            // does this work for equipped objects?
             if (ObjMaint.KnownObjectsContainsValue(worldObject.PhysicsObj))
             {
-                if (PrestigeManager.SameVariationForVisibility(myVar, objVar))
-                {
-                    // Physics can call ObjMaint.AddKnownObject (handle_visible_obj / AddVisibleObject) before
-                    // NotifyPlayers runs. ObjMaint then reports "already known" but the client never got CreateObject.
-                    if (worldObject is Player)
-                    {
-                        var key = worldObject.Guid.Full;
-                        var now = System.Environment.TickCount64;
-                        if (_lastDuplicateKnownPlayerTrackMs.TryGetValue(key, out var last) &&
-                            now - last < DuplicateKnownPlayerTrackDebounceMs)
-                            return false;
-
-                        TrackObject(worldObject);
-                        _lastDuplicateKnownPlayerTrackMs[key] = now;
-                        return true;
-                    }
-
-                    if (worldObject.TryRefreshIndoorStationarySpawnForViewer(this))
-                    {
-                        var key = worldObject.Guid.Full;
-                        var now = System.Environment.TickCount64;
-                        if (_lastDuplicateKnownPlayerTrackMs.TryGetValue(key, out var last) &&
-                            now - last < DuplicateKnownPlayerTrackDebounceMs)
-                            return false;
-
-                        _lastDuplicateKnownPlayerTrackMs[key] = now;
-                        return true;
-                    }
-
-                    return false;
-                }
-
-                if (ServerConfig.prestige_interaction_diag_verbose.Value)
-                {
-                    log.Warn($"[PrestigeInteraction] AddTrackedObject purging stale ObjMaint link: viewer={Name}({Guid.Full:X8}) target={worldObject.Name}({worldObject.Guid.Full:X8}) " +
-                             $"effVar_viewer={myVar?.ToString() ?? "null"} effVar_target={objVar?.ToString() ?? "null"}");
-                }
-
-                _lastDuplicateKnownPlayerTrackMs.Remove(worldObject.Guid.Full);
-
-                worldObject.PhysicsObj.ObjMaint?.RemoveObject(PhysicsObj);
-                if (worldObject is Player knownPlayer)
-                    knownPlayer.RemoveTrackedObject(this, false);
-                ObjMaint.RemoveObject(worldObject.PhysicsObj);
-                RemoveTrackedObject(worldObject, false);
-
-                myVar = PrestigeManager.GetEffectiveVariationForVisibility(this);
-                objVar = PrestigeManager.GetEffectiveVariationForVisibility(worldObject);
-            }
-
-            if (!PrestigeManager.SameVariationForVisibility(myVar, objVar))
-            {
-                if (ServerConfig.prestige_interaction_diag_verbose.Value)
-                {
-                    log.Warn($"[PrestigeInteraction] AddTrackedObject skipped: viewer={Name}({Guid.Full:X8}) target={worldObject.Name}({worldObject.Guid.Full:X8}) " +
-                             $"effVar_viewer={myVar?.ToString() ?? "null"} effVar_target={objVar?.ToString() ?? "null"} " +
-                             $"(SameVariationForVisibility=false; client would not receive CreateObject).");
-                }
+                //Console.WriteLine($"Player {Name} - AddTrackedObject({worldObject.Name}) skipped, already tracked");
                 return false;
             }
+            if (!PrestigeManager.SameVariationForVisibility(
+                    PrestigeManager.GetEffectiveVariationForVisibility(this),
+                    PrestigeManager.GetEffectiveVariationForVisibility(worldObject)))
+                return false;
 
             ObjMaint.AddKnownObject(worldObject.PhysicsObj);
             ObjMaint.AddVisibleObject(worldObject.PhysicsObj);
@@ -182,9 +112,6 @@ namespace ACE.Server.WorldObjects
         public void RemoveTrackedObject(WorldObject wo, bool fromPickup)
         {
             //log.Info($"{Name}.RemoveTrackedObject({wo.Name} ({wo.Guid}), {fromPickup})");
-
-            if (wo != null)
-                _lastDuplicateKnownPlayerTrackMs.Remove(wo.Guid.Full);
 
             if (fromPickup)
             {
@@ -340,22 +267,8 @@ namespace ACE.Server.WorldObjects
             // disabled by default
             if (fixLevel < 1) return;
 
-            // Variation-only teleports can keep the same Cell value while still requiring a visibility reset.
-            // If we skip here, clients can end up with stale known/visible object state across variations.
-            if (Location.Cell == newPosition.Cell && PrestigeManager.SameVariationForVisibility(Location?.Variation, newPosition?.Variation))
+            if (Location.Cell == newPosition.Cell)
                 return;
-
-            if (ServerConfig.prestige_interaction_diag_verbose.Value)
-            {
-                log.Warn($"[PrestigeInteraction] PreTeleportVisibility: player={Name}({Guid.Full:X8}) fixLevel={fixLevel} " +
-                         $"fromCell={Location.Cell:X8} fromVar={Location?.Variation?.ToString() ?? "null"} " +
-                         $"toCell={newPosition.Cell:X8} toVar={newPosition?.Variation?.ToString() ?? "null"} " +
-                         $"knownCount={ObjMaint?.GetKnownObjectsCount().ToString() ?? "null"}");
-            }
-
-            // ObjMaint is empty but duplicate-known debounce may still hold guids from before a hard reset.
-            if (ObjMaint?.GetKnownObjectsCount() == 0)
-                _lastDuplicateKnownPlayerTrackMs.Clear();
 
             var knownObjs = GetKnownObjects();
 

--- a/Source/ACE.Server/WorldObjects/Player_Tracking.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Tracking.cs
@@ -127,6 +127,19 @@ namespace ACE.Server.WorldObjects
                         _lastDuplicateKnownPlayerTrackMs[key] = now;
                         return true;
                     }
+
+                    if (worldObject.TryRefreshIndoorStationarySpawnForViewer(this))
+                    {
+                        var key = worldObject.Guid.Full;
+                        var now = System.Environment.TickCount64;
+                        if (_lastDuplicateKnownPlayerTrackMs.TryGetValue(key, out var last) &&
+                            now - last < DuplicateKnownPlayerTrackDebounceMs)
+                            return false;
+
+                        _lastDuplicateKnownPlayerTrackMs[key] = now;
+                        return true;
+                    }
+
                     return false;
                 }
 

--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -259,6 +259,57 @@ namespace ACE.Server.WorldObjects
             return true;
         }
 
+        /// <summary>
+        /// Vendors / stationary quest NPCs in dungeons — not players, monsters, or combat pets.
+        /// </summary>
+        private bool IsIndoorStationarySpawnCreature()
+        {
+            if (this is not Creature creature)
+                return false;
+
+            if (creature is Player || creature is CombatPet)
+                return false;
+
+            // IsMonster is true for any Attackable weenie; vendors/NPCs use IsNPC instead.
+            return creature.IsNPC;
+        }
+
+        /// <summary>
+        /// Physics visibility uses bare TrackObject; indoor vendors may need a fresh CreateObject after teleport/relog.
+        /// </summary>
+        internal bool TryRefreshIndoorStationarySpawnForViewer(Player viewer)
+        {
+            if (viewer == null || !IsIndoorStationarySpawnCreature())
+                return false;
+
+            RefreshIndoorStationarySpawnPhysics(viewer);
+            return true;
+        }
+
+        /// <summary>
+        /// Purge stale ObjMaint and re-send CreateObject for a viewer (teleport/relog).
+        /// Landblocks keep dungeon NPCs across relog; ObjMaint can mark them known before the client receives an updated create.
+        /// </summary>
+        internal void RefreshIndoorStationarySpawnPhysics(Player viewer)
+        {
+            if (PhysicsObj == null || !IsIndoorStationarySpawnCreature())
+                return;
+
+            if ((Location.Cell & 0xFFFF) < 0x100)
+                return;
+
+            if (viewer == null || viewer.PhysicsObj == null)
+                return;
+
+            if (viewer.ObjMaint?.KnownObjectsContainsValue(PhysicsObj) ?? false)
+            {
+                PhysicsObj.ObjMaint?.RemoveObject(viewer.PhysicsObj);
+                viewer.ObjMaint.RemoveObject(PhysicsObj);
+            }
+
+            viewer.AddTrackedObject(this);
+        }
+
         public void SyncLocation(int? Variation)
         {
             Location.LandblockId = new LandblockId(PhysicsObj.Position.ObjCellID, Variation);

--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -282,24 +282,24 @@ namespace ACE.Server.WorldObjects
             if (viewer == null || !IsIndoorStationarySpawnCreature())
                 return false;
 
-            RefreshIndoorStationarySpawnPhysics(viewer);
-            return true;
+            return RefreshIndoorStationarySpawnPhysics(viewer);
         }
 
         /// <summary>
         /// Purge stale ObjMaint and re-send CreateObject for a viewer (teleport/relog).
         /// Landblocks keep dungeon NPCs across relog; ObjMaint can mark them known before the client receives an updated create.
         /// </summary>
-        internal void RefreshIndoorStationarySpawnPhysics(Player viewer)
+        /// <returns>true if tracking was handled here; false so callers can fall back to TrackObject.</returns>
+        internal bool RefreshIndoorStationarySpawnPhysics(Player viewer)
         {
             if (PhysicsObj == null || !IsIndoorStationarySpawnCreature())
-                return;
+                return false;
 
             if ((Location.Cell & 0xFFFF) < 0x100)
-                return;
+                return false;
 
             if (viewer == null || viewer.PhysicsObj == null)
-                return;
+                return false;
 
             if (viewer.ObjMaint?.KnownObjectsContainsValue(PhysicsObj) ?? false)
             {
@@ -307,7 +307,7 @@ namespace ACE.Server.WorldObjects
                 viewer.ObjMaint.RemoveObject(PhysicsObj);
             }
 
-            viewer.AddTrackedObject(this);
+            return viewer.AddTrackedObject(this);
         }
 
         public void SyncLocation(int? Variation)

--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -129,30 +129,6 @@ namespace ACE.Server.WorldObjects
             Biota = biota;
             Guid = new ObjectGuid(Biota.Id);
 
-#if DEBUG
-            if (Biota?.PropertiesPosition != null &&
-                Biota.PropertiesPosition.TryGetValue(PositionType.Location, out var locProp) &&
-                locProp != null &&
-                (locProp.ObjCellId & 0xFFFF0000) == 0xDA550000)
-            {
-                Console.WriteLine($"[DEBUG-POS] WorldObject(Biota) DA55: Init GUID={Guid.Full:X16} Cell={locProp.ObjCellId:X8}");
-            }
-            else if (Biota?.WeenieClassId == 835)
-            {
-                if (Biota.PropertiesPosition == null || !Biota.PropertiesPosition.TryGetValue(PositionType.Location, out var loc835) || loc835 == null)
-                {
-                    var keysHint = Biota.PropertiesPosition != null
-                        ? string.Join(",", Biota.PropertiesPosition.Keys.Select(k => k.ToString()))
-                        : "n/a";
-                    Console.WriteLine($"[DEBUG-POS] WorldObject(Biota) Ven Ounan (835): Init GUID={Guid.Full:X16} — no PropertiesPosition.Location (keys: {keysHint})");
-                }
-                else if ((loc835.ObjCellId & 0xFFFF0000) != 0xDA550000)
-                {
-                    Console.WriteLine($"[DEBUG-POS] WorldObject(Biota) Ven Ounan (835): Init GUID={Guid.Full:X16} — Location ObjCellId={loc835.ObjCellId:X8} (expected DA55…)");
-                }
-            }
-#endif
-
             biotaOriginatedFromDatabase = true;
 
             InitializePropertyDictionaries();
@@ -215,7 +191,7 @@ namespace ACE.Server.WorldObjects
             if (PhysicsObj.CurCell != null)
                 return false;
 
-            AdjustDungeon(Location, preserveIndoorCells: true);
+            AdjustDungeon(Location);
 
             // exclude linkspots from spawning
             if (WeenieClassId == 10762) return true;
@@ -243,11 +219,9 @@ namespace ACE.Server.WorldObjects
 
             if (!success || PhysicsObj.CurCell == null)
             {
-                var cellWasNullAfterEnter = PhysicsObj?.CurCell == null;
                 PhysicsObj.DestroyObject();
                 PhysicsObj = null;
-                if (log.IsDebugEnabled)
-                    log.Debug($"AddPhysicsObj: failure (Success:{success}, CellIsNull:{cellWasNullAfterEnter}): {Name} ({Guid:X8}) @ {cell.ID.ToString("X8")} - {Location.Pos} - lv: {Location.Variation}, v: {VariationId}");
+                //Console.WriteLine($"AddPhysicsObj: failure: {Name} @ {cell.ID.ToString("X8")} - {Location.Pos} - {Location.Rotation} - lv: {Location.Variation}, v: {VariationId} - SetupID: {SetupTableId.ToString("X8")}, MTableID: {MotionTableId.ToString("X8")}");
                 return false;
             }
 
@@ -257,57 +231,6 @@ namespace ACE.Server.WorldObjects
             SetPosition(PositionType.Home, new Position(Location));
 
             return true;
-        }
-
-        /// <summary>
-        /// Vendors / stationary quest NPCs in dungeons — not players, monsters, or combat pets.
-        /// </summary>
-        private bool IsIndoorStationarySpawnCreature()
-        {
-            if (this is not Creature creature)
-                return false;
-
-            if (creature is Player || creature is CombatPet)
-                return false;
-
-            // IsMonster is true for any Attackable weenie; vendors/NPCs use IsNPC instead.
-            return creature.IsNPC;
-        }
-
-        /// <summary>
-        /// Physics visibility uses bare TrackObject; indoor vendors may need a fresh CreateObject after teleport/relog.
-        /// </summary>
-        internal bool TryRefreshIndoorStationarySpawnForViewer(Player viewer)
-        {
-            if (viewer == null || !IsIndoorStationarySpawnCreature())
-                return false;
-
-            return RefreshIndoorStationarySpawnPhysics(viewer);
-        }
-
-        /// <summary>
-        /// Purge stale ObjMaint and re-send CreateObject for a viewer (teleport/relog).
-        /// Landblocks keep dungeon NPCs across relog; ObjMaint can mark them known before the client receives an updated create.
-        /// </summary>
-        /// <returns>true if tracking was handled here; false so callers can fall back to TrackObject.</returns>
-        internal bool RefreshIndoorStationarySpawnPhysics(Player viewer)
-        {
-            if (PhysicsObj == null || !IsIndoorStationarySpawnCreature())
-                return false;
-
-            if ((Location.Cell & 0xFFFF) < 0x100)
-                return false;
-
-            if (viewer == null || viewer.PhysicsObj == null)
-                return false;
-
-            if (viewer.ObjMaint?.KnownObjectsContainsValue(PhysicsObj) ?? false)
-            {
-                PhysicsObj.ObjMaint?.RemoveObject(viewer.PhysicsObj);
-                viewer.ObjMaint.RemoveObject(PhysicsObj);
-            }
-
-            return viewer.AddTrackedObject(this);
         }
 
         public void SyncLocation(int? Variation)
@@ -413,7 +336,7 @@ namespace ACE.Server.WorldObjects
             if (PhysicsObj == null || wo.PhysicsObj == null)
                 return false;
 
-            var SightObj = PhysicsObj.makeObject(0x02000124, 0, false, null, true);
+            var SightObj = PhysicsObj.makeObject(0x02000124, 0, false, sightObj: true);
 
             SightObj.State |= PhysicsState.Missile;
 
@@ -799,39 +722,27 @@ namespace ACE.Server.WorldObjects
         }
 
         // todo: This should really be an extension method for Position, or a static method within Position or even AdjustPos
-        public static void AdjustDungeon(Position pos, bool preserveIndoorCells = false)
+        public static void AdjustDungeon(Position pos)
         {
             AdjustDungeonPos(pos);
-            AdjustDungeonCells(pos, preserveIndoorCells);
+            AdjustDungeonCells(pos);
         }
 
-        public static bool AdjustDungeonCells(Position pos, bool preserveIndoorCells = false)
+        // todo: This should really be an extension method for Position, or a static method within Position or even AdjustPos
+        public static bool AdjustDungeonCells(Position pos)
         {
             if (pos == null) return false;
 
             var landblock = LScape.get_landblock(pos.Cell, pos.Variation);
             if (landblock == null || !landblock.HasDungeon) return false;
 
-            var currentCellPart = pos.Cell & 0xFFFF;
-            if (preserveIndoorCells && currentCellPart >= 0x100)
-                return false;
-
             var dungeonID = pos.Cell >> 16;
 
             var adjustCell = AdjustCell.Get(dungeonID, pos.Variation);
             var cellID = adjustCell.GetCell(pos.Pos);
-            
-            //if (pos.Cell == 0xDA55001C) /* Ven Ounan check */
-            //{
-            //    Console.WriteLine($"[DEBUG-POS] AdjustDungeonCells for Cell(0x{pos.Cell:X8}) -> GetCell returned {(cellID.HasValue ? cellID.Value.ToString("X4") : "NULL")}");
-            //}
 
             if (cellID != null && pos.Cell != cellID.Value)
             {
-#if DEBUG
-                if ((pos.Cell & 0xFFFF0000) == 0xDA550000)
-                    Console.WriteLine($"[DEBUG-POS] AdjustDungeonCells CHANGED Cell: {pos.Cell:X8} -> {cellID.Value:X8} (GetCell Result) Var:{pos.Variation}");
-#endif
                 pos.LandblockId = new LandblockId(cellID.Value, pos.Variation);
                 return true;
             }


### PR DESCRIPTION
Restore normal spawn slide; keep ObjMaint refresh for stale indoor IsNPC on teleport/relog. Use SameVariationForVisibility in physics enqueue paths. Preload dungeon visible cells on landblock load.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable dungeon/cell handling when objects spawn or players enter; fixes missing indoor NPCs/vendors after teleport/login.
  * Improved corpse, loot and XP handling to correct attribution and reward delivery.

* **Improvements**
  * More consistent visibility and tracking for objects/players, including prestige/variation-based visibility rules to reduce duplicates and stale states.
  * Teleport/login timing refined to prevent premature NPC drops.

* **Documentation**
  * Added guidance for tuning server/network behavior during large mass spawns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rkroska/ACECustom/pull/459?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->