### PR TITLE
Restore pet bond XP on kill after PR #459 regression.

### DIFF
--- a/Database/Updates/World/2026-05-23-00-Combat-Pet-Tiers-250-300-Level.sql
+++ b/Database/Updates/World/2026-05-23-00-Combat-Pet-Tiers-250-300-Level.sql
@@ -1,0 +1,17 @@
+/* Set spawned combat pet Level (PropertyInt 25) to match summon tier.
+ * Tier pets 787802001–787802072 clone capstone-200 pets (Level 200); this corrects display/identification only —
+ * combat damage still comes from weenie_properties_body_part d_Val (scaled in 2026-05-12-00-Combat-Pet-Tiers-250-300.sql).
+ */
+START TRANSACTION;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+SELECT `class_Id`, 25,
+  CASE
+    WHEN `class_Id` BETWEEN 787802037 AND 787802072 THEN 300
+    ELSE 250
+  END
+FROM `weenie`
+WHERE `class_Id` BETWEEN 787802001 AND 787802072
+ON DUPLICATE KEY UPDATE `value` = VALUES(`value`);
+
+COMMIT;

--- a/Source/ACE.Server/WorldObjects/Creature_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Death.cs
@@ -214,31 +214,115 @@ namespace ACE.Server.WorldObjects
             if (totalHealth == 0)
                 return;
 
+            var monsterTier = PrestigeManager.GetKillScalingMonsterTier(this);
+
+            var baseXp = (long)(XpOverride ?? 0);
+
+            // One EarnXP / EarnLuminance per player: combine direct hits + all of that player's combat pets.
+            // Avoids duplicate fellowship splits and matches "your kill bonuses apply to the full credit you earned on the mob."
+            var xpCreditByPlayer = new Dictionary<uint, float>();
             foreach (var kvp in DamageHistory.TotalDamage)
             {
-                var damager = kvp.Value.TryGetAttacker();
-
-                var playerDamager = damager as Player;
-
-                if (playerDamager == null && kvp.Value.PetOwner != null)
-                    playerDamager = kvp.Value.TryGetPetOwner();
-
-                if (playerDamager == null)
+                var info = kvp.Value;
+                if (info.TotalDamage <= 0)
                     continue;
 
-                var totalDamage = kvp.Value.TotalDamage;
+                var damager = info.TryGetAttacker();
+                Player creditPlayer = damager as Player;
+                if (creditPlayer == null && info.PetOwner != null)
+                    creditPlayer = info.TryGetPetOwner();
 
-                var damagePercent = totalDamage / totalHealth;
+                if (creditPlayer == null)
+                    continue;
 
-                var totalXP = (XpOverride ?? 0) * damagePercent;
+                var id = creditPlayer.Guid.Full;
+                if (xpCreditByPlayer.TryGetValue(id, out var acc))
+                    xpCreditByPlayer[id] = acc + info.TotalDamage;
+                else
+                    xpCreditByPlayer[id] = info.TotalDamage;
+            }
 
-                playerDamager.EarnXP((long)Math.Round(totalXP), XpType.Kill);
+            foreach (var kv in xpCreditByPlayer)
+            {
+                var player = PlayerManager.GetOnlinePlayer(new ObjectGuid(kv.Key));
+                if (player == null)
+                    continue;
 
-                // handle luminance
+                var damagePercent = kv.Value / totalHealth;
+                if (damagePercent <= 0)
+                    continue;
+
+                if (baseXp > 0)
+                {
+                    var totalXP = baseXp * damagePercent;
+                    player.EarnXP((long)Math.Round(totalXP), XpType.Kill, ShareType.All, monsterTier);
+                }
+
                 if (LuminanceAward != null)
                 {
-                    var totalLuminance = (long)Math.Round(LuminanceAward.Value * damagePercent);
-                    playerDamager.EarnLuminance(totalLuminance, XpType.Kill);
+                    var totalLuminance = LuminanceAward.Value * damagePercent;
+                    player.EarnLuminance((long)Math.Round(totalLuminance), XpType.Kill, ShareType.All, monsterTier);
+                }
+            }
+
+            // Pet Bonding System - bond XP scales with pet damage share and the owner's kill XP modifier stack (same profile as EarnXP).
+            // Accumulate per summoning device so TryAwardBondXp (save + network) runs once per device per kill.
+            if (ServerConfig.pet_bond_enabled.Value && baseXp > 0)
+            {
+                var bondXpByDevice = new Dictionary<uint, (Player Owner, long Xp)>();
+
+                foreach (var kvp in DamageHistory.TotalDamage)
+                {
+                    var info = kvp.Value;
+                    if (info.TotalDamage <= 0)
+                        continue;
+
+                    var damager = info.TryGetAttacker();
+                    if (damager is not CombatPet combatPet || info.PetOwner == null)
+                        continue;
+
+                    var playerDamager = info.TryGetPetOwner();
+                    if (playerDamager == null)
+                        continue;
+
+                    var damagePercent = info.TotalDamage / totalHealth;
+                    if (damagePercent <= 0)
+                        continue;
+
+                    var bondXp = (long)Math.Round(baseXp * damagePercent * ServerConfig.pet_bond_xp_multiplier.Value * playerDamager.GetKillXpModifierProduct());
+                    var minAward = ServerConfig.pet_bond_xp_min_award.Value;
+                    if (bondXp < minAward) bondXp = minAward;
+
+                    PetDevice device = combatPet.TryGetSummoningDevice();
+                    if (device == null)
+                    {
+                        var devGuid = combatPet.SummoningDeviceGuid;
+                        if (devGuid != ObjectGuid.Invalid)
+                        {
+                            device = playerDamager.FindObject(devGuid.Full, Player.SearchLocations.MyInventory | Player.SearchLocations.MyEquippedItems) as PetDevice;
+                        }
+                    }
+
+                    if (device == null)
+                        continue;
+
+                    var key = device.Guid.Full;
+                    if (bondXpByDevice.TryGetValue(key, out var acc))
+                        bondXpByDevice[key] = (playerDamager, acc.Xp + bondXp);
+                    else
+                        bondXpByDevice[key] = (playerDamager, bondXp);
+                }
+
+                foreach (var kv in bondXpByDevice)
+                {
+                    var (owner, xp) = kv.Value;
+                    var device = owner.FindObject(kv.Key, Player.SearchLocations.MyInventory | Player.SearchLocations.MyEquippedItems) as PetDevice;
+                    if (device == null)
+                        continue;
+
+                    var awarded = device.TryAwardBondXp(owner, xp, out var leveledUp);
+                    if (awarded && leveledUp)
+                        owner.SendMessage($"Your bond with {device.GetBondMessageDisplayName()} deepens. (Bond Level {device.PetBondLevel:N0})");
                 }
             }
         }

--- a/Source/ACE.Server/WorldObjects/Creature_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Death.cs
@@ -90,6 +90,15 @@ namespace ACE.Server.WorldObjects
 
             var deathMessage = Strings.GetDeathMessage(damageType, criticalHit);
 
+            // ILT: always clear split arrow tracking — killer may not be a player
+            var lastHitWasSplitArrow = GetProperty(PropertyBool.LastHitWasSplitArrow) is true;
+            if (lastHitWasSplitArrow)
+            {
+                RemoveProperty(PropertyBool.LastHitWasSplitArrow);
+                RemoveProperty(PropertyInstanceId.LastSplitArrowProjectile);
+                RemoveProperty(PropertyInstanceId.LastSplitArrowShooter);
+            }
+
             // if killed by a player, send them a message
             if (lastDamagerInfo.IsPlayer)
             {
@@ -99,7 +108,16 @@ namespace ACE.Server.WorldObjects
                 var killerMsg = string.Format(deathMessage.Killer, Name);
 
                 if (lastDamager is Player playerKiller && playerKiller.Session != null)
-                    playerKiller.Session.Network.EnqueueSend(new GameEventKillerNotification(playerKiller.Session, killerMsg, GetProperty(PropertyBool.IsSplitArrowKill) == true));
+                {
+                    // ILT: build overkill suffix — applied AFTER split arrow text transformation
+                    // inside GameEventKillerNotification, so [Overkill: N] is always last.
+                    var overkillSuffix = (playerKiller.ShowOverkill && lastDamagerInfo.OverkillAmount > 0)
+                        ? $" [Overkill: {Creature.FormatDamage(lastDamagerInfo.OverkillAmount, playerKiller.DamageNumberFormat)}]"
+                        : "";
+
+                    playerKiller.Session.Network.EnqueueSend(
+                        new GameEventKillerNotification(playerKiller.Session, killerMsg, lastHitWasSplitArrow, overkillSuffix));
+                }
             }
             return deathMessage;
         }
@@ -155,7 +173,8 @@ namespace ACE.Server.WorldObjects
             var deathAnimLength = ExecuteMotion(motionDeath);
 
             // Try to generate Siphon Lens before death emotes (which might destroy the creature)
-            GenerateSiphonLens(topDamager);
+            if (!(this is Pet))
+                GenerateSiphonLens(topDamager);
 
             if (EmoteManager != null)
             {
@@ -561,6 +580,10 @@ namespace ACE.Server.WorldObjects
             {
                 if (killer != null && killer.IsOlthoiPlayer) return;
 
+                // PetDevice summons (Pet / CombatPet): no death treasure or ground drops (DeathTreasure, createlist, siphon lens)
+                if (this is Pet)
+                    return;
+
                 var loot = GenerateTreasure(killer, null);
 
                 foreach(var item in loot)
@@ -638,12 +661,10 @@ namespace ACE.Server.WorldObjects
 
                     corpse.KillerId = killer.Guid.Full;
 
-                    if (killer.PetOwner != null)
-                    {
-                        var petOwner = killer.TryGetPetOwner();
-                        if (petOwner != null)
-                            corpse.KillerId = petOwner.Guid.Full;
-                    }
+                    if (killer.TryGetPetOwner() is Player petLootPlayer)
+                        corpse.KillerId = petLootPlayer.Guid.Full;
+                    else if (killer.TryGetAttacker() is CombatPet killerPet && killerPet.P_PetOwner != null)
+                        corpse.KillerId = killerPet.P_PetOwner.Guid.Full;
                 }
             }
 
@@ -868,6 +889,7 @@ namespace ACE.Server.WorldObjects
         private List<WorldObject> GenerateTreasure(DamageHistoryInfo killer, Corpse corpse)
         {
             var droppedItems = new List<WorldObject>();
+            var tier = PrestigeManager.GetKillScalingMonsterTier(this);
 
             // create death treasure from loot generation factory
             if (DeathTreasure != null)
@@ -875,6 +897,9 @@ namespace ACE.Server.WorldObjects
                 List<WorldObject> items = LootGenerationFactory.CreateRandomLootObjects(DeathTreasure);
                 foreach (WorldObject wo in items)
                 {
+                    if (tier > 0)
+                        PrestigeManager.ApplyLootScaling(wo, tier);
+
                     if (corpse != null)
                         corpse.TryAddToInventory(wo);
                     else
@@ -933,6 +958,9 @@ namespace ACE.Server.WorldObjects
 
                     if (wo != null)
                     {
+                        if (tier > 0)
+                            PrestigeManager.ApplyLootScaling(wo, tier);
+
                         if (corpse != null)
                             corpse.TryAddToInventory(wo);
                         else


### PR DESCRIPTION
PR #459 reverted OnDeath_GrantXP to an older version that dropped TryAwardBondXp, combined player+pet kill credit, and prestige tier scaling. Restore the prior logic so bond XP scales with pet damage share and multiplier.

Also add a world patch to set Level (PropertyInt 25) on 250/300 combat pet WCIDs so spawned pets show the correct tier instead of inherited 200.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pet bond system now awards experience to companion devices during creature encounters, enabling pet advancement
  * Kill notifications to players now include overkill info

* **Balance Changes**
  * Combat pet tiers adjusted (higher level assignments)
  * XP and luminance distribution rebalanced to credit contributors more fairly
  * Loot now applies kill-scaling tiers to rewards

* **Bug Fixes**
  * Improved handling of pet deaths: no corpse drops for pets and more accurate ownership attribution

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rkroska/ACECustom/pull/464?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->