### PR TITLE
Fix capture-skin combat pets that never melee cross-creature reskins.

### DIFF
--- a/Source/ACE.Server/Entity/MonsterCapture.cs
+++ b/Source/ACE.Server/Entity/MonsterCapture.cs
@@ -830,6 +830,7 @@ namespace ACE.Server.Entity
             var capAttuned = capturedItem.Attuned;
             var capBonded = capturedItem.Bonded;
             var capCapturedDamageType = capturedItem.GetProperty(PropertyInt.CapturedSourceDamageType);
+            var capCreatureWcid = capturedItem.GetProperty(PropertyInt.CapturedCreatureWCID);
 
             var nameBeforeApply = crate.Name;
 
@@ -891,6 +892,11 @@ namespace ACE.Server.Entity
 
             if (crate.IsCombatPetDevice())
             {
+                if (capCreatureWcid.HasValue && capCreatureWcid.Value > 0)
+                    crate.SetProperty(PropertyInt.CapturedCreatureWCID, capCreatureWcid.Value);
+                else
+                    crate.RemoveProperty(PropertyInt.CapturedCreatureWCID);
+
                 if (capCapturedDamageType.HasValue && capCapturedDamageType.Value != 0 && Enum.IsDefined(typeof(DamageType), capCapturedDamageType.Value))
                     crate.SetProperty(PropertyInt.CapturedSourceDamageType, capCapturedDamageType.Value);
                 else

--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -415,6 +415,8 @@ namespace ACE.Server.Managers
         // Combat pet / bond / capture (custom): referenced by CombatPet, PetDevice, Creature_Death, etc.
         public static ConfigProperty<bool> pet_bond_enabled { get; private set; } = new(false, "If TRUE, pet bond XP and bond scaling features are enabled.");
         public static ConfigProperty<bool> pet_apply_capture_source_damage_type { get; private set; } = new(true, "If TRUE, combat pets may use captured source damage type metadata.");
+        public static ConfigProperty<bool> pet_capture_combat_sync_enabled { get; private set; } = new(true, "If TRUE, combat pet capture skins merge body parts and resolve combat stance for motion/CMT overrides.");
+        public static ConfigProperty<bool> pet_capture_combat_sync_fallback_cosmetic_only { get; private set; } = new(true, "If TRUE, when capture skin motion/CMT cannot produce valid melee, revert to essence template combat tables (look-only fallback).");
         public static ConfigProperty<bool> pet_combat_unlimited_lifespan { get; private set; } = new(false, "If TRUE, combat pets ignore summoned lifespan decay.");
         public static ConfigProperty<bool> pet_combat_summon_aug_spell_mitigation_enabled { get; private set; } = new(false, "If TRUE, reduce spell damage to combat pets from augmentation scaling.");
         public static ConfigProperty<bool> pet_combat_summon_aug_spell_mitigation_players_only { get; private set; } = new(true, "If TRUE, aug mitigation applies only when spell source is a player.");
@@ -448,8 +450,8 @@ namespace ACE.Server.Managers
         public static ConfigProperty<bool> pet_combat_recall_block_device_cooldown_visual { get; private set; } = new(false, "Legacy/no-op for refresh logic: damage-triggered essence cooldown uses pet_combat_essence_damage_cooldown_ring_seconds whenever that value is > 0. Kept for config compatibility.");
         public static ConfigProperty<bool> pet_melee_motion_dps_normalize { get; private set; } = new(false, "If TRUE, scales combat pet melee damage to normalize DPS vs motion table changes.");
         public static ConfigProperty<bool> pet_combat_follow_owner_when_idle { get; private set; } = new(true, "If TRUE, idle combat pets follow owner using Pet.Tick / leash behavior.");
-        /// <summary>If TRUE, prints verbose combat-pet AI lines to the server process console (tick routing, targeting, movement/attack). /modifybool pet_combat_debug_follow_ai_console.</summary>
-        public static ConfigProperty<bool> pet_combat_debug_follow_ai_console { get; private set; } = new(false, "If TRUE, verbose combat pet AI trace to stdout: Monster_Tick branches, HandleFindTarget/FindNextTarget, nearby-monster scan, engaged turn/move/attack, follow SlowTick, OnMoveComplete.");
+        /// <summary>If TRUE, prints combat-pet AI targeting/leash lines to stdout (not per-tick movement). /modifybool pet_combat_debug_follow_ai_console.</summary>
+        public static ConfigProperty<bool> pet_combat_debug_follow_ai_console { get; private set; } = new(false, "If TRUE, combat pet AI trace to stdout for target acquire/drop, leash/recall, and attack actions only (movement/follow ticks omitted). Default FALSE.");
         /// <summary>If TRUE, logs server physics pet↔player collision checks to stdout (throttled). Use to see if blockage is server vs client Ethereal. /modifybool pet_player_collision_debug_console.</summary>
         public static ConfigProperty<bool> pet_player_collision_debug_console { get; private set; } = new(false, "If TRUE, throttled stdout lines for pet vs player FindObjCollisions / report_object_collision (server physics only).");
         public static ConfigProperty<bool> pet_self_boost_overflow_to_combat_pet { get; private set; } = new(false, "If TRUE, beneficial self-cast overflow healing may apply to active combat pet.");

--- a/Source/ACE.Server/WorldObjects/CombatPet.cs
+++ b/Source/ACE.Server/WorldObjects/CombatPet.cs
@@ -223,6 +223,20 @@ namespace ACE.Server.WorldObjects
 
         internal float MeleeMotionDpsFactor => _meleeMotionDpsFactor;
 
+        private MotionStance? _captureSkinCombatStance;
+
+        internal void SetCaptureSkinCombatStance(MotionStance? stance) => _captureSkinCombatStance = stance;
+
+        public override MotionStance GetCombatStance()
+        {
+            if (_captureSkinCombatStance.HasValue)
+                return _captureSkinCombatStance.Value;
+
+            return base.GetCombatStance();
+        }
+
+        internal void ReconfigureMeleeMotionDpsAfterCaptureSkin() => ConfigureMeleeMotionDpsNormalization();
+
         public override void Destroy(bool raiseNotifyOfDestructionEvent = true, bool fromLandblockUnload = false)
         {
             RemoveAiDebugThrottleKeysForCombatPet(Guid.Full);
@@ -253,6 +267,8 @@ namespace ACE.Server.WorldObjects
 
         public override bool? Init(Player player, PetDevice petDevice)
         {
+            _captureSkinCombatStance = null;
+
             // Before Pet.Init -> EnterWorld: weenie defaults are creature/gold on radar; clients never get a later blip update unless we set this now so the create packet includes RadarBlipColor.
             this.RadarColor = ACE.Entity.Enum.RadarColor.Pink;
 
@@ -708,10 +724,36 @@ namespace ACE.Server.WorldObjects
         internal static bool IsAiDebugConsoleEnabled =>
             ServerConfig.pet_combat_debug_follow_ai_console.Value;
 
-        /// <summary>Verbose stdout trace when <see cref="ServerConfig.pet_combat_debug_follow_ai_console"/> is TRUE.</summary>
+        /// <summary>Movement/follow tick spam is omitted even when AI console debug is on; use target/scan stages instead.</summary>
+        private static bool ShouldEmitAiDebugConsoleLine(string stage, string detail)
+        {
+            switch (stage)
+            {
+                case "move":
+                case "follow":
+                case "idle_follow":
+                case "aggro":
+                    return false;
+                case "engaged":
+                    if (detail.Contains("action=Movement", StringComparison.Ordinal)
+                        || detail.Contains("action=AttackNotReady", StringComparison.Ordinal)
+                        || detail.Contains("action=StartTurn", StringComparison.Ordinal)
+                        || detail.Contains("action=MissileMovement", StringComparison.Ordinal)
+                        || detail.Contains("firstUpdate IsAnimating", StringComparison.Ordinal))
+                        return false;
+                    return true;
+                default:
+                    return true;
+            }
+        }
+
+        /// <summary>Verbose stdout trace when <see cref="ServerConfig.pet_combat_debug_follow_ai_console"/> is TRUE (targeting/leash only; not per-tick movement).</summary>
         internal static void DebugAiConsole(CombatPet pet, string stage, string detail, bool force = false)
         {
             if (pet == null || !IsAiDebugConsoleEnabled)
+                return;
+
+            if (!ShouldEmitAiDebugConsoleLine(stage, detail))
                 return;
 
             if (!force)

--- a/Source/ACE.Server/WorldObjects/Creature_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Combat.cs
@@ -287,7 +287,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Returns the combat stance for the currently wielded items
         /// </summary>
-        public MotionStance GetCombatStance()
+        public virtual MotionStance GetCombatStance()
         {
             var caster = GetEquippedWand();
 

--- a/Source/ACE.Server/WorldObjects/Creature_MeleeMotionDpsEstimate.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_MeleeMotionDpsEstimate.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using ACE.DatLoader;
 using ACE.DatLoader.Entity;
@@ -19,6 +20,16 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public float EstimateMeleeDamageEventsPerSecond(uint motionTableId, float meanMeleeDelaySeconds)
         {
+            var stance = CurrentMotionState?.Stance ?? MotionStance.NonCombat;
+            return EstimateMeleeDamageEventsPerSecond(motionTableId, meanMeleeDelaySeconds, stance);
+        }
+
+        /// <summary>
+        /// Same as <see cref="EstimateMeleeDamageEventsPerSecond(uint,float)"/> but uses an explicit combat stance
+        /// (for capture-skin compatibility probes before <see cref="CurrentMotionState"/> is finalized).
+        /// </summary>
+        public float EstimateMeleeDamageEventsPerSecond(uint motionTableId, float meanMeleeDelaySeconds, MotionStance stance)
+        {
             if (CombatTable == null)
                 GetCombatTable();
             if (CombatTable == null || meanMeleeDelaySeconds < 0)
@@ -28,7 +39,6 @@ namespace ACE.Server.WorldObjects
             if (motionTable == null)
                 return 0f;
 
-            var stance = CurrentMotionState.Stance;
             if (!CombatTable.Stances.TryGetValue(stance, out var stanceManeuvers))
                 return 0f;
 
@@ -83,6 +93,39 @@ namespace ACE.Server.WorldObjects
             }
 
             return count > 0 ? (float)(sum / count) : 0f;
+        }
+
+        /// <summary>
+        /// Finds a combat stance that has at least one resolvable unarmed melee maneuver for the current
+        /// <see cref="CombatTable"/> and the given motion table. Prefers <see cref="MotionStance.HandCombat"/> when tied.
+        /// </summary>
+        public bool TryFindValidUnarmedMeleeStance(uint motionTableId, float meanMeleeDelaySeconds, out MotionStance stance)
+        {
+            stance = MotionStance.HandCombat;
+
+            if (CombatTable == null)
+                GetCombatTable();
+            if (CombatTable == null || CombatTable.Stances.Count == 0)
+                return false;
+
+            MotionStance? bestStance = null;
+            var bestRate = 0f;
+
+            foreach (var candidate in CombatTable.Stances.Keys.OrderBy(s => s == MotionStance.HandCombat ? 0 : 1))
+            {
+                var rate = EstimateMeleeDamageEventsPerSecond(motionTableId, meanMeleeDelaySeconds, candidate);
+                if (rate <= bestRate)
+                    continue;
+
+                bestRate = rate;
+                bestStance = candidate;
+            }
+
+            if (!bestStance.HasValue || bestRate <= float.Epsilon)
+                return false;
+
+            stance = bestStance.Value;
+            return true;
         }
 
         private static MotionCommand? ResolveMonsterMotionCommandForEstimate(MotionCommand motionCommand, Dictionary<uint, MotionData> motions)

--- a/Source/ACE.Server/WorldObjects/PetDevice.cs
+++ b/Source/ACE.Server/WorldObjects/PetDevice.cs
@@ -23,7 +23,7 @@ namespace ACE.Server.WorldObjects
     /// <summary>
     /// Pet Devices are the essences used to summon creatures
     /// </summary>
-    public class PetDevice : WorldObject
+    public partial class PetDevice : WorldObject
     {
         private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
@@ -331,6 +331,13 @@ namespace ACE.Server.WorldObjects
         {
             get => GetProperty(PropertyInt.CapturedCreatureVariant);
             set { if (!value.HasValue) RemoveProperty(PropertyInt.CapturedCreatureVariant); else SetProperty(PropertyInt.CapturedCreatureVariant, value.Value); }
+        }
+
+        /// <summary>WCID of the creature this combat essence skin was siphoned from (<see cref="PropertyInt.CapturedCreatureWCID"/>).</summary>
+        public int? CaptureSkinCreatureWcid
+        {
+            get => GetProperty(PropertyInt.CapturedCreatureWCID);
+            set { if (!value.HasValue) RemoveProperty(PropertyInt.CapturedCreatureWCID); else SetProperty(PropertyInt.CapturedCreatureWCID, value.Value); }
         }
 
         // Serialized ObjDesc data for humanoid appearance
@@ -859,7 +866,7 @@ namespace ACE.Server.WorldObjects
             var d = new Dictionary<string, DamageType>(StringComparer.OrdinalIgnoreCase);
             foreach (var extra in new[]
                      {
-                         "Caustic", "Blistering", "Corrosion", "Corrosive"
+                         "Caustic", "Blistering", "Blistered", "Corrosion", "Corrosive"
                      })
                 add(d, extra, DamageType.Acid);
 
@@ -960,8 +967,9 @@ namespace ACE.Server.WorldObjects
         }
 
         /// <summary>
-        /// If the name begins with a known damage-type label (from <see cref="EssenceNameDamageLeadWords"/>), replace
-        /// that word with <paramref name="weaponDt"/>'s display label. If the first word is not a known damage lead-in,
+        /// If the name begins with a known damage-type label (<see cref="EssenceNameDamageLeadWords"/> or
+        /// <see cref="TryMatchEssenceDamageLeadWordToDamageType"/>), replace that word with
+        /// <paramref name="weaponDt"/>'s display label. If the first word is not a known damage lead-in,
         /// returns <paramref name="name"/> unchanged (no insertion).
         /// </summary>
         private static string ReplaceLeadingEssenceDamageLabel(string name, DamageType weaponDt)
@@ -972,7 +980,8 @@ namespace ACE.Server.WorldObjects
                 return name;
 
             var lead = n[..sp];
-            if (!EssenceNameDamageLeadWords.Contains(lead))
+            if (!EssenceNameDamageLeadWords.Contains(lead)
+                && !TryMatchEssenceDamageLeadWordToDamageType(lead).HasValue)
                 return name;
 
             var tail = n[sp..];
@@ -1053,6 +1062,10 @@ namespace ACE.Server.WorldObjects
                 log.Error($"{player.Name}.SummonCreature({wcid}) - PetDevice {WeenieClassId} - {WeenieClassName} tried to summon {wo.WeenieClassId} - {wo.WeenieClassName} of unknown type {wo.WeenieType}");
                 return false;
             }
+
+            MotionStance? captureSkinCombatStance = null;
+            var baselineMotionTableId = pet.MotionTableId;
+            var baselineCombatTableDid = pet.CombatTableDID;
 
             // Monster Capture System - Apply visual overrides if set
             if (VisualOverrideSetup.HasValue)
@@ -1233,6 +1246,9 @@ namespace ACE.Server.WorldObjects
                         }
                     }
                 }
+
+                if (pet is CombatPet combatPetForSync && IsCombatPetDevice())
+                    captureSkinCombatStance = TryApplyCaptureSkinCombatSync(combatPetForSync, player, wcid, baselineMotionTableId, baselineCombatTableDid);
             }
 
             var success = pet.Init(player, this);
@@ -1240,7 +1256,15 @@ namespace ACE.Server.WorldObjects
             if (success == true)
             {
                 if (pet is CombatPet combatPet)
+                {
+                    if (captureSkinCombatStance.HasValue)
+                        combatPet.SetCaptureSkinCombatStance(captureSkinCombatStance);
+
+                    if (VisualOverrideSetup.HasValue)
+                        combatPet.ReconfigureMeleeMotionDpsAfterCaptureSkin();
+
                     RefreshCombatPetEssenceDisplayNameForSummonedPet(combatPet, player);
+                }
                 else
                     TryNotifySummonerNameProperty(player);
             }

--- a/Source/ACE.Server/WorldObjects/PetDevice_CaptureCombatSync.cs
+++ b/Source/ACE.Server/WorldObjects/PetDevice_CaptureCombatSync.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using ACE.Database;
+using ACE.Entity.Enum;
+using ACE.Entity.Enum.Properties;
+using ACE.Entity.Models;
+using ACE.Server.Managers;
+
+namespace ACE.Server.WorldObjects
+{
+    public partial class PetDevice
+    {
+        /// <summary>
+        /// After visual overrides are applied on summon, merges capture body parts, resolves combat stance,
+        /// and optionally reverts motion/CMT to template when melee cannot be resolved.
+        /// </summary>
+        /// <returns>Resolved stance when combat sync succeeded; null when disabled, fallback, or no valid stance.</returns>
+        private MotionStance? TryApplyCaptureSkinCombatSync(CombatPet pet, Player player, uint petClassWcid, uint baselineMotionTableId, uint? baselineCombatTableDid)
+        {
+            if (!ServerConfig.pet_capture_combat_sync_enabled.Value)
+                return null;
+
+            var captureWcid = CaptureSkinCreatureWcid;
+            if (captureWcid.HasValue && captureWcid.Value > 0)
+                MergeCaptureSkinBodyParts(pet, (uint)captureWcid.Value, petClassWcid);
+
+            pet.GetCombatTable();
+            if (pet.CombatTable == null)
+                return null;
+
+            var meanDelay = (float)((pet.PowerupTime ?? 1.0f) * 0.5);
+
+            if (!pet.TryFindValidUnarmedMeleeStance(pet.MotionTableId, meanDelay, out var resolvedStance))
+            {
+                if (ServerConfig.pet_capture_combat_sync_fallback_cosmetic_only.Value)
+                    RevertCaptureSkinToTemplateCombat(pet, baselineMotionTableId, baselineCombatTableDid, player);
+                return null;
+            }
+
+            var rate = pet.EstimateMeleeDamageEventsPerSecond(pet.MotionTableId, meanDelay, resolvedStance);
+            if (rate <= float.Epsilon)
+            {
+                if (ServerConfig.pet_capture_combat_sync_fallback_cosmetic_only.Value)
+                    RevertCaptureSkinToTemplateCombat(pet, baselineMotionTableId, baselineCombatTableDid, player);
+                return null;
+            }
+
+            return resolvedStance;
+        }
+
+        private static void RevertCaptureSkinToTemplateCombat(CombatPet pet, uint baselineMotionTableId, uint? baselineCombatTableDid, Player player)
+        {
+            pet.MotionTableId = baselineMotionTableId;
+
+            if (baselineCombatTableDid.HasValue && baselineCombatTableDid.Value > 0)
+            {
+                pet.CombatTableDID = baselineCombatTableDid.Value;
+                pet.GetCombatTable();
+            }
+            else
+            {
+                pet.CombatTableDID = null;
+                pet.CombatTable = null;
+            }
+
+            if (player?.Session != null)
+            {
+                player.SendTransientError(
+                    "That creature's fighting style does not match this essence; your pet will use essence combat animations.");
+            }
+        }
+
+        /// <summary>
+        /// Ensures <see cref="CombatBodyPart"/> keys from the capture weenie exist on the pet biota with tier damage from the PetClass template.
+        /// </summary>
+        internal static void MergeCaptureSkinBodyParts(Creature pet, uint captureWcid, uint petClassWcid)
+        {
+            var captureWeenie = DatabaseManager.World.GetCachedWeenie(captureWcid);
+            var petClassWeenie = DatabaseManager.World.GetCachedWeenie(petClassWcid);
+
+            if (captureWeenie?.PropertiesBodyPart == null || captureWeenie.PropertiesBodyPart.Count == 0)
+                return;
+
+            if (petClassWeenie?.PropertiesBodyPart == null || petClassWeenie.PropertiesBodyPart.Count == 0)
+                return;
+
+            var primary = FindPrimaryAttackBodyPart(petClassWeenie.PropertiesBodyPart);
+            if (primary == null)
+                return;
+
+            pet.Biota.PropertiesBodyPart ??= new Dictionary<CombatBodyPart, PropertiesBodyPart>();
+
+            foreach (var capKvp in captureWeenie.PropertiesBodyPart)
+            {
+                if (capKvp.Key == CombatBodyPart.Breath)
+                    continue;
+
+                if (petClassWeenie.PropertiesBodyPart.TryGetValue(capKvp.Key, out var tierPart))
+                {
+                    pet.Biota.PropertiesBodyPart[capKvp.Key] = tierPart.Clone();
+                    continue;
+                }
+
+                var merged = primary.Clone();
+                CopyBodyPartHitData(capKvp.Value, merged);
+                pet.Biota.PropertiesBodyPart[capKvp.Key] = merged;
+            }
+        }
+
+        private static PropertiesBodyPart FindPrimaryAttackBodyPart(IDictionary<CombatBodyPart, PropertiesBodyPart> parts)
+        {
+            PropertiesBodyPart best = null;
+            var bestDVal = 0;
+
+            foreach (var kvp in parts)
+            {
+                if (kvp.Key == CombatBodyPart.Breath || kvp.Value.DVal <= 0)
+                    continue;
+
+                if (kvp.Value.DVal > bestDVal)
+                {
+                    bestDVal = kvp.Value.DVal;
+                    best = kvp.Value;
+                }
+            }
+
+            return best;
+        }
+
+        private static void CopyBodyPartHitData(PropertiesBodyPart from, PropertiesBodyPart to)
+        {
+            to.BH = from.BH;
+            to.HLF = from.HLF;
+            to.MLF = from.MLF;
+            to.LLF = from.LLF;
+            to.HRF = from.HRF;
+            to.MRF = from.MRF;
+            to.LRF = from.LRF;
+            to.HLB = from.HLB;
+            to.MLB = from.MLB;
+            to.LLB = from.LLB;
+            to.HRB = from.HRB;
+            to.MRB = from.MRB;
+            to.LRB = from.LRB;
+        }
+    }
+}

--- a/Source/ACE.Server/WorldObjects/PetDevice_CaptureCombatSync.cs
+++ b/Source/ACE.Server/WorldObjects/PetDevice_CaptureCombatSync.cs
@@ -22,32 +22,78 @@ namespace ACE.Server.WorldObjects
             if (!ServerConfig.pet_capture_combat_sync_enabled.Value)
                 return null;
 
+            Dictionary<CombatBodyPart, PropertiesBodyPart> bodyPartSnapshot = null;
             var captureWcid = CaptureSkinCreatureWcid;
             if (captureWcid.HasValue && captureWcid.Value > 0)
+            {
+                bodyPartSnapshot = SnapshotBodyParts(pet.Biota.PropertiesBodyPart);
                 MergeCaptureSkinBodyParts(pet, (uint)captureWcid.Value, petClassWcid);
+            }
+
+            void OnCombatSyncFailed()
+            {
+                if (ServerConfig.pet_capture_combat_sync_fallback_cosmetic_only.Value)
+                    RevertCaptureSkinToTemplateCombat(pet, baselineMotionTableId, baselineCombatTableDid, player);
+
+                if (bodyPartSnapshot != null)
+                    RestoreBodyParts(pet, bodyPartSnapshot);
+            }
 
             pet.GetCombatTable();
             if (pet.CombatTable == null)
+            {
+                if (!ServerConfig.pet_capture_combat_sync_fallback_cosmetic_only.Value)
+                {
+                    if (bodyPartSnapshot != null)
+                        RestoreBodyParts(pet, bodyPartSnapshot);
+                    return null;
+                }
+
+                OnCombatSyncFailed();
                 return null;
+            }
 
             var meanDelay = (float)((pet.PowerupTime ?? 1.0f) * 0.5);
 
             if (!pet.TryFindValidUnarmedMeleeStance(pet.MotionTableId, meanDelay, out var resolvedStance))
             {
-                if (ServerConfig.pet_capture_combat_sync_fallback_cosmetic_only.Value)
-                    RevertCaptureSkinToTemplateCombat(pet, baselineMotionTableId, baselineCombatTableDid, player);
+                OnCombatSyncFailed();
                 return null;
             }
 
             var rate = pet.EstimateMeleeDamageEventsPerSecond(pet.MotionTableId, meanDelay, resolvedStance);
             if (rate <= float.Epsilon)
             {
-                if (ServerConfig.pet_capture_combat_sync_fallback_cosmetic_only.Value)
-                    RevertCaptureSkinToTemplateCombat(pet, baselineMotionTableId, baselineCombatTableDid, player);
+                OnCombatSyncFailed();
                 return null;
             }
 
             return resolvedStance;
+        }
+
+        private static Dictionary<CombatBodyPart, PropertiesBodyPart> SnapshotBodyParts(IDictionary<CombatBodyPart, PropertiesBodyPart> source)
+        {
+            if (source == null || source.Count == 0)
+                return null;
+
+            var snapshot = new Dictionary<CombatBodyPart, PropertiesBodyPart>(source.Count);
+            foreach (var kvp in source)
+                snapshot[kvp.Key] = kvp.Value.Clone();
+
+            return snapshot;
+        }
+
+        private static void RestoreBodyParts(Creature pet, Dictionary<CombatBodyPart, PropertiesBodyPart> snapshot)
+        {
+            if (snapshot == null)
+            {
+                pet.Biota.PropertiesBodyPart = null;
+                return;
+            }
+
+            pet.Biota.PropertiesBodyPart = new Dictionary<CombatBodyPart, PropertiesBodyPart>(snapshot.Count);
+            foreach (var kvp in snapshot)
+                pet.Biota.PropertiesBodyPart[kvp.Key] = kvp.Value.Clone();
         }
 
         private static void RevertCaptureSkinToTemplateCombat(CombatPet pet, uint baselineMotionTableId, uint? baselineCombatTableDid, Player player)

--- a/Source/ACE.Server/WorldObjects/WorldObject_Teleport.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Teleport.cs
@@ -157,10 +157,10 @@ namespace ACE.Server.WorldObjects
                 newPosition.Variation = Location.Variation;
             }
 
-            // pre-validate movement
-            if (player != null && !player.ValidateMovement(newPosition))
+            // pre-validate movement (skip during forced server teleport; CurrentLandblock is often null mid-handoff)
+            if (player != null && !(Teleporting && forceUpdate) && !player.ValidateMovement(newPosition))
             {
-                log.Error($"{Name}.UpdatePosition() - movement pre-validation failed from {Location} to {newPosition}, t: {Teleporting}");
+                log.Warn($"{Name}.UpdatePosition() - movement pre-validation failed from {Location} to {newPosition}, t: {Teleporting}");
                 return false;
             }
 


### PR DESCRIPTION
Merge body-part keys from the siphoned creature with tier damage from the essence PetClass, resolve a valid combat stance for skin motion/CMT, and fall back to template combat when incompatible. Persist CapturedCreatureWCID on devices, add Blistered damage lead-word support, and reduce CombatPetAI movement spam when debug console is enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Combat pet essences now sync combat stance and motion timing from captured creatures for more authentic combat performance.
  * Pet essence naming logic improved to better recognize damage type prefixes.

* **Bug Fixes**
  * Fixed combat pet crates now correctly display the captured creature WCID.

* **Chores**
  * Added server configuration options for pet capture combat synchronization and fallback cosmetic mode.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rkroska/ACECustom/pull/463?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->