### PR TITLE
feat: unkillable developer mode and weapon EMD appraisal

### DIFF
--- a/Source/ACE.Entity/Enum/Properties/PropertyBool.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyBool.cs
@@ -322,6 +322,9 @@ namespace ACE.Entity.Enum.Properties
         /// <summary>Player has the Fork Charm active — Streak, Arc, and Bolt projectiles fork to nearby enemies on hit.</summary>
         HasForkCharm = 50039,
 
+        /// <summary>Player is in unkillable developer mode.</summary>
+        IsUnkillable = 50041,
+
         // -- ILT Player UI Preferences -> see PropertyInt.DamageNumberFormat (50101) --
     }
 }

--- a/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
@@ -108,6 +108,40 @@ namespace ACE.Server.Command.Handlers
             }
         }
 
+        [CommandHandler("unkillable", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 0, "Toggles or sets unkillable state.", "[on|off|true|false|enable|disable]")]
+        public static void HandleUnkillable(Session session, params string[] parameters)
+        {
+            var player = session.Player;
+            bool newValue;
+
+            if (parameters == null || parameters.Length == 0)
+            {
+                newValue = !player.IsUnkillable;
+            }
+            else
+            {
+                var arg = parameters[0].ToLower();
+                if (arg == "on" || arg == "true" || arg == "enable")
+                    newValue = true;
+                else if (arg == "off" || arg == "false" || arg == "disable")
+                    newValue = false;
+                else
+                {
+                    ChatPacket.SendServerMessage(session, "Usage: /unkillable [on|off|true|false|enable|disable]", ChatMessageType.Broadcast);
+                    return;
+                }
+            }
+
+            player.IsUnkillable = newValue;
+            var stateStr = newValue ? "ON" : "OFF";
+            ChatPacket.SendServerMessage(session, $"Unkillable mode is now {stateStr}.", ChatMessageType.Broadcast);
+
+            if (newValue && player.Health.Current == 0)
+            {
+                player.UpdateVital(player.Health, 1);
+            }
+        }
+
         /// <summary>
         /// Attempts to remove the hourglass / fix the busy state for the player
         /// </summary>

--- a/Source/ACE.Server/Managers/HouseManager.cs
+++ b/Source/ACE.Server/Managers/HouseManager.cs
@@ -80,7 +80,7 @@ namespace ACE.Server.Managers
 
                     if (!uint.TryParse(Regex.Match(classname, @"\d+").Value, out var houseId))
                     {
-                        log.Error($"[HOUSE] HouseManager.BuildHouseIdToGuid(): couldn't parse {classname}");
+                        log.Debug($"[HOUSE] HouseManager.BuildHouseIdToGuid(): couldn't parse classname '{classname}' — no numeric house ID found, skipping.");
                         continue;
                     }
 

--- a/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
+++ b/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
@@ -1017,22 +1017,41 @@ namespace ACE.Server.Network.Structure
                 }
             }
 
-            if (effectDescriptions.Count > 0)
+            // Calculate Effective Melee Defense
+            var meleeSkill = examiner.GetCreatureSkill(Skill.MeleeDefense).Current;
+            var wepMeleeDef = (float)(weapon.WeaponDefense ?? 1.0f);
+            if (weapon.WeaponDefense > 0 && weapon.WeaponDefense < 1 && ((weapon.GetProperty(PropertyInt.ImbueStackingBits) ?? 0) & 4) != 0)
+                wepMeleeDef += 1;
+
+            var meleeMod = wepMeleeDef + weapon.EnchantmentManager.GetDefenseMod();
+            if (weapon.IsEnchantable)
+                meleeMod += examiner.EnchantmentManager.GetDefenseMod();
+
+            var meleeImbues = examiner.GetDefenseImbues(ImbuedEffectType.MeleeDefense);
+            var meleeLum = examiner.LuminanceAugmentMeleeDefenseCount ?? 0;
+            var burdenMod = examiner.GetBurdenMod();
+
+            // Option B: stanceMod = 1.0f, not exhausted
+            uint emdVal = (uint)Math.Round(meleeSkill * meleeMod * burdenMod * 1.0f + meleeImbues + meleeLum);
+
+            effectDescriptions.Sort();
+            effectDescriptions.Add($"- Effective Melee Defense: {emdVal}");
+
+            var useParts = new List<string>();
+            useParts.Add($"Property Details:\n{string.Join("\n", effectDescriptions)}");
+
+            if (PropertiesString.TryGetValue(PropertyString.Use, out string existingUse) && !string.IsNullOrWhiteSpace(existingUse))
             {
-                effectDescriptions.Sort();
-                var enhancementsBlock = $"Property Details:\n{string.Join("\n", effectDescriptions)}";
-
-                if (PropertiesString.TryGetValue(PropertyString.Use, out string value))
-                    PropertiesString[PropertyString.Use] = enhancementsBlock + "\n\n" + value;
-                else
-                    PropertiesString[PropertyString.Use] = enhancementsBlock;
-
-                // Make sure there's a line break between the string and some of the other "details".
-                if (PropertiesInt.ContainsKey(PropertyInt.ItemMaxLevel) ||
-                    PropertiesInt.ContainsKey(PropertyInt.ItemSpellcraft) ||
-                    PropertiesInt.ContainsKey(PropertyInt.WieldRequirements))
-                    PropertiesString[PropertyString.Use] += "\n";
+                useParts.Add(existingUse);
             }
+
+            PropertiesString[PropertyString.Use] = string.Join("\n\n", useParts);
+
+            // Make sure there's a line break between the string and some of the other "details".
+            if (PropertiesInt.ContainsKey(PropertyInt.ItemMaxLevel) ||
+                PropertiesInt.ContainsKey(PropertyInt.ItemSpellcraft) ||
+                PropertiesInt.ContainsKey(PropertyInt.WieldRequirements))
+                PropertiesString[PropertyString.Use] += "\n";
 
             // item enchantments can also be on wielder currently
             AddEnchantments(weapon);

--- a/Source/ACE.Server/WorldObjects/Player_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Properties.cs
@@ -1489,5 +1489,11 @@ namespace ACE.Server.WorldObjects
             set { if (!value) RemoveProperty(PropertyBool.IsVPHardcore); else SetProperty(PropertyBool.IsVPHardcore, value); }
         }
 
+        public bool IsUnkillable
+        {
+            get => GetProperty(PropertyBool.IsUnkillable) ?? false;
+            set { if (!value) RemoveProperty(PropertyBool.IsUnkillable); else SetProperty(PropertyBool.IsUnkillable, value); }
+        }
+
     }
 }

--- a/Source/ACE.Server/WorldObjects/Player_Vitals.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Vitals.cs
@@ -123,6 +123,12 @@ namespace ACE.Server.WorldObjects
         /// <returns>The actual change in the vital, after clamping between 0 and MaxVital</returns>
         public override int UpdateVital(CreatureVital vital, int newVal)
         {
+            if (vital.Vital == PropertyAttribute2nd.MaxHealth && IsUnkillable)
+            {
+                if (newVal < 1)
+                    newVal = 1;
+            }
+
             var prevVal = vital.Current;
 
             var change = base.UpdateVital(vital, newVal);

--- a/Source/ACE.Server/WorldObjects/WorldObject_Links.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Links.cs
@@ -69,14 +69,12 @@ namespace ACE.Server.WorldObjects
 
         public virtual void SetLinkProperties(WorldObject wo)
         {
-            // empty base
-            Console.WriteLine($"{Name}.SetLinkProperties({wo.Name}) called for unknown parent type: {WeenieType}");
+            // empty base — not all WeenieTypes override this (e.g. Hook), and that's fine
         }
 
         public virtual void UpdateLinkProperties(WorldObject wo)
         {
-            // empty base
-            Console.WriteLine($"{Name}.UpdateLinkProperties({wo.Name}) called for unknown parent type: {WeenieType}");
+            // empty base — not all WeenieTypes override this (e.g. Hook), and that's fine
         }
 
         public void UpdateLinks()


### PR DESCRIPTION
Adds the /unkillable developer command to clamp health at 1 (preventing combat death) and calculates/displays the wielder's current Effective Melee Defense (EMD) on weapon appraisal details.