### PR TITLE
Fix landblock pendingRemovals race causing Collection was modified cr…

### DIFF
--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -99,7 +99,8 @@ namespace ACE.Server.Entity
 
         private readonly ConcurrentDictionary<ObjectGuid, WorldObject> worldObjects = new ConcurrentDictionary<ObjectGuid, WorldObject>();
         private readonly ConcurrentDictionary<ObjectGuid, WorldObject> pendingAdditions = new ConcurrentDictionary<ObjectGuid, WorldObject>();
-        private readonly List<ObjectGuid> pendingRemovals = new List<ObjectGuid>();
+        private readonly object pendingRemovalsLock = new object();
+        private readonly HashSet<ObjectGuid> pendingRemovals = new HashSet<ObjectGuid>();
 
         // Cache used for Tick efficiency
         public readonly List<Player> players = new List<Player>();
@@ -1020,11 +1021,47 @@ namespace ACE.Server.Entity
             }
         }
 
+        private bool HasPendingRemovals()
+        {
+            lock (pendingRemovalsLock)
+                return pendingRemovals.Count > 0;
+        }
+
+        private bool IsPendingRemoval(ObjectGuid guid)
+        {
+            lock (pendingRemovalsLock)
+                return pendingRemovals.Contains(guid);
+        }
+
+        private void QueuePendingRemoval(ObjectGuid guid)
+        {
+            lock (pendingRemovalsLock)
+                pendingRemovals.Add(guid);
+        }
+
+        private void CancelPendingRemoval(ObjectGuid guid)
+        {
+            lock (pendingRemovalsLock)
+                pendingRemovals.Remove(guid);
+        }
+
+        private ObjectGuid[] SnapshotPendingRemovals()
+        {
+            lock (pendingRemovalsLock)
+                return pendingRemovals.Count == 0 ? Array.Empty<ObjectGuid>() : pendingRemovals.ToArray();
+        }
+
+        private bool TryClaimPendingRemoval(ObjectGuid guid)
+        {
+            lock (pendingRemovalsLock)
+                return pendingRemovals.Remove(guid);
+        }
+
         private void ProcessPendingWorldObjectAdditionsAndRemovals()
         {
             // Early exit optimization - this method is called 11 times per tick
             // Most calls find nothing to process, so avoid the iteration overhead
-            if (pendingAdditions.IsEmpty && pendingRemovals.Count == 0)
+            if (pendingAdditions.IsEmpty && !HasPendingRemovals())
                 return;
             
             if (!pendingAdditions.IsEmpty)
@@ -1049,10 +1086,15 @@ namespace ACE.Server.Entity
                 pendingAdditions.Clear();
             }
 
-            if (pendingRemovals.Count > 0)
+            var removals = SnapshotPendingRemovals();
+            if (removals.Length > 0)
             {
-                foreach (var objectGuid in pendingRemovals)
+                foreach (var objectGuid in removals)
                 {
+                    // Skip if another thread (or a re-add) cancelled this removal after the snapshot.
+                    if (!TryClaimPendingRemoval(objectGuid))
+                        continue;
+
                     if (worldObjects.Remove(objectGuid, out var wo))
                     {
                         if (wo is Player player)
@@ -1073,8 +1115,6 @@ namespace ACE.Server.Entity
                         }
                     }
                 }
-
-                pendingRemovals.Clear();
             }
         }
 
@@ -1275,7 +1315,7 @@ namespace ACE.Server.Entity
 
             // Defensive: If a player is already resident in this landblock (and not pending removal), do not re-add/re-init physics or re-notify.
             // This prevents accidental high-frequency re-add call sites from spamming CreateObject tracking.
-            if (alreadyPresent && wo is Player alreadyHerePlayer && ReferenceEquals(alreadyHerePlayer.CurrentLandblock, this) && !pendingRemovals.Contains(wo.Guid))
+            if (alreadyPresent && wo is Player alreadyHerePlayer && ReferenceEquals(alreadyHerePlayer.CurrentLandblock, this) && !IsPendingRemoval(wo.Guid))
                 return true;
 
             wo.CurrentLandblock = this;
@@ -1315,7 +1355,7 @@ namespace ACE.Server.Entity
             if (!worldObjects.ContainsKey(wo.Guid))
                 pendingAdditions[wo.Guid] = wo;
             else
-                pendingRemovals.Remove(wo.Guid);
+                CancelPendingRemoval(wo.Guid);
 
             // broadcast to nearby players
             if (!alreadyPresent)
@@ -1406,7 +1446,7 @@ namespace ACE.Server.Entity
             }
 
             if (worldObjects.TryGetValue(objectId, out var wo))
-                pendingRemovals.Add(objectId);
+                QueuePendingRemoval(objectId);
             else if (!pendingAdditions.Remove(objectId, out wo))
             {
                 if (showError)
@@ -1491,7 +1531,7 @@ namespace ACE.Server.Entity
         /// </summary>
         public WorldObject GetObject(ObjectGuid guid, bool searchAdjacents = true, bool searchVariations = false)
         {
-            if (pendingRemovals.Contains(guid))
+            if (IsPendingRemoval(guid))
                 return null;
 
             if (worldObjects.TryGetValue(guid, out var worldObject) || pendingAdditions.TryGetValue(guid, out worldObject))


### PR DESCRIPTION
…ash.

Serialize pendingRemovals access during parallel landblock ticks and use a HashSet to prevent duplicate removal queue entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the reliability of world object removal operations to prevent race conditions and duplicate removals that could occur during concurrent add or cancel operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->