### PR TITLE
Fix quest bonus leaderboard hiding every account that owns a mule

### DIFF
--- a/Database/Updates/Authentication/leaderboard_topqb_sp.sql
+++ b/Database/Updates/Authentication/leaderboard_topqb_sp.sql
@@ -25,7 +25,7 @@ BEGIN
        AND NOT EXISTS (
            SELECT 1
            FROM ace_shard.character cex
-                    INNER JOIN ace_shard.biota_properties_bool bx ON bx.object_id = cex.id AND bx.type IN (9011, 131) AND bx.value <> 0
+                    INNER JOIN ace_shard.biota_properties_bool bx ON bx.object_id = cex.id AND bx.type = 9011 AND bx.value <> 0
            WHERE cex.account_Id = a.accountId
              AND cex.is_Deleted = 0
        )

--- a/Source/ACE.Database/Models/Auth/LeaderboardInlineSql.cs
+++ b/Source/ACE.Database/Models/Auth/LeaderboardInlineSql.cs
@@ -9,7 +9,9 @@ namespace ACE.Database.Models.Auth;
 /// Requires auth MySQL user to have SELECT on ace_shard.* (same as CALL-based procs).
 /// Character exclusion: <see cref="PropertyBool.ExcludeFromLeaderboards"/> (9011) on biota_properties_bool.
 /// Account exclusion: non-player access levels (staff) and accounts with an active ban (ban_Expire_Time in the future).
-/// Mule characters (PropertyBool.IsMule) are eligible unless individually flagged ExcludeFromLeaderboards.
+/// Mule characters (PropertyBool.IsMule) are hidden from the per-character boards, but only the mule
+/// itself: the flag never removes the rest of the account. The account-scoped quest bonus board
+/// therefore excludes on ExcludeFromLeaderboards only, or a single mule would hide its owner's score.
 /// </summary>
 public static class LeaderboardInlineSql
 {
@@ -120,7 +122,7 @@ public static class LeaderboardInlineSql
         HAVING `Character` IS NOT NULL
         AND NOT EXISTS (
             SELECT 1 FROM ace_shard.character cex
-            INNER JOIN ace_shard.biota_properties_bool bx ON bx.object_id = cex.id AND bx.type IN (9011, 131) AND bx.value <> 0
+            INNER JOIN ace_shard.biota_properties_bool bx ON bx.object_id = cex.id AND bx.type = 9011 AND bx.value <> 0
             WHERE cex.account_Id = a.accountId AND cex.is_Deleted = 0
         )
         ORDER BY Score DESC, a.accountId DESC
@@ -346,7 +348,7 @@ public static class LeaderboardInlineSql
             HAVING `Character` IS NOT NULL
             AND NOT EXISTS (
                 SELECT 1 FROM ace_shard.character cex
-                INNER JOIN ace_shard.biota_properties_bool bx ON bx.object_id = cex.id AND bx.type IN (9011, 131) AND bx.value <> 0
+                INNER JOIN ace_shard.biota_properties_bool bx ON bx.object_id = cex.id AND bx.type = 9011 AND bx.value <> 0
                 WHERE cex.account_Id = a.accountId AND cex.is_Deleted = 0
             )
           ) agg


### PR DESCRIPTION
## Problem

`TopQuestBonus` and `SelfPlacementQuestBonus` are the only account-scoped leaderboards — they `GROUP BY a.accountId` rather than by character, because quest bonus is tallied per account in `account_quest`.

Both exclude an account when **any** non-deleted character on it has `PropertyBool.IsMule` (131) set:

```sql
AND NOT EXISTS (
    SELECT 1 FROM ace_shard.character cex
    INNER JOIN ace_shard.biota_properties_bool bx
        ON bx.object_id = cex.id AND bx.type IN (9011, 131) AND bx.value <> 0
    WHERE cex.account_Id = a.accountId AND cex.is_Deleted = 0
)
```

Because the check is account-wide, a single mule erases its owner's real character from the board. The player has no way to tell why they vanished, and `/top qb` self-placement returns nothing for them either.

Every other leaderboard filters mules **per character** — `LEFT JOIN` on 131 plus `(m.value IS NULL OR m.value = 0)` — which hides only the mule itself and leaves the rest of the account alone. That is the intended behaviour, and it is what the class doc describes.

Introduced in #502, which changed `bx.type = 9011` to `bx.type IN (9011, 131)` in these two queries.

## Fix

Exclude on `ExcludeFromLeaderboards` (9011) only in the two account-scoped queries. No other leaderboard changes behaviour — mules stay hidden from the per-character boards.

Also updates `Database/Updates/Authentication/leaderboard_topqb_sp.sql`. That proc is not executed at runtime (everything goes through `LeaderboardInlineSql` via `FromSqlRaw`), but it carries the same clause and would reintroduce the bug if the procs were reinstalled.

## Impact

Measured against a copy of a live shard: **1,941 of 6,144 accounts** with quest bonus rows were being hidden by the mule clause — 32%. Only 11 accounts were excluded by the intended `ExcludeFromLeaderboards` flag.

**13 of the hidden accounts belong inside the top 25**, including one that ranks #8. The board was effectively "top 25 among players who never flagged a mule".

## Verification

- `dotnet build Source/ACE.sln -c Release` — 0 errors.
- Ran the post-fix query text against a shard copy: 25 rows returned, the 13 hidden accounts restored in correct score order, no change to any account that was already listed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated quest-bonus leaderboards to exclude accounts only when explicitly marked for leaderboard exclusion.
  * Mule status no longer removes accounts from account-wide quest-bonus rankings.
  * Mule characters remain excluded from per-character leaderboards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->