### PR TITLE
fix: prevent NPC turn-in items from being voided when rewards can't b…

### DIFF
--- a/Source/ACE.Server/Entity/ItemsToReceive.cs
+++ b/Source/ACE.Server/Entity/ItemsToReceive.cs
@@ -29,6 +29,16 @@ namespace ACE.Server.Entity
 
         public bool PlayerExceedsLimits => PlayerOutOfInventorySlots || PlayerOutOfContainerSlots || PlayerExceedsAvailableBurden;
 
+        /// <summary>
+        /// How many MORE slots the player must free to receive the batch (the deficit), accounting for
+        /// the slots they already have free (including side packs). This is what to show the player —
+        /// not <see cref="RequiredSlots"/>, which is the gross size of the reward and over-states what
+        /// they actually need to clear.
+        /// </summary>
+        public int RequiredAdditionalSlots =>
+            (RequiredInventorySlots > playerFreeInventorySlots ? RequiredInventorySlots - playerFreeInventorySlots : 0)
+            + (RequiredContainerSlots > playerFreeContainerSlots ? RequiredContainerSlots - playerFreeContainerSlots : 0);
+
         public bool Add(uint weenieClassId, int amount)
         {
             return Process(weenieClassId, amount);

--- a/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
@@ -640,14 +640,14 @@ namespace ACE.Server.WorldObjects.Managers
 
                         if (batchItems.PlayerExceedsLimits)
                         {
-                            var slotsNeeded = batchItems.RequiredSlots;
+                            var slotsNeeded = batchItems.RequiredAdditionalSlots;
                             if (batchItems.PlayerExceedsAvailableBurden)
                                 player.Session.Network.EnqueueSend(new GameMessageSystemChat(
                                     $"{WorldObject.Name} has rewards for you, but you are too encumbered to carry them! Drop some items and try again.",
                                     ChatMessageType.Broadcast));
                             else
                                 player.Session.Network.EnqueueSend(new GameMessageSystemChat(
-                                    $"{WorldObject.Name} has rewards for you, but you need {slotsNeeded} free inventory slot(s). Free up some space and try again.",
+                                    $"{WorldObject.Name} has rewards for you, but you need {slotsNeeded} more free inventory slot(s). Free up some space and try again.",
                                     ChatMessageType.Broadcast));
 
                             AbortEmoteChain = true;
@@ -3607,14 +3607,14 @@ namespace ACE.Server.WorldObjects.Managers
                     // If no upcoming Gives, the batch has no requirements and PlayerExceedsLimits is false.
                     if (batchItems.PlayerExceedsLimits)
                     {
-                        var slotsNeeded = batchItems.RequiredSlots;
+                        var slotsNeeded = batchItems.RequiredAdditionalSlots;
                         if (batchItems.PlayerExceedsAvailableBurden)
                             preCheckPlayer.Session.Network.EnqueueSend(new GameMessageSystemChat(
                                 $"{WorldObject.Name} has rewards for you, but you are too encumbered to carry them! Drop some items and try again.",
                                 ChatMessageType.Broadcast));
                         else
                             preCheckPlayer.Session.Network.EnqueueSend(new GameMessageSystemChat(
-                                $"{WorldObject.Name} has rewards for you, but you need {slotsNeeded} free inventory slot(s). Free up some space and try again.",
+                                $"{WorldObject.Name} has rewards for you, but you need {slotsNeeded} more free inventory slot(s). Free up some space and try again.",
                                 ChatMessageType.Broadcast));
 
                         // No AbortEmoteChain flag here: we return without enqueueing the next action,

--- a/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
@@ -635,24 +635,8 @@ namespace ACE.Server.WorldObjects.Managers
                         // bundle before scheduling anything. Scanning from the current emote's
                         // index forward captures all remaining Gives without touching earlier
                         // Gives that already fired in previous interactions.
-                        var batchItems = new ItemsToReceive(player);
                         var currentEmoteIdx = emoteSet.PropertiesEmoteAction.IndexOf(emote);
-                        for (var i = currentEmoteIdx; i < emoteSet.PropertiesEmoteAction.Count; i++)
-                        {
-                            var la = emoteSet.PropertiesEmoteAction[i];
-                            if ((EmoteType)la.Type != EmoteType.Give || la.WeenieClassId == null)
-                                continue; // skip non-Give actions but keep scanning for later Gives
-                            var laAmt = la.StackSize ?? 1;
-                            if (laAmt > 0 && (la.WeenieClassId == 300004 || la.WeenieClassId == 300003))
-                            {
-                                var laCoinMult = ServerConfig.coin_reward_mult.Value;
-                                if (double.IsNaN(laCoinMult) || double.IsInfinity(laCoinMult))
-                                    laCoinMult = 0;
-                                laCoinMult = Math.Max(0, laCoinMult);
-                                laAmt = (int)(laAmt * laCoinMult);
-                            }
-                            batchItems.Add(la.WeenieClassId.Value, laAmt > 0 ? laAmt : 1);
-                        }
+                        var batchItems = BuildRewardBatch(player, emoteSet, currentEmoteIdx);
 
                         if (batchItems.PlayerExceedsLimits)
                         {
@@ -3618,58 +3602,29 @@ namespace ACE.Server.WorldObjects.Managers
                 var preCheckPlayer = targetObject as Player;
                 if (preCheckPlayer != null)
                 {
-                    var batchItems = new ItemsToReceive(preCheckPlayer);
-                    var hasUpcomingGives = false;
-                    for (var scanIdx = emoteIdx; scanIdx < emoteSet.PropertiesEmoteAction.Count; scanIdx++)
+                    var batchItems = BuildRewardBatch(preCheckPlayer, emoteSet, emoteIdx);
+
+                    // If no upcoming Gives, the batch has no requirements and PlayerExceedsLimits is false.
+                    if (batchItems.PlayerExceedsLimits)
                     {
-                        var scanEmote = emoteSet.PropertiesEmoteAction[scanIdx];
-                        var scanType = (EmoteType)scanEmote.Type;
-                        if (scanType == EmoteType.Give && scanEmote.WeenieClassId != null)
-                        {
-                            hasUpcomingGives = true;
-                            var gAmt = scanEmote.StackSize ?? 1;
-                            if (gAmt > 0 && (scanEmote.WeenieClassId == 300004 || scanEmote.WeenieClassId == 300003))
-                            {
-                                var laCoinMult = ServerConfig.coin_reward_mult.Value;
-                                if (double.IsNaN(laCoinMult) || double.IsInfinity(laCoinMult))
-                                    laCoinMult = 0;
-                                laCoinMult = Math.Max(0, laCoinMult);
-                                gAmt = (int)(gAmt * laCoinMult);
-                            }
-                            batchItems.Add(scanEmote.WeenieClassId.Value, gAmt > 0 ? gAmt : 1);
-                        }
-                        else if (scanType == EmoteType.TakeItems && scanEmote.WeenieClassId != null)
-                        {
-                            // Simulate items being taken — they free slots/burden for subsequent Gives
-                            var tAmt = scanEmote.StackSize ?? 1;
-                            batchItems.Remove(scanEmote.WeenieClassId.Value, tAmt > 0 ? tAmt : 1);
-                        }
-                    }
+                        var slotsNeeded = batchItems.RequiredSlots;
+                        if (batchItems.PlayerExceedsAvailableBurden)
+                            preCheckPlayer.Session.Network.EnqueueSend(new GameMessageSystemChat(
+                                $"{WorldObject.Name} has rewards for you, but you are too encumbered to carry them! Drop some items and try again.",
+                                ChatMessageType.Broadcast));
+                        else
+                            preCheckPlayer.Session.Network.EnqueueSend(new GameMessageSystemChat(
+                                $"{WorldObject.Name} has rewards for you, but you need {slotsNeeded} free inventory slot(s). Free up some space and try again.",
+                                ChatMessageType.Broadcast));
 
-                    if (hasUpcomingGives)
-                    {
-
-                        if (batchItems.PlayerExceedsLimits)
+                        AbortEmoteChain = true;
+                        Nested--;
+                        if (Nested == 0)
                         {
-                            var slotsNeeded = batchItems.RequiredSlots;
-                            if (batchItems.PlayerExceedsAvailableBurden)
-                                preCheckPlayer.Session.Network.EnqueueSend(new GameMessageSystemChat(
-                                    $"{WorldObject.Name} has rewards for you, but you are too encumbered to carry them! Drop some items and try again.",
-                                    ChatMessageType.Broadcast));
-                            else
-                                preCheckPlayer.Session.Network.EnqueueSend(new GameMessageSystemChat(
-                                    $"{WorldObject.Name} has rewards for you, but you need {slotsNeeded} free inventory slot(s). Free up some space and try again.",
-                                    ChatMessageType.Broadcast));
-
-                            AbortEmoteChain = true;
-                            Nested--;
-                            if (Nested == 0)
-                            {
-                                AbortEmoteChain = false;
-                                IsBusy = false;
-                            }
-                            return;
+                            AbortEmoteChain = false;
+                            IsBusy = false;
                         }
+                        return;
                     }
                 }
             }
@@ -4023,6 +3978,51 @@ namespace ACE.Server.WorldObjects.Managers
 
             foreach (var emoteSet in SelectReceiveDamageEmotes(receiveDamageEmotes, damageType, () => ThreadSafeRandom.Next(0.0f, 1.0f)))
                 ExecuteEmoteSet(emoteSet, attacker, nested: true);
+        }
+
+        /// <summary>
+        /// Builds an <see cref="ItemsToReceive"/> batch describing the reward items an emote set would
+        /// hand out: every Give action (with the coin-reward multiplier applied to pyreal/lucent rewards),
+        /// minus any TakeItems actions which free space. Scans from <paramref name="startIndex"/> forward.
+        /// Shared by the give-to-NPC pre-removal gate and the in-chain reward prechecks so a turn-in item
+        /// is never consumed when the player cannot actually carry the rewards.
+        /// </summary>
+        public static ItemsToReceive BuildRewardBatch(Player player, PropertiesEmote emoteSet, int startIndex)
+        {
+            var batch = new ItemsToReceive(player);
+
+            if (emoteSet?.PropertiesEmoteAction == null)
+                return batch;
+
+            for (var i = startIndex; i < emoteSet.PropertiesEmoteAction.Count; i++)
+            {
+                var action = emoteSet.PropertiesEmoteAction[i];
+                if (action.WeenieClassId == null)
+                    continue;
+
+                switch ((EmoteType)action.Type)
+                {
+                    case EmoteType.Give:
+                        var amount = action.StackSize ?? 1;
+                        if (amount > 0 && (action.WeenieClassId == 300004 || action.WeenieClassId == 300003))
+                        {
+                            var coinMult = ServerConfig.coin_reward_mult.Value;
+                            if (double.IsNaN(coinMult) || double.IsInfinity(coinMult))
+                                coinMult = 0;
+                            coinMult = Math.Max(0, coinMult);
+                            amount = (int)(amount * coinMult);
+                        }
+                        batch.Add(action.WeenieClassId.Value, amount > 0 ? amount : 1);
+                        break;
+
+                    case EmoteType.TakeItems:
+                        var takeAmount = action.StackSize ?? 1;
+                        batch.Remove(action.WeenieClassId.Value, takeAmount > 0 ? takeAmount : 1);
+                        break;
+                }
+            }
+
+            return batch;
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
@@ -3617,13 +3617,12 @@ namespace ACE.Server.WorldObjects.Managers
                                 $"{WorldObject.Name} has rewards for you, but you need {slotsNeeded} free inventory slot(s). Free up some space and try again.",
                                 ChatMessageType.Broadcast));
 
-                        AbortEmoteChain = true;
+                        // No AbortEmoteChain flag here: we return without enqueueing the next action,
+                        // so this chain stops on its own. Setting the shared flag would leak to a
+                        // sibling nested chain (the guard at the top of DoEnqueue) when Nested > 0.
                         Nested--;
                         if (Nested == 0)
-                        {
-                            AbortEmoteChain = false;
                             IsBusy = false;
-                        }
                         return;
                     }
                 }
@@ -4012,7 +4011,11 @@ namespace ACE.Server.WorldObjects.Managers
                             coinMult = Math.Max(0, coinMult);
                             amount = (int)(amount * coinMult);
                         }
-                        batch.Add(action.WeenieClassId.Value, amount > 0 ? amount : 1);
+                        // Gives are scheduled in data order before any later TakeItems run, so a
+                        // running batch that exceeds here must fail now — a later Remove must not
+                        // mask an earlier over-capacity Give.
+                        if (!batch.Add(action.WeenieClassId.Value, amount > 0 ? amount : 1))
+                            return batch;
                         break;
 
                     case EmoteType.TakeItems:

--- a/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
@@ -3986,9 +3986,16 @@ namespace ACE.Server.WorldObjects.Managers
         /// Shared by the give-to-NPC pre-removal gate and the in-chain reward prechecks so a turn-in item
         /// is never consumed when the player cannot actually carry the rewards.
         /// </summary>
-        public static ItemsToReceive BuildRewardBatch(Player player, PropertiesEmote emoteSet, int startIndex)
+        public static ItemsToReceive BuildRewardBatch(Player player, PropertiesEmote emoteSet, int startIndex,
+            uint turnInWcid = 0, int turnInAmount = 0)
         {
             var batch = new ItemsToReceive(player);
+
+            // Credit the turn-in first: in execution it is removed before any reward is handed out,
+            // freeing its slot/burden. Applying it up front keeps the running-capacity early-out below
+            // accurate — otherwise a give could trip the limit before the freed slot is accounted for.
+            if (turnInWcid != 0 && turnInAmount > 0)
+                batch.Remove(turnInWcid, turnInAmount);
 
             if (emoteSet?.PropertiesEmoteAction == null)
                 return batch;

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -16,6 +16,7 @@ using ACE.Server.Entity.Actions;
 using ACE.Server.Factories;
 using ACE.Server.Managers;
 using ACE.Server.Network;
+using ACE.Server.WorldObjects.Managers;
 using ACE.Server.Network.GameEvent.Events;
 using ACE.Server.Network.GameMessages.Messages;
 
@@ -3865,6 +3866,34 @@ namespace ACE.Server.WorldObjects
             {
                 if (acceptAll || (emoteResult.Category == EmoteCategory.Give && target.AllowGive))
                 {
+                    // Pre-removal gate: verify the player can carry the rewards BEFORE consuming the
+                    // turn-in. The reward emote chain runs asynchronously, but the turn-in is removed
+                    // and Destroy()-ed synchronously below — so without this check a full inventory
+                    // would void the turn-in while the async chain aborts the (uncarriable) reward.
+                    var givenAmount = acceptAll ? amount : 1;
+                    var rewardBatch = EmoteManager.BuildRewardBatch(this, emoteResult, 0);
+
+                    // Credit the slot/burden the turn-in frees, but only if the whole stack leaves
+                    // (giving 1 from a larger stack frees no slot). Conservative: never over-credits.
+                    if (item.WeenieClassId != 0 && givenAmount >= (item.StackSize ?? 1))
+                        rewardBatch.Remove(item.WeenieClassId, givenAmount);
+
+                    if (rewardBatch.PlayerExceedsLimits)
+                    {
+                        if (rewardBatch.PlayerExceedsAvailableBurden)
+                            Session.Network.EnqueueSend(new GameMessageSystemChat(
+                                $"{target.Name} has rewards for you, but you are too encumbered to carry them! Drop some items and try again.",
+                                ChatMessageType.Broadcast));
+                        else
+                            Session.Network.EnqueueSend(new GameMessageSystemChat(
+                                $"{target.Name} has rewards for you, but you need {rewardBatch.RequiredSlots} free inventory slot(s). Free up some space and try again.",
+                                ChatMessageType.Broadcast));
+
+                        // Bounce the item back on the client; the server never removed it.
+                        Session.Network.EnqueueSend(new GameEventInventoryServerSaveFailed(Session, item.Guid.Full));
+                        return;
+                    }
+
                     // for NPCs that accept items with EmoteCategory.Give,
                     // if stacked item, only give 1, ignoring amount indicated, unless they are AiAcceptEverything in which case, take full amount indicated
                     if (RemoveItemForGive(item, itemFoundInContainer, itemWasEquipped, itemRootOwner, acceptAll ? amount : 1, out WorldObject itemToGive))

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -3870,12 +3870,14 @@ namespace ACE.Server.WorldObjects
                     // turn-in. The reward emote chain runs asynchronously, but the turn-in is removed
                     // and Destroy()-ed synchronously below — so without this check a full inventory
                     // would void the turn-in while the async chain aborts the (uncarriable) reward.
-                    var givenAmount = acceptAll ? amount : 1;
+                    var turnInStack = item.StackSize ?? 1;
+                    var givenAmount = acceptAll ? Math.Min(amount, turnInStack) : 1;
                     var rewardBatch = EmoteManager.BuildRewardBatch(this, emoteResult, 0);
 
-                    // Credit the slot/burden the turn-in frees, but only if the whole stack leaves
-                    // (giving 1 from a larger stack frees no slot). Conservative: never over-credits.
-                    if (item.WeenieClassId != 0 && givenAmount >= (item.StackSize ?? 1))
+                    // Credit the slot the turn-in frees, but only if the whole stack leaves (giving 1
+                    // from a larger stack frees no slot) AND it was in a pack (an equipped item frees
+                    // an equipment slot + burden, not a pack slot). Conservative: never over-credits.
+                    if (!itemWasEquipped && item.WeenieClassId != 0 && givenAmount >= turnInStack)
                         rewardBatch.Remove(item.WeenieClassId, givenAmount);
 
                     if (rewardBatch.PlayerExceedsLimits)
@@ -3896,7 +3898,7 @@ namespace ACE.Server.WorldObjects
 
                     // for NPCs that accept items with EmoteCategory.Give,
                     // if stacked item, only give 1, ignoring amount indicated, unless they are AiAcceptEverything in which case, take full amount indicated
-                    if (RemoveItemForGive(item, itemFoundInContainer, itemWasEquipped, itemRootOwner, acceptAll ? amount : 1, out WorldObject itemToGive))
+                    if (RemoveItemForGive(item, itemFoundInContainer, itemWasEquipped, itemRootOwner, givenAmount, out WorldObject itemToGive))
                     {
                         // Track the actual transferred item for emote handlers (may differ from original for stack splits)
                         LastGivenItemGuid = itemToGive.Guid;

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -3872,13 +3872,16 @@ namespace ACE.Server.WorldObjects
                     // would void the turn-in while the async chain aborts the (uncarriable) reward.
                     var turnInStack = item.StackSize ?? 1;
                     var givenAmount = acceptAll ? Math.Min(amount, turnInStack) : 1;
-                    var rewardBatch = EmoteManager.BuildRewardBatch(this, emoteResult, 0);
 
                     // Credit the slot the turn-in frees, but only if the whole stack leaves (giving 1
                     // from a larger stack frees no slot) AND it was in a pack (an equipped item frees
                     // an equipment slot + burden, not a pack slot). Conservative: never over-credits.
-                    if (!itemWasEquipped && item.WeenieClassId != 0 && givenAmount >= turnInStack)
-                        rewardBatch.Remove(item.WeenieClassId, givenAmount);
+                    // The credit is applied inside BuildRewardBatch (before the gives) so its running
+                    // capacity check stays accurate.
+                    var creditWcid = (!itemWasEquipped && item.WeenieClassId != 0 && givenAmount >= turnInStack)
+                        ? item.WeenieClassId : 0u;
+                    var rewardBatch = EmoteManager.BuildRewardBatch(this, emoteResult, 0,
+                        creditWcid, creditWcid != 0 ? givenAmount : 0);
 
                     if (rewardBatch.PlayerExceedsLimits)
                     {

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -3888,7 +3888,7 @@ namespace ACE.Server.WorldObjects
                                 ChatMessageType.Broadcast));
                         else
                             Session.Network.EnqueueSend(new GameMessageSystemChat(
-                                $"{target.Name} has rewards for you, but you need {rewardBatch.RequiredSlots} free inventory slot(s). Free up some space and try again.",
+                                $"{target.Name} has rewards for you, but you need {rewardBatch.RequiredAdditionalSlots} more free inventory slot(s). Free up some space and try again.",
                                 ChatMessageType.Broadcast));
 
                         // Bounce the item back on the client; the server never removed it.


### PR DESCRIPTION
## Summary

Fixes a bug where turn-in items to NPCs were consumed and destroyed even when the player's inventory had no space for the rewards, leaving the player without both the item and the reward.

## Root Cause

In `GiveObjectToNPC`, the turn-in item was removed/destroyed **synchronously**, but the inventory/burden check lived in the **asynchronous** reward emote chain. On a full pack (e.g. spamming an NPC), the item was gone before the check ever ran.

## The Fix

- **Pre-removal gate** in `GiveObjectToNPC`: checks if player can carry rewards BEFORE consuming the turn-in. If not, sends the "need N free slots" / "too encumbered" message and bounces the item back (`InventoryServerSaveFailed`) — no removal, no void.
- **Conservative turn-in credit**: only counts freed slots/burden when the whole stack leaves (giving 1 of N items frees no space).
- **Shared helper** `EmoteManager.BuildRewardBatch()`: extracted the Give/TakeItems batch-scan logic, now used by the new gate AND both existing in-chain prechecks, eliminating duplication.

## Verification

- Build: 0 errors.
- Live test: confirmed turn-in items are refused and kept when rewards won't fit, with proper messaging. No item loss.

## Files Changed

- `Source/ACE.Server/WorldObjects/Player_Inventory.cs` — added pre-removal gate and using
- `Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs` — extracted BuildRewardBatch(), refactored existing checks to use it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * NPC turn-ins now validate available inventory and burden capacity for rewards before consuming the traded item, preventing potential loss due to insufficient space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->