### PR TITLE
Revert #479 visibility changes; keep landblock crash fix only.

### DIFF
--- a/Source/ACE.Server/Managers/PrestigeManager.cs
+++ b/Source/ACE.Server/Managers/PrestigeManager.cs
@@ -503,12 +503,6 @@ namespace ACE.Server.Managers
             if (wo == null)
                 return null;
 
-            // During server teleports, set_current_pos / enter_cell_server run before
-            // WorldObject.Location is committed in UpdatePosition. Prefer physics so
-            // prestige→retail arrivals do not keep filtering on the source variation.
-            if (wo is Player teleportingPlayer && teleportingPlayer.Teleporting && wo.PhysicsObj != null)
-                return wo.PhysicsObj.Position.Variation;
-
             // Most world objects have a location (or physics position) with a variation.
             // However, non-spatial objects (inventory items, escrow items, etc.) may not.
             // For networking boundaries we still need a deterministic "effective variation"

--- a/Source/ACE.Server/Physics/PhysicsObj.cs
+++ b/Source/ACE.Server/Physics/PhysicsObj.cs
@@ -1899,14 +1899,14 @@ namespace ACE.Server.Physics
             if (!IsPlayer || WeenieObj.WorldObject is not Player player)
                 return;
 
+            var playerVar = PrestigeManager.GetEffectiveVariationForVisibility(player);
+
             if (DateTime.UtcNow - player.LastTeleportTime < TeleportCreateObjectDelay)
             {
                 var actionChain = new ActionChain();
                 actionChain.AddDelaySeconds(TeleportCreateObjectDelay.TotalSeconds);
                 actionChain.AddAction(player, ActionType.PhysicsObj_TrackObjects, () =>
                 {
-                    var playerVar = PrestigeManager.GetEffectiveVariationForVisibility(player);
-
                     foreach (var obj in newlyVisible)
                     {
                         var wo = obj.WeenieObj.WorldObject;
@@ -1923,8 +1923,6 @@ namespace ACE.Server.Physics
             }
             else
             {
-                var playerVar = PrestigeManager.GetEffectiveVariationForVisibility(player);
-
                 foreach (var obj in newlyVisible)
                 {
                     var wo = obj.WeenieObj.WorldObject;
@@ -1958,26 +1956,17 @@ namespace ACE.Server.Physics
             if (wo == null)
                 return;
 
+            if (!PrestigeManager.SameVariationForVisibility(
+                    PrestigeManager.GetEffectiveVariationForVisibility(player),
+                    PrestigeManager.GetEffectiveVariationForVisibility(wo)))
+                return;
+
             if (DateTime.UtcNow - player.LastTeleportTime < TeleportCreateObjectDelay)
             {
                 var actionChain = new ActionChain();
                 actionChain.AddDelaySeconds(TeleportCreateObjectDelay.TotalSeconds);
-                actionChain.AddAction(player, ActionType.PhysicsObj_TrackObject, () =>
-                {
-                    if (!PrestigeManager.SameVariationForVisibility(
-                            PrestigeManager.GetEffectiveVariationForVisibility(player),
-                            PrestigeManager.GetEffectiveVariationForVisibility(wo)))
-                        return;
-
-                    player.TrackObject(wo, true, "enqueue_obj_post_teleport_delay");
-                });
+                actionChain.AddAction(player, ActionType.PhysicsObj_TrackObject, () => player.TrackObject(wo, true, "enqueue_obj_post_teleport_delay"));
                 actionChain.EnqueueChain();
-            }
-            else if (!PrestigeManager.SameVariationForVisibility(
-                    PrestigeManager.GetEffectiveVariationForVisibility(player),
-                    PrestigeManager.GetEffectiveVariationForVisibility(wo)))
-            {
-                return;
             }
             else
             {
@@ -2021,8 +2010,8 @@ namespace ACE.Server.Physics
             enter_cell(newCell);
             RequestPos.ObjCellID = newCell.ID;      // document this control flow better
 
-            // sync location for initial CO / post-teleport visibility (Location lags physics during Teleport())
-            if (entering_world || (IsPlayer && WeenieObj.WorldObject is Player tp && tp.Teleporting))
+            // sync location for initial CO
+            if (entering_world)
                 WeenieObj.WorldObject.SyncLocation(newCell.VariationId);
 
             // handle self

--- a/Source/ACE.Server/WorldObjects/Player_Tracking.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Tracking.cs
@@ -33,22 +33,11 @@ namespace ACE.Server.WorldObjects
         public Dictionary<int, DateTime> LastUseTracker { get; set; }
 
         /// <summary>
-        /// Last time a CreateObject was sent to this client per target guid (TickCount64).
-        /// Used to suppress duplicate CO from post-teleport reconcile (#467) after delayed physics enqueue.
+        /// Debounce for <see cref="TryResendCreateObjectForStaleKnown"/> (post-teleport reconcile only).
         /// </summary>
-        private readonly Dictionary<uint, long> _lastCreateObjectSentMs = new();
-
-        private readonly Dictionary<uint, string> _lastCreateObjectPath = new();
+        private readonly Dictionary<uint, long> _lastStaleKnownResendMs = new();
 
         private const int StaleKnownResendDebounceMs = 750;
-
-        /// <summary>
-        /// Skip StaleKnownResend when another path (e.g. enqueue_obj_post_teleport_delay) sent CO recently.
-        /// Slightly longer than the 1.05s reconcile delay after the 1s physics CO delay.
-        /// </summary>
-        private const int CreateObjectResendSuppressMs = 2500;
-
-        private bool _postTeleportReconcileScheduled;
 
         /// <summary>
         /// The link to this player's Object Maintenance
@@ -98,11 +87,6 @@ namespace ACE.Server.WorldObjects
 
             Session.Network.EnqueueSend(new GameMessageCreateObject(worldObject, Adminvision, Adminvision));
 
-            var coKey = worldObject.Guid.Full;
-            _lastCreateObjectSentMs[coKey] = Environment.TickCount64;
-            if (!string.IsNullOrEmpty(createObjectPath))
-                _lastCreateObjectPath[coKey] = createObjectPath;
-
             //Console.WriteLine($"Player {Name} - TrackObject({worldObject.Name})");
 
             // add creature equipped objects / wielded items
@@ -136,8 +120,7 @@ namespace ACE.Server.WorldObjects
                                  $"effVar_viewer={myVar?.ToString() ?? "null"} effVar_target={objVar?.ToString() ?? "null"}");
                     }
 
-                    _lastCreateObjectSentMs.Remove(worldObject.Guid.Full);
-                    _lastCreateObjectPath.Remove(worldObject.Guid.Full);
+                    _lastStaleKnownResendMs.Remove(worldObject.Guid.Full);
 
                     worldObject.PhysicsObj.ObjMaint?.RemoveObject(PhysicsObj);
                     if (worldObject is Player knownPlayer)
@@ -200,19 +183,11 @@ namespace ACE.Server.WorldObjects
 
             var key = worldObject.Guid.Full;
             var now = Environment.TickCount64;
-            if (_lastCreateObjectSentMs.TryGetValue(key, out var lastCo))
-            {
-                var elapsed = now - lastCo;
-                if (_lastCreateObjectPath.TryGetValue(key, out var lastPath) &&
-                    lastPath != "StaleKnownResend_#467" &&
-                    elapsed < CreateObjectResendSuppressMs)
-                    return false;
-
-                if (elapsed < StaleKnownResendDebounceMs)
-                    return false;
-            }
+            if (_lastStaleKnownResendMs.TryGetValue(key, out var last) && now - last < StaleKnownResendDebounceMs)
+                return false;
 
             TrackObject(worldObject, createObjectPath: "StaleKnownResend_#467");
+            _lastStaleKnownResendMs[key] = now;
             return true;
         }
 
@@ -276,11 +251,6 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public void SchedulePostTeleportVisibilityReconcile()
         {
-            if (_postTeleportReconcileScheduled)
-                return;
-
-            _postTeleportReconcileScheduled = true;
-
             var actionChain = new ActionChain();
             actionChain.AddDelaySeconds(1.05);
             actionChain.AddAction(this, ActionType.PlayerTracking_PostTeleportVisibilityReconcile, ReconcileVisibilityAfterArrival);
@@ -292,10 +262,7 @@ namespace ACE.Server.WorldObjects
             //log.Info($"{Name}.RemoveTrackedObject({wo.Name} ({wo.Guid}), {fromPickup})");
 
             if (wo != null)
-            {
-                _lastCreateObjectSentMs.Remove(wo.Guid.Full);
-                _lastCreateObjectPath.Remove(wo.Guid.Full);
-            }
+                _lastStaleKnownResendMs.Remove(wo.Guid.Full);
 
             if (fromPickup)
             {
@@ -454,9 +421,7 @@ namespace ACE.Server.WorldObjects
             if (Location.Cell == newPosition.Cell && Location.Variation == newPosition.Variation)
                 return;
 
-            _lastCreateObjectSentMs.Clear();
-            _lastCreateObjectPath.Clear();
-            _postTeleportReconcileScheduled = false;
+            _lastStaleKnownResendMs.Clear();
 
             var knownObjs = GetKnownObjects();
 

--- a/Source/ACE.Server/WorldObjects/WorldObject_Teleport.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Teleport.cs
@@ -116,10 +116,7 @@ namespace ACE.Server.WorldObjects
             {
                 if (knownObj.PhysicsObj == null) continue;
                 if (knownObj.Location == null) continue;
-                if (PrestigeManager.SameVariationForVisibility(
-                        PrestigeManager.GetEffectiveVariationForVisibility(knownObj),
-                        destinationVariation))
-                    continue;
+                if (knownObj.Location.Variation == destinationVariation) continue;
 
                 knownObj.PhysicsObj.ObjMaint?.RemoveObject(PhysicsObj);
                 PhysicsObj?.ObjMaint?.RemoveObject(knownObj.PhysicsObj);


### PR DESCRIPTION
Restore PrestigeManager, PhysicsObj, Player_Tracking, and WorldObject_Teleport to pre-#479 (e50cfafe4). Landblock.cs pendingRemovals race fix from #479/#480 is unchanged.