### PR TITLE
fix: close three item dupe paths in inventory/wield/stack-split handlers

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -2718,7 +2718,8 @@ namespace ACE.Server.WorldObjects
             if (!AdjustStack(stack, -amount, stackFoundInContainer, stackRootOwner))
             {
                 // Undo the TryAddToInventory so no orphaned stack is left in the container
-                container.TryRemoveFromInventory(newStack.Guid);
+                if (!container.TryRemoveFromInventory(newStack.Guid))
+                    log.Warn($"{Name}.DoHandleActionStackableSplitToContainer - rollback failed: could not remove newStack 0x{newStack.Guid} from container 0x{container.Guid}");
                 Session.Network.EnqueueSend(new GameEventInventoryServerSaveFailed(Session, stack.Guid.Full));
                 return false;
             }

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -1565,6 +1565,7 @@ namespace ACE.Server.WorldObjects
                 {
                     Session.Network.EnqueueSend(new GameEventCommunicationTransientString(Session, "TryRemoveFromInventory failed!")); // Custom error message
                     Session.Network.EnqueueSend(new GameEventInventoryServerSaveFailed(Session, item.Guid.Full));
+                    return false; // fix: execution was falling through to TryAddToInventory, duping the item
                 }
 
                 if (itemRootOwner == this && containerRootOwner != this)
@@ -2115,6 +2116,7 @@ namespace ACE.Server.WorldObjects
                 {
                     Session.Network.EnqueueSend(new GameEventCommunicationTransientString(Session, "TryRemoveFromInventory failed!")); // Custom error message
                     Session.Network.EnqueueSend(new GameEventInventoryServerSaveFailed(Session, item.Guid.Full));
+                    return false; // fix: execution was falling through to TryEquipObjectWithNetworking, duping the item into both inventory and equipped dicts
                 }
             }
 
@@ -2710,6 +2712,18 @@ namespace ACE.Server.WorldObjects
                 return false;
             }
 
+            // fix: deduct source stack BEFORE notifying client — if AdjustStack fails after GameMessageCreateObject,
+            // the client believes the new stack exists but the source was never reduced, creating a dupe.
+            var oldStackSize = stack.StackSize;
+            if (!AdjustStack(stack, -amount, stackFoundInContainer, stackRootOwner))
+            {
+                // Undo the TryAddToInventory so no orphaned stack is left in the container
+                container.TryRemoveFromInventory(newStack.Guid);
+                Session.Network.EnqueueSend(new GameEventInventoryServerSaveFailed(Session, stack.Guid.Full));
+                return false;
+            }
+
+            // Both operations succeeded — safe to update encumbrance and notify client
             if (container != containerRootOwner && containerRootOwner != null)
             {
                 containerRootOwner.EncumbranceVal += (stack.StackUnitEncumbrance * amount);
@@ -2718,10 +2732,6 @@ namespace ACE.Server.WorldObjects
 
             Session.Network.EnqueueSend(new GameMessageCreateObject(newStack));
             Session.Network.EnqueueSend(new GameEventItemServerSaysContainId(Session, newStack, container));
-
-            var oldStackSize = stack.StackSize;
-            if (!AdjustStack(stack, -amount, stackFoundInContainer, stackRootOwner))
-                return false;
 
             var newStackSize = stack.StackSize;
             log.Debug($"[STACK SPLIT] Original stack {stack.Name} (0x{stack.Guid}) | Old StackSize={oldStackSize} | New StackSize={newStackSize} | Amount split={amount} | ChangesDetected={stack.ChangesDetected}");


### PR DESCRIPTION
Bug 1 - DoHandleActionPutItemInContainer (pack move path):
  TryRemoveFromInventory failure had no return false, execution fell
  through to TryAddToInventory, leaving the item in both the original
  container dict and the destination container dict.

Bug 2 - DoHandleActionGetAndWieldItem (wield from pack path):
  Same pattern - TryRemoveFromInventory failure had no return false,
  execution fell through to TryEquipObjectWithNetworking, leaving the
  item in both Inventory and EquippedObjects dicts simultaneously.

Bug 3 - DoHandleActionStackableSplitToContainer (stack split):
  GameMessageCreateObject (new stack) was sent to client before
  AdjustStack deducted the source. If AdjustStack failed, client
  believed the new stack existed while the source remained at full
  size. Fixed by moving AdjustStack before network messages and
  undoing TryAddToInventory on failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed item duplication issues that could occur during inventory operations when removing items from containers and splitting item stacks.
  * Improved inventory operation sequencing to ensure consistency between server and client states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rkroska/ACECustom/pull/471?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->