### PR TITLE
fix: guard PhysicsObj null in MoveReady/AttackReady - prevents server crash on freshly spawned creatures

### DIFF
--- a/Source/ACE.Server/WorldObjects/Monster_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Combat.cs
@@ -232,6 +232,8 @@ namespace ACE.Server.WorldObjects
             if (Timers.RunningTime < NextMoveTime)
                 return false;
 
+            if (PhysicsObj == null) return false;
+
             PhysicsObj.update_object();
             UpdatePosition_SyncLocation();
 
@@ -248,6 +250,8 @@ namespace ACE.Server.WorldObjects
 
             if (Timers.RunningTime < nextAttackTime || !IsAttackRange())
                 return false;
+
+            if (PhysicsObj == null) return false;
 
             PhysicsObj.update_object();
             UpdatePosition_SyncLocation();


### PR DESCRIPTION
## Summary

Prevents a server crash caused by the enrage system's hotspot spawner. When the spawner drops a creature into the world (e.g. the iron cage, WCID 90000417), the monster tick loop can call `MoveReady()` or `AttackReady()` before the object's `PhysicsObj` is fully initialized, causing a `NullReferenceException` that brings down the entire server.

## Root Cause

`MoveReady()` and `AttackReady()` both call `PhysicsObj.update_object()` and read `PhysicsObj.IsAnimating` without guarding against a null `PhysicsObj`. A freshly spawned world object's `PhysicsObj` is not guaranteed to be set when the first tick fires.

## Changes

### `Monster_Combat.cs`
- Added `if (PhysicsObj == null) return false;` guard in `MoveReady()` before the `PhysicsObj.update_object()` call
- Added the same guard in `AttackReady()`
- If `PhysicsObj` isn't ready yet, the creature simply skips its move/attack tick - correct behaviour with no impact on normal mobs

## Reproduction

1. Use the Explosive Arrow Charm in VOD (Vale of Destruction)
2. Charm proc fires AOE ring ? hits multiple mobs simultaneously
3. A mob drops to enrage threshold ? enrage triggers ? hotspot spawner fires
4. Iron cage weenie (WCID 90000417) enters the world mid-tick ? null crash ? server down

## Testing
- Build: 0 errors
- Server boots cleanly
- Charm proc no longer crashes the server when triggering enrage hotspot spawns