### PR TITLE
feat: Developer test character commands (/testchar T11 / T0)

### DIFF
--- a/Content/sql/weenies/777700028 Far Shot Charm.sql
+++ b/Content/sql/weenies/777700028 Far Shot Charm.sql
@@ -29,8 +29,7 @@ VALUES (777700028,     1, 2048) /* ItemType - Gem */
      , (777700028,   114,    1) /* Attuned */
      , (777700028, 50000,   28) /* CharmGrantsAbility - ID 28 = Far Shot */
      , (777700028, 50005,    1) /* CharmLevel - 1 */
-     , (777700028, 50006,    3) /* CharmMaxLevel - 3 tiers */
-     , (777700028, 50060, 1780887600); /* ItemExpirationTimestamp - Sunday June 7, 2026 11:00 PM EST */
+     , (777700028, 50006,    3); /* CharmMaxLevel - 3 tiers */
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
 VALUES (777700028,    1, 33554556)  /* Setup - Coffer/Chest */

--- a/Content/sql/weenies/777700028 Far Shot Charm.sql
+++ b/Content/sql/weenies/777700028 Far Shot Charm.sql
@@ -15,8 +15,7 @@ VALUES (777700028,    11, 1)  /* IgnoreCollisions */
      , (777700028,    14, 1)  /* GravityStatus */
      , (777700028,    63, 1)  /* UnlimitedUse */
      , (777700028,  9040, 1)  /* IsCharm */
-     , (777700028, 50000, 1)  /* IsAbilityCharm */
-     , (777700028, 50002, 1); /* IsTestCharm */
+     , (777700028, 50000, 1); /* IsAbilityCharm */
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (777700028,     1, 2048) /* ItemType - Gem */

--- a/Content/sql/weenies/777700028 Far Shot Charm.sql
+++ b/Content/sql/weenies/777700028 Far Shot Charm.sql
@@ -1,0 +1,45 @@
+-- ============================================================
+-- Far Shot Charm (Tier 1) — WCID 777700028
+-- ILT Ability Charm — Ability ID 28 (HasFarShotCharm)
+-- While active, your maximum missile attack range is increased
+-- by +15% and final missile damage is increased by +5%.
+-- ============================================================
+
+DELETE FROM `weenie` WHERE `class_Id` = 777700028;
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (777700028, 'ilt_farshotcharm_t1', 38, NOW());
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (777700028,    11, 1)  /* IgnoreCollisions */
+     , (777700028,    13, 1)  /* Ethereal */
+     , (777700028,    14, 1)  /* GravityStatus */
+     , (777700028,    63, 1)  /* UnlimitedUse */
+     , (777700028,  9040, 1)  /* IsCharm */
+     , (777700028, 50000, 1)  /* IsAbilityCharm */
+     , (777700028, 50002, 1); /* IsTestCharm */
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (777700028,     1, 2048) /* ItemType - Gem */
+     , (777700028,     5,    5) /* EncumbranceVal */
+     , (777700028,     8,    5) /* Mass */
+     , (777700028,    16,    8) /* ItemUseable - Contained */
+     , (777700028,    19,    1) /* UiEffects - Magical */
+     , (777700028,    33,    1) /* Bonded */
+     , (777700028,    83,    2) /* ActivationResponse - Use */
+     , (777700028,    93, 1044) /* PhysicsState */
+     , (777700028,   114,    1) /* Attuned */
+     , (777700028, 50000,   28) /* CharmGrantsAbility - ID 28 = Far Shot */
+     , (777700028, 50005,    1) /* CharmLevel - 1 */
+     , (777700028, 50006,    3) /* CharmMaxLevel - 3 tiers */
+     , (777700028, 50060, 1780887600); /* ItemExpirationTimestamp - Sunday June 7, 2026 11:00 PM EST */
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (777700028,    1, 33554556)  /* Setup - Coffer/Chest */
+     , (777700028,    3, 536870932) /* SoundTable */
+     , (777700028,    8, 100672653) /* Icon - bow/arrow icon */
+     , (777700028,   48, 100676435) /* IconUnderlay */
+     , (777700028,   50, 100667550); /* IconOverlay - Tier 1 badge */
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (777700028,  1, 'Far Shot Charm')
+     , (777700028, 14, 'Double-click to activate. While active, your maximum missile attack range is increased by +15% and final missile damage is increased by +5%.');

--- a/Content/sql/weenies/777700029 Tou Tou Prestige Portal Gem.sql
+++ b/Content/sql/weenies/777700029 Tou Tou Prestige Portal Gem.sql
@@ -1,0 +1,52 @@
+DELETE FROM `weenie` WHERE `class_Id` = 777700029;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (777700029, '777700029TouTouPrestigeRecallGem', 38, '2026-06-04 23:25:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (777700029,   1,       2048) /* ItemType - Gem */
+     , (777700029,   3,          8) /* PaletteTemplate */
+     , (777700029,   5,         10) /* EncumbranceVal */
+     , (777700029,   8,         10) /* Mass */
+     , (777700029,   9,          0) /* ValidLocations - None */
+     , (777700029,  11,          1) /* MaxStackSize */
+     , (777700029,  12,          1) /* IsContainer - True */
+     , (777700029,  13,         10) /* StackUnitEncumbrance */
+     , (777700029,  14,         10) /* StackUnitMass */
+     , (777700029,  15,         50) /* StackUnitValue */
+     , (777700029,  16,          8) /* ItemUseable - Contained */
+     , (777700029,  18,          1) /* UiEffects - Magical */
+     , (777700029,  19,         50) /* Value */
+     , (777700029,  33,          1) /* Bonded - Bonded */
+     , (777700029,  93,       3092) /* PhysicsState */
+     , (777700029,  94,         16) /* TargetType - Creature */
+     , (777700029, 106,        210) /* ItemSpellcraft */
+     , (777700029, 107,         50) /* ItemCurMana */
+     , (777700029, 108,         50) /* ItemMaxMana */
+     , (777700029, 114,          1) /* Attuned - Attuned */
+     , (777700029, 150,        103) /* HookPlacement - Hook */
+     , (777700029, 151,          2) /* HookType - Wall */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (777700029,  15, True ) /* LightsStatus */
+     , (777700029,  63, True ) /* UnlimitedUse */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (777700029,   1, 'Tou Tou Prestige Portal Gem') /* Name */
+     , (777700029,  16, 'Use this gem to be teleported to the Tou Tou Prestige Area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (777700029,   1, 0x02000C79) /* Setup */
+     , (777700029,   3, 0x20000014) /* SoundTable */
+     , (777700029,   6, 0x04000BEF) /* PaletteBase */
+     , (777700029,   7, 0x1000010B) /* ClothingBase */
+     , (777700029,   8, 0x060013CA) /* Icon */
+     , (777700029,  22, 0x3400002B) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (777700029, 7 /* Use */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 99 /* TeleportTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 11, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0xF559003D /* 0xF559003D [171.403397 113.162933 20.265999] -0.969513 0 0 0.245041 */, 171.403397, 113.162933, 20.265999, -0.969513, 0, 0, 0.245041);

--- a/Content/sql/weenies/777701012 Far Shot Charm Upgrade Recipes.sql
+++ b/Content/sql/weenies/777701012 Far Shot Charm Upgrade Recipes.sql
@@ -1,0 +1,20 @@
+-- Far Shot Charm Upgrade Recipes
+-- Uses Charm Catalyst (777700010) to upgrade Far Shot Charm between tiers.
+-- Tier 1 (777700028) -> Tier 2 (777710008) -> Tier 3 (777720008)
+
+START TRANSACTION;
+
+DELETE FROM `cook_book` WHERE `recipe_Id` IN (777701012, 777701013);
+DELETE FROM `recipe` WHERE `id` IN (777701012, 777701013);
+
+-- T1 -> T2 (777701012)
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `data_Id`)
+VALUES (777701012, 0, 0, 0, 0, 777710008, 1, 'You use the Catalyst to strengthen the Far Shot Charm. Greater Far Shot Charm takes hold!', 0, 0, 'You fail to upgrade the charm.', 1.0, 1, 1.0, 1, 0.0, 0, 0.0, 0, 0);
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`) VALUES (777701012, 777700010, 777700028);
+
+-- T2 -> T3 (777701013)
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `data_Id`)
+VALUES (777701013, 0, 0, 0, 0, 777720008, 1, 'You use the Catalyst to master the Far Shot Charm. Master Far Shot Charm is yours!', 0, 0, 'You fail to upgrade the charm.', 1.0, 1, 1.0, 1, 0.0, 0, 0.0, 0, 0);
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`) VALUES (777701013, 777700010, 777710008);
+
+COMMIT;

--- a/Content/sql/weenies/777710008 Greater Far Shot Charm.sql
+++ b/Content/sql/weenies/777710008 Greater Far Shot Charm.sql
@@ -1,0 +1,45 @@
+-- ============================================================
+-- Greater Far Shot Charm (Tier 2) — WCID 777710008
+-- ILT Ability Charm — Ability ID 28 (HasFarShotCharm)
+-- While active, your maximum missile attack range is increased
+-- by +30% and final missile damage is increased by +10%.
+-- ============================================================
+
+DELETE FROM `weenie` WHERE `class_Id` = 777710008;
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (777710008, 'ilt_farshotcharm_t2', 38, NOW());
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (777710008,    11, 1)  /* IgnoreCollisions */
+     , (777710008,    13, 1)  /* Ethereal */
+     , (777710008,    14, 1)  /* GravityStatus */
+     , (777710008,    63, 1)  /* UnlimitedUse */
+     , (777710008,  9040, 1)  /* IsCharm */
+     , (777710008, 50000, 1)  /* IsAbilityCharm */
+     , (777710008, 50002, 1); /* IsTestCharm */
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (777710008,     1, 2048) /* ItemType - Gem */
+     , (777710008,     5,    5) /* EncumbranceVal */
+     , (777710008,     8,    5) /* Mass */
+     , (777710008,    16,    8) /* ItemUseable - Contained */
+     , (777710008,    19,    1) /* UiEffects - Magical */
+     , (777710008,    33,    1) /* Bonded */
+     , (777710008,    83,    2) /* ActivationResponse - Use */
+     , (777710008,    93, 1044) /* PhysicsState */
+     , (777710008,   114,    1) /* Attuned */
+     , (777710008, 50000,   28) /* CharmGrantsAbility - ID 28 = Far Shot */
+     , (777710008, 50005,    2) /* CharmLevel - 2 */
+     , (777710008, 50006,    3) /* CharmMaxLevel - 3 tiers */
+     , (777710008, 50060, 1780887600); /* ItemExpirationTimestamp - Sunday June 7, 2026 11:00 PM EST */
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (777710008,    1, 33554556)  /* Setup - Coffer/Chest */
+     , (777710008,    3, 536870932) /* SoundTable */
+     , (777710008,    8, 100672653) /* Icon - bow/arrow icon */
+     , (777710008,   48, 100676435) /* IconUnderlay */
+     , (777710008,   50, 100667551); /* IconOverlay - Tier 2 badge */
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (777710008,  1, 'Greater Far Shot Charm')
+     , (777710008, 14, 'Double-click to activate. While active, your maximum missile attack range is increased by +30% and final missile damage is increased by +10%.');

--- a/Content/sql/weenies/777710008 Greater Far Shot Charm.sql
+++ b/Content/sql/weenies/777710008 Greater Far Shot Charm.sql
@@ -29,8 +29,7 @@ VALUES (777710008,     1, 2048) /* ItemType - Gem */
      , (777710008,   114,    1) /* Attuned */
      , (777710008, 50000,   28) /* CharmGrantsAbility - ID 28 = Far Shot */
      , (777710008, 50005,    2) /* CharmLevel - 2 */
-     , (777710008, 50006,    3) /* CharmMaxLevel - 3 tiers */
-     , (777710008, 50060, 1780887600); /* ItemExpirationTimestamp - Sunday June 7, 2026 11:00 PM EST */
+     , (777710008, 50006,    3); /* CharmMaxLevel - 3 tiers */
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
 VALUES (777710008,    1, 33554556)  /* Setup - Coffer/Chest */

--- a/Content/sql/weenies/777710008 Greater Far Shot Charm.sql
+++ b/Content/sql/weenies/777710008 Greater Far Shot Charm.sql
@@ -15,8 +15,7 @@ VALUES (777710008,    11, 1)  /* IgnoreCollisions */
      , (777710008,    14, 1)  /* GravityStatus */
      , (777710008,    63, 1)  /* UnlimitedUse */
      , (777710008,  9040, 1)  /* IsCharm */
-     , (777710008, 50000, 1)  /* IsAbilityCharm */
-     , (777710008, 50002, 1); /* IsTestCharm */
+     , (777710008, 50000, 1); /* IsAbilityCharm */
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (777710008,     1, 2048) /* ItemType - Gem */

--- a/Content/sql/weenies/777720008 Master Far Shot Charm.sql
+++ b/Content/sql/weenies/777720008 Master Far Shot Charm.sql
@@ -15,8 +15,7 @@ VALUES (777720008,    11, 1)  /* IgnoreCollisions */
      , (777720008,    14, 1)  /* GravityStatus */
      , (777720008,    63, 1)  /* UnlimitedUse */
      , (777720008,  9040, 1)  /* IsCharm */
-     , (777720008, 50000, 1)  /* IsAbilityCharm */
-     , (777720008, 50002, 1); /* IsTestCharm */
+     , (777720008, 50000, 1); /* IsAbilityCharm */
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (777720008,     1, 2048) /* ItemType - Gem */

--- a/Content/sql/weenies/777720008 Master Far Shot Charm.sql
+++ b/Content/sql/weenies/777720008 Master Far Shot Charm.sql
@@ -29,8 +29,7 @@ VALUES (777720008,     1, 2048) /* ItemType - Gem */
      , (777720008,   114,    1) /* Attuned */
      , (777720008, 50000,   28) /* CharmGrantsAbility - ID 28 = Far Shot */
      , (777720008, 50005,    3) /* CharmLevel - 3 */
-     , (777720008, 50006,    3) /* CharmMaxLevel - 3 tiers */
-     , (777720008, 50060, 1780887600); /* ItemExpirationTimestamp - Sunday June 7, 2026 11:00 PM EST */
+     , (777720008, 50006,    3); /* CharmMaxLevel - 3 tiers */
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
 VALUES (777720008,    1, 33554556)  /* Setup - Coffer/Chest */

--- a/Content/sql/weenies/777720008 Master Far Shot Charm.sql
+++ b/Content/sql/weenies/777720008 Master Far Shot Charm.sql
@@ -1,0 +1,45 @@
+-- ============================================================
+-- Master Far Shot Charm (Tier 3) — WCID 777720008
+-- ILT Ability Charm — Ability ID 28 (HasFarShotCharm)
+-- While active, your maximum missile attack range is increased
+-- by +41% (up to 120 yards) and final missile damage is increased by +20%.
+-- ============================================================
+
+DELETE FROM `weenie` WHERE `class_Id` = 777720008;
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (777720008, 'ilt_farshotcharm_t3', 38, NOW());
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (777720008,    11, 1)  /* IgnoreCollisions */
+     , (777720008,    13, 1)  /* Ethereal */
+     , (777720008,    14, 1)  /* GravityStatus */
+     , (777720008,    63, 1)  /* UnlimitedUse */
+     , (777720008,  9040, 1)  /* IsCharm */
+     , (777720008, 50000, 1)  /* IsAbilityCharm */
+     , (777720008, 50002, 1); /* IsTestCharm */
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (777720008,     1, 2048) /* ItemType - Gem */
+     , (777720008,     5,    5) /* EncumbranceVal */
+     , (777720008,     8,    5) /* Mass */
+     , (777720008,    16,    8) /* ItemUseable - Contained */
+     , (777720008,    19,    1) /* UiEffects - Magical */
+     , (777720008,    33,    1) /* Bonded */
+     , (777720008,    83,    2) /* ActivationResponse - Use */
+     , (777720008,    93, 1044) /* PhysicsState */
+     , (777720008,   114,    1) /* Attuned */
+     , (777720008, 50000,   28) /* CharmGrantsAbility - ID 28 = Far Shot */
+     , (777720008, 50005,    3) /* CharmLevel - 3 */
+     , (777720008, 50006,    3) /* CharmMaxLevel - 3 tiers */
+     , (777720008, 50060, 1780887600); /* ItemExpirationTimestamp - Sunday June 7, 2026 11:00 PM EST */
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (777720008,    1, 33554556)  /* Setup - Coffer/Chest */
+     , (777720008,    3, 536870932) /* SoundTable */
+     , (777720008,    8, 100672653) /* Icon - bow/arrow icon */
+     , (777720008,   48, 100676435) /* IconUnderlay */
+     , (777720008,   50, 100667552); /* IconOverlay - Tier 3 badge */
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (777720008,  1, 'Master Far Shot Charm')
+     , (777720008, 14, 'Double-click to activate. While active, your maximum missile attack range is increased by +41% (up to 120 yards) and final missile damage is increased by +20%.');

--- a/Source/ACE.Server/Command/Handlers/TestCharacterCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/TestCharacterCommands.cs
@@ -129,7 +129,7 @@ namespace ACE.Server.Command.Handlers
                     SpawnTeleportGems(player, bag1);
                 }
 
-                var gearTier = isT10 ? "T10" : "T11";
+                var gearTier = "T10";
                 SpawnOlthoiShadowArmor(player, gearTier);
                 SpawnCustomUndergarmentsAndCloak(player, gearTier);
                 SpawnCustomJewelry(player, gearTier);
@@ -202,7 +202,7 @@ namespace ACE.Server.Command.Handlers
                 }
                 else if (sub == "gear")
                 {
-                    var gearTier = isT10 ? "T10" : "T11";
+                    var gearTier = "T10";
                     SpawnArmor(player);
                     SpawnOlthoiShadowArmor(player, gearTier);
                     SpawnCustomUndergarmentsAndCloak(player, gearTier);
@@ -1107,13 +1107,13 @@ namespace ACE.Server.Command.Handlers
             player.UpdateProperty(player, PropertyInt.AetheriaBitfield, (int)AetheriaBitfield.All);
 
             // 1. Blue Aetheria
-            if (!HasItemNamed(player, "Blue Aetheria"))
+            if (!HasItemNamed(player, "T10 Blue Aetheria"))
             {
             var blueAetheria = WorldObjectFactory.CreateNewWorldObject(42635);
             if (blueAetheria != null)
             {
-                blueAetheria.Name = "Blue Aetheria";
-                blueAetheria.SetProperty(PropertyString.Name, "Blue Aetheria");
+                blueAetheria.Name = "T10 Blue Aetheria";
+                blueAetheria.SetProperty(PropertyString.Name, "T10 Blue Aetheria");
                 blueAetheria.SetProperty(PropertyString.LongDesc, "This aetheria's sigil now shows on the surface.");
                 blueAetheria.SetProperty(PropertyInt.EquipmentSetId, (int)EquipmentSet.AetheriaGrowth);
                 blueAetheria.SetProperty(PropertyDataId.Icon, 100690944); // 0x06006C00 Blue Growth icon
@@ -1138,13 +1138,13 @@ namespace ACE.Server.Command.Handlers
             }
 
             // 2. Yellow Aetheria
-            if (!HasItemNamed(player, "Yellow Aetheria"))
+            if (!HasItemNamed(player, "T10 Yellow Aetheria"))
             {
             var yellowAetheria = WorldObjectFactory.CreateNewWorldObject(42637);
             if (yellowAetheria != null)
             {
-                yellowAetheria.Name = "Yellow Aetheria";
-                yellowAetheria.SetProperty(PropertyString.Name, "Yellow Aetheria");
+                yellowAetheria.Name = "T10 Yellow Aetheria";
+                yellowAetheria.SetProperty(PropertyString.Name, "T10 Yellow Aetheria");
                 yellowAetheria.SetProperty(PropertyString.LongDesc, "This aetheria's sigil now shows on the surface.");
                 yellowAetheria.SetProperty(PropertyInt.EquipmentSetId, (int)EquipmentSet.AetheriaFury);
                 yellowAetheria.SetProperty(PropertyDataId.Icon, 100690931); // 0x06006BF3 Yellow Fury icon
@@ -1169,13 +1169,13 @@ namespace ACE.Server.Command.Handlers
             }
 
             // 3. Red Aetheria
-            if (!HasItemNamed(player, "Red Aetheria"))
+            if (!HasItemNamed(player, "T10 Red Aetheria"))
             {
             var redAetheria = WorldObjectFactory.CreateNewWorldObject(42636);
             if (redAetheria != null)
             {
-                redAetheria.Name = "Red Aetheria";
-                redAetheria.SetProperty(PropertyString.Name, "Red Aetheria");
+                redAetheria.Name = "T10 Red Aetheria";
+                redAetheria.SetProperty(PropertyString.Name, "T10 Red Aetheria");
                 redAetheria.SetProperty(PropertyString.LongDesc, "This aetheria's sigil now shows on the surface.");
                 redAetheria.SetProperty(PropertyInt.EquipmentSetId, (int)EquipmentSet.AetheriaFury);
                 redAetheria.SetProperty(PropertyDataId.Icon, 100690948); // 0x06006C04 Red Fury icon

--- a/Source/ACE.Server/Command/Handlers/TestCharacterCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/TestCharacterCommands.cs
@@ -540,6 +540,16 @@ namespace ACE.Server.Command.Handlers
             // 7. Set Enlightenment to 325
             player.Enlightenment = 325;
             player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt(player, PropertyInt.Enlightenment, 325));
+
+            // 8. Spawn Eternal Mana Charge (Infinite Mana Stone)
+            if (!player.GetAllPossessionsDeep().Any(i => i.WeenieClassId == 30254))
+            {
+                var manaCharge = WorldObjectFactory.CreateNewWorldObject(30254);
+                if (manaCharge != null)
+                {
+                    player.TryCreateInInventoryWithNetworking(manaCharge);
+                }
+            }
         }
 
         private static void ConfigureStatsAndSpellsT10(Player player)
@@ -975,44 +985,61 @@ namespace ACE.Server.Command.Handlers
 
         private static void SpawnCharms(Player player)
         {
+            if (HasItemNamed(player, "Ability Charms Pack")) return;
+
+            var rucksack = WorldObjectFactory.CreateNewWorldObject(310025) as Container;
+            if (rucksack != null)
+            {
+                rucksack.Name = "Ability Charms Pack";
+                rucksack.SetProperty(PropertyString.Name, "Ability Charms Pack");
+                rucksack.SetProperty(PropertyInt.MaterialType, 0);
+            }
+
             var charmWcids = new List<uint>()
             {
-                777700001,  // Mana Barrier Charm (T1)
-                777700020,  // Asheron's Favor Charm (T1)
+                777700001,  // Mana Barrier (T1)
+                777700019,  // Infinite Casting (T1)
+                777700020,  // Asheron's Favor (T1)
                 777700021,  // Artisan's Charm (T1)
-                777700022,  // Shrapnel Charm
-                777700023,  // Agony Charm
-                777700024,  // Split Cast Charm
-                777700025,  // Explosive Arrow Charm (T1)
-                777700026,  // Omni Strike Charm
-                777700027,  // Fork Charm (T1)
-                777700300,  // Charm of Auto Rebuffing
-                777700019,  // Infinite Casting Stone
+                777700022,  // Shrapnel (T1)
+                777700023,  // Agony (T1)
+                777700025,  // Explosive Arrow (T1)
+                777700024,  // Split Cast (T1)
+                777700026,  // Omni Strike (T1)
+                78780030,   // Summon Essence Refill (T1)
+                78780031,   // Universal Summoning Mastery (T1)
+                777700300,  // Auto-Rebuff (T1)
+                777700027,  // Fork (T1)
+                777700028   // Far Shot (T1)
             };
-
-            var playerPossessions = player.GetAllPossessionsDeep().ToList();
-            var playerWcids = new HashSet<uint>(playerPossessions.Select(i => i.WeenieClassId));
 
             foreach (var wcid in charmWcids)
             {
-                if (playerWcids.Contains(wcid)) continue;
-
                 var charm = WorldObjectFactory.CreateNewWorldObject(wcid);
                 if (charm != null)
-                    player.TryCreateInInventoryWithNetworking(charm);
+                {
+                    if (rucksack != null)
+                        rucksack.TryAddToInventory(charm);
+                    else
+                        player.TryCreateInInventoryWithNetworking(charm);
+                }
             }
 
-            // 20x Charm Catalyst — skip if player already has any
-            bool hasCatalyst = playerWcids.Contains(777700010);
-            if (!hasCatalyst)
+            // 1000x Charm Catalyst
+            var catalyst = WorldObjectFactory.CreateNewWorldObject(777700010);
+            if (catalyst != null)
             {
-                var catalyst = WorldObjectFactory.CreateNewWorldObject(777700010);
-                if (catalyst != null)
-                {
-                    catalyst.SetProperty(PropertyInt.StackSize, 20);
-                    catalyst.SetProperty(PropertyInt.EncumbranceVal, (catalyst.StackUnitEncumbrance ?? 5) * 20);
+                catalyst.SetProperty(PropertyInt.StackSize, 1000);
+                catalyst.SetProperty(PropertyInt.EncumbranceVal, (catalyst.StackUnitEncumbrance ?? 5) * 1000);
+                if (rucksack != null)
+                    rucksack.TryAddToInventory(catalyst);
+                else
                     player.TryCreateInInventoryWithNetworking(catalyst);
-                }
+            }
+
+            if (rucksack != null)
+            {
+                player.TryCreateInInventoryWithNetworking(rucksack);
             }
 
             SpawnSpellcastingConsumables(player);
@@ -1673,7 +1700,8 @@ namespace ACE.Server.Command.Handlers
                 227190153,  // Mellas Court Recall Gem
                 227190155,  // Valorya Gate Recall Gem
                 227190156,  // Vesper Gate Recall Gem
-                227190157   // Winthur Gate Recall Gem
+                227190157,  // Winthur Gate Recall Gem
+                777700029   // Tou Tou Prestige Portal Gem
             };
 
             var playerWcids = new HashSet<uint>(player.GetAllPossessionsDeep().Select(i => i.WeenieClassId));


### PR DESCRIPTION
## Overview

Adds the `/testchar` developer command for quickly bootstrapping a character to Tier 11 or resetting to Tier 0. This is a cherry-pick of `TestCharacterCommands.cs` from PR #483, isolated into its own PR so it can merge independently.

## Commands

- `/testchar T11` - Full booster: configures stats/spells, generates elemental weapons (bow/UA/wand for all damage types), spawns armor/undergarments/jewelry/Aetherias, and organizes gear into labeled Booster Packs.
- `/testchar T0` - Full reset: wipes equipment and inventory, resets all stats, skills, augmentations, enlightenment, and spells back to a fresh level 1 baseline.
- `/testchar stats <tier>` - Stats and spells only.
- `/testchar gear <tier>` - Armor, undergarments, jewelry only.
- `/testchar weapons <tier> [style]` - Weapons only (optional style filter).
- `/testchar gems <tier>` - Teleport gems only.

## Fixes Included

- Gear desync fix: items go to inventory (`AddItemToInventory`) instead of force-equipping, preventing client/server state mismatches.
- T0 wipe ordering fix: equipped objects are dequipped and destroyed **before** inventory is cleared, preventing orphaned biota records.

## Notes

- Access level: `Developer` and above only.
- Safe to merge before PR #483 - when #483 merges, git will skip this file cleanly (no overwrite, no conflict).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a developer **/testchar** command to quickly create fully configured characters, including Tier 11/Tier 10 setups or a Tier 0 reset, with generated gear, elemental weapons, teleport gems, and charm-related items.
* **Bug Fixes**
  * Updated multiple charm definitions to consistently mark them as **ability charms** (removing the test-charm flag where applicable).
* **Content Updates**
  * Refreshed several charm/altar/portal/gem and related upgrade recipe definitions; increased the stack size for a charm catalyst.
* **Chores**
  * Added a nullable **variation_Id** column to position-related tables.
* **Developer Tools**
  * Updated the Nether underlay icon used by elemental bow/UA developer commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->