### PR TITLE
Fix/wounded taunt phase transitions

### DIFF
--- a/Database/Updates/World/2026-06-21-00-Aerbax-Phase-Threshold-Fix.sql
+++ b/Database/Updates/World/2026-06-21-00-Aerbax-Phase-Threshold-Fix.sql
@@ -1,0 +1,20 @@
+/* Aerbax's Prodigal - correct platform-port health thresholds to retail values.
+
+   Each phase is a WoundedTaunt emote (category 15) that ports Aerbax's Shadow
+   to the next platform when health drops to/below the band's max_Health.
+
+   Retail thresholds:  East 90%, North 77%, West 72%, South 60%, Center 33%
+   North/West/Center already matched. This corrects East (was 60%) and South (61%).
+
+   Pairs with the engine fix that fires every crossed WoundedTaunt band on lethal
+   hits (EmoteManager.SelectWoundedTauntBands). */
+
+-- East port  | Aerbax's Shadow WCID 36951, emote 199801 | 60% -> 90%
+UPDATE weenie_properties_emote
+SET    max_Health = 0.9
+WHERE  id = 199801 AND object_Id = 36951;
+
+-- South port | Aerbax's Shadow WCID 37381, emote 199850 | 61% -> 60% (exact retail)
+UPDATE weenie_properties_emote
+SET    max_Health = 0.6
+WHERE  id = 199850 AND object_Id = 37381;

--- a/Source/ACE.Server.Tests/WoundedTauntBandSelectionTests.cs
+++ b/Source/ACE.Server.Tests/WoundedTauntBandSelectionTests.cs
@@ -227,5 +227,54 @@ namespace ACE.Server.Tests
 
             Assert.AreEqual(0, results.Count);
         }
+
+        // -------------------------------------------------------------------
+        // Stateful re-arm flow
+        //
+        // OnDamage threads health state across hits: it uses the previously
+        // observed percent as prev, fires crossed bands, then stores the current
+        // percent as the new prev (TriggerWoundedTaunt -> _lastWoundedTauntHealthPercent).
+        // These tests replay that exact threading through the pure selector to
+        // cover the re-arm-after-heal behavior. (Invoking OnDamage directly is not
+        // unit-testable here: it requires a live Creature with vitals/Biota and an
+        // action queue for ExecuteEmoteSet -- the reason the selection logic was
+        // extracted. The lethal-hit ordering is validated by live in-game testing.)
+        // -------------------------------------------------------------------
+
+        [TestMethod]
+        public void StateThreading_HealAboveThenRedrop_RefiresBand()
+        {
+            var band = Band(0.60f, 0.01f); // East-style port band
+            var emotes = new List<PropertiesEmote> { band };
+            double last = 1.0;
+
+            // Hit 1: 100% -> 50% crosses 0.60 -> fires.
+            var r1 = EmoteManager.SelectWoundedTauntBands(emotes, last, 0.50, () => 0.0); last = 0.50;
+            Assert.AreEqual(1, r1.Count, "first drop should fire the band");
+
+            // Heal: 50% -> 80% no fire, state re-arms upward.
+            var r2 = EmoteManager.SelectWoundedTauntBands(emotes, last, 0.80, () => 0.0); last = 0.80;
+            Assert.AreEqual(0, r2.Count, "heal must not fire");
+
+            // Hit 2: 80% -> 50% crosses 0.60 again -> fires again.
+            var r3 = EmoteManager.SelectWoundedTauntBands(emotes, last, 0.50, () => 0.0); last = 0.50;
+            Assert.AreEqual(1, r3.Count, "re-drop after heal should re-fire");
+        }
+
+        [TestMethod]
+        public void StateThreading_ContinuedDropWithoutHeal_DoesNotRefire()
+        {
+            var band = Band(0.60f, 0.01f);
+            var emotes = new List<PropertiesEmote> { band };
+            double last = 1.0;
+
+            // Hit 1: 100% -> 50% fires.
+            var r1 = EmoteManager.SelectWoundedTauntBands(emotes, last, 0.50, () => 0.0); last = 0.50;
+            Assert.AreEqual(1, r1.Count);
+
+            // Hit 2: 50% -> 20% (no heal): prev already below band max, must not re-fire.
+            var r2 = EmoteManager.SelectWoundedTauntBands(emotes, last, 0.20, () => 0.0); last = 0.20;
+            Assert.AreEqual(0, r2.Count, "continued drop without a heal must not re-fire the band");
+        }
     }
 }

--- a/Source/ACE.Server.Tests/WoundedTauntBandSelectionTests.cs
+++ b/Source/ACE.Server.Tests/WoundedTauntBandSelectionTests.cs
@@ -1,0 +1,231 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using ACE.Entity.Enum;
+using ACE.Entity.Models;
+using ACE.Server.WorldObjects.Managers;
+
+namespace ACE.Server.Tests
+{
+    /// <summary>
+    /// Tests for the health-banded WoundedTaunt phase selection used by multi-phase bosses
+    /// (Aerbax shadows, Galivak, Rajael, etc.). The bug being guarded against: a large or lethal
+    /// hit would skip phase bands because selection only looked at *current* health. The fix fires
+    /// every band CROSSED by the damage, highest-band-first, including on a one-shot to 0%.
+    /// </summary>
+    [TestClass]
+    public class WoundedTauntBandSelectionTests
+    {
+        private static PropertiesEmote Band(float maxHealth, float minHealth, float probability = 1.0f) =>
+            new PropertiesEmote
+            {
+                Category = EmoteCategory.WoundedTaunt,
+                Quest = string.Empty,
+                MinHealth = minHealth,
+                MaxHealth = maxHealth,
+                Probability = probability
+            };
+
+        // -------------------------------------------------------------------
+        // No-op cases
+        // -------------------------------------------------------------------
+
+        [TestMethod]
+        public void EmptyList_ReturnsNoResults()
+        {
+            var results = EmoteManager.SelectWoundedTauntBands(
+                new List<PropertiesEmote>(), 1.0, 0.5, () => 0.0);
+
+            Assert.AreEqual(0, results.Count);
+        }
+
+        [TestMethod]
+        public void HealthRose_ReturnsNothing()
+        {
+            // A heal (curr > prev) must not fire any band.
+            var band = Band(0.6f, 0.01f);
+
+            var results = EmoteManager.SelectWoundedTauntBands(
+                new List<PropertiesEmote> { band }, 0.3, 0.8, () => 0.0);
+
+            Assert.AreEqual(0, results.Count);
+        }
+
+        [TestMethod]
+        public void NonWoundedTauntRows_Ignored()
+        {
+            var other = new PropertiesEmote
+            {
+                Category = EmoteCategory.ReceiveDamage,
+                Quest = string.Empty,
+                MinHealth = 0.01f,
+                MaxHealth = 0.98f,
+                Probability = 1.0f
+            };
+
+            var results = EmoteManager.SelectWoundedTauntBands(
+                new List<PropertiesEmote> { other }, 1.0, 0.0, () => 0.0);
+
+            Assert.AreEqual(0, results.Count);
+        }
+
+        // -------------------------------------------------------------------
+        // Gradual damage — one band crossed at a time
+        // -------------------------------------------------------------------
+
+        [TestMethod]
+        public void GradualCross_EntersBand_Fires()
+        {
+            // Aerbax shadow 36951 phase 1 band: 75%-98%. Hit 100% -> 90% enters it.
+            var phase1 = Band(0.98f, 0.75f);
+
+            var results = EmoteManager.SelectWoundedTauntBands(
+                new List<PropertiesEmote> { phase1 }, 1.0, 0.90, () => 0.0);
+
+            Assert.AreEqual(1, results.Count);
+            Assert.AreSame(phase1, results[0]);
+        }
+
+        [TestMethod]
+        public void StayingAboveBand_DoesNotFire()
+        {
+            var phase1 = Band(0.98f, 0.75f);
+
+            // 100% -> 99%: never dropped to/below the band's max (0.98).
+            var results = EmoteManager.SelectWoundedTauntBands(
+                new List<PropertiesEmote> { phase1 }, 1.0, 0.99, () => 0.0);
+
+            Assert.AreEqual(0, results.Count);
+        }
+
+        [TestMethod]
+        public void AlreadyBelowBand_DoesNotRefire()
+        {
+            var phase1 = Band(0.98f, 0.75f);
+
+            // Already inside/below the band last time (prev 0.90) and dropping further (0.80):
+            // prev is not above max, so this band is not newly crossed.
+            var results = EmoteManager.SelectWoundedTauntBands(
+                new List<PropertiesEmote> { phase1 }, 0.90, 0.80, () => 0.0);
+
+            Assert.AreEqual(0, results.Count);
+        }
+
+        // -------------------------------------------------------------------
+        // The core bug: overkill / lethal hits
+        // -------------------------------------------------------------------
+
+        [TestMethod]
+        public void OneShotToZero_FiresAllBands_HighestFirst()
+        {
+            // 36951: phase1 (75-98) and phase2 (1-60). A one-shot from full to 0 must fire BOTH,
+            // phase1 before phase2 (so StartEvent master1 precedes phase2's StopEvent master1).
+            var phase1 = Band(0.98f, 0.75f);
+            var phase2 = Band(0.60f, 0.01f);
+
+            var results = EmoteManager.SelectWoundedTauntBands(
+                new List<PropertiesEmote> { phase2, phase1 }, 1.0, 0.0, () => 0.0);
+
+            Assert.AreEqual(2, results.Count);
+            Assert.AreSame(phase1, results[0], "highest band must fire first");
+            Assert.AreSame(phase2, results[1]);
+        }
+
+        [TestMethod]
+        public void OverkillSkippingBand_StillFiresSkippedBand()
+        {
+            // Hit jumps 98% -> 5%: lands in phase2's range but must NOT skip phase1.
+            var phase1 = Band(0.98f, 0.75f);
+            var phase2 = Band(0.60f, 0.01f);
+
+            var results = EmoteManager.SelectWoundedTauntBands(
+                new List<PropertiesEmote> { phase1, phase2 }, 0.98001, 0.05, () => 0.0);
+
+            Assert.AreEqual(2, results.Count);
+            Assert.AreSame(phase1, results[0]);
+            Assert.AreSame(phase2, results[1]);
+        }
+
+        [TestMethod]
+        public void ThreeNarrowBands_OneShot_FiresAllInOrder()
+        {
+            // 37378 toggle bands: 86-90, 70-75, 20-25. A one-shot crosses all three; highest first.
+            var b90 = Band(0.90f, 0.86f);
+            var b75 = Band(0.75f, 0.70f);
+            var b25 = Band(0.25f, 0.20f);
+
+            var results = EmoteManager.SelectWoundedTauntBands(
+                new List<PropertiesEmote> { b25, b90, b75 }, 1.0, 0.0, () => 0.0);
+
+            Assert.AreEqual(3, results.Count);
+            Assert.AreSame(b90, results[0]);
+            Assert.AreSame(b75, results[1]);
+            Assert.AreSame(b25, results[2]);
+        }
+
+        [TestMethod]
+        public void NarrowBandWithGap_DamageThroughGap_FiresCrossedBand()
+        {
+            // 37378 has gaps between bands. A hit 92% -> 80% passes entirely through the 86-90 band.
+            var b90 = Band(0.90f, 0.86f);
+
+            var results = EmoteManager.SelectWoundedTauntBands(
+                new List<PropertiesEmote> { b90 }, 0.92, 0.80, () => 0.0);
+
+            Assert.AreEqual(1, results.Count);
+            Assert.AreSame(b90, results[0]);
+        }
+
+        // -------------------------------------------------------------------
+        // Probability handling
+        // -------------------------------------------------------------------
+
+        [TestMethod]
+        public void CrossedBand_ProbabilityFails_DoesNotFire()
+        {
+            var band = Band(0.60f, 0.01f, probability: 0.10f);
+
+            // roll 0.5 >= probability 0.10 -> fails.
+            var results = EmoteManager.SelectWoundedTauntBands(
+                new List<PropertiesEmote> { band }, 1.0, 0.0, () => 0.5);
+
+            Assert.AreEqual(0, results.Count);
+        }
+
+        [TestMethod]
+        public void CrossedBand_ProbabilityPasses_Fires()
+        {
+            var band = Band(0.60f, 0.01f, probability: 0.10f);
+
+            // roll 0.05 < probability 0.10 -> fires.
+            var results = EmoteManager.SelectWoundedTauntBands(
+                new List<PropertiesEmote> { band }, 1.0, 0.0, () => 0.05);
+
+            Assert.AreEqual(1, results.Count);
+        }
+
+        // -------------------------------------------------------------------
+        // Null bound guard
+        // -------------------------------------------------------------------
+
+        [TestMethod]
+        public void NullMaxHealth_NeverCrossed()
+        {
+            var band = new PropertiesEmote
+            {
+                Category = EmoteCategory.WoundedTaunt,
+                Quest = string.Empty,
+                MinHealth = null,
+                MaxHealth = null,
+                Probability = 1.0f
+            };
+
+            var results = EmoteManager.SelectWoundedTauntBands(
+                new List<PropertiesEmote> { band }, 1.0, 0.0, () => 0.0);
+
+            Assert.AreEqual(0, results.Count);
+        }
+    }
+}

--- a/Source/ACE.Server/WorldObjects/Creature_Vitals.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Vitals.cs
@@ -51,7 +51,14 @@ namespace ACE.Server.WorldObjects
         {
             var before = vital.Current;
             vital.Current = (uint)Math.Clamp(newVal, 0, vital.MaxValue);
-            return (int)(vital.Current - before);
+            var delta = (int)(vital.Current - before);
+
+            // Keep the WoundedTaunt phase tracker fresh on any health gain (heal/regen) so banded
+            // bosses re-arm correctly if healed above a threshold and then re-damaged through it.
+            if (delta > 0 && vital == Health)
+                EmoteManager?.OnHealthRaised();
+
+            return delta;
         }
 
         public virtual int UpdateVital(CreatureVital vital, uint newVal)

--- a/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
@@ -58,6 +58,15 @@ namespace ACE.Server.WorldObjects.Managers
         public bool Debug = false;
         private readonly HashSet<string> _singleLocalBroadcastsSent = new HashSet<string>();
 
+        /// <summary>
+        /// Last health percent observed by WoundedTaunt phase tracking. Used to edge-trigger
+        /// health-banded phase emotes (EmoteCategory.WoundedTaunt) so that every band CROSSED
+        /// by a damage event fires — including bands skipped by a large/overkill hit and the
+        /// final band on a lethal blow. Seeded to full health; reset upward on heals so bands
+        /// can re-arm if a boss is healed back above a threshold. See <see cref="TriggerWoundedTaunt"/>.
+        /// </summary>
+        private double _lastWoundedTauntHealthPercent = 1.0;
+
         public EmoteManager(WorldObject worldObject)
         {
             _worldObject = worldObject;
@@ -4011,8 +4020,9 @@ namespace ACE.Server.WorldObjects.Managers
         /// </remarks>
         public void OnDamage(Creature attacker, DamageType damageType = DamageType.Undef)
         {
-            if (_worldObject is Creature wounded && wounded.IsAlive)
-                ExecuteEmoteSet(EmoteCategory.WoundedTaunt, null, attacker);
+            // WoundedTaunt drives health-banded phase transitions. Fire every band crossed by
+            // this hit (including on a lethal blow), not just the band current health lands in.
+            TriggerWoundedTaunt(attacker);
 
             if (_worldObject.Biota.PropertiesEmote == null)
                 return;
@@ -4023,6 +4033,65 @@ namespace ACE.Server.WorldObjects.Managers
 
             foreach (var emoteSet in SelectReceiveDamageEmotes(receiveDamageEmotes, damageType, () => ThreadSafeRandom.Next(0.0f, 1.0f)))
                 ExecuteEmoteSet(emoteSet, attacker, nested: true);
+        }
+
+        /// <summary>
+        /// Fires all WoundedTaunt (health-banded phase) emote sets whose upper bound was crossed
+        /// downward by the most recent damage. Edge-triggered against <see cref="_lastWoundedTauntHealthPercent"/>
+        /// so each band fires once per crossing, ordered highest-band-first to preserve phase
+        /// sequencing (e.g. StartEvent phase1 before StopEvent phase1 in phase2). Fires regardless
+        /// of whether the creature survived the hit, so a one-shot still runs the final phase and
+        /// the quest event chain can complete. Does not alter the death outcome.
+        /// </summary>
+        private void TriggerWoundedTaunt(WorldObject attacker)
+        {
+            if (!(_worldObject is Creature creature))
+                return;
+
+            var prev = _lastWoundedTauntHealthPercent;
+            var curr = creature.Health.Percent; // post-damage; may be 0 on a lethal hit
+
+            _lastWoundedTauntHealthPercent = curr;
+
+            // Health didn't drop (heal, regen, no-op), or nothing to evaluate: bands simply re-arm.
+            if (curr >= prev || _worldObject.Biota.PropertiesEmote == null)
+                return;
+
+            var bands = SelectWoundedTauntBands(
+                _worldObject.Biota.PropertiesEmote, prev, curr, () => ThreadSafeRandom.Next(0.0f, 1.0f));
+
+            foreach (var band in bands)
+                ExecuteEmoteSet(band, attacker, nested: true);
+        }
+
+        /// <summary>
+        /// Selects which WoundedTaunt (health-banded phase) emote sets should fire for a health drop
+        /// from <paramref name="prevPercent"/> to <paramref name="currPercent"/>. A band is "crossed"
+        /// when health goes from above its MaxHealth to at/below it; every crossed band is returned,
+        /// ordered highest-band-first so phase sequencing is preserved on large/overkill hits. MinHealth
+        /// is intentionally ignored so a lethal hit (curr == 0) still triggers low bands. Each crossed
+        /// band rolls its Probability via <paramref name="rng"/>. Pure/deterministic for unit testing.
+        /// </summary>
+        public static List<PropertiesEmote> SelectWoundedTauntBands(
+            IEnumerable<PropertiesEmote> emotes, double prevPercent, double currPercent, Func<double> rng)
+        {
+            var results = new List<PropertiesEmote>();
+
+            if (emotes == null || currPercent >= prevPercent)
+                return results;
+
+            var crossed = emotes
+                .Where(e => e.Category == EmoteCategory.WoundedTaunt
+                            && e.MaxHealth.HasValue
+                            && prevPercent > e.MaxHealth.Value
+                            && currPercent <= e.MaxHealth.Value)
+                .OrderByDescending(e => e.MaxHealth.Value);
+
+            foreach (var band in crossed)
+                if (band.Probability > rng())
+                    results.Add(band);
+
+            return results;
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
@@ -4060,8 +4060,25 @@ namespace ACE.Server.WorldObjects.Managers
             var bands = SelectWoundedTauntBands(
                 _worldObject.Biota.PropertiesEmote, prev, curr, () => ThreadSafeRandom.Next(0.0f, 1.0f));
 
+            // Bands are returned highest-first and executed in that order. Each set runs as its own
+            // nested chain; ordering holds as long as phase-transition actions use delay 0 (true for
+            // all known WoundedTaunt phase scripts, e.g. Aerbax). If a band ever needs delayed
+            // StartEvent/StopEvent actions across multiple crossed bands, this would need to become a
+            // single ordered continuation instead of independent chains.
             foreach (var band in bands)
                 ExecuteEmoteSet(band, attacker, nested: true);
+        }
+
+        /// <summary>
+        /// Keeps the WoundedTaunt phase tracker fresh when the creature's health RISES (heal/regen).
+        /// Damage-driven lowering is handled in <see cref="TriggerWoundedTaunt"/>; without this, a boss
+        /// healed above a band and then re-damaged through it would not re-fire that band, because the
+        /// tracker would still hold the lower pre-heal value. Invoked from the UpdateVital chokepoint.
+        /// </summary>
+        public void OnHealthRaised()
+        {
+            if (_worldObject is Creature creature && creature.Health.Percent > _lastWoundedTauntHealthPercent)
+                _lastWoundedTauntHealthPercent = creature.Health.Percent;
         }
 
         /// <summary>


### PR DESCRIPTION
## 1. Problem

On high-damage custom servers, multi-phase bosses break their quest scripting. The reported case: **Aerbax's Prodigal** -- players one-shot (or heavily overkill) the boss shadow, the encounter fails to advance to the next phase, and the quest chain dead-ends.

## 2. Root cause

Boss phase transitions are driven by **`WoundedTaunt` emotes** (EmoteCategory `15`), gated by health bands. Each band fires `StartEvent` / `StopEvent` actions that toggle the spawn generators for the next stage (the next shadow, portals, etc.). Two compounding bugs in the shared combat path defeated this:

1. **Lethal hits skipped phases entirely.** In `EmoteManager.OnDamage`, WoundedTaunt was gated behind `IsAlive`:

   ```csharp
   if (_worldObject is Creature wounded && wounded.IsAlive)
       ExecuteEmoteSet(EmoteCategory.WoundedTaunt, ...);
   ```

   A one-shot leaves the creature dead, so the final phase's events never fired -- directly contradicting the existing comment in `Player_Combat.cs` ("run on any connecting hit, including lethal").

2. **Band selection used only current (post-damage) health.** A hit jumping e.g. 98% to 5% landed in a low band but **skipped** intermediate bands, so their `StartEvent`s never ran while a later band's `StopEvent` tried to stop something that was never started -- desyncing the whole sequence.

This is a **shared engine path**, so it affected every health-banded boss (Galivak 7 bands, Rajael 5, Shadow Kresovus 4, the Aerbax shadows, ~30 others) -- not just Aerbax.

## 3. The code fix -- `EmoteManager.cs`

- **Added health tracking field** `_lastWoundedTauntHealthPercent` (seeded to full HP; re-arms upward on heals).
- **Replaced the WoundedTaunt call in `OnDamage`** with `TriggerWoundedTaunt(attacker)`, which:
  - Fires **every band crossed** by the damage event (`prev > MaxHealth && curr <= MaxHealth`)
  - Orders them **highest-band-first**, preserving phase sequencing on overkill
  - Fires **regardless of alive-state**, so one-shots still run the final phase
  - Edge-triggers (each band fires once per crossing; re-arms on heals)
  - Does **not** alter the death outcome -- the creature still dies; the phase events just fire first. The next stage is a separately-spawned, generator-gated object, so the encounter continues.
- **Extracted the selection into a pure static helper** `SelectWoundedTauntBands(emotes, prevPercent, currPercent, rng)`, mirroring the existing `SelectReceiveDamageEmotes` pattern so it is unit-testable.

## 4. Tests -- new file

`Source/ACE.Server.Tests/WoundedTauntBandSelectionTests.cs` -- **13 cases, all passing**, mapped to real DB band layouts:

| Coverage | Examples |
| --- | --- |
| One-shot to 0% fires all bands, highest-first | `OneShotToZero_FiresAllBands_HighestFirst` |
| Overkill skipping a band still fires it | `OverkillSkippingBand_StillFiresSkippedBand` |
| 37378 three narrow toggle bands, with gaps | `ThreeNarrowBands_OneShot_FiresAllInOrder`, `NarrowBandWithGap_DamageThroughGap` |
| Gradual play unchanged, no re-fire | `GradualCross_EntersBand_Fires`, `AlreadyBelowBand_DoesNotRefire` |
| Heal re-arm, probability rolls, null guards | `HealthRose_ReturnsNothing`, `CrossedBand_Probability*`, `NullMaxHealth_NeverCrossed` |

## 5. The data fix -- Aerbax thresholds

Investigation confirmed **no custom code** exists for Aerbax -- the entire fight is data-driven (emotes + generators + events). The only deviation from retail was in the phase-band percentages:

| Platform | Was (custom) | Retail | Action |
| --- | --- | --- | --- |
| East | 60% | 90% | **fixed to 90%** |
| North | 77% | 77% | already correct |
| West | 72% | 72% | already correct |
| South | 61% | 60% | **fixed to 60%** |
| Center | 33% | 33% | already correct |

`Database/Updates/World/2026-06-21-00-Aerbax-Phase-Threshold-Fix.sql`:

```sql
UPDATE weenie_properties_emote SET max_Health = 0.9 WHERE id = 199801 AND object_Id = 36951;  -- East 60 to 90
UPDATE weenie_properties_emote SET max_Health = 0.6 WHERE id = 199850 AND object_Id = 37381;  -- South 61 to 60
```

Placed in the dated `Updates/World` folder so it runs via `AutoApplyDatabaseUpdates` on next deploy.

## 6. Verification

- **Unit tests:** 13/13 pass (`dotnet test --filter WoundedTauntBandSelectionTests`).
- **Build:** 0 errors off `master`.
- **Live in-game test:** after deploying the fixed binary, one-shotting Aerbax's Shadow fired the phase events on the lethal hit:

  ```
  killed Aerbax's Shadow (37380) -> started aerbaxmaster2, started aerbaxshadow6event, stopped aerbaxmaster1...
  ```

  The chain progressed through shadows (37380 -> 37378 -> ...), confirming the fix end-to-end. Pre-fix runs showed the kill with **no** following `aerbaxshadowNevent` -- the bug.

## 7. Scope and risk

- Generic fix in the shared `OnDamage` / WoundedTaunt path -- repairs all health-banded bosses, no per-mob code.
- No DB schema changes; data change is two `max_Health` values.
- Death behavior unchanged; only adds the missing phase-event firing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Aerbax “Aerbax’s Shadow” platform-port health thresholds to match intended retail values for two specific emote/platform combinations.

* **Improvements**
  * Updated wounded taunt emote behavior to trigger at the proper downward health-percentage thresholds during combat, including correct handling when damage overkills or passes through band gaps.
  * Healing/health increases now re-arm wounded taunt triggers for future drops, and multiple crossed bands fire in the correct priority order while honoring per-band chance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->