### PR TITLE
feat: Fellowship logout race condition and NPC inventory/burden capacity checks

### DIFF
--- a/Source/ACE.Server/Entity/Fellowship.cs
+++ b/Source/ACE.Server/Entity/Fellowship.cs
@@ -106,6 +106,12 @@ namespace ACE.Server.Entity
             }
             else
             {
+                if (newMember.IsLoggingOut)
+                {
+                    inviter.Session.Network.EnqueueSend(new GameMessageSystemChat($"{newMember.Name} is not available.", ChatMessageType.Broadcast));
+                    return;
+                }
+
                 if (ServerConfig.fellow_busy_no_recruit.Value && newMember.IsBusy)
                 {
                     inviter.Session.Network.EnqueueSend(new GameMessageSystemChat($"{newMember.Name} is busy.", ChatMessageType.Broadcast));
@@ -134,6 +140,11 @@ namespace ACE.Server.Entity
         public void AddConfirmedMember(Player inviter, Player player, bool response)
         {
             if (inviter == null || inviter.Session == null || inviter.Session.Player == null || player == null) return;
+
+            // Do not add a player who is in the middle of logging out.
+            // This closes the race where FellowshipQuit fires during logout, then an auto-accept
+            // or a previously-queued confirmation dialog re-adds the departing player.
+            if (player.IsLoggingOut) return;
 
             if (!response)
             {

--- a/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
@@ -641,7 +641,7 @@ namespace ACE.Server.WorldObjects.Managers
                         {
                             var la = emoteSet.PropertiesEmoteAction[i];
                             if ((EmoteType)la.Type != EmoteType.Give || la.WeenieClassId == null)
-                                break; // stop at the first non-Give action
+                                continue; // skip non-Give actions but keep scanning for later Gives
                             var laAmt = la.StackSize ?? 1;
                             if (laAmt > 0 && (la.WeenieClassId == 300004 || la.WeenieClassId == 300003))
                             {
@@ -3605,18 +3605,17 @@ namespace ACE.Server.WorldObjects.Managers
                 var preCheckPlayer = targetObject as Player;
                 if (preCheckPlayer != null)
                 {
-                    var upcomingGives = emoteSet.PropertiesEmoteAction
-                        .Skip(emoteIdx)
-                        .Where(a => (EmoteType)a.Type == EmoteType.Give && a.WeenieClassId != null)
-                        .ToList();
-
-                    if (upcomingGives.Count > 0)
+                    var batchItems = new ItemsToReceive(preCheckPlayer);
+                    var hasUpcomingGives = false;
+                    for (var scanIdx = emoteIdx; scanIdx < emoteSet.PropertiesEmoteAction.Count; scanIdx++)
                     {
-                        var batchItems = new ItemsToReceive(preCheckPlayer);
-                        foreach (var g in upcomingGives)
+                        var scanEmote = emoteSet.PropertiesEmoteAction[scanIdx];
+                        var scanType = (EmoteType)scanEmote.Type;
+                        if (scanType == EmoteType.Give && scanEmote.WeenieClassId != null)
                         {
-                            var gAmt = g.StackSize ?? 1;
-                            if (gAmt > 0 && (g.WeenieClassId == 300004 || g.WeenieClassId == 300003))
+                            hasUpcomingGives = true;
+                            var gAmt = scanEmote.StackSize ?? 1;
+                            if (gAmt > 0 && (scanEmote.WeenieClassId == 300004 || scanEmote.WeenieClassId == 300003))
                             {
                                 var laCoinMult = ServerConfig.coin_reward_mult.Value;
                                 if (double.IsNaN(laCoinMult) || double.IsInfinity(laCoinMult))
@@ -3624,8 +3623,18 @@ namespace ACE.Server.WorldObjects.Managers
                                 laCoinMult = Math.Max(0, laCoinMult);
                                 gAmt = (int)(gAmt * laCoinMult);
                             }
-                            batchItems.Add(g.WeenieClassId.Value, gAmt > 0 ? gAmt : 1);
+                            batchItems.Add(scanEmote.WeenieClassId.Value, gAmt > 0 ? gAmt : 1);
                         }
+                        else if (scanType == EmoteType.TakeItems && scanEmote.WeenieClassId != null)
+                        {
+                            // Simulate items being taken — they free slots/burden for subsequent Gives
+                            var tAmt = scanEmote.StackSize ?? 1;
+                            batchItems.Remove(scanEmote.WeenieClassId.Value, tAmt > 0 ? tAmt : 1);
+                        }
+                    }
+
+                    if (hasUpcomingGives)
+                    {
 
                         if (batchItems.PlayerExceedsLimits)
                         {
@@ -3642,7 +3651,10 @@ namespace ACE.Server.WorldObjects.Managers
                             AbortEmoteChain = true;
                             Nested--;
                             if (Nested == 0)
+                            {
+                                AbortEmoteChain = false;
                                 IsBusy = false;
+                            }
                             return;
                         }
                     }
@@ -3666,6 +3678,7 @@ namespace ACE.Server.WorldObjects.Managers
                     delayChain.AddDelaySeconds(nextDelay);
                     delayChain.AddAction(WorldObject, ActionType.EmoteManager_ReduceNested, () =>
                     {
+                        AbortEmoteChain = false; // safety reset on delayed chain completion
                         Nested--;
 
                         if (Nested == 0)

--- a/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
@@ -48,6 +48,13 @@ namespace ACE.Server.WorldObjects.Managers
         public bool IsBusy { get; set; }
         public int Nested { get; set; }
 
+        /// <summary>
+        /// When set to true, the current emote chain will abort before firing the next action.
+        /// Used by GiveFromEmote/TryCreateForGive to halt the chain if an item cannot be delivered,
+        /// preventing StampQuest from firing after a failed Give.
+        /// </summary>
+        public bool AbortEmoteChain { get; set; } = false;
+
         public bool Debug = false;
         private readonly HashSet<string> _singleLocalBroadcastsSent = new HashSet<string>();
 
@@ -607,7 +614,7 @@ namespace ACE.Server.WorldObjects.Managers
 
                     bool success = false;
 
-                    var stackSize = emote.StackSize ?? 1;                        
+                    var stackSize = emote.StackSize ?? 1;
 
                     if (player != null && emote.WeenieClassId != null)
                     {
@@ -619,7 +626,53 @@ namespace ACE.Server.WorldObjects.Managers
                             coinMult = Math.Max(0, coinMult);
                             stackSize = (int)(stackSize * coinMult);
                         }
-                            
+
+                        // ── Look-ahead batch pre-check ───────────────────────────────────────────
+                        // DoEnqueue processes all emotes synchronously when delay == 0, meaning
+                        // StampQuest (and subsequent Gives) are scheduled BEFORE any ActionChain
+                        // has fired. Checking only the current Give item is not enough for
+                        // multi-Give emote sets — we must check the player can receive the ENTIRE
+                        // bundle before scheduling anything. Scanning from the current emote's
+                        // index forward captures all remaining Gives without touching earlier
+                        // Gives that already fired in previous interactions.
+                        var batchItems = new ItemsToReceive(player);
+                        var currentEmoteIdx = emoteSet.PropertiesEmoteAction.IndexOf(emote);
+                        for (var i = currentEmoteIdx; i < emoteSet.PropertiesEmoteAction.Count; i++)
+                        {
+                            var la = emoteSet.PropertiesEmoteAction[i];
+                            if ((EmoteType)la.Type != EmoteType.Give || la.WeenieClassId == null)
+                                break; // stop at the first non-Give action
+                            var laAmt = la.StackSize ?? 1;
+                            if (laAmt > 0 && (la.WeenieClassId == 300004 || la.WeenieClassId == 300003))
+                            {
+                                var laCoinMult = ServerConfig.coin_reward_mult.Value;
+                                if (double.IsNaN(laCoinMult) || double.IsInfinity(laCoinMult))
+                                    laCoinMult = 0;
+                                laCoinMult = Math.Max(0, laCoinMult);
+                                laAmt = (int)(laAmt * laCoinMult);
+                            }
+                            batchItems.Add(la.WeenieClassId.Value, laAmt > 0 ? laAmt : 1);
+                        }
+
+                        if (batchItems.PlayerExceedsLimits)
+                        {
+                            var slotsNeeded = batchItems.RequiredSlots;
+                            if (batchItems.PlayerExceedsAvailableBurden)
+                                player.Session.Network.EnqueueSend(new GameMessageSystemChat(
+                                    $"{WorldObject.Name} has rewards for you, but you are too encumbered to carry them! Drop some items and try again.",
+                                    ChatMessageType.Broadcast));
+                            else
+                                player.Session.Network.EnqueueSend(new GameMessageSystemChat(
+                                    $"{WorldObject.Name} has rewards for you, but you need {slotsNeeded} free inventory slot(s). Free up some space and try again.",
+                                    ChatMessageType.Broadcast));
+
+                            AbortEmoteChain = true;
+                            break;
+                        }
+                        // ────────────────────────────────────────────────────────────────────────
+
+
+                        var giveAmount = stackSize > 0 ? stackSize : 1;
                         var motionChain = new ActionChain();
 
                         if (!WorldObject.DontTurnOrMoveWhenGiving && creature != null && targetCreature != null)
@@ -627,7 +680,7 @@ namespace ACE.Server.WorldObjects.Managers
                             delay = creature.Rotate(targetCreature);
                             motionChain.AddDelaySeconds(delay);
                         }
-                        motionChain.AddAction(WorldObject, ActionType.EmoteManager_Give, () => player.GiveFromEmote(WorldObject, emote.WeenieClassId ?? 0, stackSize > 0 ? stackSize : 1, emote.Palette ?? 0, emote.Shade ?? 0));
+                        motionChain.AddAction(WorldObject, ActionType.EmoteManager_Give, () => player.GiveFromEmote(WorldObject, emote.WeenieClassId ?? 0, giveAmount, emote.Palette ?? 0, emote.Shade ?? 0));
                         motionChain.EnqueueChain();
                     }
 
@@ -3524,22 +3577,81 @@ namespace ACE.Server.WorldObjects.Managers
         /// </summary>
         private void DoEnqueue(PropertiesEmote emoteSet, WorldObject targetObject, int emoteIdx, PropertiesEmoteAction emote)
         {
+            // If a previous emote in this chain (e.g. a failed Give) requested an abort,
+            // stop here before firing this action. This prevents StampQuest from running
+            // after a Give that failed due to full inventory or over-burden.
+            if (AbortEmoteChain)
+            {
+                AbortEmoteChain = false;
+                Nested--;
+                if (Nested == 0)
+                    IsBusy = false;
+                return;
+            }
+
             if (Debug)
                 Console.Write($"{(EmoteType)emote.Type}");
 
-            //if (!string.IsNullOrEmpty(emoteSet.Quest) && emoteSet.Quest == emote.Message && EmoteIsBranchingType(emote))
-            //{
-            //    log.Error($"[EMOTE] {WorldObject.Name}.EmoteManager.DoEnqueue(): Infinite loop detected on 0x{WorldObject.Guid}:{WorldObject.WeenieClassId}\n-> {emoteSet.Category}: {emoteSet.Quest} to {(EmoteType)emote.Type}: {emote.Message}");
+            // ── Pre-emote scan-ahead for upcoming Gives ──────────────────────────────
+            // When this emote is NOT itself a Give (e.g. Tell, AwardXP, AwardLuminance),
+            // scan forward for any upcoming Give emotes in this emote set. If the player
+            // can't receive the full bundle (full inventory OR cumulative burden would
+            // push them over the limit), abort the entire chain NOW — before any XP,
+            // Luminance, or Tell fires. The Give case handles this same check internally
+            // for chains where the first emote IS a Give; this block covers chains where
+            // non-Give rewards precede the Give emotes.
+            if ((EmoteType)emote.Type != EmoteType.Give)
+            {
+                var preCheckPlayer = targetObject as Player;
+                if (preCheckPlayer != null)
+                {
+                    var upcomingGives = emoteSet.PropertiesEmoteAction
+                        .Skip(emoteIdx)
+                        .Where(a => (EmoteType)a.Type == EmoteType.Give && a.WeenieClassId != null)
+                        .ToList();
 
-            //    Nested--;
+                    if (upcomingGives.Count > 0)
+                    {
+                        var batchItems = new ItemsToReceive(preCheckPlayer);
+                        foreach (var g in upcomingGives)
+                        {
+                            var gAmt = g.StackSize ?? 1;
+                            if (gAmt > 0 && (g.WeenieClassId == 300004 || g.WeenieClassId == 300003))
+                            {
+                                var laCoinMult = ServerConfig.coin_reward_mult.Value;
+                                if (double.IsNaN(laCoinMult) || double.IsInfinity(laCoinMult))
+                                    laCoinMult = 0;
+                                laCoinMult = Math.Max(0, laCoinMult);
+                                gAmt = (int)(gAmt * laCoinMult);
+                            }
+                            batchItems.Add(g.WeenieClassId.Value, gAmt > 0 ? gAmt : 1);
+                        }
 
-            //    if (Nested == 0)
-            //        IsBusy = false;
+                        if (batchItems.PlayerExceedsLimits)
+                        {
+                            var slotsNeeded = batchItems.RequiredSlots;
+                            if (batchItems.PlayerExceedsAvailableBurden)
+                                preCheckPlayer.Session.Network.EnqueueSend(new GameMessageSystemChat(
+                                    $"{WorldObject.Name} has rewards for you, but you are too encumbered to carry them! Drop some items and try again.",
+                                    ChatMessageType.Broadcast));
+                            else
+                                preCheckPlayer.Session.Network.EnqueueSend(new GameMessageSystemChat(
+                                    $"{WorldObject.Name} has rewards for you, but you need {slotsNeeded} free inventory slot(s). Free up some space and try again.",
+                                    ChatMessageType.Broadcast));
 
-            //    return;
-            //}
+                            AbortEmoteChain = true;
+                            Nested--;
+                            if (Nested == 0)
+                                IsBusy = false;
+                            return;
+                        }
+                    }
+                }
+            }
+            // ────────────────────────────────────────────────────────────────────────
 
             var nextDelay = ExecuteEmote(emoteSet, emote, targetObject);
+
 
             if (Debug)
                 Console.WriteLine($" - {nextDelay}");
@@ -3563,6 +3675,7 @@ namespace ACE.Server.WorldObjects.Managers
                 }
                 else
                 {
+                    AbortEmoteChain = false; // safety reset on natural chain completion
                     Nested--;
 
                     if (Nested == 0)

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -4193,8 +4193,8 @@ namespace ACE.Server.WorldObjects
             {
                 // Tell the player specifically why they can't receive the item
                 var itemBeingGiven = DatabaseManager.World.GetCachedWeenie(weenieClassId);
-                var itemName = itemStacks > 1 ? itemBeingGiven.GetPluralName() : itemBeingGiven.GetName();
-                var countPrefix = itemStacks > 1 ? $"{itemStacks} " : "";
+                var itemName = amount > 1 ? itemBeingGiven.GetPluralName() : itemBeingGiven.GetName();
+                var countPrefix = amount > 1 ? $"{amount:N0} " : "";
 
                 if (itemsToReceive.PlayerExceedsAvailableBurden)
                     Session.Network.EnqueueSend(new GameMessageSystemChat(

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -4191,17 +4191,23 @@ namespace ACE.Server.WorldObjects
 
             if (itemsToReceive.PlayerExceedsLimits)
             {
-                //if (itemsToReceive.PlayerExceedsAvailableBurden)
-                //    Session.Network.EnqueueSend(new GameEventCommunicationTransientString(Session, "You are too encumbered to use that!"));
-                //else if (itemsToReceive.PlayerOutOfInventorySlots)
-                //    Session.Network.EnqueueSend(new GameEventCommunicationTransientString(Session, "You do not have enough pack space to use that!"));
-                //else if (itemsToReceive.PlayerOutOfContainerSlots)
-                //    Session.Network.EnqueueSend(new GameEventCommunicationTransientString(Session, "You do not have enough container slots to use that!"));
-
-                // Font of Enlightenment and Rebirth tries to give you Attribute Reset Certificate.
+                // Tell the player specifically why they can't receive the item
                 var itemBeingGiven = DatabaseManager.World.GetCachedWeenie(weenieClassId);
-                var msg = new GameMessageSystemChat($"{emoter.Name} tries to give you {(itemStacks > 1 ? $"{itemStacks} " : "")}{(itemStacks > 1 ? itemBeingGiven.GetPluralName() : itemBeingGiven.GetName())}.", ChatMessageType.Broadcast);
-                Session.Network.EnqueueSend(msg);
+                var itemName = itemStacks > 1 ? itemBeingGiven.GetPluralName() : itemBeingGiven.GetName();
+                var countPrefix = itemStacks > 1 ? $"{itemStacks} " : "";
+
+                if (itemsToReceive.PlayerExceedsAvailableBurden)
+                    Session.Network.EnqueueSend(new GameMessageSystemChat(
+                        $"{emoter.Name} tries to give you {countPrefix}{itemName}, but you are too encumbered to carry it! Drop some items and try again.",
+                        ChatMessageType.Broadcast));
+                else
+                    Session.Network.EnqueueSend(new GameMessageSystemChat(
+                        $"{emoter.Name} tries to give you {countPrefix}{itemName}, but your inventory is full! Free up some space and try again.",
+                        ChatMessageType.Broadcast));
+
+                // Abort the NPC's emote chain so StampQuest (or any following action) does not fire
+                if (emoter?.EmoteManager != null)
+                    emoter.EmoteManager.AbortEmoteChain = true;
 
                 return;
             }
@@ -4257,8 +4263,22 @@ namespace ACE.Server.WorldObjects
 
             if (!TryCreateInInventoryWithNetworking(itemBeingGiven))
             {
-                var msg = new GameMessageSystemChat($"{giver.Name} tries to give you {(itemBeingGiven.StackSize > 1 ? $"{itemBeingGiven.StackSize} " : "")}{itemBeingGiven.GetNameWithMaterial(itemBeingGiven.StackSize)}.", ChatMessageType.Broadcast);
-                Session.Network.EnqueueSend(msg);
+                // Determine why the give failed and tell the player
+                if (!HasEnoughBurdenToAddToInventory(itemBeingGiven))
+                    Session.Network.EnqueueSend(new GameMessageSystemChat(
+                        $"{giver.Name} tries to give you {(itemBeingGiven.StackSize > 1 ? $"{itemBeingGiven.StackSize} " : "")}{itemBeingGiven.GetNameWithMaterial(itemBeingGiven.StackSize)}, but you are too encumbered to carry it! Drop some items and try again.",
+                        ChatMessageType.Broadcast));
+                else
+                    Session.Network.EnqueueSend(new GameMessageSystemChat(
+                        $"{giver.Name} tries to give you {(itemBeingGiven.StackSize > 1 ? $"{itemBeingGiven.StackSize} " : "")}{itemBeingGiven.GetNameWithMaterial(itemBeingGiven.StackSize)}, but your inventory is full! Free up some space and try again.",
+                        ChatMessageType.Broadcast));
+
+                // Abort the giver's emote chain so StampQuest (or any following action) does not fire
+                if (giver?.EmoteManager != null)
+                    giver.EmoteManager.AbortEmoteChain = true;
+
+                // Destroy the orphaned item — previously it was silently discarded with no cleanup
+                itemBeingGiven.Destroy();
                 return false;
             }
 


### PR DESCRIPTION
## Overview
This PR introduces targeted bug fixes for the Fellowship recruitment system and NPC interaction inventory guards on the ILT server:

1. **Fellowship Logout Race Condition Fix**
   * Adds guards in Fellowship.cs (AddFellowshipMember and AddConfirmedMember) to check if a recruited player is currently logging out (player.IsLoggingOut). If so, the request is rejected to prevent race conditions during logout.

2. **NPC Inventory and Burden Capacity Guards**
   * Updates EmoteManager.cs to scan ahead for item Give actions in NPC emote chains.
   * If a player's inventory or burden limits are exceeded, it aborts the emote chain, displays a clear warning in the player's chat, and safely destroys the item instance being generated to prevent item duplicates and resource leaks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Emote reward chains now properly abort if full delivery cannot be completed
  * Clearer feedback distinguishes between inventory full and encumbrance issues
  * Proper cleanup of items when reward delivery fails
  * Improved handling of group member additions during logout scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->