### PR TITLE
fix: Variation Landblock Adjacency Physics Sync & Portal Collision

### DIFF
--- a/Source/ACE.Server/Managers/LandblockManager.cs
+++ b/Source/ACE.Server/Managers/LandblockManager.cs
@@ -660,7 +660,7 @@ namespace ACE.Server.Managers
             if (traverse)
             {
                 foreach (var adjacent in landblock.Adjacents)
-                    SetAdjacents(adjacent, false);
+                    SetAdjacents(adjacent, false, pSync);
             }
         }
 

--- a/Source/ACE.Server/WorldObjects/Portal.cs
+++ b/Source/ACE.Server/WorldObjects/Portal.cs
@@ -103,6 +103,12 @@ namespace ACE.Server.WorldObjects
 
         public virtual void OnCollideObject(Player player)
         {
+            // Don't fire portals that belong to a different variation than the player.
+            // This prevents base-world portals (Town Network, lifestone recalls, etc.)
+            // from being invisibly usable inside a prestige variation zone.
+            if (!PrestigeManager.SameVariationForVisibility(Location?.Variation, player.Location?.Variation))
+                return;
+
             OnActivate(player);
         }
 


### PR DESCRIPTION
## Summary

Two targeted fixes for variation (prestige) landblock behavior:

1. **Adjacent landblocks in variations don't spawn/show objects until the player physically walks into them**
2. **Base-world portals can trigger when a player is inside a prestige variation zone**

---

## Bug 1: Variation Adjacent Landblock Visibility

### Symptom
When standing in a variation 11 landblock (e.g. `0xF559`), objects (generators, mobs) in adjacent landblocks (e.g. `0xF659`) are completely invisible. They only appear after the player **physically walks into** the adjacent landblock. This does not happen in retail/base-world (variation null).

Even generators placed within 20m of each other across a landblock border — one visible, one not — would not render until the player crossed into the neighboring landblock.

### Root Cause
The bug is in `SetAdjacents()` in `LandblockManager.cs`:

`csharp
private static void SetAdjacents(Landblock landblock, bool traverse = true, bool pSync = false)
{
    landblock.Adjacents = GetAdjacents(landblock, landblock.VariationId);

    if (pSync)
        landblock.PhysicsLandblock.SetAdjacents(landblock.Adjacents);

    if (traverse)
    {
        foreach (var adjacent in landblock.Adjacents)
            SetAdjacents(adjacent, false);  // ← pSync defaults to false!
    }
}
`

When `GetLandblock()` loads a landblock with `loadAdjacents=true`, it calls `SetAdjacents(landblock, traverse=true, pSync=true)`. This correctly sets up the **primary** landblock's physics adjacents. However, during **traversal** to each adjacent landblock, `pSync` is not forwarded — it defaults to `false`. This means `PhysicsLandblock.SetAdjacents()` is **never called** for neighboring landblocks.

The visibility pipeline depends on the physics layer:
- `handle_visible_cells()` → `GetVisibleObjects()` → `CurLandblock.GetServerObjects(includeAdjacents=true)`
- `GetServerObjects(true)` iterates `Physics.Landblock.adjacents` to collect all server objects from neighbors
- If `adjacents` is null/empty on the physics landblock, **no objects from neighbors are ever returned**

For **retail** (variation null), this is masked because when a player crosses into a new landblock, `RelocateObjectForPhysics` calls `GetLandblock(newLB, loadAdjacents=true)`, which re-runs `SetAdjacents` with `pSync=true` for the new primary landblock. For **variations**, the adjacent landblocks are already loaded from the initial entry, so the `loadAdjacents` code path is skipped — they never get a fresh `pSync=true` call.

### Fix
Pass `pSync` through during traversal:

`diff
-            SetAdjacents(adjacent, false);
+            SetAdjacents(adjacent, false, pSync);
`

---

## Bug 2: Base-World Portal Collision in Variation Zones

### Symptom
Players inside a prestige variation zone can collide with and be teleported by base-world portals (Town Network, lifestone portals, etc.) that exist at the same physical coordinates but belong to variation null.

### Fix
Add a variation visibility check in `Portal.OnCollideObject` before firing `OnActivate`:

`csharp
public virtual void OnCollideObject(Player player)
{
    if (!PrestigeManager.SameVariationForVisibility(Location?.Variation, player.Location?.Variation))
        return;

    OnActivate(player);
}
`

---

## Files Changed

| File | Change |
|------|--------|
| `Source/ACE.Server/Managers/LandblockManager.cs` | Pass `pSync` through `SetAdjacents` traversal |
| `Source/ACE.Server/WorldObjects/Portal.cs` | Add variation check in `OnCollideObject` |

## Testing

Both fixes verified in-game on the test server:
- ✅ Generators and mobs in adjacent variation landblocks are now visible from neighboring landblocks without needing to walk into them
- ✅ Base-world portals no longer trigger when standing in a prestige variation zone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved adjacent landblock synchronization so neighboring areas now update correctly during physics/adjacency refreshes.
  * Added a visibility check for portal interactions, preventing activation when the player and portal are in different variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->