### PR TITLE
feat(stickychat): implement server-side persistent sticky chat

### DIFF
--- a/Source/ACE.Entity/Enum/Properties/PropertyBool.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyBool.cs
@@ -316,6 +316,8 @@ namespace ACE.Entity.Enum.Properties
 
         /// <summary>Player has the Fork Charm active — Streak, Arc, and Bolt projectiles fork to nearby enemies on hit.</summary>
         HasForkCharm = 50039,
+        /// <summary>Player has Sticky Chat enabled. Toggling channels (/a or /f) locks normal text to that channel.</summary>
+        StickyChatEnabled = 50040,
 
         // -- ILT Player UI Preferences -> see PropertyInt.DamageNumberFormat (50101) --
     }

--- a/Source/ACE.Server/Command/Handlers/ILTCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/ILTCommands.cs
@@ -43,7 +43,7 @@ namespace ACE.Server.Command.Handlers
 
         [CommandHandler("ilt", AccessLevel.Player, CommandHandlerFlag.RequiresWorld, 0,
             "ILT custom server commands and player preferences.",
-            "Usage: /ilt [help|features|dmgformat|showoverkill|levelskills|trainskills|xp level|train|smartring [on|off]|ringmode|ringrange|arrowdebug]")]
+            "Usage: /ilt [help|features|dmgformat|showoverkill|levelskills|trainskills|xp level|train|smartring [on|off]|ringmode|ringrange|arrowdebug|stickychat [on|off]]")]
         public static void HandleILT(Session session, params string[] parameters)
         {
             var player = session.Player;
@@ -122,6 +122,39 @@ namespace ACE.Server.Command.Handlers
                     session.Network.EnqueueSend(new GameMessageSystemChat(
                         $"Usage: /ilt {usageName} [on | off]", ChatMessageType.System));
                 }
+            }
+            else if (sub == "stickychat")
+            {
+                bool newValue;
+                if (parameters.Length >= 2)
+                {
+                    var opt = parameters[1].ToLower();
+                    if (opt == "on" || opt == "true" || opt == "enable")
+                        newValue = true;
+                    else if (opt == "off" || opt == "false" || opt == "disable")
+                        newValue = false;
+                    else
+                    {
+                        session.Network.EnqueueSend(new GameMessageSystemChat(
+                            $"Unknown value '{parameters[1]}'. Valid options: on, off.", ChatMessageType.System));
+                        return;
+                    }
+                }
+                else
+                    newValue = !player.StickyChatEnabled; // toggle if no param
+
+                player.StickyChatEnabled = newValue;
+                player.SaveBiotaToDatabase(enqueueSave: true);
+
+                if (!newValue)
+                {
+                    player.StickyChatMode = StickyChatType.None; // Reset active state if disabled
+                }
+
+                var state = newValue ? "ON" : "OFF";
+                session.Network.EnqueueSend(new GameMessageSystemChat(
+                    $"Sticky Chat is now {state}. {(newValue ? "Typing to Fellowship (/f) or Allegiance (/a) will automatically lock subsequent standard chat to that channel." : "Chat routing operates in standard retail mode (no lock).")}",
+                    ChatMessageType.System));
             }
             else if (sub == "dmgformat")
             {
@@ -402,9 +435,12 @@ namespace ACE.Server.Command.Handlers
                 var dmgLabel  = player.DamageNumberFormat switch { 1 => "commas", 2 => "short", _ => "default" };
                 var okLabel   = player.ShowOverkill ? "ON" : "OFF";
                 var ringLabel = (player.GetProperty(PropertyBool.ClassicRingAoe) ?? false) ? "Classic" : "New";
+                var stickyLabel = player.StickyChatEnabled ? "ON" : "OFF";
                 session.Network.EnqueueSend(new GameMessageSystemChat("=== ILT Custom Commands ===", ChatMessageType.System));
                 session.Network.EnqueueSend(new GameMessageSystemChat("  /ilt features", ChatMessageType.System));
                 session.Network.EnqueueSend(new GameMessageSystemChat("      View a list of custom ILT server features.", ChatMessageType.System));
+                session.Network.EnqueueSend(new GameMessageSystemChat($"  /ilt stickychat [on|off]", ChatMessageType.System));
+                session.Network.EnqueueSend(new GameMessageSystemChat($"      Toggle Sticky Chat lock mode globally. (currently: {stickyLabel})", ChatMessageType.System));
                 session.Network.EnqueueSend(new GameMessageSystemChat($"  /ilt dmgformat [default|commas|short]", ChatMessageType.System));
                 session.Network.EnqueueSend(new GameMessageSystemChat($"      Set your damage number display style. (currently: {dmgLabel})", ChatMessageType.System));
                 session.Network.EnqueueSend(new GameMessageSystemChat($"  /ilt showoverkill [on|off]", ChatMessageType.System));

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionChatChannel.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionChatChannel.cs
@@ -4,6 +4,8 @@ using ACE.Common.Extensions;
 using ACE.Entity.Enum;
 using ACE.Server.Managers;
 using ACE.Server.Network.GameEvent.Events;
+using ACE.Server.WorldObjects;
+using ACE.Server.Network.GameMessages.Messages;
 
 namespace ACE.Server.Network.GameAction.Actions
 {
@@ -14,6 +16,48 @@ namespace ACE.Server.Network.GameAction.Actions
         {
             var groupChatType = (Channel)clientMessage.Payload.ReadUInt32();
             var message = clientMessage.Payload.ReadString16L();
+
+            if (string.IsNullOrEmpty(message))
+            {
+                if (groupChatType == Channel.Vassals)
+                {
+                    if (session.Player.StickyChatMode == StickyChatType.Allegiance)
+                    {
+                        session.Player.StickyChatMode = StickyChatType.None;
+                        session.Network.EnqueueSend(new GameMessageSystemChat("Sticky Chat: Disabled. Normal chat will go to local speech.", ChatMessageType.Broadcast));
+                    }
+                    else
+                    {
+                        if (session.Player.Allegiance == null)
+                        {
+                            session.Network.EnqueueSend(new GameEventWeenieError(session, WeenieError.YouAreNotInAllegiance));
+                            return;
+                        }
+                        session.Player.StickyChatMode = StickyChatType.Allegiance;
+                        session.Network.EnqueueSend(new GameMessageSystemChat("Sticky Chat: [Allegiance] is now active. Normal chat will go to Allegiance. Type /say to disable.", ChatMessageType.Broadcast));
+                    }
+                    return;
+                }
+                else if (groupChatType == Channel.Fellow)
+                {
+                    if (session.Player.StickyChatMode == StickyChatType.Fellowship)
+                    {
+                        session.Player.StickyChatMode = StickyChatType.None;
+                        session.Network.EnqueueSend(new GameMessageSystemChat("Sticky Chat: Disabled. Normal chat will go to local speech.", ChatMessageType.Broadcast));
+                    }
+                    else
+                    {
+                        if (session.Player.Fellowship == null)
+                        {
+                            session.Network.EnqueueSend(new GameEventWeenieError(session, WeenieError.YouDoNotBelongToAFellowship));
+                            return;
+                        }
+                        session.Player.StickyChatMode = StickyChatType.Fellowship;
+                        session.Network.EnqueueSend(new GameMessageSystemChat("Sticky Chat: [Fellowship] is now active. Normal chat will go to Fellowship. Type /say to disable.", ChatMessageType.Broadcast));
+                    }
+                    return;
+                }
+            }
 
             switch (groupChatType)
             {

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionChatChannel.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionChatChannel.cs
@@ -20,16 +20,81 @@ namespace ACE.Server.Network.GameAction.Actions
             // DEBUG LOGGING
             session.Network.EnqueueSend(new GameMessageSystemChat($"[DEBUG GameActionChatChannel] Channel: {groupChatType} (0x{(uint)groupChatType:X8}) | Msg: '{(message ?? "null")}' | Len: {message?.Length ?? 0}", ChatMessageType.Broadcast));
 
-            if (string.IsNullOrEmpty(message))
+            var trimmedMsg = message?.Trim();
+
+            // Disable check on any channel message
+            if (string.Equals(trimmedMsg, "/say", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(trimmedMsg, "/s", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(trimmedMsg, "/local", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(trimmedMsg, "@sticky off", StringComparison.OrdinalIgnoreCase))
+            {
+                if (session.Player.StickyChatMode != StickyChatType.None)
+                {
+                    session.Player.StickyChatMode = StickyChatType.None;
+                    session.Network.EnqueueSend(new GameMessageSystemChat("Sticky Chat: Disabled. Normal chat will go to local speech.", ChatMessageType.Broadcast));
+                }
+                return;
+            }
+
+            // Allegiance Sticky Toggle
+            bool isAllegianceToggle = string.Equals(trimmedMsg, "/a", StringComparison.OrdinalIgnoreCase) ||
+                                      string.Equals(trimmedMsg, "/v", StringComparison.OrdinalIgnoreCase) ||
+                                      string.Equals(trimmedMsg, "/vassals", StringComparison.OrdinalIgnoreCase) ||
+                                      string.Equals(trimmedMsg, "@a", StringComparison.OrdinalIgnoreCase) ||
+                                      (string.IsNullOrEmpty(trimmedMsg) && (groupChatType == Channel.Vassals || groupChatType == Channel.AllegianceBroadcast));
+
+            if (isAllegianceToggle)
+            {
+                if (session.Player.StickyChatMode == StickyChatType.Allegiance)
+                {
+                    session.Player.StickyChatMode = StickyChatType.None;
+                    session.Network.EnqueueSend(new GameMessageSystemChat("Sticky Chat: Disabled. Normal chat will go to local speech.", ChatMessageType.Broadcast));
+                }
+                else
+                {
+                    if (session.Player.Allegiance == null)
+                    {
+                        session.Network.EnqueueSend(new GameEventWeenieError(session, WeenieError.YouAreNotInAllegiance));
+                        return;
+                    }
+                    session.Player.StickyChatMode = StickyChatType.Allegiance;
+                    session.Network.EnqueueSend(new GameMessageSystemChat("Sticky Chat: [Allegiance] is now active. Normal chat will go to Allegiance. Type /say to disable.", ChatMessageType.Broadcast));
+                }
+                return;
+            }
+
+            // Fellowship Sticky Toggle
+            bool isFellowshipToggle = string.Equals(trimmedMsg, "/f", StringComparison.OrdinalIgnoreCase) ||
+                                      string.Equals(trimmedMsg, "/fellow", StringComparison.OrdinalIgnoreCase) ||
+                                      string.Equals(trimmedMsg, "@f", StringComparison.OrdinalIgnoreCase) ||
+                                      (string.IsNullOrEmpty(trimmedMsg) && groupChatType == Channel.Fellow);
+
+            if (isFellowshipToggle)
+            {
+                if (session.Player.StickyChatMode == StickyChatType.Fellowship)
+                {
+                    session.Player.StickyChatMode = StickyChatType.None;
+                    session.Network.EnqueueSend(new GameMessageSystemChat("Sticky Chat: Disabled. Normal chat will go to local speech.", ChatMessageType.Broadcast));
+                }
+                else
+                {
+                    if (session.Player.Fellowship == null)
+                    {
+                        session.Network.EnqueueSend(new GameEventWeenieError(session, WeenieError.YouDoNotBelongToAFellowship));
+                        return;
+                    }
+                    session.Player.StickyChatMode = StickyChatType.Fellowship;
+                    session.Network.EnqueueSend(new GameMessageSystemChat("Sticky Chat: [Fellowship] is now active. Normal chat will go to Fellowship. Type /say to disable.", ChatMessageType.Broadcast));
+                }
+                return;
+            }
+
+            // Automatic Sticky Lock when stickychat is enabled and a message is typed
+            if (session.Player.StickyChatEnabled && !string.IsNullOrEmpty(trimmedMsg))
             {
                 if (groupChatType == Channel.Vassals || groupChatType == Channel.AllegianceBroadcast)
                 {
-                    if (session.Player.StickyChatMode == StickyChatType.Allegiance)
-                    {
-                        session.Player.StickyChatMode = StickyChatType.None;
-                        session.Network.EnqueueSend(new GameMessageSystemChat("Sticky Chat: Disabled. Normal chat will go to local speech.", ChatMessageType.Broadcast));
-                    }
-                    else
+                    if (session.Player.StickyChatMode != StickyChatType.Allegiance)
                     {
                         if (session.Player.Allegiance == null)
                         {
@@ -39,16 +104,10 @@ namespace ACE.Server.Network.GameAction.Actions
                         session.Player.StickyChatMode = StickyChatType.Allegiance;
                         session.Network.EnqueueSend(new GameMessageSystemChat("Sticky Chat: [Allegiance] is now active. Normal chat will go to Allegiance. Type /say to disable.", ChatMessageType.Broadcast));
                     }
-                    return;
                 }
                 else if (groupChatType == Channel.Fellow)
                 {
-                    if (session.Player.StickyChatMode == StickyChatType.Fellowship)
-                    {
-                        session.Player.StickyChatMode = StickyChatType.None;
-                        session.Network.EnqueueSend(new GameMessageSystemChat("Sticky Chat: Disabled. Normal chat will go to local speech.", ChatMessageType.Broadcast));
-                    }
-                    else
+                    if (session.Player.StickyChatMode != StickyChatType.Fellowship)
                     {
                         if (session.Player.Fellowship == null)
                         {
@@ -58,7 +117,6 @@ namespace ACE.Server.Network.GameAction.Actions
                         session.Player.StickyChatMode = StickyChatType.Fellowship;
                         session.Network.EnqueueSend(new GameMessageSystemChat("Sticky Chat: [Fellowship] is now active. Normal chat will go to Fellowship. Type /say to disable.", ChatMessageType.Broadcast));
                     }
-                    return;
                 }
             }
 

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionChatChannel.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionChatChannel.cs
@@ -20,13 +20,91 @@ namespace ACE.Server.Network.GameAction.Actions
             // DEBUG LOGGING
             session.Network.EnqueueSend(new GameMessageSystemChat($"[DEBUG GameActionChatChannel] Channel: {groupChatType} (0x{(uint)groupChatType:X8}) | Msg: '{(message ?? "null")}' | Len: {message?.Length ?? 0}", ChatMessageType.Broadcast));
 
+            if (message != null)
+            {
+                // Intercept say with content to turn off sticky
+                if (message.StartsWith("/s ", StringComparison.OrdinalIgnoreCase) ||
+                    message.StartsWith("/say ", StringComparison.OrdinalIgnoreCase) ||
+                    message.StartsWith("/local ", StringComparison.OrdinalIgnoreCase) ||
+                    message.StartsWith("@s ", StringComparison.OrdinalIgnoreCase) ||
+                    message.StartsWith("@say ", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (session.Player.StickyChatMode != StickyChatType.None)
+                    {
+                        session.Player.StickyChatMode = StickyChatType.None;
+                        session.Network.EnqueueSend(new GameMessageSystemChat("Sticky Chat: Disabled. Normal chat will go to local speech.", ChatMessageType.Broadcast));
+                    }
+                    var prefixLen = 3;
+                    if (message.StartsWith("/say ", StringComparison.OrdinalIgnoreCase) || message.StartsWith("@say ", StringComparison.OrdinalIgnoreCase))
+                        prefixLen = 5;
+                    else if (message.StartsWith("/local ", StringComparison.OrdinalIgnoreCase))
+                        prefixLen = 7;
+                    
+                    session.Player.HandleActionTalk(message.Substring(prefixLen));
+                    return;
+                }
+
+                // Intercept channels with content to trigger sticky
+                if (message.StartsWith("/a ", StringComparison.OrdinalIgnoreCase) ||
+                    message.StartsWith("/v ", StringComparison.OrdinalIgnoreCase) ||
+                    message.StartsWith("/vassals ", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (session.Player.StickyChatEnabled)
+                    {
+                        if (session.Player.StickyChatMode != StickyChatType.Allegiance)
+                        {
+                            if (session.Player.Allegiance == null)
+                            {
+                                session.Network.EnqueueSend(new GameEventWeenieError(session, WeenieError.YouAreNotInAllegiance));
+                                return;
+                            }
+                            session.Player.StickyChatMode = StickyChatType.Allegiance;
+                            session.Network.EnqueueSend(new GameMessageSystemChat("Sticky Chat: [Allegiance] is now active. Normal chat will go to Allegiance. Type /say to disable.", ChatMessageType.Broadcast));
+                        }
+                    }
+                    var prefixLen = message.StartsWith("/vassals ", StringComparison.OrdinalIgnoreCase) ? 9 : 3;
+                    session.Player.BroadcastToAllegiance(message.Substring(prefixLen));
+                    return;
+                }
+
+                if (message.StartsWith("/f ", StringComparison.OrdinalIgnoreCase) ||
+                    message.StartsWith("/fellow ", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (session.Player.StickyChatEnabled)
+                    {
+                        if (session.Player.StickyChatMode != StickyChatType.Fellowship)
+                        {
+                            if (session.Player.Fellowship == null)
+                            {
+                                session.Network.EnqueueSend(new GameEventWeenieError(session, WeenieError.YouDoNotBelongToAFellowship));
+                                return;
+                            }
+                            session.Player.StickyChatMode = StickyChatType.Fellowship;
+                            session.Network.EnqueueSend(new GameMessageSystemChat("Sticky Chat: [Fellowship] is now active. Normal chat will go to Fellowship. Type /say to disable.", ChatMessageType.Broadcast));
+                        }
+                    }
+                    var prefixLen = message.StartsWith("/fellow ", StringComparison.OrdinalIgnoreCase) ? 8 : 3;
+                    session.Player.BroadcastToFellowship(message.Substring(prefixLen));
+                    return;
+                }
+
+                // Bypass other commands/slashes entirely to local talk
+                if (message.StartsWith("/") || message.StartsWith("@"))
+                {
+                    session.Player.HandleActionTalk(message);
+                    return;
+                }
+            }
+
             var trimmedMsg = message?.Trim();
 
             // Disable check on any channel message
             if (string.Equals(trimmedMsg, "/say", StringComparison.OrdinalIgnoreCase) ||
                 string.Equals(trimmedMsg, "/s", StringComparison.OrdinalIgnoreCase) ||
                 string.Equals(trimmedMsg, "/local", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(trimmedMsg, "@sticky off", StringComparison.OrdinalIgnoreCase))
+                string.Equals(trimmedMsg, "@sticky off", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(trimmedMsg, "@say", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(trimmedMsg, "@s", StringComparison.OrdinalIgnoreCase))
             {
                 if (session.Player.StickyChatMode != StickyChatType.None)
                 {

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionChatChannel.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionChatChannel.cs
@@ -17,9 +17,12 @@ namespace ACE.Server.Network.GameAction.Actions
             var groupChatType = (Channel)clientMessage.Payload.ReadUInt32();
             var message = clientMessage.Payload.ReadString16L();
 
+            // DEBUG LOGGING
+            session.Network.EnqueueSend(new GameMessageSystemChat($"[DEBUG GameActionChatChannel] Channel: {groupChatType} (0x{(uint)groupChatType:X8}) | Msg: '{(message ?? "null")}' | Len: {message?.Length ?? 0}", ChatMessageType.Broadcast));
+
             if (string.IsNullOrEmpty(message))
             {
-                if (groupChatType == Channel.Vassals)
+                if (groupChatType == Channel.Vassals || groupChatType == Channel.AllegianceBroadcast)
                 {
                     if (session.Player.StickyChatMode == StickyChatType.Allegiance)
                     {

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionTalk.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionTalk.cs
@@ -6,6 +6,7 @@ using ACE.Common.Extensions;
 using ACE.Entity.Enum;
 using ACE.Server.Command;
 using ACE.Server.Network.GameMessages.Messages;
+using ACE.Server.WorldObjects;
 
 namespace ACE.Server.Network.GameAction.Actions
 {
@@ -97,6 +98,19 @@ namespace ACE.Server.Network.GameAction.Actions
             }
             else
             {
+                if (message.Equals("/say", StringComparison.OrdinalIgnoreCase) || 
+                    message.Equals("/s", StringComparison.OrdinalIgnoreCase) ||
+                    message.Equals("/local", StringComparison.OrdinalIgnoreCase) ||
+                    message.Equals("@sticky off", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (session.Player.StickyChatMode != StickyChatType.None)
+                    {
+                        session.Player.StickyChatMode = StickyChatType.None;
+                        session.Network.EnqueueSend(new GameMessageSystemChat("Sticky Chat: Disabled. Normal chat will go to local speech.", ChatMessageType.Broadcast));
+                        return;
+                    }
+                }
+
                 session.Player.HandleActionTalk(message);
             }
         }

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionTalk.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionTalk.cs
@@ -7,6 +7,7 @@ using ACE.Entity.Enum;
 using ACE.Server.Command;
 using ACE.Server.Network.GameMessages.Messages;
 using ACE.Server.WorldObjects;
+using ACE.Server.Network.GameEvent.Events;
 
 namespace ACE.Server.Network.GameAction.Actions
 {
@@ -19,6 +20,54 @@ namespace ACE.Server.Network.GameAction.Actions
         {
             var message = clientMessage.Payload.ReadString16L();
             
+            // DEBUG LOGGING
+            session.Network.EnqueueSend(new GameMessageSystemChat($"[DEBUG GameActionTalk] Msg: '{(message ?? "null")}'", ChatMessageType.Broadcast));
+
+            var trimmedMsg = message?.Trim();
+            if (string.Equals(trimmedMsg, "/a", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(trimmedMsg, "/v", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(trimmedMsg, "/vassals", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(trimmedMsg, "@a", StringComparison.OrdinalIgnoreCase))
+            {
+                if (session.Player.StickyChatMode == StickyChatType.Allegiance)
+                {
+                    session.Player.StickyChatMode = StickyChatType.None;
+                    session.Network.EnqueueSend(new GameMessageSystemChat("Sticky Chat: Disabled. Normal chat will go to local speech.", ChatMessageType.Broadcast));
+                }
+                else
+                {
+                    if (session.Player.Allegiance == null)
+                    {
+                        session.Network.EnqueueSend(new GameEventWeenieError(session, WeenieError.YouAreNotInAllegiance));
+                        return;
+                    }
+                    session.Player.StickyChatMode = StickyChatType.Allegiance;
+                    session.Network.EnqueueSend(new GameMessageSystemChat("Sticky Chat: [Allegiance] is now active. Normal chat will go to Allegiance. Type /say to disable.", ChatMessageType.Broadcast));
+                }
+                return;
+            }
+            else if (string.Equals(trimmedMsg, "/f", StringComparison.OrdinalIgnoreCase) ||
+                     string.Equals(trimmedMsg, "/fellow", StringComparison.OrdinalIgnoreCase) ||
+                     string.Equals(trimmedMsg, "@f", StringComparison.OrdinalIgnoreCase))
+            {
+                if (session.Player.StickyChatMode == StickyChatType.Fellowship)
+                {
+                    session.Player.StickyChatMode = StickyChatType.None;
+                    session.Network.EnqueueSend(new GameMessageSystemChat("Sticky Chat: Disabled. Normal chat will go to local speech.", ChatMessageType.Broadcast));
+                }
+                else
+                {
+                    if (session.Player.Fellowship == null)
+                    {
+                        session.Network.EnqueueSend(new GameEventWeenieError(session, WeenieError.YouDoNotBelongToAFellowship));
+                        return;
+                    }
+                    session.Player.StickyChatMode = StickyChatType.Fellowship;
+                    session.Network.EnqueueSend(new GameMessageSystemChat("Sticky Chat: [Fellowship] is now active. Normal chat will go to Fellowship. Type /say to disable.", ChatMessageType.Broadcast));
+                }
+                return;
+            }
+
             if (message.StartsWith("@"))
             {
                 string commandRaw = message.Remove(0, 1);

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionTalk.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionTalk.cs
@@ -23,6 +23,65 @@ namespace ACE.Server.Network.GameAction.Actions
             // DEBUG LOGGING
             session.Network.EnqueueSend(new GameMessageSystemChat($"[DEBUG GameActionTalk] Msg: '{(message ?? "null")}'", ChatMessageType.Broadcast));
 
+            // Intercept say with content to turn off sticky
+            if (message.StartsWith("/s ", StringComparison.OrdinalIgnoreCase) ||
+                message.StartsWith("/say ", StringComparison.OrdinalIgnoreCase) ||
+                message.StartsWith("/local ", StringComparison.OrdinalIgnoreCase))
+            {
+                if (session.Player.StickyChatMode != StickyChatType.None)
+                {
+                    session.Player.StickyChatMode = StickyChatType.None;
+                    session.Network.EnqueueSend(new GameMessageSystemChat("Sticky Chat: Disabled. Normal chat will go to local speech.", ChatMessageType.Broadcast));
+                }
+                var prefixLen = message.StartsWith("/say ", StringComparison.OrdinalIgnoreCase) ? 5 : (message.StartsWith("/local ", StringComparison.OrdinalIgnoreCase) ? 7 : 3);
+                session.Player.HandleActionTalk(message.Substring(prefixLen));
+                return;
+            }
+
+            // Intercept channels with content to trigger sticky
+            if (message.StartsWith("/a ", StringComparison.OrdinalIgnoreCase) ||
+                message.StartsWith("/v ", StringComparison.OrdinalIgnoreCase) ||
+                message.StartsWith("/vassals ", StringComparison.OrdinalIgnoreCase))
+            {
+                if (session.Player.StickyChatEnabled)
+                {
+                    if (session.Player.StickyChatMode != StickyChatType.Allegiance)
+                    {
+                        if (session.Player.Allegiance == null)
+                        {
+                            session.Network.EnqueueSend(new GameEventWeenieError(session, WeenieError.YouAreNotInAllegiance));
+                            return;
+                        }
+                        session.Player.StickyChatMode = StickyChatType.Allegiance;
+                        session.Network.EnqueueSend(new GameMessageSystemChat("Sticky Chat: [Allegiance] is now active. Normal chat will go to Allegiance. Type /say to disable.", ChatMessageType.Broadcast));
+                    }
+                }
+                var prefixLen = message.StartsWith("/vassals ", StringComparison.OrdinalIgnoreCase) ? 9 : 3;
+                session.Player.BroadcastToAllegiance(message.Substring(prefixLen));
+                return;
+            }
+
+            if (message.StartsWith("/f ", StringComparison.OrdinalIgnoreCase) ||
+                message.StartsWith("/fellow ", StringComparison.OrdinalIgnoreCase))
+            {
+                if (session.Player.StickyChatEnabled)
+                {
+                    if (session.Player.StickyChatMode != StickyChatType.Fellowship)
+                    {
+                        if (session.Player.Fellowship == null)
+                        {
+                            session.Network.EnqueueSend(new GameEventWeenieError(session, WeenieError.YouDoNotBelongToAFellowship));
+                            return;
+                        }
+                        session.Player.StickyChatMode = StickyChatType.Fellowship;
+                        session.Network.EnqueueSend(new GameMessageSystemChat("Sticky Chat: [Fellowship] is now active. Normal chat will go to Fellowship. Type /say to disable.", ChatMessageType.Broadcast));
+                    }
+                }
+                var prefixLen = message.StartsWith("/fellow ", StringComparison.OrdinalIgnoreCase) ? 8 : 3;
+                session.Player.BroadcastToFellowship(message.Substring(prefixLen));
+                return;
+            }
+
             var trimmedMsg = message?.Trim();
             if (string.Equals(trimmedMsg, "/a", StringComparison.OrdinalIgnoreCase) ||
                 string.Equals(trimmedMsg, "/v", StringComparison.OrdinalIgnoreCase) ||

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -948,7 +948,7 @@ namespace ACE.Server.WorldObjects
                 return;
             }
 
-            if (StickyChatMode == StickyChatType.Allegiance)
+            if (StickyChatEnabled && StickyChatMode == StickyChatType.Allegiance)
             {
                 if (Allegiance != null)
                 {
@@ -961,7 +961,7 @@ namespace ACE.Server.WorldObjects
                     Session.Network.EnqueueSend(new GameMessageSystemChat("Sticky Chat disabled: You are not in an allegiance.", ChatMessageType.Broadcast));
                 }
             }
-            else if (StickyChatMode == StickyChatType.Fellowship)
+            else if (StickyChatEnabled && StickyChatMode == StickyChatType.Fellowship)
             {
                 if (Fellowship != null)
                 {

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -948,7 +948,7 @@ namespace ACE.Server.WorldObjects
                 return;
             }
 
-            if (StickyChatEnabled && StickyChatMode == StickyChatType.Allegiance)
+            if (!message.StartsWith("/") && StickyChatEnabled && StickyChatMode == StickyChatType.Allegiance)
             {
                 if (Allegiance != null)
                 {
@@ -961,7 +961,7 @@ namespace ACE.Server.WorldObjects
                     Session.Network.EnqueueSend(new GameMessageSystemChat("Sticky Chat disabled: You are not in an allegiance.", ChatMessageType.Broadcast));
                 }
             }
-            else if (StickyChatEnabled && StickyChatMode == StickyChatType.Fellowship)
+            else if (!message.StartsWith("/") && StickyChatEnabled && StickyChatMode == StickyChatType.Fellowship)
             {
                 if (Fellowship != null)
                 {

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -32,6 +32,13 @@ using MotionTable = ACE.DatLoader.FileTypes.MotionTable;
 
 namespace ACE.Server.WorldObjects
 {
+    public enum StickyChatType
+    {
+        None,
+        Allegiance,
+        Fellowship
+    }
+
     public partial class Player : Creature, IPlayer
     {
         private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
@@ -584,6 +591,8 @@ namespace ACE.Server.WorldObjects
 
         public bool IsLoggingOut;
 
+        public StickyChatType StickyChatMode { get; set; } = StickyChatType.None;
+
         /// <summary>
         /// Do the player log out work.<para />
         /// If you want to force a player to logout, use Session.LogOffPlayer().
@@ -933,14 +942,83 @@ namespace ACE.Server.WorldObjects
 
         public void HandleActionTalk(string message)
         {
-            if (!IsGagged)
+            if (IsGagged)
             {
-                EnqueueBroadcast(new GameMessageHearSpeech(message, GetNameWithSuffix(), Guid.Full, ChatMessageType.Speech), LocalBroadcastRange, ChatMessageType.Speech);
-
-                OnTalk(message);
-            }
-            else
                 SendGagError();
+                return;
+            }
+
+            if (StickyChatMode == StickyChatType.Allegiance)
+            {
+                if (Allegiance != null)
+                {
+                    BroadcastToAllegiance(message);
+                    return;
+                }
+                else
+                {
+                    StickyChatMode = StickyChatType.None;
+                    Session.Network.EnqueueSend(new GameMessageSystemChat("Sticky Chat disabled: You are not in an allegiance.", ChatMessageType.Broadcast));
+                }
+            }
+            else if (StickyChatMode == StickyChatType.Fellowship)
+            {
+                if (Fellowship != null)
+                {
+                    BroadcastToFellowship(message);
+                    return;
+                }
+                else
+                {
+                    StickyChatMode = StickyChatType.None;
+                    Session.Network.EnqueueSend(new GameMessageSystemChat("Sticky Chat disabled: You are not in a fellowship.", ChatMessageType.Broadcast));
+                }
+            }
+
+            // Fallback / standard local say
+            EnqueueBroadcast(new GameMessageHearSpeech(message, GetNameWithSuffix(), Guid.Full, ChatMessageType.Speech), LocalBroadcastRange, ChatMessageType.Speech);
+            OnTalk(message);
+        }
+
+        public void BroadcastToAllegiance(string message)
+        {
+            var allegiance = AllegianceManager.GetAllegiance(this);
+            if (allegiance == null) return;
+
+            if (!allegiance.IsMember(Guid)) return;
+            if (allegiance.IsFiltered(Guid)) return;
+
+            var gameMessageTurbineChat = new GameMessageTurbineChat(
+                ChatNetworkBlobType.NETBLOB_EVENT_BINARY, 
+                ChatNetworkBlobDispatchType.ASYNCMETHOD_SENDTOROOMBYNAME, 
+                TurbineChatChannel.Allegiance, 
+                Name, 
+                message, 
+                Guid.Full, 
+                ChatType.Allegiance);
+
+            foreach (var member in allegiance.Members.Keys)
+            {
+                var online = PlayerManager.GetOnlinePlayer(member);
+                if (online == null)
+                    continue;
+
+                if (allegiance.IsFiltered(member) || online.SquelchManager.Squelches.Contains(this, ChatMessageType.Allegiance))
+                    continue;
+
+                if (!online.GetCharacterOption(CharacterOption.ListenToAllegianceChat))
+                    continue;
+
+                online.Session.Network.EnqueueSend(gameMessageTurbineChat);
+            }
+        }
+
+        public void BroadcastToFellowship(string message)
+        {
+            if (Fellowship != null)
+            {
+                Fellowship.TellFellow(this, message);
+            }
         }
 
         public void SendGagError()

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -3484,6 +3484,13 @@ namespace ACE.Server.WorldObjects
             set { if (value) RemoveProperty(PropertyBool.ShowOverkill); else SetProperty(PropertyBool.ShowOverkill, false); }
         }
 
+        /// <summary>True if player has Sticky Chat enabled. Default OFF.</summary>
+        public bool StickyChatEnabled
+        {
+            get => GetProperty(PropertyBool.StickyChatEnabled) ?? false;
+            set { if (!value) RemoveProperty(PropertyBool.StickyChatEnabled); else SetProperty(PropertyBool.StickyChatEnabled, value); }
+        }
+
         // ── ILT Player UI Preferences ────────────────────────────────────────────────
         /// <summary>0 = default (vanilla), 1 = commas, 2 = short (K/M/B/T/Q)</summary>
         public int DamageNumberFormat


### PR DESCRIPTION
This PR implements a robust, fully server-side **Sticky Chat** feature.

### Key Changes
1. **Global Persisted Toggle (/ilt stickychat [on|off])**:
   - Persists dynamically in the database for each character via PropertyBool.StickyChatEnabled = 50040.
2. **Automatic Sticky Lock Redirection**:
   - In `GameActionChatChannel.cs` and `GameActionTalk.cs`, typing a message to a channel (Fellowship or Allegiance) automatically activates or switches the sticky lock.
   - Cross-channel prefix routing intercepts and routes messages sent on active tabs of the wrong channel.
3. **Command & Slash Bypass**:
   - Messages starting with standard prefixes `/` or `@` (that are not channel prefixes) bypass sticky locks so custom player commands work flawlessly.
4. **Dynamic Talk Redirection**:
   - Automatically routes local talk to Fellowship or Allegiance when the lock is active.
   - Toggles off immediately if the player types `/say`, `/s`, or `/local` on any channel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Sticky Chat functionality allowing players to lock normal text messages to a selected channel (allegiance or fellowship).
  * Added `/ilt stickychat [on|off]` command to toggle Sticky Chat on/off.
  * Players can now switch between allegiance, fellowship, or normal chat modes using dedicated commands while Sticky Chat is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->