### PR TITLE
T11 part 1: loot tables and mutation data (tier 11 rows, TierTable cl…

### DIFF
--- a/Source/ACE.Server/Entity/Mutations/ArmorLevel/armor_level_extremity.txt
+++ b/Source/ACE.Server/Entity/Mutations/ArmorLevel/armor_level_extremity.txt
@@ -1,13 +1,13 @@
 Armor Mutation #0:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 100%:
         ArmorLevel = 140
 
 Armor Mutation #1:
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         ArmorLevel += 10
@@ -35,7 +35,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 Armor Mutation #2:
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         ArmorLevel += 50
@@ -60,7 +60,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 Armor Mutation #3:
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         ArmorLevel += 80
@@ -85,7 +85,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 Armor Mutation #4:
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         ArmorLevel += 100
@@ -110,7 +110,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 Armor Mutation #5:
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         ArmorLevel += 110
@@ -135,7 +135,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 Armor Mutation #6:
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         ArmorLevel += 120
@@ -160,7 +160,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 Armor Mutation #7:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0
 
     - Chance: 5%:
         ArmorLevel += 130
@@ -190,7 +190,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 1, 0, 0
 
 Armor Mutation #8:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 10%:
 
@@ -204,14 +204,14 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 Armor Mutation #9:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 100%:
         ArmorLevel += Random(-5, 5)
 
 Armor Mutation #10:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 5%:
         ArmorLevel += 170
@@ -241,7 +241,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
         Armor Mutation #11:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 5%:
         ArmorLevel += 210
@@ -263,3 +263,28 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
 
     - Chance: 1%:
         ArmorLevel += 270
+
+Tier 11 Mutation #12:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 5%:
+        ArmorLevel += 290
+
+    - Chance: 30%:
+        ArmorLevel += 300
+
+    - Chance: 35%:
+        ArmorLevel += 310
+
+    - Chance: 25%:
+        ArmorLevel += 320
+
+    - Chance: 3%:
+        ArmorLevel += 330
+
+    - Chance: 1%:
+        ArmorLevel += 340
+
+    - Chance: 1%:
+        ArmorLevel += 350

--- a/Source/ACE.Server/Entity/Mutations/ArmorLevel/armor_level_non_extremity.txt
+++ b/Source/ACE.Server/Entity/Mutations/ArmorLevel/armor_level_non_extremity.txt
@@ -1,13 +1,13 @@
 Armor Mutation #0:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 100%:
         ArmorLevel = 110
 
 Armor Mutation #1:
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         ArmorLevel += 10
@@ -35,7 +35,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 Armor Mutation #2:
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         ArmorLevel += 50
@@ -60,7 +60,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 Armor Mutation #3:
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         ArmorLevel += 80
@@ -85,7 +85,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 Armor Mutation #4:
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         ArmorLevel += 100
@@ -110,7 +110,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 Armor Mutation #5:
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         ArmorLevel += 110
@@ -135,7 +135,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 Armor Mutation #6:
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         ArmorLevel += 120
@@ -160,7 +160,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 Armor Mutation #7:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0
 
     - Chance: 5%:
         ArmorLevel += 130
@@ -190,7 +190,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 1, 0, 0
 
 Armor Mutation #8:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 10%:
 
@@ -204,14 +204,14 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 Armor Mutation #9:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 100%:
         ArmorLevel += Random(-5, 5)
 
  Armor Mutation #10:
 
- Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 5%:
         ArmorLevel += 170
@@ -241,7 +241,7 @@ Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
          Armor Mutation #11:
 
- Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 5%:
         ArmorLevel += 210
@@ -268,3 +268,28 @@ Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
         WieldRequirements = Level
         WieldDifficulty = 750
         WieldSkillType = 1
+
+Tier 11 Mutation #12:
+
+ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 5%:
+        ArmorLevel += 290
+
+    - Chance: 30%:
+        ArmorLevel += 300
+
+    - Chance: 35%:
+        ArmorLevel += 310
+
+    - Chance: 25%:
+        ArmorLevel += 320
+
+    - Chance: 3%:
+        ArmorLevel += 330
+
+    - Chance: 1%:
+        ArmorLevel += 340
+
+    - Chance: 1%:
+        ArmorLevel += 350

--- a/Source/ACE.Server/Entity/Mutations/ArmorLevel/shield_level.txt
+++ b/Source/ACE.Server/Entity/Mutations/ArmorLevel/shield_level.txt
@@ -1,6 +1,6 @@
 Shield Mutation #0:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 100%:
         ArmorLevel = 70
@@ -151,7 +151,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0
 
 Shield Mutation #7:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0
 
     - Chance: 5%:
         ArmorLevel += 70
@@ -181,7 +181,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 1, 0, 0
 
 Shield Mutation #8:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 10%:
 
@@ -195,14 +195,14 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 Shield Mutation #9:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 100%:
         ArmorLevel += Random(-5, 5)
 
         Shield Mutation #10:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 5%:
         ArmorLevel += 100
@@ -227,7 +227,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
 
         Shield Mutation #11:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 10%:
 
@@ -236,3 +236,38 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
         ArmorLevel += 300
 
         Shield Mutation #12:
+
+Tier 11 Mutation #13:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 5%:
+        ArmorLevel += 145
+
+    - Chance: 10%:
+        ArmorLevel += 155
+
+    - Chance: 20%:
+        ArmorLevel += 165
+
+    - Chance: 30%:
+        ArmorLevel += 175
+
+    - Chance: 20%:
+        ArmorLevel += 185
+
+    - Chance: 10%:
+        ArmorLevel += 195
+
+    - Chance: 5%:
+        ArmorLevel += 205
+
+Tier 11 Mutation #14:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 10%:
+
+    - Chance: 90%:
+
+        ArmorLevel += 345

--- a/Source/ACE.Server/Entity/Mutations/Casters/caster.txt
+++ b/Source/ACE.Server/Entity/Mutations/Casters/caster.txt
@@ -1,6 +1,6 @@
 Caster Mutation #1 (500 samples):
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 30%:
         ManaConversionMod = 0
@@ -13,7 +13,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 Caster Mutation #2 (807 samples):
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         ManaConversionMod = 0
@@ -32,7 +32,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 Caster Mutation #3 (781 samples):
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         ManaConversionMod = 0
@@ -57,7 +57,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 Caster Mutation #4 (712 samples):
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         ManaConversionMod = 0.02
@@ -82,7 +82,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 Caster Mutation #5 (302 samples):
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         ManaConversionMod = 0.04
@@ -107,7 +107,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 Caster Mutation #6 (860 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 1, 1, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0
 
     - Chance: 5%:
         ManaConversionMod = 0.05
@@ -129,7 +129,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 1, 1, 0, 0
 
     Caster Mutation #7 (860 samples):
 
-    Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+    Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 5%:
         ManaConversionMod = 0.10
@@ -151,7 +151,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 1, 1, 0, 0
 
         Caster Mutation #8 (860 samples):
 
-    Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+    Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 5%:
         ManaConversionMod = 0.15
@@ -170,3 +170,25 @@ Tier chances: 0, 0, 0, 0, 0, 1, 1, 1, 0, 0
 
     - Chance: 10%:
         ManaConversionMod = 0.20
+
+Tier 11 Mutation #9:
+
+    Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 5%:
+        ManaConversionMod = 0.25
+
+    - Chance: 15%:
+        ManaConversionMod = 0.26
+
+    - Chance: 20%:
+        ManaConversionMod = 0.27
+
+    - Chance: 30%:
+        ManaConversionMod = 0.28
+
+    - Chance: 20%:
+        ManaConversionMod = 0.29
+
+    - Chance: 10%:
+        ManaConversionMod = 0.3

--- a/Source/ACE.Server/Entity/Mutations/Casters/caster_elemental.txt
+++ b/Source/ACE.Server/Entity/Mutations/Casters/caster_elemental.txt
@@ -1,6 +1,6 @@
 Caster (Elemental) Mutation #4 (1,590 samples):
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 65%:
         ElementalDamageMod = 1.01
@@ -19,7 +19,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 Caster (Elemental) Mutation #5 (1,491 samples):
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 40%:
         ElementalDamageMod = 1.02
@@ -48,7 +48,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 Caster (Elemental) Mutation #6 (4,055 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         ElementalDamageMod = 1.02
@@ -102,7 +102,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 Caster (Elemental) Mutation #7 (979 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 20%:
         ElementalDamageMod = 1.1
@@ -141,7 +141,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 Caster (Elemental) Mutation #8 (1,585 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 2%:
         ElementalDamageMod = 1.1
@@ -200,7 +200,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 Caster (Elemental) Mutation #9 (1,585 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 13%:
         ElementalDamageMod = 1.185
@@ -284,7 +284,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
 Caster (Elemental) Mutation #10 (1,585 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 13%:
         ElementalDamageMod = 1.275
@@ -366,3 +366,87 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
         WieldRequirements = RawSkill
         WieldDifficulty = 725
 
+
+Tier 11 Mutation #11:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 13%:
+        ElementalDamageMod = 1.455
+        WieldRequirements = RawSkill
+        WieldDifficulty = 950
+
+    - Chance: 7%:
+        ElementalDamageMod = 1.46
+        WieldRequirements = RawSkill
+        WieldDifficulty = 950
+
+    - Chance: 3%:
+        ElementalDamageMod = 1.465
+        WieldRequirements = RawSkill
+        WieldDifficulty = 950
+
+    - Chance: 2%:
+        ElementalDamageMod = 1.47
+        WieldRequirements = RawSkill
+        WieldDifficulty = 950
+
+    - Chance: 13%:
+        ElementalDamageMod = 1.475
+        WieldRequirements = RawSkill
+        WieldDifficulty = 950
+
+   - Chance: 7%:
+        ElementalDamageMod = 1.48
+        WieldRequirements = RawSkill
+        WieldDifficulty = 950
+
+    - Chance: 3%:
+        ElementalDamageMod = 1.485
+        WieldRequirements = RawSkill
+        WieldDifficulty = 1025
+
+    - Chance: 2%:
+        ElementalDamageMod = 1.49
+        WieldRequirements = RawSkill
+        WieldDifficulty = 1025
+
+   - Chance: 13%:
+        ElementalDamageMod = 1.495
+        WieldRequirements = RawSkill
+        WieldDifficulty = 1025
+
+    - Chance: 7%:
+        ElementalDamageMod = 1.5
+        WieldRequirements = RawSkill
+        WieldDifficulty = 1025
+
+    - Chance: 3%:
+        ElementalDamageMod = 1.505
+        WieldRequirements = RawSkill
+        WieldDifficulty = 1025
+
+    - Chance: 2%:
+        ElementalDamageMod = 1.51
+        WieldRequirements = RawSkill
+        WieldDifficulty = 1100
+
+   - Chance: 13%:
+        ElementalDamageMod = 1.515
+        WieldRequirements = RawSkill
+        WieldDifficulty = 1100
+
+    - Chance: 7%:
+        ElementalDamageMod = 1.52
+        WieldRequirements = RawSkill
+        WieldDifficulty = 1100
+
+    - Chance: 3%:
+        ElementalDamageMod = 1.525
+        WieldRequirements = RawSkill
+        WieldDifficulty = 1100
+
+    - Chance: 2%:
+        ElementalDamageMod = 1.53
+        WieldRequirements = RawSkill
+        WieldDifficulty = 1100

--- a/Source/ACE.Server/Entity/Mutations/Casters/caster_non_elemental.txt
+++ b/Source/ACE.Server/Entity/Mutations/Casters/caster_non_elemental.txt
@@ -1,6 +1,6 @@
 Caster (NonElemental) Mutation #7 (116 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 100%:
         WieldRequirements = Level
@@ -9,7 +9,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 Caster (NonElemental) Mutation #8 (208 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 10%:
         WieldRequirements = Level
@@ -23,7 +23,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     Caster (NonElemental) Mutation #9 (208 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 100%:
         WieldRequirements = Level
@@ -32,9 +32,14 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
         Caster (NonElemental) Mutation #10 (208 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0 ,0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0 ,0, 1, 0
 
     - Chance: 100%:
         WieldRequirements = Level
         WieldDifficulty = 750
         WieldSkillType = 1
+
+// Tier 11 intentionally has NO block here. This script exists only to stamp Level wield
+// requirements, and tier 11 loot carries none (owner decision 2026-07-20), so there is
+// nothing for it to do. Every Tier chances line above ends in 0 for tier 11, so no mutation
+// fires -- harmless: LootGenerationFactory_Caster discards the TryMutate return value.

--- a/Source/ACE.Server/Entity/Mutations/Casters/weapon_defense.txt
+++ b/Source/ACE.Server/Entity/Mutations/Casters/weapon_defense.txt
@@ -1,6 +1,6 @@
 Caster Mutation #1 (484 samples):
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponDefense = 1.00
@@ -22,7 +22,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 Caster Mutation #2 (831 samples):
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponDefense = 1.01
@@ -44,7 +44,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 Caster Mutation #3 (741 samples):
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         WeaponDefense = 1.03
@@ -72,7 +72,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 Caster Mutation #4 (1695 samples):
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponDefense = 1.05
@@ -100,7 +100,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 Caster Mutation #5 (777 samples):
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponDefense = 1.07
@@ -128,7 +128,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 Caster Mutation #6 (3959 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponDefense = 1.08
@@ -156,7 +156,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 Caster Mutation #7 (939 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 25%:
         WeaponDefense = 1.13
@@ -184,7 +184,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 Caster Mutation #8 (1357 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 25%:
         WeaponDefense = 1.13
@@ -212,7 +212,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     Caster Mutation #9 (1357 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 25%:
         WeaponDefense = 1.21
@@ -240,7 +240,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
         Caster Mutation #10 (1357 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 25%:
         WeaponDefense = 1.23
@@ -265,3 +265,31 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
 
     - Chance: 2%:
         WeaponDefense = 1.30
+
+Tier 11 Mutation #11:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 25%:
+        WeaponDefense = 1.39
+
+    - Chance: 15%:
+        WeaponDefense = 1.4
+
+    - Chance: 20%:
+        WeaponDefense = 1.41
+
+    - Chance: 14%:
+        WeaponDefense = 1.42
+
+    - Chance: 12%:
+        WeaponDefense = 1.43
+
+    - Chance: 8%:
+        WeaponDefense = 1.44
+
+    - Chance: 4%:
+        WeaponDefense = 1.45
+
+    - Chance: 2%:
+        WeaponDefense = 1.46

--- a/Source/ACE.Server/Entity/Mutations/MeleeWeapons/Damage_WieldDifficulty_DamageVariance/heavy_axe.txt
+++ b/Source/ACE.Server/Entity/Mutations/MeleeWeapons/Damage_WieldDifficulty_DamageVariance/heavy_axe.txt
@@ -1,13 +1,13 @@
 Axe (HeavyWeapons) Mutation #0:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 100%:
 	    Damage = 12
 
 Axe (HeavyWeapons) Mutation #1 (199 samples):
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 3%:
         Damage += 1
@@ -38,7 +38,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 Axe (HeavyWeapons) Mutation #2 (337 samples):
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         Damage += 1
@@ -123,7 +123,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 Axe (HeavyWeapons) Mutation #3 (311 samples):
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         Damage += 13
@@ -205,7 +205,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 Axe (HeavyWeapons) Mutation #4 (732 samples):
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         Damage += 28
@@ -263,7 +263,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 Axe (HeavyWeapons) Mutation #5 (623 samples):
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         Damage += 32
@@ -327,7 +327,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 Axe (HeavyWeapons) Mutation #6 (1,692 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 15%:
         Damage += 37
@@ -427,7 +427,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 Axe (HeavyWeapons) Mutation #7 (439 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 10%:
         Damage += 47
@@ -515,7 +515,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 Axe (HeavyWeapons) Mutation #8 (646 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 0.5%:
         Damage += 47
@@ -633,7 +633,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 Axe (HeavyWeapons) Mutation #9:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 10%:
         DamageVariance = 0.99
@@ -653,7 +653,7 @@ Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
 Axe (HeavyWeapons) Mutation #10 (646 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 15%:
         Damage += 75
@@ -753,7 +753,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
 Axe (HeavyWeapons) Mutation #11 (646 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 15%:
         Damage += 118
@@ -826,3 +826,79 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
         WieldRequirements = RawSkill
         WieldSkillType = WeaponSkill
         WieldDifficulty = 800
+
+Tier 11 Mutation #12:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 15%:
+        Damage += 216
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 10%:
+        Damage += 217
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 6%:
+        Damage += 218
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 4%:
+        Damage += 219
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 13%:
+        Damage += 228
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 10%:
+        Damage += 229
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 7%:
+        Damage += 230
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 5%:
+        Damage += 231
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 12%:
+        Damage += 240
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 8%:
+        Damage += 241
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 6%:
+        Damage += 242
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 4%:
+        Damage += 243
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175

--- a/Source/ACE.Server/Entity/Mutations/MeleeWeapons/Damage_WieldDifficulty_DamageVariance/heavy_dagger.txt
+++ b/Source/ACE.Server/Entity/Mutations/MeleeWeapons/Damage_WieldDifficulty_DamageVariance/heavy_dagger.txt
@@ -1,13 +1,13 @@
 Dagger (HeavyWeapons) Mutation #0:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 100%:
 	    Damage = 10
 
 Dagger (HeavyWeapons) Mutation #1 (93 samples):
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 3%:
         Damage += 1
@@ -38,7 +38,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 Dagger (HeavyWeapons) Mutation #2 (229 samples):
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         Damage += 1
@@ -123,7 +123,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 Dagger (HeavyWeapons) Mutation #3 (177 samples):
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         Damage += 13
@@ -205,7 +205,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 Dagger (HeavyWeapons) Mutation #4 (396 samples):
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         Damage += 26
@@ -269,7 +269,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 Dagger (HeavyWeapons) Mutation #5 (386 samples):
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         Damage += 31
@@ -339,7 +339,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 Dagger (HeavyWeapons) Mutation #6 (1,005 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 15%:
         Damage += 37
@@ -433,7 +433,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 Dagger (HeavyWeapons) Mutation #7 (230 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 10%:
         Damage += 47
@@ -515,7 +515,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 Dagger (HeavyWeapons) Mutation #8 (399 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 0.5%:
         Damage += 47
@@ -627,7 +627,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 Dagger (HeavyWeapons) Mutation #9:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 10%:
         DamageVariance = 0.62
@@ -646,7 +646,7 @@ Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     Dagger (HeavyWeapons) Mutation #10 (399 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 15%:
         Damage += 74
@@ -746,7 +746,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
         Dagger (HeavyWeapons) Mutation #11 (399 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 15%:
         Damage += 116
@@ -819,3 +819,79 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
         WieldRequirements = RawSkill
         WieldSkillType = WeaponSkill
         WieldDifficulty = 800
+
+Tier 11 Mutation #12:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 15%:
+        Damage += 212
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 10%:
+        Damage += 213
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 6%:
+        Damage += 214
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 4%:
+        Damage += 215
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 13%:
+        Damage += 224
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 10%:
+        Damage += 225
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 7%:
+        Damage += 226
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 5%:
+        Damage += 227
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 12%:
+        Damage += 236
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 8%:
+        Damage += 237
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 6%:
+        Damage += 238
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 4%:
+        Damage += 239
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175

--- a/Source/ACE.Server/Entity/Mutations/MeleeWeapons/Damage_WieldDifficulty_DamageVariance/heavy_dagger_ms.txt
+++ b/Source/ACE.Server/Entity/Mutations/MeleeWeapons/Damage_WieldDifficulty_DamageVariance/heavy_dagger_ms.txt
@@ -1,13 +1,13 @@
 DaggerMS (HeavyWeapons) Mutation #0:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 100%:
 	    Damage = 4
 
 DaggerMS (HeavyWeapons) Mutation #1 (94 samples):
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 3%:
         Damage += 1
@@ -38,7 +38,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 DaggerMS (HeavyWeapons) Mutation #2 (120 samples):
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         Damage += 1
@@ -123,7 +123,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 DaggerMS (HeavyWeapons) Mutation #3 (117 samples):
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         Damage += 5
@@ -199,7 +199,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 DaggerMS (HeavyWeapons) Mutation #4 (283 samples):
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         Damage += 14
@@ -239,7 +239,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 DaggerMS (HeavyWeapons) Mutation #5 (232 samples):
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 25%:
         Damage += 17
@@ -279,7 +279,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 DaggerMS (HeavyWeapons) Mutation #6 (613 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 25%:
         Damage += 20
@@ -331,7 +331,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 DaggerMS (HeavyWeapons) Mutation #7 (186 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 10%:
         Damage += 25
@@ -383,7 +383,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 DaggerMS (HeavyWeapons) Mutation #8 (276 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 1%:
         Damage += 25
@@ -459,7 +459,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 DaggerMS (HeavyWeapons) Mutation #9:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 10%:
         DamageVariance = 0.58
@@ -478,7 +478,7 @@ Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
 DaggerMS (HeavyWeapons) Mutation #10 (276 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 15%:
         Damage += 47
@@ -536,7 +536,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
 DaggerMS (HeavyWeapons) Mutation #11 (276 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 15%:
         Damage += 61
@@ -609,3 +609,79 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
         WieldRequirements = RawSkill
         WieldSkillType = WeaponSkill
         WieldDifficulty = 800
+
+Tier 11 Mutation #12:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 15%:
+        Damage += 92
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 10%:
+        Damage += 93
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 6%:
+        Damage += 94
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 4%:
+        Damage += 95
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 13%:
+        Damage += 96
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 10%:
+        Damage += 97
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 7%:
+        Damage += 98
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 5%:
+        Damage += 99
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 12%:
+        Damage += 100
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 8%:
+        Damage += 101
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 6%:
+        Damage += 102
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 4%:
+        Damage += 103
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175

--- a/Source/ACE.Server/Entity/Mutations/MeleeWeapons/Damage_WieldDifficulty_DamageVariance/heavy_mace.txt
+++ b/Source/ACE.Server/Entity/Mutations/MeleeWeapons/Damage_WieldDifficulty_DamageVariance/heavy_mace.txt
@@ -1,13 +1,13 @@
 Mace (HeavyWeapons) Mutation #0:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 100%:
 	    Damage = 9
 
 Mace (HeavyWeapons) Mutation #1 (188 samples):
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 3%:
         Damage += 1
@@ -38,7 +38,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 Mace (HeavyWeapons) Mutation #2 (371 samples):
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         Damage += 1
@@ -123,7 +123,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 Mace (HeavyWeapons) Mutation #3 (378 samples):
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         Damage += 12
@@ -205,7 +205,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 Mace (HeavyWeapons) Mutation #4 (803 samples):
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         Damage += 25
@@ -269,7 +269,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 Mace (HeavyWeapons) Mutation #5 (703 samples):
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         Damage += 30
@@ -339,7 +339,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 Mace (HeavyWeapons) Mutation #6 (1,845 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 15%:
         Damage += 36
@@ -433,7 +433,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 Mace (HeavyWeapons) Mutation #7 (501 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 10%:
         Damage += 46
@@ -515,7 +515,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 Mace (HeavyWeapons) Mutation #8 (660 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 0.5%:
         Damage += 46
@@ -627,7 +627,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 Mace (HeavyWeapons) Mutation #9:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 10%:
         DamageVariance = 0.46
@@ -646,7 +646,7 @@ Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     Mace (HeavyWeapons) Mutation #10 (660 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 15%:
         Damage += 73
@@ -734,7 +734,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
         Mace (HeavyWeapons) Mutation #11 (660 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 15%:
         Damage += 112
@@ -807,3 +807,79 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
         WieldRequirements = RawSkill
         WieldSkillType = WeaponSkill
         WieldDifficulty = 800
+
+Tier 11 Mutation #12:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 15%:
+        Damage += 204
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 10%:
+        Damage += 205
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 6%:
+        Damage += 206
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 4%:
+        Damage += 207
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 13%:
+        Damage += 216
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 10%:
+        Damage += 217
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 7%:
+        Damage += 218
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 5%:
+        Damage += 219
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 12%:
+        Damage += 228
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 8%:
+        Damage += 229
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 6%:
+        Damage += 230
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 4%:
+        Damage += 231
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175

--- a/Source/ACE.Server/Entity/Mutations/MeleeWeapons/Damage_WieldDifficulty_DamageVariance/heavy_spear.txt
+++ b/Source/ACE.Server/Entity/Mutations/MeleeWeapons/Damage_WieldDifficulty_DamageVariance/heavy_spear.txt
@@ -1,13 +1,13 @@
 Spear (HeavyWeapons) Mutation #0:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 100%:
 	    Damage = 10
 
 Spear (HeavyWeapons) Mutation #1 (307 samples):
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 3%:
         Damage += 1
@@ -38,7 +38,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 Spear (HeavyWeapons) Mutation #2 (609 samples):
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         Damage += 1
@@ -123,7 +123,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 Spear (HeavyWeapons) Mutation #3 (596 samples):
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         Damage += 14
@@ -211,7 +211,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 Spear (HeavyWeapons) Mutation #4 (1,211 samples):
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         Damage += 27
@@ -281,7 +281,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 Spear (HeavyWeapons) Mutation #5 (1,070 samples):
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 15%:
         Damage += 32
@@ -345,7 +345,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 Spear (HeavyWeapons) Mutation #6 (2,950 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 15%:
         Damage += 38
@@ -439,7 +439,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 Spear (HeavyWeapons) Mutation #7 (775 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 10%:
         Damage += 47
@@ -527,7 +527,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 Spear (HeavyWeapons) Mutation #8 (1,143 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 0.5%:
         Damage += 47
@@ -645,7 +645,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 Spear (HeavyWeapons) Mutation #9:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 10%:
         DamageVariance = 0.75
@@ -664,7 +664,7 @@ Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
 Spear (HeavyWeapons) Mutation #10 (1,143 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 15%:
         Damage += 75
@@ -764,7 +764,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
         Spear (HeavyWeapons) Mutation #11 (1,143 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 15%:
         Damage += 117
@@ -838,3 +838,79 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
         WieldSkillType = WeaponSkill
         WieldDifficulty = 800
 
+
+Tier 11 Mutation #12:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 15%:
+        Damage += 213
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 10%:
+        Damage += 214
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 6%:
+        Damage += 215
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 4%:
+        Damage += 216
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 13%:
+        Damage += 225
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 10%:
+        Damage += 226
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 7%:
+        Damage += 227
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 5%:
+        Damage += 228
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 12%:
+        Damage += 237
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 8%:
+        Damage += 238
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 6%:
+        Damage += 239
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 4%:
+        Damage += 240
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175

--- a/Source/ACE.Server/Entity/Mutations/MeleeWeapons/Damage_WieldDifficulty_DamageVariance/heavy_staff.txt
+++ b/Source/ACE.Server/Entity/Mutations/MeleeWeapons/Damage_WieldDifficulty_DamageVariance/heavy_staff.txt
@@ -1,13 +1,13 @@
 Staff (HeavyWeapons) Mutation #0:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 100%:
 	    Damage = 10
 
 Staff (HeavyWeapons) Mutation #1 (258 samples):
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 3%:
         Damage += 1
@@ -38,7 +38,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 Staff (HeavyWeapons) Mutation #2 (475 samples):
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         Damage += 1
@@ -123,7 +123,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 Staff (HeavyWeapons) Mutation #3 (406 samples):
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         Damage += 12
@@ -211,7 +211,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 Staff (HeavyWeapons) Mutation #4 (893 samples):
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         Damage += 25
@@ -281,7 +281,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 Staff (HeavyWeapons) Mutation #5 (858 samples):
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 15%:
         Damage += 30
@@ -345,7 +345,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 Staff (HeavyWeapons) Mutation #6 (2,246 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 15%:
         Damage += 36
@@ -439,7 +439,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 Staff (HeavyWeapons) Mutation #7 (591 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 10%:
         Damage += 45
@@ -521,7 +521,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 Staff (HeavyWeapons) Mutation #8 (804 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 1%:
         Damage += 45
@@ -633,7 +633,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 Staff (HeavyWeapons) Mutation #9:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 10%:
         DamageVariance = 0.52
@@ -652,7 +652,7 @@ Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
 Staff (HeavyWeapons) Mutation #10 (1,143 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 15%:
         Damage += 62
@@ -746,7 +746,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
         Staff (HeavyWeapons) Mutation #11 (1,143 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 15%:
         Damage += 99
@@ -819,3 +819,79 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
         WieldRequirements = RawSkill
         WieldSkillType = WeaponSkill
         WieldDifficulty = 800
+
+Tier 11 Mutation #12:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 15%:
+        Damage += 186
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 10%:
+        Damage += 187
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 6%:
+        Damage += 188
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 4%:
+        Damage += 189
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 13%:
+        Damage += 198
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 10%:
+        Damage += 199
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 7%:
+        Damage += 200
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 5%:
+        Damage += 201
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 12%:
+        Damage += 210
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 8%:
+        Damage += 211
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 6%:
+        Damage += 212
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 4%:
+        Damage += 213
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175

--- a/Source/ACE.Server/Entity/Mutations/MeleeWeapons/Damage_WieldDifficulty_DamageVariance/heavy_sword.txt
+++ b/Source/ACE.Server/Entity/Mutations/MeleeWeapons/Damage_WieldDifficulty_DamageVariance/heavy_sword.txt
@@ -1,13 +1,13 @@
 Sword (HeavyWeapons) Mutation #0:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 100%:
 	    Damage = 10
 
 Sword (HeavyWeapons) Mutation #1 (158 samples):
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 3%:
         Damage += 1
@@ -38,7 +38,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 Sword (HeavyWeapons) Mutation #2 (268 samples):
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         Damage += 1
@@ -123,7 +123,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 Sword (HeavyWeapons) Mutation #3 (289 samples):
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         Damage += 13
@@ -205,7 +205,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 Sword (HeavyWeapons) Mutation #4 (560 samples):
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         Damage += 26
@@ -269,7 +269,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 Sword (HeavyWeapons) Mutation #5 (473 samples):
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         Damage += 31
@@ -339,7 +339,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 Sword (HeavyWeapons) Mutation #6 (1,303 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 15%:
         Damage += 37
@@ -433,7 +433,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 Sword (HeavyWeapons) Mutation #7 (320 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 10%:
         Damage += 47
@@ -515,7 +515,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 Sword (HeavyWeapons) Mutation #8 (508 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 0.5%:
         Damage += 47
@@ -627,7 +627,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 Sword (HeavyWeapons) Mutation #9:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 10%:
         DamageVariance = 0.62
@@ -646,7 +646,7 @@ Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
 Sword (HeavyWeapons) Mutation #10 (1,143 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 15%:
         Damage += 74
@@ -740,7 +740,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
         Sword (HeavyWeapons) Mutation #11 (1,143 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 15%:
         Damage += 115
@@ -813,3 +813,79 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
         WieldRequirements = RawSkill
         WieldSkillType = WeaponSkill
         WieldDifficulty = 800
+
+Tier 11 Mutation #12:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 15%:
+        Damage += 210
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 10%:
+        Damage += 211
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 6%:
+        Damage += 212
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 4%:
+        Damage += 213
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 13%:
+        Damage += 222
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 10%:
+        Damage += 223
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 7%:
+        Damage += 224
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 5%:
+        Damage += 225
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 12%:
+        Damage += 234
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 8%:
+        Damage += 235
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 6%:
+        Damage += 236
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 4%:
+        Damage += 237
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175

--- a/Source/ACE.Server/Entity/Mutations/MeleeWeapons/Damage_WieldDifficulty_DamageVariance/heavy_sword_ms.txt
+++ b/Source/ACE.Server/Entity/Mutations/MeleeWeapons/Damage_WieldDifficulty_DamageVariance/heavy_sword_ms.txt
@@ -1,13 +1,13 @@
 SwordMS (HeavyWeapons) Mutation #0:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 100%:
 	    Damage = 4
 
 SwordMS (HeavyWeapons) Mutation #1 (24 samples):
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 3%:
         Damage += 1
@@ -38,7 +38,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 SwordMS (HeavyWeapons) Mutation #2 (40 samples):
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         Damage += 2
@@ -111,7 +111,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 SwordMS (HeavyWeapons) Mutation #3 (50 samples):
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 3%:
         Damage += 5
@@ -175,7 +175,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 SwordMS (HeavyWeapons) Mutation #4 (89 samples):
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         Damage += 14
@@ -215,7 +215,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 SwordMS (HeavyWeapons) Mutation #5 (106 samples):
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 25%:
         Damage += 17
@@ -255,7 +255,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 SwordMS (HeavyWeapons) Mutation #6 (221 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 25%:
         Damage += 20
@@ -307,7 +307,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 SwordMS (HeavyWeapons) Mutation #7 (59 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 10%:
         Damage += 25
@@ -359,7 +359,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 SwordMS (HeavyWeapons) Mutation #8 (69 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 1%:
         Damage += 25
@@ -429,7 +429,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 SwordMS (HeavyWeapons) Mutation #9:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 10%:
         DamageVariance = 0.58
@@ -448,7 +448,7 @@ Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
 SwordMS (HeavyWeapons) Mutation #10 (1,143 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 20%:
         Damage += 47
@@ -512,7 +512,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
 SwordMS (HeavyWeapons) Mutation #11 (1,143 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 15%:
         Damage += 62
@@ -585,3 +585,79 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
         WieldRequirements = RawSkill
         WieldSkillType = WeaponSkill
         WieldDifficulty = 800
+
+Tier 11 Mutation #12:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 15%:
+        Damage += 94
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 10%:
+        Damage += 95
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 6%:
+        Damage += 96
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 4%:
+        Damage += 97
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 13%:
+        Damage += 98
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 10%:
+        Damage += 99
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 7%:
+        Damage += 100
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 5%:
+        Damage += 101
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 12%:
+        Damage += 102
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 8%:
+        Damage += 103
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 6%:
+        Damage += 104
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 4%:
+        Damage += 105
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175

--- a/Source/ACE.Server/Entity/Mutations/MeleeWeapons/Damage_WieldDifficulty_DamageVariance/heavy_unarmed.txt
+++ b/Source/ACE.Server/Entity/Mutations/MeleeWeapons/Damage_WieldDifficulty_DamageVariance/heavy_unarmed.txt
@@ -1,13 +1,13 @@
 Unarmed (HeavyWeapons) Mutation #0:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 100%:
 	    Damage = 8
 
 Unarmed (HeavyWeapons) Mutation #1 (148 samples):
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 3%:
         Damage += 1
@@ -38,7 +38,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 Unarmed (HeavyWeapons) Mutation #2 (255 samples):
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         Damage += 1
@@ -123,7 +123,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 Unarmed (HeavyWeapons) Mutation #3 (259 samples):
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         Damage += 10
@@ -205,7 +205,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 Unarmed (HeavyWeapons) Mutation #4 (537 samples):
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         Damage += 22
@@ -263,7 +263,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 Unarmed (HeavyWeapons) Mutation #5 (519 samples):
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         Damage += 26
@@ -321,7 +321,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 Unarmed (HeavyWeapons) Mutation #6 (1,288 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 15%:
         Damage += 31
@@ -403,7 +403,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 Unarmed (HeavyWeapons) Mutation #7 (323 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 9%:
         Damage += 39
@@ -479,7 +479,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 Unarmed (HeavyWeapons) Mutation #8 (540 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 0.5%:
         Damage += 39
@@ -579,7 +579,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 Unarmed (HeavyWeapons) Mutation #9:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 10%:
         DamageVariance = 0.6
@@ -598,7 +598,7 @@ Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
 Unarmed (HeavyWeapons) Mutation #10 (1,143 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 15%:
         Damage += 64
@@ -674,7 +674,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
         Unarmed (HeavyWeapons) Mutation #11 (1,143 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 15%:
         Damage += 97
@@ -747,3 +747,79 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
         WieldRequirements = RawSkill
         WieldSkillType = WeaponSkill
         WieldDifficulty = 800
+
+Tier 11 Mutation #12:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 15%:
+        Damage += 179
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 10%:
+        Damage += 180
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 6%:
+        Damage += 181
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 4%:
+        Damage += 182
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 13%:
+        Damage += 191
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 10%:
+        Damage += 192
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 7%:
+        Damage += 193
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 5%:
+        Damage += 194
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 12%:
+        Damage += 203
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 8%:
+        Damage += 204
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 6%:
+        Damage += 205
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 4%:
+        Damage += 206
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175

--- a/Source/ACE.Server/Entity/Mutations/MeleeWeapons/Damage_WieldDifficulty_DamageVariance/light_finesse_axe.txt
+++ b/Source/ACE.Server/Entity/Mutations/MeleeWeapons/Damage_WieldDifficulty_DamageVariance/light_finesse_axe.txt
@@ -1,13 +1,13 @@
 Axe (LightWeapons, FinesseWeapons) Mutation #0:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 100%:
 	    Damage = 9
 
 Axe (LightWeapons, FinesseWeapons) Mutation #1 (378 samples):
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 3%:
         Damage += 1
@@ -38,7 +38,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 Axe (LightWeapons, FinesseWeapons) Mutation #2 (612 samples):
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         Damage += 1
@@ -123,7 +123,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 Axe (LightWeapons, FinesseWeapons) Mutation #3 (667 samples):
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         Damage += 12
@@ -205,7 +205,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 Axe (LightWeapons, FinesseWeapons) Mutation #4 (1,177 samples):
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         Damage += 23
@@ -263,7 +263,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 Axe (LightWeapons, FinesseWeapons) Mutation #5 (1,089 samples):
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         Damage += 27
@@ -321,7 +321,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 Axe (LightWeapons, FinesseWeapons) Mutation #6 (3,239 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 15%:
         Damage += 31
@@ -397,7 +397,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 Axe (LightWeapons, FinesseWeapons) Mutation #7 (866 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 9%:
         Damage += 39
@@ -473,7 +473,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 Axe (LightWeapons, FinesseWeapons) Mutation #8 (1,302 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 1%:
         Damage += 39
@@ -579,7 +579,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 Axe (LightWeapons, FinesseWeapons) Mutation #9:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 10%:
         DamageVariance = 0.95
@@ -598,7 +598,7 @@ Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
 Axe (LightWeapons, FinesseWeapons) Mutation #10 (1,143 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 15%:
         Damage += 65
@@ -698,7 +698,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
         Axe (LightWeapons, FinesseWeapons) Mutation #11 (1,143 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 15%:
         Damage += 104
@@ -774,3 +774,79 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
 
     
 
+
+Tier 11 Mutation #12:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 15%:
+        Damage += 194
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 10%:
+        Damage += 195
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 6%:
+        Damage += 196
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 4%:
+        Damage += 197
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 13%:
+        Damage += 206
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 10%:
+        Damage += 207
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 7%:
+        Damage += 208
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 5%:
+        Damage += 209
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 12%:
+        Damage += 218
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 8%:
+        Damage += 219
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 6%:
+        Damage += 220
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 4%:
+        Damage += 221
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175

--- a/Source/ACE.Server/Entity/Mutations/MeleeWeapons/Damage_WieldDifficulty_DamageVariance/light_finesse_dagger.txt
+++ b/Source/ACE.Server/Entity/Mutations/MeleeWeapons/Damage_WieldDifficulty_DamageVariance/light_finesse_dagger.txt
@@ -1,13 +1,13 @@
 Dagger (LightWeapons, FinesseWeapons) Mutation #0:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 100%:
 	    Damage = 7
 
 Dagger (LightWeapons, FinesseWeapons) Mutation #1 (65 samples):
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 3%:
         Damage += 1
@@ -38,7 +38,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 Dagger (LightWeapons, FinesseWeapons) Mutation #2 (129 samples):
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         Damage += 1
@@ -123,7 +123,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 Dagger (LightWeapons, FinesseWeapons) Mutation #3 (127 samples):
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         Damage += 12
@@ -199,7 +199,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 Dagger (LightWeapons, FinesseWeapons) Mutation #4 (246 samples):
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         Damage += 23
@@ -257,7 +257,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 Dagger (LightWeapons, FinesseWeapons) Mutation #5 (236 samples):
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         Damage += 27
@@ -309,7 +309,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 Dagger (LightWeapons, FinesseWeapons) Mutation #6 (670 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 15%:
         Damage += 32
@@ -379,7 +379,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 Dagger (LightWeapons, FinesseWeapons) Mutation #7 (185 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 10%:
         Damage += 39
@@ -449,7 +449,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 Dagger (LightWeapons, FinesseWeapons) Mutation #8 (245 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 1%:
         Damage += 39
@@ -549,7 +549,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 Dagger (LightWeapons, FinesseWeapons) Mutation #9:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 10%:
         DamageVariance = 0.6
@@ -568,7 +568,7 @@ Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
 Dagger (LightWeapons, FinesseWeapons) Mutation #10 (1,143 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 15%:
         Damage += 64
@@ -668,7 +668,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
         Dagger (LightWeapons, FinesseWeapons) Mutation #11 (1,143 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 15%:
         Damage += 102
@@ -741,3 +741,79 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
         WieldRequirements = RawSkill
         WieldSkillType = WeaponSkill
         WieldDifficulty = 800
+
+Tier 11 Mutation #12:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 15%:
+        Damage += 190
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 10%:
+        Damage += 191
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 6%:
+        Damage += 192
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 4%:
+        Damage += 193
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 13%:
+        Damage += 202
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 10%:
+        Damage += 203
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 7%:
+        Damage += 204
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 5%:
+        Damage += 205
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 12%:
+        Damage += 214
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 8%:
+        Damage += 215
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 6%:
+        Damage += 216
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 4%:
+        Damage += 217
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175

--- a/Source/ACE.Server/Entity/Mutations/MeleeWeapons/Damage_WieldDifficulty_DamageVariance/light_finesse_dagger_ms.txt
+++ b/Source/ACE.Server/Entity/Mutations/MeleeWeapons/Damage_WieldDifficulty_DamageVariance/light_finesse_dagger_ms.txt
@@ -1,13 +1,13 @@
 DaggerMS (LightWeapons, FinesseWeapons) Mutation #0:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 100%:
 	    Damage = 1
 
 DaggerMS (LightWeapons, FinesseWeapons) Mutation #1 (331 samples):
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         Damage += 1
@@ -29,7 +29,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 DaggerMS (LightWeapons, FinesseWeapons) Mutation #2 (629 samples):
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         Damage += 1
@@ -87,7 +87,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 DaggerMS (LightWeapons, FinesseWeapons) Mutation #3 (594 samples):
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 3%:
         Damage += 5
@@ -145,7 +145,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 DaggerMS (LightWeapons, FinesseWeapons) Mutation #4 (1,202 samples):
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         Damage += 10
@@ -185,7 +185,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 DaggerMS (LightWeapons, FinesseWeapons) Mutation #5 (1,005 samples):
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         Damage += 13
@@ -219,7 +219,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 DaggerMS (LightWeapons, FinesseWeapons) Mutation #6 (2,972 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 15%:
         Damage += 16
@@ -259,7 +259,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 DaggerMS (LightWeapons, FinesseWeapons) Mutation #7 (762 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 10%:
         Damage += 20
@@ -299,7 +299,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 DaggerMS (LightWeapons, FinesseWeapons) Mutation #8 (1,048 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 2%:
         Damage += 20
@@ -369,7 +369,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 DaggerMS (LightWeapons, FinesseWeapons) Mutation #9:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 10%:
         DamageVariance = 0.45
@@ -388,7 +388,7 @@ Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
 DaggerMS (LightWeapons, FinesseWeapons) Mutation #10 (1,143 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 15%:
         Damage += 40
@@ -488,7 +488,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
 DaggerMS (LightWeapons, FinesseWeapons) Mutation #11 (1,143 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 15%:
         Damage += 60
@@ -561,3 +561,79 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
         WieldRequirements = RawSkill
         WieldSkillType = WeaponSkill
         WieldDifficulty = 800
+
+Tier 11 Mutation #12:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 15%:
+        Damage += 96
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 10%:
+        Damage += 97
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 6%:
+        Damage += 98
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 4%:
+        Damage += 99
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 13%:
+        Damage += 100
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 10%:
+        Damage += 101
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 7%:
+        Damage += 102
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 5%:
+        Damage += 103
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 12%:
+        Damage += 104
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 8%:
+        Damage += 105
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 6%:
+        Damage += 106
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 4%:
+        Damage += 107
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175

--- a/Source/ACE.Server/Entity/Mutations/MeleeWeapons/Damage_WieldDifficulty_DamageVariance/light_finesse_mace.txt
+++ b/Source/ACE.Server/Entity/Mutations/MeleeWeapons/Damage_WieldDifficulty_DamageVariance/light_finesse_mace.txt
@@ -1,13 +1,13 @@
 Mace (LightWeapons, FinesseWeapons) Mutation #0:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 100%:
 	    Damage = 7
 
 Mace (LightWeapons, FinesseWeapons) Mutation #1 (340 samples):
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 3%:
         Damage += 1
@@ -38,7 +38,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 Mace (LightWeapons, FinesseWeapons) Mutation #2 (635 samples):
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         Damage += 1
@@ -123,7 +123,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 Mace (LightWeapons, FinesseWeapons) Mutation #3 (591 samples):
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         Damage += 11
@@ -205,7 +205,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 Mace (LightWeapons, FinesseWeapons) Mutation #4 (1,172 samples):
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         Damage += 21
@@ -263,7 +263,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 Mace (LightWeapons, FinesseWeapons) Mutation #5 (1,097 samples):
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         Damage += 25
@@ -315,7 +315,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 Mace (LightWeapons, FinesseWeapons) Mutation #6 (3,204 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 15%:
         Damage += 30
@@ -385,7 +385,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 Mace (LightWeapons, FinesseWeapons) Mutation #7 (831 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 10%:
         Damage += 37
@@ -455,7 +455,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 Mace (LightWeapons, FinesseWeapons) Mutation #8 (1,260 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 1%:
         Damage += 37
@@ -555,7 +555,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 Mace (LightWeapons, FinesseWeapons) Mutation #9:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 10%:
         DamageVariance = 0.43
@@ -574,7 +574,7 @@ Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
 Mace (LightWeapons, FinesseWeapons) Mutation #10 (1,143 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 15%:
         Damage += 62
@@ -674,7 +674,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
         Mace (LightWeapons, FinesseWeapons) Mutation #11 (1,143 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 15%:
         Damage += 98
@@ -747,3 +747,79 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
         WieldRequirements = RawSkill
         WieldSkillType = WeaponSkill
         WieldDifficulty = 800
+
+Tier 11 Mutation #12:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 15%:
+        Damage += 183
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 10%:
+        Damage += 184
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 6%:
+        Damage += 185
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 4%:
+        Damage += 186
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 13%:
+        Damage += 195
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 10%:
+        Damage += 196
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 7%:
+        Damage += 197
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 5%:
+        Damage += 198
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 12%:
+        Damage += 207
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 8%:
+        Damage += 208
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 6%:
+        Damage += 209
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 4%:
+        Damage += 210
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175

--- a/Source/ACE.Server/Entity/Mutations/MeleeWeapons/Damage_WieldDifficulty_DamageVariance/light_finesse_mace_jitte.txt
+++ b/Source/ACE.Server/Entity/Mutations/MeleeWeapons/Damage_WieldDifficulty_DamageVariance/light_finesse_mace_jitte.txt
@@ -1,13 +1,13 @@
 MaceJitte (FinesseWeapons) Mutation #0:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 100%:
 	    Damage = 7
 
 MaceJitte (FinesseWeapons) Mutation #1 (33 samples):
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 3%:
         Damage += 1
@@ -38,7 +38,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 MaceJitte (FinesseWeapons) Mutation #2 (55 samples):
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         Damage += 1
@@ -123,7 +123,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 MaceJitte (FinesseWeapons) Mutation #3 (62 samples):
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         Damage += 11
@@ -205,7 +205,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 MaceJitte (FinesseWeapons) Mutation #4 (104 samples):
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         Damage += 22
@@ -257,7 +257,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 MaceJitte (FinesseWeapons) Mutation #5 (93 samples):
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 25%:
         Damage += 26
@@ -309,7 +309,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 MaceJitte (FinesseWeapons) Mutation #6 (201 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 15%:
         Damage += 30
@@ -385,7 +385,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 MaceJitte (FinesseWeapons) Mutation #7 (63 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 10%:
         Damage += 38
@@ -455,7 +455,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 MaceJitte (FinesseWeapons) Mutation #8 (86 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 2%:
         Damage += 39
@@ -543,7 +543,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 MaceJitte (FinesseWeapons) Mutation #9:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 10%:
         DamageVariance = 0.5
@@ -562,7 +562,7 @@ Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
 MaceJitte (FinesseWeapons) Mutation #10 (1,143 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 15%:
         Damage += 63
@@ -662,7 +662,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
         MaceJitte (FinesseWeapons) Mutation #11 (1,143 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 15%:
         Damage += 98
@@ -735,3 +735,79 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
         WieldRequirements = RawSkill
         WieldSkillType = WeaponSkill
         WieldDifficulty = 800
+
+Tier 11 Mutation #12:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 15%:
+        Damage += 180
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 10%:
+        Damage += 181
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 6%:
+        Damage += 182
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 4%:
+        Damage += 183
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 13%:
+        Damage += 192
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 10%:
+        Damage += 193
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 7%:
+        Damage += 194
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 5%:
+        Damage += 195
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 12%:
+        Damage += 204
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 8%:
+        Damage += 205
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 6%:
+        Damage += 206
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 4%:
+        Damage += 207
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175

--- a/Source/ACE.Server/Entity/Mutations/MeleeWeapons/Damage_WieldDifficulty_DamageVariance/light_finesse_spear.txt
+++ b/Source/ACE.Server/Entity/Mutations/MeleeWeapons/Damage_WieldDifficulty_DamageVariance/light_finesse_spear.txt
@@ -1,13 +1,13 @@
 Spear (LightWeapons, FinesseWeapons) Mutation #0:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 100%:
 	    Damage = 7
 
 Spear (LightWeapons, FinesseWeapons) Mutation #1 (302 samples):
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 3%:
         Damage += 1
@@ -38,7 +38,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 Spear (LightWeapons, FinesseWeapons) Mutation #2 (457 samples):
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         Damage += 1
@@ -123,7 +123,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 Spear (LightWeapons, FinesseWeapons) Mutation #3 (437 samples):
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         Damage += 13
@@ -205,7 +205,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 Spear (LightWeapons, FinesseWeapons) Mutation #4 (879 samples):
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         Damage += 24
@@ -263,7 +263,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 Spear (LightWeapons, FinesseWeapons) Mutation #5 (836 samples):
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         Damage += 28
@@ -321,7 +321,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 Spear (LightWeapons, FinesseWeapons) Mutation #6 (2,276 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 15%:
         Damage += 33
@@ -397,7 +397,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 Spear (LightWeapons, FinesseWeapons) Mutation #7 (603 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 10%:
         Damage += 41
@@ -467,7 +467,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 Spear (LightWeapons, FinesseWeapons) Mutation #8 (892 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 1%:
         Damage += 41
@@ -561,7 +561,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 Spear (LightWeapons, FinesseWeapons) Mutation #9:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 10%:
         DamageVariance = 0.8
@@ -580,7 +580,7 @@ Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
 Spear (LightWeapons, FinesseWeapons) Mutation #10 (1,143 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 15%:
         Damage += 66
@@ -680,7 +680,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
         Spear (LightWeapons, FinesseWeapons) Mutation #11 (1,143 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 15%:
         Damage += 104
@@ -753,3 +753,79 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
         WieldRequirements = RawSkill
         WieldSkillType = WeaponSkill
         WieldDifficulty = 800
+
+Tier 11 Mutation #12:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 15%:
+        Damage += 192
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 10%:
+        Damage += 193
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 6%:
+        Damage += 194
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 4%:
+        Damage += 195
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 13%:
+        Damage += 204
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 10%:
+        Damage += 205
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 7%:
+        Damage += 206
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 5%:
+        Damage += 207
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 12%:
+        Damage += 216
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 8%:
+        Damage += 217
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 6%:
+        Damage += 218
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 4%:
+        Damage += 219
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175

--- a/Source/ACE.Server/Entity/Mutations/MeleeWeapons/Damage_WieldDifficulty_DamageVariance/light_finesse_staff.txt
+++ b/Source/ACE.Server/Entity/Mutations/MeleeWeapons/Damage_WieldDifficulty_DamageVariance/light_finesse_staff.txt
@@ -1,13 +1,13 @@
 Staff (LightWeapons, FinesseWeapons) Mutation #0:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 100%:
 	    Damage = 7
 
 Staff (LightWeapons, FinesseWeapons) Mutation #1 (307 samples):
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 3%:
         Damage += 1
@@ -38,7 +38,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 Staff (LightWeapons, FinesseWeapons) Mutation #2 (624 samples):
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         Damage += 1
@@ -123,7 +123,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 Staff (LightWeapons, FinesseWeapons) Mutation #3 (564 samples):
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         Damage += 11
@@ -205,7 +205,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 Staff (LightWeapons, FinesseWeapons) Mutation #4 (1,193 samples):
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         Damage += 22
@@ -257,7 +257,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 Staff (LightWeapons, FinesseWeapons) Mutation #5 (1,129 samples):
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 25%:
         Damage += 26
@@ -309,7 +309,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 Staff (LightWeapons, FinesseWeapons) Mutation #6 (3,106 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 15%:
         Damage += 30
@@ -385,7 +385,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 Staff (LightWeapons, FinesseWeapons) Mutation #7 (783 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 10%:
         Damage += 38
@@ -455,7 +455,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 Staff (LightWeapons, FinesseWeapons) Mutation #8 (1,187 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 1%:
         Damage += 38
@@ -555,7 +555,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 Staff (LightWeapons, FinesseWeapons) Mutation #9:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 10%:
         DamageVariance = 0.5
@@ -574,7 +574,7 @@ Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
 Staff (LightWeapons, FinesseWeapons) Mutation #10 (1,143 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 15%:
         Damage += 63
@@ -674,7 +674,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
 Staff (LightWeapons, FinesseWeapons) Mutation #11 (1,143 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 15%:
         Damage += 101
@@ -747,3 +747,79 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
         WieldRequirements = RawSkill
         WieldSkillType = WeaponSkill
         WieldDifficulty = 800
+
+Tier 11 Mutation #12:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 15%:
+        Damage += 189
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 10%:
+        Damage += 190
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 6%:
+        Damage += 191
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 4%:
+        Damage += 192
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 13%:
+        Damage += 201
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 10%:
+        Damage += 202
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 7%:
+        Damage += 203
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 5%:
+        Damage += 204
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 12%:
+        Damage += 213
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 8%:
+        Damage += 214
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 6%:
+        Damage += 215
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 4%:
+        Damage += 216
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175

--- a/Source/ACE.Server/Entity/Mutations/MeleeWeapons/Damage_WieldDifficulty_DamageVariance/light_finesse_sword.txt
+++ b/Source/ACE.Server/Entity/Mutations/MeleeWeapons/Damage_WieldDifficulty_DamageVariance/light_finesse_sword.txt
@@ -1,13 +1,13 @@
 Sword (LightWeapons, FinesseWeapons) Mutation #0:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 100%:
 	    Damage = 7
 
 Sword (LightWeapons, FinesseWeapons) Mutation #1 (326 samples):
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 3%:
         Damage += 1
@@ -38,7 +38,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 Sword (LightWeapons, FinesseWeapons) Mutation #2 (620 samples):
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         Damage += 1
@@ -123,7 +123,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 Sword (LightWeapons, FinesseWeapons) Mutation #3 (642 samples):
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         Damage += 12
@@ -205,7 +205,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 Sword (LightWeapons, FinesseWeapons) Mutation #4 (1,219 samples):
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         Damage += 23
@@ -263,7 +263,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 Sword (LightWeapons, FinesseWeapons) Mutation #5 (1,170 samples):
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         Damage += 27
@@ -315,7 +315,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 Sword (LightWeapons, FinesseWeapons) Mutation #6 (2,962 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 15%:
         Damage += 32
@@ -385,7 +385,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 Sword (LightWeapons, FinesseWeapons) Mutation #7 (769 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 10%:
         Damage += 39
@@ -455,7 +455,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 Sword (LightWeapons, FinesseWeapons) Mutation #8 (1,230 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 1%:
         Damage += 39
@@ -555,7 +555,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 Sword (LightWeapons, FinesseWeapons) Mutation #9:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 10%:
         DamageVariance = 0.6
@@ -574,7 +574,7 @@ Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
 Sword (LightWeapons, FinesseWeapons) Mutation #10 (1,143 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 15%:
         Damage += 64
@@ -674,7 +674,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
         Sword (LightWeapons, FinesseWeapons) Mutation #11 (1,143 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 15%:
         Damage += 102
@@ -747,3 +747,79 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
         WieldRequirements = RawSkill
         WieldSkillType = WeaponSkill
         WieldDifficulty = 800
+
+Tier 11 Mutation #12:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 15%:
+        Damage += 190
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 10%:
+        Damage += 191
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 6%:
+        Damage += 192
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 4%:
+        Damage += 193
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 13%:
+        Damage += 202
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 10%:
+        Damage += 203
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 7%:
+        Damage += 204
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 5%:
+        Damage += 205
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 12%:
+        Damage += 214
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 8%:
+        Damage += 215
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 6%:
+        Damage += 216
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 4%:
+        Damage += 217
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175

--- a/Source/ACE.Server/Entity/Mutations/MeleeWeapons/Damage_WieldDifficulty_DamageVariance/light_finesse_sword_ms.txt
+++ b/Source/ACE.Server/Entity/Mutations/MeleeWeapons/Damage_WieldDifficulty_DamageVariance/light_finesse_sword_ms.txt
@@ -1,13 +1,13 @@
 SwordMS (LightWeapons, FinesseWeapons) Mutation #0:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 100%:
 	    Damage = 1
 
 SwordMS (LightWeapons, FinesseWeapons) Mutation #1 (79 samples):
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         Damage += 1
@@ -29,7 +29,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 SwordMS (LightWeapons, FinesseWeapons) Mutation #2 (140 samples):
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         Damage += 1
@@ -84,7 +84,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 SwordMS (LightWeapons, FinesseWeapons) Mutation #3 (130 samples):
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 3%:
         Damage += 5
@@ -142,7 +142,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 SwordMS (LightWeapons, FinesseWeapons) Mutation #4 (274 samples):
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         Damage += 10
@@ -182,7 +182,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 SwordMS (LightWeapons, FinesseWeapons) Mutation #5 (220 samples):
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         Damage += 13
@@ -216,7 +216,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 SwordMS (LightWeapons, FinesseWeapons) Mutation #6 (674 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 15%:
         Damage += 16
@@ -256,7 +256,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 SwordMS (LightWeapons, FinesseWeapons) Mutation #7 (163 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 10%:
         Damage += 20
@@ -296,7 +296,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 SwordMS (LightWeapons, FinesseWeapons) Mutation #8 (258 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 2%:
         Damage += 20
@@ -360,7 +360,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 SwordMS (LightWeapons, FinesseWeapons) Mutation #9:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 10%:
         DamageVariance = 0.45
@@ -379,7 +379,7 @@ Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
 SwordMS (LightWeapons, FinesseWeapons) Mutation #10 (1,143 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 15%:
         Damage += 40
@@ -479,7 +479,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
         SwordMS (LightWeapons, FinesseWeapons) Mutation #11 (1,143 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 15%:
         Damage += 60
@@ -552,3 +552,79 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
         WieldRequirements = RawSkill
         WieldSkillType = WeaponSkill
         WieldDifficulty = 800
+
+Tier 11 Mutation #12:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 15%:
+        Damage += 96
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 10%:
+        Damage += 97
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 6%:
+        Damage += 98
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 4%:
+        Damage += 99
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 13%:
+        Damage += 100
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 10%:
+        Damage += 101
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 7%:
+        Damage += 102
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 5%:
+        Damage += 103
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 12%:
+        Damage += 104
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 8%:
+        Damage += 105
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 6%:
+        Damage += 106
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 4%:
+        Damage += 107
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175

--- a/Source/ACE.Server/Entity/Mutations/MeleeWeapons/Damage_WieldDifficulty_DamageVariance/light_finesse_unarmed.txt
+++ b/Source/ACE.Server/Entity/Mutations/MeleeWeapons/Damage_WieldDifficulty_DamageVariance/light_finesse_unarmed.txt
@@ -1,13 +1,13 @@
 Unarmed (LightWeapons, FinesseWeapons) Mutation #0:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 100%:
 	    Damage = 6
 
 Unarmed (LightWeapons, FinesseWeapons) Mutation #1 (428 samples):
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 3%:
         Damage += 1
@@ -38,7 +38,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 Unarmed (LightWeapons, FinesseWeapons) Mutation #2 (793 samples):
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         Damage += 1
@@ -117,7 +117,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 Unarmed (LightWeapons, FinesseWeapons) Mutation #3 (679 samples):
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         Damage += 9
@@ -193,7 +193,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 Unarmed (LightWeapons, FinesseWeapons) Mutation #4 (1,560 samples):
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         Damage += 18
@@ -245,7 +245,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 Unarmed (LightWeapons, FinesseWeapons) Mutation #5 (1,461 samples):
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         Damage += 22
@@ -291,7 +291,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 Unarmed (LightWeapons, FinesseWeapons) Mutation #6 (3,949 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 15%:
         Damage += 26
@@ -355,7 +355,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 Unarmed (LightWeapons, FinesseWeapons) Mutation #7 (1,043 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 10%:
         Damage += 32
@@ -419,7 +419,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 Unarmed (LightWeapons, FinesseWeapons) Mutation #8 (1,492 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 1%:
         Damage += 32
@@ -507,7 +507,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 Unarmed (LightWeapons, FinesseWeapons) Mutation #9:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 10%:
         DamageVariance = 0.6
@@ -527,7 +527,7 @@ Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
 Unarmed (LightWeapons, FinesseWeapons) Mutation #10:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 15%:
         Damage += 55
@@ -627,7 +627,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
         Unarmed (LightWeapons, FinesseWeapons) Mutation #11:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 15%:
         Damage += 90
@@ -700,3 +700,79 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
         WieldRequirements = RawSkill
         WieldSkillType = WeaponSkill
         WieldDifficulty = 800
+
+Tier 11 Mutation #12:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 15%:
+        Damage += 172
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 10%:
+        Damage += 173
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 6%:
+        Damage += 174
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 4%:
+        Damage += 175
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 13%:
+        Damage += 184
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 10%:
+        Damage += 185
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 7%:
+        Damage += 186
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 5%:
+        Damage += 187
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 12%:
+        Damage += 196
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 8%:
+        Damage += 197
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 6%:
+        Damage += 198
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 4%:
+        Damage += 199
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175

--- a/Source/ACE.Server/Entity/Mutations/MeleeWeapons/Damage_WieldDifficulty_DamageVariance/two_handed_cleaver.txt
+++ b/Source/ACE.Server/Entity/Mutations/MeleeWeapons/Damage_WieldDifficulty_DamageVariance/two_handed_cleaver.txt
@@ -1,13 +1,13 @@
 Axe, Mace, Sword (TwoHandedCombat) Mutation #0:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 100%:
 	    Damage = 4
 
 Axe, Mace, Sword (TwoHandedCombat) Mutation #1 (483 samples):
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 3%:
         Damage += 1
@@ -38,7 +38,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 Axe, Mace, Sword (TwoHandedCombat) Mutation #2 (776 samples):
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         Damage += 1
@@ -117,7 +117,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 Axe, Mace, Sword (TwoHandedCombat) Mutation #3 (721 samples):
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         Damage += 9
@@ -187,7 +187,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 Axe, Mace, Sword (TwoHandedCombat) Mutation #4 (1,543 samples):
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         Damage += 17
@@ -233,7 +233,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 Axe, Mace, Sword (TwoHandedCombat) Mutation #5 (1,436 samples):
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         Damage += 20
@@ -279,7 +279,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 Axe, Mace, Sword (TwoHandedCombat) Mutation #6 (3,976 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 15%:
         Damage += 24
@@ -343,7 +343,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 Axe, Mace, Sword (TwoHandedCombat) Mutation #7 (1,045 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 15%:
         Damage += 30
@@ -401,7 +401,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 Axe, Mace, Sword (TwoHandedCombat) Mutation #8 (1,591 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 1%:
         Damage += 30
@@ -495,7 +495,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 Axe, Mace, Sword (TwoHandedCombat) Mutation #9:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 5%:
         DamageVariance = 0.55
@@ -517,7 +517,7 @@ Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
 Axe, Mace, Sword (TwoHandedCombat) Mutation #10:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 15%:
         Damage += 54
@@ -617,7 +617,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
         Axe, Mace, Sword (TwoHandedCombat) Mutation #11:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 15%:
         Damage += 88
@@ -690,3 +690,79 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
         WieldRequirements = RawSkill
         WieldSkillType = WeaponSkill
         WieldDifficulty = 800
+
+Tier 11 Mutation #12:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 15%:
+        Damage += 168
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 10%:
+        Damage += 169
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 6%:
+        Damage += 170
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 4%:
+        Damage += 171
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 13%:
+        Damage += 180
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 10%:
+        Damage += 181
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 7%:
+        Damage += 182
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 5%:
+        Damage += 183
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 12%:
+        Damage += 192
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 8%:
+        Damage += 193
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 6%:
+        Damage += 194
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 4%:
+        Damage += 195
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175

--- a/Source/ACE.Server/Entity/Mutations/MeleeWeapons/Damage_WieldDifficulty_DamageVariance/two_handed_spear.txt
+++ b/Source/ACE.Server/Entity/Mutations/MeleeWeapons/Damage_WieldDifficulty_DamageVariance/two_handed_spear.txt
@@ -1,13 +1,13 @@
 Spear (TwoHandedCombat) Mutation #0:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 100%:
 	    Damage = 5
 
 Spear (TwoHandedCombat) Mutation #1 (206 samples):
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 3%:
         Damage += 1
@@ -38,7 +38,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 Spear (TwoHandedCombat) Mutation #2 (388 samples):
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         Damage += 1
@@ -117,7 +117,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 Spear (TwoHandedCombat) Mutation #3 (369 samples):
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         Damage += 9
@@ -193,7 +193,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 Spear (TwoHandedCombat) Mutation #4 (774 samples):
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         Damage += 17
@@ -245,7 +245,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 Spear (TwoHandedCombat) Mutation #5 (691 samples):
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         Damage += 21
@@ -291,7 +291,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 Spear (TwoHandedCombat) Mutation #6 (1,872 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 15%:
         Damage += 25
@@ -361,7 +361,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 Spear (TwoHandedCombat) Mutation #7 (490 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 15%:
         Damage += 32
@@ -419,7 +419,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 Spear (TwoHandedCombat) Mutation #8 (690 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 1%:
         Damage += 32
@@ -507,7 +507,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 Spear (TwoHandedCombat) Mutation #9:
 
-Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
     - Chance: 5%:
         DamageVariance = 0.55
@@ -529,7 +529,7 @@ Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 
 Spear (TwoHandedCombat) Mutation #10:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 15%:
         Damage += 56
@@ -629,7 +629,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
         Spear (TwoHandedCombat) Mutation #11:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 15%:
         Damage += 91
@@ -702,3 +702,79 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
         WieldRequirements = RawSkill
         WieldSkillType = WeaponSkill
         WieldDifficulty = 800
+
+Tier 11 Mutation #12:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 15%:
+        Damage += 173
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 10%:
+        Damage += 174
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 6%:
+        Damage += 175
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 4%:
+        Damage += 176
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 13%:
+        Damage += 185
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 10%:
+        Damage += 186
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 7%:
+        Damage += 187
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 5%:
+        Damage += 188
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 12%:
+        Damage += 197
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 8%:
+        Damage += 198
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 6%:
+        Damage += 199
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175
+
+    - Chance: 4%:
+        Damage += 200
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1175

--- a/Source/ACE.Server/Entity/Mutations/MeleeWeapons/WeaponOffense_WeaponDefense/axe_offense_defense.txt
+++ b/Source/ACE.Server/Entity/Mutations/MeleeWeapons/WeaponOffense_WeaponDefense/axe_offense_defense.txt
@@ -1,6 +1,6 @@
 Axe (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #1:
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponOffense = 1.00
@@ -22,7 +22,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 Axe (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #2:
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponOffense = 1.02
@@ -44,7 +44,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 Axe (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #3:
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         WeaponOffense = 1.05
@@ -72,7 +72,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 Axe (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #4:
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponOffense = 1.07
@@ -100,7 +100,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 Axe (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #5:
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponOffense = 1.09
@@ -128,7 +128,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 Axe (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #6:
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponOffense = 1.10
@@ -156,7 +156,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 Axe (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #7:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 	- Chance: 25%:
         WeaponOffense = 1.15
@@ -184,7 +184,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 		
 Axe (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #8:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 	- Chance: 25%:
         WeaponOffense = 1.15
@@ -212,7 +212,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 Axe (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #9:
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 50%:
         WeaponDefense = 1.00
@@ -228,7 +228,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 Axe (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #10:
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         WeaponDefense = 1.00
@@ -247,7 +247,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 Axe (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #11:
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         WeaponDefense = 1.01
@@ -275,7 +275,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 Axe (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #12:
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponDefense = 1.03
@@ -303,7 +303,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 Axe (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #13:
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponDefense = 1.05
@@ -331,7 +331,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 Axe (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #14:
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponDefense = 1.06
@@ -359,7 +359,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 Axe (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #15:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 25%:
         WeaponDefense = 1.11
@@ -387,7 +387,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 		
 Axe (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #16:
 		
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 25%:
         WeaponDefense = 1.11
@@ -472,7 +472,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1
 
         Axe (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #19:
 		
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 25%:
         WeaponDefense = 1.23
@@ -500,7 +500,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
 
 Axe (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #20:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
 	- Chance: 25%:
         WeaponOffense = 1.23
@@ -525,3 +525,59 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
 
     - Chance: 2.5%:
         WeaponOffense = 1.30
+
+Tier 11 Mutation #21:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 25%:
+        WeaponDefense = 1.39
+
+    - Chance: 15%:
+        WeaponDefense = 1.4
+
+    - Chance: 20%:
+        WeaponDefense = 1.41
+
+    - Chance: 12.5%:
+        WeaponDefense = 1.42
+
+    - Chance: 12.5%:
+        WeaponDefense = 1.43
+
+    - Chance: 7.5%:
+        WeaponDefense = 1.44
+
+    - Chance: 5%:
+        WeaponDefense = 1.45
+
+    - Chance: 2.5%:
+        WeaponDefense = 1.46
+
+Tier 11 Mutation #22:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+	- Chance: 25%:
+        WeaponOffense = 1.39
+
+    - Chance: 15%:
+        WeaponOffense = 1.4
+
+    - Chance: 20%:
+        WeaponOffense = 1.41
+
+    - Chance: 12.5%:
+        WeaponOffense = 1.42
+
+    - Chance: 12.5%:
+        WeaponOffense = 1.43
+
+    - Chance: 7.5%:
+        WeaponOffense = 1.44
+
+    - Chance: 5%:
+        WeaponOffense = 1.45
+
+    - Chance: 2.5%:
+        WeaponOffense = 1.46

--- a/Source/ACE.Server/Entity/Mutations/MeleeWeapons/WeaponOffense_WeaponDefense/axe_offense_defense.txt
+++ b/Source/ACE.Server/Entity/Mutations/MeleeWeapons/WeaponOffense_WeaponDefense/axe_offense_defense.txt
@@ -416,7 +416,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 Axe (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #17:
 		
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 25%:
         WeaponDefense = 1.13
@@ -444,7 +444,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1
 
 Axe (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #18:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 	- Chance: 25%:
         WeaponOffense = 1.17

--- a/Source/ACE.Server/Entity/Mutations/MeleeWeapons/WeaponOffense_WeaponDefense/dagger_offense_defense.txt
+++ b/Source/ACE.Server/Entity/Mutations/MeleeWeapons/WeaponOffense_WeaponDefense/dagger_offense_defense.txt
@@ -368,7 +368,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 Dagger, DaggerMS (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #15:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 25%:
         WeaponDefense = 1.13
@@ -396,7 +396,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 Dagger, DaggerMS (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #16:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 25%:
         WeaponDefense = 1.13
@@ -425,7 +425,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 Dagger, DaggerMS (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #17:
 		
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 25%:
         WeaponDefense = 1.15
@@ -453,7 +453,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
 Dagger, DaggerMS (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #18:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 	- Chance: 25%:
         WeaponOffense = 1.15
@@ -481,7 +481,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
 Dagger, DaggerMS (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #19:
 		
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 25%:
         WeaponDefense = 1.23
@@ -509,7 +509,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
 
 Dagger, DaggerMS (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #20:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
 	- Chance: 25%:
         WeaponOffense = 1.23
@@ -534,3 +534,59 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
 
     - Chance: 2.5%:
         WeaponOffense = 1.30
+
+Tier 11 Mutation #21:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 25%:
+        WeaponDefense = 1.39
+
+    - Chance: 15%:
+        WeaponDefense = 1.4
+
+    - Chance: 20%:
+        WeaponDefense = 1.41
+
+    - Chance: 12.5%:
+        WeaponDefense = 1.42
+
+    - Chance: 12.5%:
+        WeaponDefense = 1.43
+
+    - Chance: 7.5%:
+        WeaponDefense = 1.44
+
+    - Chance: 5%:
+        WeaponDefense = 1.45
+
+    - Chance: 2.5%:
+        WeaponDefense = 1.46
+
+Tier 11 Mutation #22:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+	- Chance: 25%:
+        WeaponOffense = 1.39
+
+    - Chance: 15%:
+        WeaponOffense = 1.4
+
+    - Chance: 20%:
+        WeaponOffense = 1.41
+
+    - Chance: 12.5%:
+        WeaponOffense = 1.42
+
+    - Chance: 12.5%:
+        WeaponOffense = 1.43
+
+    - Chance: 7.5%:
+        WeaponOffense = 1.44
+
+    - Chance: 5%:
+        WeaponOffense = 1.45
+
+    - Chance: 2.5%:
+        WeaponOffense = 1.46

--- a/Source/ACE.Server/Entity/Mutations/MeleeWeapons/WeaponOffense_WeaponDefense/mace_jitte_offense_defense.txt
+++ b/Source/ACE.Server/Entity/Mutations/MeleeWeapons/WeaponOffense_WeaponDefense/mace_jitte_offense_defense.txt
@@ -1,6 +1,6 @@
 MaceJitte (FinesseWeapons) Mutation #1:
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 95%:
         WeaponOffense = 1.00
@@ -10,7 +10,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 MaceJitte (FinesseWeapons) Mutation #2:
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 95%:
         WeaponOffense = 1.00
@@ -20,7 +20,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 MaceJitte (FinesseWeapons) Mutation #3:
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         WeaponOffense = 1.00
@@ -42,7 +42,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 MaceJitte (FinesseWeapons) Mutation #4:
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponOffense = 1.00
@@ -70,7 +70,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 MaceJitte (FinesseWeapons) Mutation #5:
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponOffense = 1.02
@@ -98,7 +98,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 MaceJitte (FinesseWeapons) Mutation #6:
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponOffense = 1.03
@@ -126,7 +126,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 MaceJitte (FinesseWeapons) Mutation #7:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 25%:
         WeaponOffense = 1.08
@@ -154,7 +154,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 MaceJitte (FinesseWeapons) Mutation #8:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 25%:
         WeaponOffense = 1.08
@@ -182,7 +182,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 MaceJitte (FinesseWeapons) Mutation #9:
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponDefense = 1.00
@@ -204,7 +204,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 MaceJitte (FinesseWeapons) Mutation #10:
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponDefense = 1.05
@@ -226,7 +226,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 MaceJitte (FinesseWeapons) Mutation #11:
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         WeaponDefense = 1.08
@@ -254,7 +254,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 MaceJitte (FinesseWeapons) Mutation #12:
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponDefense = 1.10
@@ -282,7 +282,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 MaceJitte (FinesseWeapons) Mutation #13:
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponDefense = 1.12
@@ -310,7 +310,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 MaceJitte (FinesseWeapons) Mutation #14:
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponDefense = 1.13
@@ -338,7 +338,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 MaceJitte (FinesseWeapons) Mutation #15:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 25%:
         WeaponDefense = 1.18
@@ -366,7 +366,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 MaceJitte (FinesseWeapons) Mutation #16:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 25%:
         WeaponDefense = 1.18
@@ -394,7 +394,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 MaceJitte (FinesseWeapons) Mutation #17:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 25%:
         WeaponDefense = 1.20
@@ -422,7 +422,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
 MaceJitte (FinesseWeapons) Mutation #18:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 	- Chance: 25%:
         WeaponOffense = 1.10
@@ -450,7 +450,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
 MaceJitte (FinesseWeapons) Mutation #19:
 		
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 25%:
         WeaponDefense = 1.23
@@ -478,7 +478,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
 
 MaceJitte (FinesseWeapons) Mutation #20:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
 	- Chance: 25%:
         WeaponOffense = 1.23
@@ -503,3 +503,59 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
 
     - Chance: 2.5%:
         WeaponOffense = 1.30
+
+Tier 11 Mutation #21:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 25%:
+        WeaponDefense = 1.39
+
+    - Chance: 15%:
+        WeaponDefense = 1.4
+
+    - Chance: 20%:
+        WeaponDefense = 1.41
+
+    - Chance: 12.5%:
+        WeaponDefense = 1.42
+
+    - Chance: 12.5%:
+        WeaponDefense = 1.43
+
+    - Chance: 7.5%:
+        WeaponDefense = 1.44
+
+    - Chance: 5%:
+        WeaponDefense = 1.45
+
+    - Chance: 2.5%:
+        WeaponDefense = 1.46
+
+Tier 11 Mutation #22:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+	- Chance: 25%:
+        WeaponOffense = 1.39
+
+    - Chance: 15%:
+        WeaponOffense = 1.4
+
+    - Chance: 20%:
+        WeaponOffense = 1.41
+
+    - Chance: 12.5%:
+        WeaponOffense = 1.42
+
+    - Chance: 12.5%:
+        WeaponOffense = 1.43
+
+    - Chance: 7.5%:
+        WeaponOffense = 1.44
+
+    - Chance: 5%:
+        WeaponOffense = 1.45
+
+    - Chance: 2.5%:
+        WeaponOffense = 1.46

--- a/Source/ACE.Server/Entity/Mutations/MeleeWeapons/WeaponOffense_WeaponDefense/mace_offense_defense.txt
+++ b/Source/ACE.Server/Entity/Mutations/MeleeWeapons/WeaponOffense_WeaponDefense/mace_offense_defense.txt
@@ -1,6 +1,6 @@
 Mace (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #1:
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 50%:
         WeaponOffense = 1.00
@@ -16,7 +16,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 Mace (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #2:
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         WeaponOffense = 1.00
@@ -35,7 +35,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 Mace (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #3:
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         WeaponOffense = 1.01
@@ -63,7 +63,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 Mace (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #4:
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponOffense = 1.03
@@ -91,7 +91,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 Mace (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #5:
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponOffense = 1.05
@@ -119,7 +119,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 Mace (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #6:
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponOffense = 1.06
@@ -147,7 +147,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 Mace (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #7:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 25%:
         WeaponOffense = 1.11
@@ -175,7 +175,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 Mace (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #8:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 25%:
         WeaponOffense = 1.11
@@ -203,7 +203,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 Mace (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #9:
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponDefense = 1.00
@@ -225,7 +225,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 Mace (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #10:
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponDefense = 1.02
@@ -247,7 +247,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 Mace (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #11:
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         WeaponDefense = 1.05
@@ -275,7 +275,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 Mace (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #12:
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponDefense = 1.07
@@ -303,7 +303,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 Mace (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #13:
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponDefense = 1.09
@@ -331,7 +331,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 Mace (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #14:
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponDefense = 1.10
@@ -359,7 +359,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 Mace (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #15:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 25%:
         WeaponDefense = 1.15
@@ -387,7 +387,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 Mace (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #16:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 25%:
         WeaponDefense = 1.15
@@ -415,7 +415,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 Mace (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #17:
 		
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 25%:
         WeaponDefense = 1.17
@@ -443,7 +443,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
 Mace (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #18:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 	- Chance: 25%:
         WeaponOffense = 1.13
@@ -471,7 +471,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
 Mace (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #19:
 		
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 25%:
         WeaponDefense = 1.23
@@ -499,7 +499,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
 
 Mace (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #20:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
 	- Chance: 25%:
         WeaponOffense = 1.23
@@ -524,3 +524,59 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
 
     - Chance: 2.5%:
         WeaponOffense = 1.30
+
+Tier 11 Mutation #21:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 25%:
+        WeaponDefense = 1.39
+
+    - Chance: 15%:
+        WeaponDefense = 1.4
+
+    - Chance: 20%:
+        WeaponDefense = 1.41
+
+    - Chance: 12.5%:
+        WeaponDefense = 1.42
+
+    - Chance: 12.5%:
+        WeaponDefense = 1.43
+
+    - Chance: 7.5%:
+        WeaponDefense = 1.44
+
+    - Chance: 5%:
+        WeaponDefense = 1.45
+
+    - Chance: 2.5%:
+        WeaponDefense = 1.46
+
+Tier 11 Mutation #22:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+	- Chance: 25%:
+        WeaponOffense = 1.39
+
+    - Chance: 15%:
+        WeaponOffense = 1.4
+
+    - Chance: 20%:
+        WeaponOffense = 1.41
+
+    - Chance: 12.5%:
+        WeaponOffense = 1.42
+
+    - Chance: 12.5%:
+        WeaponOffense = 1.43
+
+    - Chance: 7.5%:
+        WeaponOffense = 1.44
+
+    - Chance: 5%:
+        WeaponOffense = 1.45
+
+    - Chance: 2.5%:
+        WeaponOffense = 1.46

--- a/Source/ACE.Server/Entity/Mutations/MeleeWeapons/WeaponOffense_WeaponDefense/spear_offense_defense.txt
+++ b/Source/ACE.Server/Entity/Mutations/MeleeWeapons/WeaponOffense_WeaponDefense/spear_offense_defense.txt
@@ -1,6 +1,6 @@
 Spear (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #1:
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponOffense = 1.00
@@ -22,7 +22,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 Spear (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #2:
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponOffense = 1.05
@@ -44,7 +44,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 Spear (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #3:
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         WeaponOffense = 1.08
@@ -72,7 +72,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 Spear (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #4:
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponOffense = 1.10
@@ -100,7 +100,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 Spear (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #5:
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponOffense = 1.12
@@ -128,7 +128,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 Spear (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #6:
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponOffense = 1.13
@@ -156,7 +156,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 Spear (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #7:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 25%:
         WeaponOffense = 1.18
@@ -184,7 +184,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 Spear (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #8:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 25%:
         WeaponOffense = 1.18
@@ -212,7 +212,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 Spear (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #9:
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 95%:
         WeaponDefense = 1.00
@@ -222,7 +222,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 Spear (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #10:
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 95%:
         WeaponDefense = 1.00
@@ -232,7 +232,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 Spear (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #11:
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         WeaponDefense = 1.00
@@ -254,7 +254,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 Spear (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #12:
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponDefense = 1.00
@@ -282,7 +282,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 Spear (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #13:
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponDefense = 1.02
@@ -310,7 +310,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 Spear (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #14:
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponDefense = 1.03
@@ -338,7 +338,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 Spear (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #15:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 	- Chance: 25%:
         WeaponDefense = 1.08
@@ -366,7 +366,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 Spear (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #16:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 25%:
         WeaponDefense = 1.08
@@ -394,7 +394,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 Spear (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #17:
 		
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 25%:
         WeaponDefense = 1.10
@@ -422,7 +422,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
 Spear (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #18:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 	- Chance: 25%:
         WeaponOffense = 1.20
@@ -450,7 +450,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
 Spear (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #19:
 		
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 25%:
         WeaponDefense = 1.23
@@ -478,7 +478,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
 
 Spear (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #20:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
 	- Chance: 25%:
         WeaponOffense = 1.23
@@ -503,3 +503,59 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
 
     - Chance: 2.5%:
         WeaponOffense = 1.30
+
+Tier 11 Mutation #21:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 25%:
+        WeaponDefense = 1.39
+
+    - Chance: 15%:
+        WeaponDefense = 1.4
+
+    - Chance: 20%:
+        WeaponDefense = 1.41
+
+    - Chance: 12.5%:
+        WeaponDefense = 1.42
+
+    - Chance: 12.5%:
+        WeaponDefense = 1.43
+
+    - Chance: 7.5%:
+        WeaponDefense = 1.44
+
+    - Chance: 5%:
+        WeaponDefense = 1.45
+
+    - Chance: 2.5%:
+        WeaponDefense = 1.46
+
+Tier 11 Mutation #22:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+	- Chance: 25%:
+        WeaponOffense = 1.39
+
+    - Chance: 15%:
+        WeaponOffense = 1.4
+
+    - Chance: 20%:
+        WeaponOffense = 1.41
+
+    - Chance: 12.5%:
+        WeaponOffense = 1.42
+
+    - Chance: 12.5%:
+        WeaponOffense = 1.43
+
+    - Chance: 7.5%:
+        WeaponOffense = 1.44
+
+    - Chance: 5%:
+        WeaponOffense = 1.45
+
+    - Chance: 2.5%:
+        WeaponOffense = 1.46

--- a/Source/ACE.Server/Entity/Mutations/MeleeWeapons/WeaponOffense_WeaponDefense/staff_offense_defense.txt
+++ b/Source/ACE.Server/Entity/Mutations/MeleeWeapons/WeaponOffense_WeaponDefense/staff_offense_defense.txt
@@ -1,6 +1,6 @@
 Staff (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #1:
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 95%:
         WeaponOffense = 1.00
@@ -10,7 +10,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 Staff (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #2:
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 95%:
         WeaponOffense = 1.00
@@ -20,7 +20,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 Staff (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #3:
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         WeaponOffense = 1.00
@@ -42,7 +42,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 Staff (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #4:
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponOffense = 1.00
@@ -70,7 +70,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 Staff (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #5:
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponOffense = 1.02
@@ -98,7 +98,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 Staff (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #6:
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponOffense = 1.03
@@ -126,7 +126,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 Staff (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #7:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 25%:
         WeaponOffense = 1.08
@@ -154,7 +154,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 Staff (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #8:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 25%:
         WeaponOffense = 1.08
@@ -182,7 +182,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 Staff (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #9:
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponDefense = 1.00
@@ -204,7 +204,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 Staff (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #10:
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponDefense = 1.05
@@ -226,7 +226,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 Staff (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #11:
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         WeaponDefense = 1.08
@@ -254,7 +254,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 Staff (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #12:
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponDefense = 1.10
@@ -282,7 +282,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 Staff (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #13:
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponDefense = 1.12
@@ -310,7 +310,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 Staff (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #14:
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponDefense = 1.13
@@ -338,7 +338,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 Staff (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #15:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 25%:
         WeaponDefense = 1.18
@@ -366,7 +366,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 Staff (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #16:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 25%:
         WeaponDefense = 1.18
@@ -394,7 +394,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 Staff (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #17:
 		
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 25%:
         WeaponDefense = 1.20
@@ -422,7 +422,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
 Staff (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #18:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 	- Chance: 25%:
         WeaponOffense = 1.10
@@ -450,7 +450,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
 Staff (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #19:
 		
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 25%:
         WeaponDefense = 1.23
@@ -478,7 +478,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
 
 Staff (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #20:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
 	- Chance: 25%:
         WeaponOffense = 1.23
@@ -503,3 +503,59 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
 
     - Chance: 2.5%:
         WeaponOffense = 1.30
+
+Tier 11 Mutation #21:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 25%:
+        WeaponDefense = 1.39
+
+    - Chance: 15%:
+        WeaponDefense = 1.4
+
+    - Chance: 20%:
+        WeaponDefense = 1.41
+
+    - Chance: 12.5%:
+        WeaponDefense = 1.42
+
+    - Chance: 12.5%:
+        WeaponDefense = 1.43
+
+    - Chance: 7.5%:
+        WeaponDefense = 1.44
+
+    - Chance: 5%:
+        WeaponDefense = 1.45
+
+    - Chance: 2.5%:
+        WeaponDefense = 1.46
+
+Tier 11 Mutation #22:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+	- Chance: 25%:
+        WeaponOffense = 1.39
+
+    - Chance: 15%:
+        WeaponOffense = 1.4
+
+    - Chance: 20%:
+        WeaponOffense = 1.41
+
+    - Chance: 12.5%:
+        WeaponOffense = 1.42
+
+    - Chance: 12.5%:
+        WeaponOffense = 1.43
+
+    - Chance: 7.5%:
+        WeaponOffense = 1.44
+
+    - Chance: 5%:
+        WeaponOffense = 1.45
+
+    - Chance: 2.5%:
+        WeaponOffense = 1.46

--- a/Source/ACE.Server/Entity/Mutations/MeleeWeapons/WeaponOffense_WeaponDefense/sword_offense_defense.txt
+++ b/Source/ACE.Server/Entity/Mutations/MeleeWeapons/WeaponOffense_WeaponDefense/sword_offense_defense.txt
@@ -1,6 +1,6 @@
 Sword, SwordMS (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #1:
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponOffense = 1.00
@@ -22,7 +22,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 Sword, SwordMS (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #2:
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponOffense = 1.01
@@ -44,7 +44,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 Sword, SwordMS (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #3:
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         WeaponOffense = 1.03
@@ -72,7 +72,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 Sword, SwordMS (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #4:
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponOffense = 1.05
@@ -100,7 +100,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 Sword, SwordMS (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #5:
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponOffense = 1.07
@@ -128,7 +128,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 Sword, SwordMS (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #6:
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponOffense = 1.08
@@ -156,7 +156,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 Sword, SwordMS (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #7:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 25%:
         WeaponOffense = 1.13
@@ -184,7 +184,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 Sword, SwordMS (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #8:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 25%:
         WeaponOffense = 1.13
@@ -212,7 +212,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 Sword, SwordMS (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #9:
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponDefense = 1.00
@@ -234,7 +234,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 Sword, SwordMS (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #10:
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponDefense = 1.01
@@ -256,7 +256,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 Sword, SwordMS (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #11:
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         WeaponDefense = 1.03
@@ -284,7 +284,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 Sword, SwordMS (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #12:
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponDefense = 1.05
@@ -312,7 +312,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 Sword, SwordMS (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #13:
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponDefense = 1.07
@@ -340,7 +340,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 Sword, SwordMS (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #14:
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponDefense = 1.08
@@ -368,7 +368,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 Sword, SwordMS (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #15:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 25%:
         WeaponDefense = 1.13
@@ -396,7 +396,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 Sword, SwordMS (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #16:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 25%:
         WeaponDefense = 1.13
@@ -424,7 +424,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 Sword, SwordMS (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #17:
 		
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 25%:
         WeaponDefense = 1.15
@@ -452,7 +452,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
 Sword, SwordMS (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #18:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 	- Chance: 25%:
         WeaponOffense = 1.15
@@ -480,7 +480,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
 Sword, SwordMS (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #19:
 		
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 25%:
         WeaponDefense = 1.23
@@ -508,7 +508,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
 
 Sword, SwordMS (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #20:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
 	- Chance: 25%:
         WeaponOffense = 1.23
@@ -533,3 +533,59 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
 
     - Chance: 2.5%:
         WeaponOffense = 1.30
+
+Tier 11 Mutation #21:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 25%:
+        WeaponDefense = 1.39
+
+    - Chance: 15%:
+        WeaponDefense = 1.4
+
+    - Chance: 20%:
+        WeaponDefense = 1.41
+
+    - Chance: 12.5%:
+        WeaponDefense = 1.42
+
+    - Chance: 12.5%:
+        WeaponDefense = 1.43
+
+    - Chance: 7.5%:
+        WeaponDefense = 1.44
+
+    - Chance: 5%:
+        WeaponDefense = 1.45
+
+    - Chance: 2.5%:
+        WeaponDefense = 1.46
+
+Tier 11 Mutation #22:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+	- Chance: 25%:
+        WeaponOffense = 1.39
+
+    - Chance: 15%:
+        WeaponOffense = 1.4
+
+    - Chance: 20%:
+        WeaponOffense = 1.41
+
+    - Chance: 12.5%:
+        WeaponOffense = 1.42
+
+    - Chance: 12.5%:
+        WeaponOffense = 1.43
+
+    - Chance: 7.5%:
+        WeaponOffense = 1.44
+
+    - Chance: 5%:
+        WeaponOffense = 1.45
+
+    - Chance: 2.5%:
+        WeaponOffense = 1.46

--- a/Source/ACE.Server/Entity/Mutations/MeleeWeapons/WeaponOffense_WeaponDefense/two_handed_axe_offense_defense.txt
+++ b/Source/ACE.Server/Entity/Mutations/MeleeWeapons/WeaponOffense_WeaponDefense/two_handed_axe_offense_defense.txt
@@ -1,6 +1,6 @@
 Axe (TwoHandedCombat) Mutation #1:
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponOffense = 1.00
@@ -22,7 +22,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 Axe (TwoHandedCombat) Mutation #2:
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponOffense = 1.02
@@ -44,7 +44,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 Axe (TwoHandedCombat) Mutation #3:
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         WeaponOffense = 1.05
@@ -72,7 +72,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 Axe (TwoHandedCombat) Mutation #4:
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponOffense = 1.07
@@ -100,7 +100,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 Axe (TwoHandedCombat) Mutation #5:
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponOffense = 1.09
@@ -128,7 +128,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 Axe (TwoHandedCombat) Mutation #6:
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponOffense = 1.10
@@ -156,7 +156,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 Axe (TwoHandedCombat) Mutation #7:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 25%:
         WeaponOffense = 1.15
@@ -184,7 +184,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 Axe (TwoHandedCombat) Mutation #8:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 25%:
         WeaponOffense = 1.15
@@ -212,7 +212,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 Axe (TwoHandedCombat) Mutation #9:
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 50%:
         WeaponDefense = 1.00
@@ -228,7 +228,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 Axe (TwoHandedCombat) Mutation #10:
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         WeaponDefense = 1.00
@@ -247,7 +247,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 Axe (TwoHandedCombat) Mutation #11:
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponDefense = 1.02
@@ -269,7 +269,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 Axe (TwoHandedCombat) Mutation #12:
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponDefense = 1.03
@@ -297,7 +297,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 Axe (TwoHandedCombat) Mutation #13:
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponDefense = 1.05
@@ -325,7 +325,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 Axe (TwoHandedCombat) Mutation #14:
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponDefense = 1.06
@@ -353,7 +353,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 Axe (TwoHandedCombat) Mutation #15:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 25%:
         WeaponDefense = 1.11
@@ -381,7 +381,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 Axe (TwoHandedCombat) Mutation #16:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 25%:
         WeaponDefense = 1.11
@@ -409,7 +409,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 Axe (TwoHandedCombat) Mutation #17:
 		
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 25%:
         WeaponDefense = 1.13
@@ -437,7 +437,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
 Axe (TwoHandedCombat) Mutation #18:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 	- Chance: 25%:
         WeaponOffense = 1.17
@@ -465,7 +465,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
 Axe (TwoHandedCombat) Mutation #19:
 		
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 25%:
         WeaponDefense = 1.23
@@ -493,7 +493,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
 
 Axe (TwoHandedCombat) Mutation #20:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
 	- Chance: 25%:
         WeaponOffense = 1.23
@@ -518,3 +518,59 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
 
     - Chance: 2.5%:
         WeaponOffense = 1.30
+
+Tier 11 Mutation #21:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 25%:
+        WeaponDefense = 1.39
+
+    - Chance: 15%:
+        WeaponDefense = 1.4
+
+    - Chance: 20%:
+        WeaponDefense = 1.41
+
+    - Chance: 12.5%:
+        WeaponDefense = 1.42
+
+    - Chance: 12.5%:
+        WeaponDefense = 1.43
+
+    - Chance: 7.5%:
+        WeaponDefense = 1.44
+
+    - Chance: 5%:
+        WeaponDefense = 1.45
+
+    - Chance: 2.5%:
+        WeaponDefense = 1.46
+
+Tier 11 Mutation #22:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+	- Chance: 25%:
+        WeaponOffense = 1.39
+
+    - Chance: 15%:
+        WeaponOffense = 1.4
+
+    - Chance: 20%:
+        WeaponOffense = 1.41
+
+    - Chance: 12.5%:
+        WeaponOffense = 1.42
+
+    - Chance: 12.5%:
+        WeaponOffense = 1.43
+
+    - Chance: 7.5%:
+        WeaponOffense = 1.44
+
+    - Chance: 5%:
+        WeaponOffense = 1.45
+
+    - Chance: 2.5%:
+        WeaponOffense = 1.46

--- a/Source/ACE.Server/Entity/Mutations/MeleeWeapons/WeaponOffense_WeaponDefense/two_handed_mace_offense_defense.txt
+++ b/Source/ACE.Server/Entity/Mutations/MeleeWeapons/WeaponOffense_WeaponDefense/two_handed_mace_offense_defense.txt
@@ -1,6 +1,6 @@
 Mace (TwoHandedCombat) Mutation #1:
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponOffense = 1.00
@@ -22,7 +22,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 Mace (TwoHandedCombat) Mutation #2:
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponOffense = 1.02
@@ -44,7 +44,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 Mace (TwoHandedCombat) Mutation #3:
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         WeaponOffense = 1.05
@@ -72,7 +72,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 Mace (TwoHandedCombat) Mutation #4:
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponOffense = 1.07
@@ -100,7 +100,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 Mace (TwoHandedCombat) Mutation #5:
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponOffense = 1.09
@@ -128,7 +128,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 Mace (TwoHandedCombat) Mutation #6:
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponOffense = 1.10
@@ -156,7 +156,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 Mace (TwoHandedCombat) Mutation #7:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 25%:
         WeaponOffense = 1.15
@@ -184,7 +184,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 Mace (TwoHandedCombat) Mutation #8:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 25%:
         WeaponOffense = 1.15
@@ -212,7 +212,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 Mace (TwoHandedCombat) Mutation #9:
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 50%:
         WeaponDefense = 1.00
@@ -228,7 +228,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 Mace (TwoHandedCombat) Mutation #10:
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         WeaponDefense = 1.00
@@ -247,7 +247,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 Mace (TwoHandedCombat) Mutation #11:
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         WeaponDefense = 1.01
@@ -275,7 +275,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 Mace (TwoHandedCombat) Mutation #12:
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponDefense = 1.03
@@ -303,7 +303,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 Mace (TwoHandedCombat) Mutation #13:
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponDefense = 1.05
@@ -331,7 +331,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 Mace (TwoHandedCombat) Mutation #14:
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponDefense = 1.06
@@ -359,7 +359,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 Mace (TwoHandedCombat) Mutation #15:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 25%:
         WeaponDefense = 1.11
@@ -387,7 +387,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 Mace (TwoHandedCombat) Mutation #16:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 25%:
         WeaponDefense = 1.11
@@ -415,7 +415,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 Mace (TwoHandedCombat) Mutation #17:
 		
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 25%:
         WeaponDefense = 1.13
@@ -443,7 +443,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
 Mace (TwoHandedCombat) Mutation #18:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 	- Chance: 25%:
         WeaponOffense = 1.17
@@ -471,7 +471,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
 Mace (TwoHandedCombat) Mutation #19:
 		
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 25%:
         WeaponDefense = 1.23
@@ -499,7 +499,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
 
 Mace (TwoHandedCombat) Mutation #20:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
 	- Chance: 25%:
         WeaponOffense = 1.23
@@ -524,3 +524,59 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
 
     - Chance: 2.5%:
         WeaponOffense = 1.30
+
+Tier 11 Mutation #21:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 25%:
+        WeaponDefense = 1.39
+
+    - Chance: 15%:
+        WeaponDefense = 1.4
+
+    - Chance: 20%:
+        WeaponDefense = 1.41
+
+    - Chance: 12.5%:
+        WeaponDefense = 1.42
+
+    - Chance: 12.5%:
+        WeaponDefense = 1.43
+
+    - Chance: 7.5%:
+        WeaponDefense = 1.44
+
+    - Chance: 5%:
+        WeaponDefense = 1.45
+
+    - Chance: 2.5%:
+        WeaponDefense = 1.46
+
+Tier 11 Mutation #22:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+	- Chance: 25%:
+        WeaponOffense = 1.39
+
+    - Chance: 15%:
+        WeaponOffense = 1.4
+
+    - Chance: 20%:
+        WeaponOffense = 1.41
+
+    - Chance: 12.5%:
+        WeaponOffense = 1.42
+
+    - Chance: 12.5%:
+        WeaponOffense = 1.43
+
+    - Chance: 7.5%:
+        WeaponOffense = 1.44
+
+    - Chance: 5%:
+        WeaponOffense = 1.45
+
+    - Chance: 2.5%:
+        WeaponOffense = 1.46

--- a/Source/ACE.Server/Entity/Mutations/MeleeWeapons/WeaponOffense_WeaponDefense/two_handed_spear_offense_defense.txt
+++ b/Source/ACE.Server/Entity/Mutations/MeleeWeapons/WeaponOffense_WeaponDefense/two_handed_spear_offense_defense.txt
@@ -1,6 +1,6 @@
 Spear (TwoHandedCombat) Mutation #1:
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponOffense = 1.00
@@ -22,7 +22,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 Spear (TwoHandedCombat) Mutation #2:
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponOffense = 1.01
@@ -44,7 +44,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 Spear (TwoHandedCombat) Mutation #3:
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         WeaponOffense = 1.03
@@ -72,7 +72,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 Spear (TwoHandedCombat) Mutation #4:
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponOffense = 1.05
@@ -100,7 +100,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 Spear (TwoHandedCombat) Mutation #5:
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponOffense = 1.07
@@ -128,7 +128,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 Spear (TwoHandedCombat) Mutation #6:
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponOffense = 1.08
@@ -156,7 +156,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 Spear (TwoHandedCombat) Mutation #7:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 25%:
         WeaponOffense = 1.13
@@ -184,7 +184,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 Spear (TwoHandedCombat) Mutation #8:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 25%:
         WeaponOffense = 1.13
@@ -212,7 +212,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 Spear (TwoHandedCombat) Mutation #9:
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponDefense = 1.00
@@ -234,7 +234,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 Spear (TwoHandedCombat) Mutation #10:
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponDefense = 1.01
@@ -256,7 +256,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 Spear (TwoHandedCombat) Mutation #11:
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         WeaponDefense = 1.03
@@ -284,7 +284,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 Spear (TwoHandedCombat) Mutation #12:
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponDefense = 1.05
@@ -312,7 +312,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 Spear (TwoHandedCombat) Mutation #13:
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponDefense = 1.07
@@ -340,7 +340,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 Spear (TwoHandedCombat) Mutation #14:
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponDefense = 1.08
@@ -368,7 +368,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 Spear (TwoHandedCombat) Mutation #15:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 25%:
         WeaponDefense = 1.13
@@ -396,7 +396,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 Spear (TwoHandedCombat) Mutation #16:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 25%:
         WeaponDefense = 1.13
@@ -424,7 +424,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 Spear (TwoHandedCombat) Mutation #17:
 		
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 25%:
         WeaponDefense = 1.15
@@ -452,7 +452,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
 Spear (TwoHandedCombat) Mutation #18:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 	- Chance: 25%:
         WeaponOffense = 1.15
@@ -480,7 +480,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
 Spear (TwoHandedCombat) Mutation #19:
 		
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 25%:
         WeaponDefense = 1.23
@@ -508,7 +508,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
 
 Spear (TwoHandedCombat) Mutation #20:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
 	- Chance: 25%:
         WeaponOffense = 1.23
@@ -533,3 +533,59 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
 
     - Chance: 2.5%:
         WeaponOffense = 1.30
+
+Tier 11 Mutation #21:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 25%:
+        WeaponDefense = 1.39
+
+    - Chance: 15%:
+        WeaponDefense = 1.4
+
+    - Chance: 20%:
+        WeaponDefense = 1.41
+
+    - Chance: 12.5%:
+        WeaponDefense = 1.42
+
+    - Chance: 12.5%:
+        WeaponDefense = 1.43
+
+    - Chance: 7.5%:
+        WeaponDefense = 1.44
+
+    - Chance: 5%:
+        WeaponDefense = 1.45
+
+    - Chance: 2.5%:
+        WeaponDefense = 1.46
+
+Tier 11 Mutation #22:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+	- Chance: 25%:
+        WeaponOffense = 1.39
+
+    - Chance: 15%:
+        WeaponOffense = 1.4
+
+    - Chance: 20%:
+        WeaponOffense = 1.41
+
+    - Chance: 12.5%:
+        WeaponOffense = 1.42
+
+    - Chance: 12.5%:
+        WeaponOffense = 1.43
+
+    - Chance: 7.5%:
+        WeaponOffense = 1.44
+
+    - Chance: 5%:
+        WeaponOffense = 1.45
+
+    - Chance: 2.5%:
+        WeaponOffense = 1.46

--- a/Source/ACE.Server/Entity/Mutations/MeleeWeapons/WeaponOffense_WeaponDefense/two_handed_sword_offense_defense.txt
+++ b/Source/ACE.Server/Entity/Mutations/MeleeWeapons/WeaponOffense_WeaponDefense/two_handed_sword_offense_defense.txt
@@ -1,6 +1,6 @@
 Sword (TwoHandedCombat) Mutation #1:
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponOffense = 1.00
@@ -22,7 +22,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 Sword (TwoHandedCombat) Mutation #2:
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponOffense = 1.02
@@ -44,7 +44,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 Sword (TwoHandedCombat) Mutation #3:
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         WeaponOffense = 1.05
@@ -72,7 +72,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 Sword (TwoHandedCombat) Mutation #4:
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponOffense = 1.07
@@ -100,7 +100,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 Sword (TwoHandedCombat) Mutation #5:
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponOffense = 1.09
@@ -128,7 +128,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 Sword (TwoHandedCombat) Mutation #6:
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponOffense = 1.10
@@ -156,7 +156,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 Sword (TwoHandedCombat) Mutation #7:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 25%:
         WeaponOffense = 1.15
@@ -184,7 +184,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 Sword (TwoHandedCombat) Mutation #8:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 25%:
         WeaponOffense = 1.15
@@ -212,7 +212,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 Sword (TwoHandedCombat) Mutation #9:
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 50%:
         WeaponDefense = 1.00
@@ -228,7 +228,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 Sword (TwoHandedCombat) Mutation #10:
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 20%:
         WeaponDefense = 1.00
@@ -247,7 +247,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 Sword (TwoHandedCombat) Mutation #11:
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         WeaponDefense = 1.01
@@ -275,7 +275,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 Sword (TwoHandedCombat) Mutation #12:
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponDefense = 1.03
@@ -303,7 +303,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 Sword (TwoHandedCombat) Mutation #13:
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponDefense = 1.05
@@ -331,7 +331,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 Sword (TwoHandedCombat) Mutation #14:
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponDefense = 1.06
@@ -359,7 +359,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 Sword (TwoHandedCombat) Mutation #15:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 25%:
         WeaponDefense = 1.11
@@ -387,7 +387,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 Sword (TwoHandedCombat) Mutation #16:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 25%:
         WeaponDefense = 1.11
@@ -415,7 +415,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 Sword (TwoHandedCombat) Mutation #17:
 		
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 25%:
         WeaponDefense = 1.13
@@ -443,7 +443,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
 Sword (TwoHandedCombat) Mutation #18:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 	- Chance: 25%:
         WeaponOffense = 1.17
@@ -471,7 +471,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
 Sword (TwoHandedCombat) Mutation #19:
 		
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 25%:
         WeaponDefense = 1.23
@@ -499,7 +499,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
 
 Sword (TwoHandedCombat) Mutation #20:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
 	- Chance: 25%:
         WeaponOffense = 1.23
@@ -524,3 +524,59 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
 
     - Chance: 2.5%:
         WeaponOffense = 1.30
+
+Tier 11 Mutation #21:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 25%:
+        WeaponDefense = 1.39
+
+    - Chance: 15%:
+        WeaponDefense = 1.4
+
+    - Chance: 20%:
+        WeaponDefense = 1.41
+
+    - Chance: 12.5%:
+        WeaponDefense = 1.42
+
+    - Chance: 12.5%:
+        WeaponDefense = 1.43
+
+    - Chance: 7.5%:
+        WeaponDefense = 1.44
+
+    - Chance: 5%:
+        WeaponDefense = 1.45
+
+    - Chance: 2.5%:
+        WeaponDefense = 1.46
+
+Tier 11 Mutation #22:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+	- Chance: 25%:
+        WeaponOffense = 1.39
+
+    - Chance: 15%:
+        WeaponOffense = 1.4
+
+    - Chance: 20%:
+        WeaponOffense = 1.41
+
+    - Chance: 12.5%:
+        WeaponOffense = 1.42
+
+    - Chance: 12.5%:
+        WeaponOffense = 1.43
+
+    - Chance: 7.5%:
+        WeaponOffense = 1.44
+
+    - Chance: 5%:
+        WeaponOffense = 1.45
+
+    - Chance: 2.5%:
+        WeaponOffense = 1.46

--- a/Source/ACE.Server/Entity/Mutations/MeleeWeapons/WeaponOffense_WeaponDefense/unarmed_offense_defense.txt
+++ b/Source/ACE.Server/Entity/Mutations/MeleeWeapons/WeaponOffense_WeaponDefense/unarmed_offense_defense.txt
@@ -1,6 +1,6 @@
 Unarmed (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #1:
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponOffense = 1.00
@@ -22,7 +22,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 Unarmed (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #2:
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponOffense = 1.01
@@ -44,7 +44,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 Unarmed (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #3:
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         WeaponOffense = 1.03
@@ -72,7 +72,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 Unarmed (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #4:
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponOffense = 1.05
@@ -100,7 +100,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 Unarmed (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #5:
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponOffense = 1.07
@@ -128,7 +128,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 Unarmed (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #6:
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponOffense = 1.08
@@ -156,7 +156,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 Unarmed (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #7:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 25%:
         WeaponOffense = 1.13
@@ -184,7 +184,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 Unarmed (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #8:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 25%:
         WeaponOffense = 1.13
@@ -212,7 +212,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 Unarmed (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #9:
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponDefense = 1.00
@@ -234,7 +234,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 Unarmed (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #10:
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponDefense = 1.01
@@ -256,7 +256,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 Unarmed (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #11:
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         WeaponDefense = 1.03
@@ -284,7 +284,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 Unarmed (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #12:
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponDefense = 1.05
@@ -312,7 +312,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 Unarmed (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #13:
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponDefense = 1.07
@@ -340,7 +340,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 Unarmed (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #14:
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponDefense = 1.08
@@ -368,7 +368,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 Unarmed (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #15:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 25%:
         WeaponDefense = 1.13
@@ -396,7 +396,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 Unarmed (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #16:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
     - Chance: 25%:
         WeaponDefense = 1.13
@@ -424,7 +424,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 Unarmed (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #17:
 		
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 25%:
         WeaponDefense = 1.15
@@ -452,7 +452,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
 Unarmed (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #18:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
 	- Chance: 25%:
         WeaponOffense = 1.15
@@ -480,7 +480,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
 Unarmed (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #19:
 		
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 25%:
         WeaponDefense = 1.23
@@ -508,7 +508,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
 
 Unarmed (HeavyWeapons, LightWeapons, FinesseWeapons) Mutation #20:
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
 	- Chance: 25%:
         WeaponOffense = 1.23
@@ -533,3 +533,59 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
 
     - Chance: 2.5%:
         WeaponOffense = 1.30
+
+Tier 11 Mutation #21:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 25%:
+        WeaponDefense = 1.39
+
+    - Chance: 15%:
+        WeaponDefense = 1.4
+
+    - Chance: 20%:
+        WeaponDefense = 1.41
+
+    - Chance: 12.5%:
+        WeaponDefense = 1.42
+
+    - Chance: 12.5%:
+        WeaponDefense = 1.43
+
+    - Chance: 7.5%:
+        WeaponDefense = 1.44
+
+    - Chance: 5%:
+        WeaponDefense = 1.45
+
+    - Chance: 2.5%:
+        WeaponDefense = 1.46
+
+Tier 11 Mutation #22:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+	- Chance: 25%:
+        WeaponOffense = 1.39
+
+    - Chance: 15%:
+        WeaponOffense = 1.4
+
+    - Chance: 20%:
+        WeaponOffense = 1.41
+
+    - Chance: 12.5%:
+        WeaponOffense = 1.42
+
+    - Chance: 12.5%:
+        WeaponOffense = 1.43
+
+    - Chance: 7.5%:
+        WeaponOffense = 1.44
+
+    - Chance: 5%:
+        WeaponOffense = 1.45
+
+    - Chance: 2.5%:
+        WeaponOffense = 1.46

--- a/Source/ACE.Server/Entity/Mutations/MissileWeapons/atlatl_elemental.txt
+++ b/Source/ACE.Server/Entity/Mutations/MissileWeapons/atlatl_elemental.txt
@@ -38,7 +38,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1
 
 Atlatl (MissileWeapons) Mutation #3 (6,150 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
      - Chance: 10%:
         DamageMod = 2.92
@@ -461,7 +461,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1
 
 Atlatl (MissileWeapons) Mutation #10 (1,355 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 13%:
         ElementalDamageBonus = 28
@@ -559,3 +559,128 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
         WieldSkillType = WeaponSkill
         WieldDifficulty = 725
 
+
+Tier 11 Mutation #11:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+     - Chance: 10%:
+        DamageMod = 3.64
+
+    - Chance: 10%:
+        DamageMod = 3.68
+
+    - Chance: 10%:
+        DamageMod = 3.72
+
+    - Chance: 10%:
+        DamageMod = 3.76
+
+    - Chance: 15%:
+        DamageMod = 3.8
+
+    - Chance: 30%:
+        DamageMod = 3.84
+
+    - Chance: 15%:
+        DamageMod = 3.88
+
+Tier 11 Mutation #12:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 13%:
+        ElementalDamageBonus = 42
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 950
+
+    - Chance: 7%:
+        ElementalDamageBonus = 43
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 950
+
+    - Chance: 3%:
+        ElementalDamageBonus = 44
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 950
+
+    - Chance: 2%:
+        ElementalDamageBonus = 45
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 950
+
+    - Chance: 13%:
+        ElementalDamageBonus = 43
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 950
+
+    - Chance: 7%:
+        ElementalDamageBonus = 44
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 950
+
+    - Chance: 3%:
+        ElementalDamageBonus = 45
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 2%:
+        ElementalDamageBonus = 46
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 13%:
+        ElementalDamageBonus = 44
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 7%:
+        ElementalDamageBonus = 45
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 3%:
+        ElementalDamageBonus = 46
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 2%:
+        ElementalDamageBonus = 47
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 13%:
+        ElementalDamageBonus = 45
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 7%:
+        ElementalDamageBonus = 46
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 3%:
+        ElementalDamageBonus = 47
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 2%:
+        ElementalDamageBonus = 48
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100

--- a/Source/ACE.Server/Entity/Mutations/MissileWeapons/atlatl_elemental.txt
+++ b/Source/ACE.Server/Entity/Mutations/MissileWeapons/atlatl_elemental.txt
@@ -19,7 +19,7 @@ Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 0
 
 Atlatl (MissileWeapons) Mutation #2 (6,150 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 15%:
         DamageMod = 2.66
@@ -361,7 +361,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0
 
 Atlatl (MissileWeapons) Mutation #9 (1,355 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 13%:
         ElementalDamageBonus = 21

--- a/Source/ACE.Server/Entity/Mutations/MissileWeapons/bow_elemental.txt
+++ b/Source/ACE.Server/Entity/Mutations/MissileWeapons/bow_elemental.txt
@@ -50,7 +50,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1
 
 Bow (MissileWeapons) Mutation #3 (6,996 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 10%:
         DamageMod = 2.84
@@ -467,7 +467,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1
 
 Bow (MissileWeapons) Mutation #10 (1,355 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 13%:
         ElementalDamageBonus = 28
@@ -564,3 +564,128 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
         WieldRequirements = RawSkill
         WieldSkillType = WeaponSkill
         WieldDifficulty = 725
+
+Tier 11 Mutation #11:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 10%:
+        DamageMod = 3.66
+
+    - Chance: 10%:
+        DamageMod = 3.7
+
+    - Chance: 10%:
+        DamageMod = 3.74
+
+    - Chance: 10%:
+        DamageMod = 3.78
+
+    - Chance: 15%:
+        DamageMod = 3.82
+
+    - Chance: 30%:
+        DamageMod = 3.86
+
+    - Chance: 15%:
+        DamageMod = 3.9
+
+Tier 11 Mutation #12:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 13%:
+        ElementalDamageBonus = 42
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 950
+
+    - Chance: 7%:
+        ElementalDamageBonus = 43
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 950
+
+    - Chance: 3%:
+        ElementalDamageBonus = 44
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 950
+
+    - Chance: 2%:
+        ElementalDamageBonus = 45
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 950
+
+    - Chance: 13%:
+        ElementalDamageBonus = 43
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 950
+
+    - Chance: 7%:
+        ElementalDamageBonus = 44
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 950
+
+    - Chance: 3%:
+        ElementalDamageBonus = 45
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 2%:
+        ElementalDamageBonus = 46
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 13%:
+        ElementalDamageBonus = 44
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 7%:
+        ElementalDamageBonus = 45
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 3%:
+        ElementalDamageBonus = 46
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 2%:
+        ElementalDamageBonus = 47
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 13%:
+        ElementalDamageBonus = 45
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 7%:
+        ElementalDamageBonus = 46
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 3%:
+        ElementalDamageBonus = 47
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 2%:
+        ElementalDamageBonus = 48
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100

--- a/Source/ACE.Server/Entity/Mutations/MissileWeapons/bow_elemental.txt
+++ b/Source/ACE.Server/Entity/Mutations/MissileWeapons/bow_elemental.txt
@@ -25,7 +25,7 @@ Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 0
 
 Bow (MissileWeapons) Mutation #2 (6,996 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 10%:
         DamageMod = 2.46
@@ -367,7 +367,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0
 
 Bow (MissileWeapons) Mutation #9 (1,607 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 13%:
         ElementalDamageBonus = 21

--- a/Source/ACE.Server/Entity/Mutations/MissileWeapons/crossbow_elemental.txt
+++ b/Source/ACE.Server/Entity/Mutations/MissileWeapons/crossbow_elemental.txt
@@ -50,7 +50,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1
 
 Crossbow (MissileWeapons) Mutation #3 (7,015 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 10%:
         DamageMod = 2.96
@@ -467,7 +467,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1
 
 Crossbow (MissileWeapons) Mutation #10 (1,355 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 13%:
         ElementalDamageBonus = 28
@@ -565,3 +565,128 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
         WieldSkillType = WeaponSkill
         WieldDifficulty = 725
 
+
+Tier 11 Mutation #11:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 10%:
+        DamageMod = 3.58
+
+    - Chance: 10%:
+        DamageMod = 3.62
+
+    - Chance: 10%:
+        DamageMod = 3.66
+
+    - Chance: 10%:
+        DamageMod = 3.7
+
+    - Chance: 15%:
+        DamageMod = 3.74
+
+    - Chance: 30%:
+        DamageMod = 3.78
+
+    - Chance: 15%:
+        DamageMod = 3.82
+
+Tier 11 Mutation #12:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 13%:
+        ElementalDamageBonus = 42
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 950
+
+    - Chance: 7%:
+        ElementalDamageBonus = 43
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 950
+
+    - Chance: 3%:
+        ElementalDamageBonus = 44
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 950
+
+    - Chance: 2%:
+        ElementalDamageBonus = 45
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 950
+
+    - Chance: 13%:
+        ElementalDamageBonus = 43
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 950
+
+    - Chance: 7%:
+        ElementalDamageBonus = 44
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 950
+
+    - Chance: 3%:
+        ElementalDamageBonus = 45
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 2%:
+        ElementalDamageBonus = 46
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 13%:
+        ElementalDamageBonus = 44
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 7%:
+        ElementalDamageBonus = 45
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 3%:
+        ElementalDamageBonus = 46
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 2%:
+        ElementalDamageBonus = 47
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1025
+
+    - Chance: 13%:
+        ElementalDamageBonus = 45
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 7%:
+        ElementalDamageBonus = 46
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 3%:
+        ElementalDamageBonus = 47
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100
+
+    - Chance: 2%:
+        ElementalDamageBonus = 48
+        WieldRequirements = RawSkill
+        WieldSkillType = WeaponSkill
+        WieldDifficulty = 1100

--- a/Source/ACE.Server/Entity/Mutations/MissileWeapons/crossbow_elemental.txt
+++ b/Source/ACE.Server/Entity/Mutations/MissileWeapons/crossbow_elemental.txt
@@ -25,7 +25,7 @@ Tier chances: 1, 1, 1, 1, 1, 1, 1, 1, 0
 
 Crossbow (MissileWeapons) Mutation #2 (7,015 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 10%:
         DamageMod = 2.68
@@ -367,7 +367,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 0
 
 Crossbow (MissileWeapons) Mutation #9 (1,508 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0
 
     - Chance: 13%:
         ElementalDamageBonus = 21

--- a/Source/ACE.Server/Entity/Mutations/MissileWeapons/weapon_defense.txt
+++ b/Source/ACE.Server/Entity/Mutations/MissileWeapons/weapon_defense.txt
@@ -1,6 +1,6 @@
 MissileWeapons Mutation #1 (484 samples):
 
-Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponDefense = 1.00
@@ -22,7 +22,7 @@ Tier chances: 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 MissileWeapons Mutation #2 (831 samples):
 
-Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponDefense = 1.01
@@ -44,7 +44,7 @@ Tier chances: 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
 MissileWeapons Mutation #3 (741 samples):
 
-Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 2%:
         WeaponDefense = 1.03
@@ -72,7 +72,7 @@ Tier chances: 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
 MissileWeapons Mutation #4 (1695 samples):
 
-Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
 
     - Chance: 5%:
         WeaponDefense = 1.05
@@ -100,7 +100,7 @@ Tier chances: 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
 MissileWeapons Mutation #5 (777 samples):
 
-Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponDefense = 1.07
@@ -128,7 +128,7 @@ Tier chances: 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
 MissileWeapons Mutation #6 (3959 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0
 
     - Chance: 10%:
         WeaponDefense = 1.08
@@ -156,7 +156,7 @@ Tier chances: 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
 MissileWeapons Mutation #7 (939 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0
 
     - Chance: 25%:
         WeaponDefense = 1.13
@@ -184,7 +184,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 1, 0, 0, 0
 
 MissileWeapons Mutation #8 (1357 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 1, 0
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0
 
     - Chance: 25%:
         WeaponDefense = 1.13
@@ -212,7 +212,7 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 1, 1, 0
 
 MissileWeapons Mutation #9 (1357 samples):
 
-Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
 
     - Chance: 25%:
         WeaponDefense = 1.23
@@ -237,3 +237,31 @@ Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
 
     - Chance: 2%:
         WeaponDefense = 1.30
+
+Tier 11 Mutation #10:
+
+Tier chances: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+
+    - Chance: 25%:
+        WeaponDefense = 1.39
+
+    - Chance: 15%:
+        WeaponDefense = 1.4
+
+    - Chance: 20%:
+        WeaponDefense = 1.41
+
+    - Chance: 14%:
+        WeaponDefense = 1.42
+
+    - Chance: 12%:
+        WeaponDefense = 1.43
+
+    - Chance: 8%:
+        WeaponDefense = 1.44
+
+    - Chance: 4%:
+        WeaponDefense = 1.45
+
+    - Chance: 2%:
+        WeaponDefense = 1.46

--- a/Source/ACE.Server/Factories/Tables/ArmorModVsTypeChance.cs
+++ b/Source/ACE.Server/Factories/Tables/ArmorModVsTypeChance.cs
@@ -35,7 +35,7 @@ namespace ACE.Server.Factories.Tables
             // quality mod?
             var rng = ThreadSafeRandom.Next(0.0f, 1.0f);
 
-            return rng < TierChances[tier - 1];
+            return rng < TierTable.Entry(TierChances, tier);
         }
 
         // if the initial roll was successful for an elemental type,
@@ -114,7 +114,7 @@ namespace ACE.Server.Factories.Tables
             if (profile.Tier < 2)
                 return 0;
 
-            var table = qualityLevels[profile.Tier - 1];
+            var table = TierTable.Entry(qualityLevels, profile.Tier);
 
             // quality mod?
             return table.Roll(profile.LootQualityMod);

--- a/Source/ACE.Server/Factories/Tables/ArmorTypeChance.cs
+++ b/Source/ACE.Server/Factories/Tables/ArmorTypeChance.cs
@@ -160,7 +160,7 @@ namespace ACE.Server.Factories.Tables
         {
             tier = Math.Clamp(tier, 1, 10);
 
-            return armorTiers[tier - 1].Roll();
+            return TierTable.Entry(armorTiers, tier).Roll();
         }
     }
 }

--- a/Source/ACE.Server/Factories/Tables/Cantrips/CantripChance.cs
+++ b/Source/ACE.Server/Factories/Tables/Cantrips/CantripChance.cs
@@ -100,7 +100,7 @@ namespace ACE.Server.Factories.Tables
         public static int RollNumCantrips(TreasureDeath profile)
         {
             var tier = Math.Clamp(profile.Tier, 1, 10);
-            return numCantrips[tier - 1].Roll(profile.LootQualityMod);
+            return TierTable.Entry(numCantrips, tier).Roll(profile.LootQualityMod);
         }
 
 
@@ -181,7 +181,7 @@ namespace ACE.Server.Factories.Tables
         public static int RollCantripLevel(TreasureDeath profile)
         {
             var tier = Math.Clamp(profile.Tier, 1, 10);
-            return cantripLevels[tier - 1].Roll(profile.LootQualityMod);
+            return TierTable.Entry(cantripLevels, tier).Roll(profile.LootQualityMod);
         }
 
 

--- a/Source/ACE.Server/Factories/Tables/Cantrips/NumCantrips.cs
+++ b/Source/ACE.Server/Factories/Tables/Cantrips/NumCantrips.cs
@@ -94,7 +94,7 @@ namespace ACE.Server.Factories.Tables
         public static int RollNumCantrips(TreasureDeath profile)
         {
             var tier = Math.Clamp(profile.Tier, 1, 10);
-            return numCantrips[tier - 1].Roll(profile.LootQualityMod);
+            return TierTable.Entry(numCantrips, tier).Roll(profile.LootQualityMod);
         }
 
         private static readonly ChanceTable<int> T1_T2_CantripLevel = new ChanceTable<int>()
@@ -174,7 +174,7 @@ namespace ACE.Server.Factories.Tables
         public static int RollCantripLevel(TreasureDeath profile)
         {
             var tier = Math.Clamp(profile.Tier, 1, 10);
-            return cantripLevels[tier - 1].Roll(profile.LootQualityMod);
+            return TierTable.Entry(cantripLevels, tier).Roll(profile.LootQualityMod);
         }
     }
 }

--- a/Source/ACE.Server/Factories/Tables/CloakChance.cs
+++ b/Source/ACE.Server/Factories/Tables/CloakChance.cs
@@ -79,7 +79,7 @@ namespace ACE.Server.Factories.Tables
         public static int Roll_ItemMaxLevel(TreasureDeath profile)
         {
             var tier = Math.Clamp(profile.Tier, 1, 10);
-            var table = cloakLevels[tier - 1];
+            var table = TierTable.Entry(cloakLevels, tier);
 
             return table.Roll(profile.LootQualityMod);
         }

--- a/Source/ACE.Server/Factories/Tables/GearRatingChance.cs
+++ b/Source/ACE.Server/Factories/Tables/GearRatingChance.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+
 using log4net;
 
 using ACE.Database.Models.World;
@@ -97,6 +99,53 @@ namespace ACE.Server.Factories.Tables
             ( 3, 0.10f ),
         };
 
+        private static ChanceTable<bool> RatingChanceT11 = new ChanceTable<bool>()
+        {
+            ( false, 0.0f ),
+            ( true,  1.0f ),
+        };
+
+        // Tier 11 = T10 plus twice the T9->T10 step, matching the mutation scripts:
+        //   armor    T9 2..4 -> T10 6..10  (step +4/+6)  -> T11 16..20
+        //   clothing T9 3..5 -> T10 6..10  (step +3/+5)  -> T11 14..18
+        // Weapons have no T9 basis (WeaponRatingT10 was the first weapon table), so they
+        // take a flat +2. Jewelry is NOT delta-doubled: T9 3..5 -> T10 20..100 is a change
+        // of scale rather than a step, so doubling that delta is meaningless -- it takes a
+        // straight 2x instead.
+        private static ChanceTable<int> ArmorRatingT11 = new ChanceTable<int>()
+        {
+            (16, 0.50f ),
+            (17, 0.20f ),
+            (18, 0.15f ),
+            (19, 0.10f ),
+            (20, 0.05f ),
+        };
+
+        private static ChanceTable<int> ClothingRatingT11 = new ChanceTable<int>()
+        {
+            (14, 0.50f ),
+            (15, 0.25f ),
+            (16, 0.15f ),
+            (17, 0.07f ),
+            (18, 0.03f ),
+        };
+
+        private static ChanceTable<int> JewelryRatingT11 = new ChanceTable<int>()
+        {
+            ( 40, 0.50f ),
+            ( 50, 0.25f ),
+            (100, 0.15f ),
+            (150, 0.07f ),
+            (200, 0.03f ),
+        };
+
+        private static ChanceTable<int> WeaponRatingT11 = new ChanceTable<int>()
+        {
+            ( 3, 0.70f ),
+            ( 4, 0.20f ),
+            ( 5, 0.10f ),
+        };
+
         public static int Roll(WorldObject wo, TreasureDeath profile, TreasureRoll roll)
         {
             // initial roll for rating chance
@@ -181,6 +230,77 @@ namespace ACE.Server.Factories.Tables
             }
 
             return rating.Roll(profile.LootQualityMod);
+        }
+
+        public static int RollT11(WorldObject wo, TreasureDeath profile, TreasureRoll roll)
+        {
+            // initial roll for rating chance
+            if (!RatingChanceT11.Roll(profile.LootQualityMod))
+                return 0;
+
+            // roll for the actual rating
+            ChanceTable<int> rating = null;
+
+            if (roll.HasArmorLevel(wo))
+            {
+                rating = ArmorRatingT11;
+            }
+            else if (roll.IsClothing || roll.IsCloak)
+            {
+                rating = ClothingRatingT11;
+            }
+            else if (roll.IsJewelry)
+            {
+                rating = JewelryRatingT11;
+            }
+            else if (roll.IsCaster || roll.IsMeleeWeapon || roll.IsMissileWeapon)
+            {
+                rating = WeaponRatingT11;
+            }
+            else
+            {
+                log.Error($"GearRatingChance.RollT11({wo.Name}, {profile.TreasureType}, {roll.ItemType}): unknown item type");
+                return 0;
+            }
+
+            return rating.Roll(profile.LootQualityMod);
+        }
+
+        /// <summary>
+        /// Dispatches to the highest authored gear-rating table for the profile's tier.
+        /// Tiers above the last authored table clamp to it.
+        /// </summary>
+        public static int RollForTier(WorldObject wo, TreasureDeath profile, TreasureRoll roll)
+        {
+            return profile.Tier >= 11
+                ? RollT11(wo, profile, roll)
+                : RollT10(wo, profile, roll);
+        }
+
+        public enum GearRatingCategory
+        {
+            Armor,      // pieces with an armor level, incl. shields and crowns
+            Clothing,   // clothing / cloaks
+            Jewelry,
+            Weapon,
+        }
+
+        /// <summary>
+        /// The possible roll range of the tier-11 table for a category — used by the item's
+        /// appraisal Ratings block ("min X, max Y"). Computed from the tables so it can never
+        /// drift from what actually rolls.
+        /// </summary>
+        public static (int Min, int Max) GetRangeT11(GearRatingCategory category)
+        {
+            var table = category switch
+            {
+                GearRatingCategory.Armor => ArmorRatingT11,
+                GearRatingCategory.Clothing => ClothingRatingT11,
+                GearRatingCategory.Jewelry => JewelryRatingT11,
+                _ => WeaponRatingT11,
+            };
+
+            return (table.Min(e => e.result), table.Max(e => e.result));
         }
     }
 }

--- a/Source/ACE.Server/Factories/Tables/GearRatingChance.cs
+++ b/Source/ACE.Server/Factories/Tables/GearRatingChance.cs
@@ -272,9 +272,13 @@ namespace ACE.Server.Factories.Tables
         /// </summary>
         public static int RollForTier(WorldObject wo, TreasureDeath profile, TreasureRoll roll)
         {
-            return profile.Tier >= 11
-                ? RollT11(wo, profile, roll)
-                : RollT10(wo, profile, roll);
+            return profile.Tier switch
+            {
+                >= 11 => RollT11(wo, profile, roll),
+                10 => RollT10(wo, profile, roll),
+                9 => RollT9(wo, profile, roll),
+                _ => Roll(wo, profile, roll),
+            };
         }
 
         public enum GearRatingCategory

--- a/Source/ACE.Server/Factories/Tables/GemClassChance.cs
+++ b/Source/ACE.Server/Factories/Tables/GemClassChance.cs
@@ -70,7 +70,7 @@ namespace ACE.Server.Factories.Tables
             // todo: add t7 / t8
             tier = Math.Clamp(tier, 1, 6);
 
-            var gemClassChanceTable = gemClassChances[tier - 1];
+            var gemClassChanceTable = TierTable.Entry(gemClassChances, tier);
 
             return gemClassChanceTable.Roll();
         }

--- a/Source/ACE.Server/Factories/Tables/PetDeviceChance.cs
+++ b/Source/ACE.Server/Factories/Tables/PetDeviceChance.cs
@@ -87,7 +87,7 @@ namespace ACE.Server.Factories.Tables
         public static int Roll(TreasureDeath profile)
         {
             var tier = Math.Clamp(profile.Tier, 1, 10);
-            var table = petLevelChances[tier - 1];
+            var table = TierTable.Entry(petLevelChances, tier);
 
             return table.Roll(profile.LootQualityMod);
         }

--- a/Source/ACE.Server/Factories/Tables/QualityChance.cs
+++ b/Source/ACE.Server/Factories/Tables/QualityChance.cs
@@ -208,6 +208,11 @@ namespace ACE.Server.Factories.Tables
         /// </summary>
         public static List<float> GetQualityChancesForTier(int tier)
         {
+            // a treasure_death row with tier <= 0 is malformed data: keep it on the tier-1 table
+            // (master's default) rather than letting the clamp below hand it the tier-11 table
+            if (tier < 1)
+                tier = 1;
+
             switch (tier)
             {
                 case 1:

--- a/Source/ACE.Server/Factories/Tables/QualityChance.cs
+++ b/Source/ACE.Server/Factories/Tables/QualityChance.cs
@@ -184,6 +184,25 @@ namespace ACE.Server.Factories.Tables
             1.00f,
         };
 
+        // Cumulative: entry i is the chance of rolling quality <= i+1. T10 is a flat ramp
+        // (10% chance of quality 1). T11 pushes the mass to the top of the 1-12 range --
+        // quality 1 drops to 2% and roughly two thirds of rolls land at 9 or better.
+        private static readonly List<float> T11_QualityChances = new List<float>()
+        {
+            0.02f,
+            0.04f,
+            0.06f,
+            0.08f,
+            0.12f,
+            0.18f,
+            0.26f,
+            0.36f,
+            0.50f,
+            0.66f,
+            0.83f,
+            1.00f,
+        };
+
         /// <summary>
         /// Returns the quality chance tables for a tier
         /// </summary>
@@ -192,7 +211,6 @@ namespace ACE.Server.Factories.Tables
             switch (tier)
             {
                 case 1:
-                default:
                     return T1_QualityChances;
                 case 2:
                     return T2_QualityChances;
@@ -212,6 +230,9 @@ namespace ACE.Server.Factories.Tables
                     return T9_QualityChances;
                 case 10:
                     return T10_QualityChances;
+                case 11:
+                default:    // tiers above the last authored table clamp to the highest
+                    return T11_QualityChances;
             }
         }
 
@@ -222,7 +243,7 @@ namespace ACE.Server.Factories.Tables
         private static bool RollTierChance(TreasureDeath treasureDeath)
         {
             var tier = Math.Clamp(treasureDeath.Tier, 1, 10);
-            var tierChance = QualityChancePerTier[tier - 1];
+            var tierChance = TierTable.Entry(QualityChancePerTier, tier);
 
             // use for initial roll? logic seems backwards here...
             var rng = ThreadSafeRandom.NextInterval(treasureDeath.LootQualityMod);

--- a/Source/ACE.Server/Factories/Tables/ScrollLevelChance.cs
+++ b/Source/ACE.Server/Factories/Tables/ScrollLevelChance.cs
@@ -63,7 +63,7 @@ namespace ACE.Server.Factories.Tables
             if (profile.Tier >= 5)
                 return 7;
 
-            var table = scrollLevelChances[profile.Tier - 1];
+            var table = TierTable.Entry(scrollLevelChances, profile.Tier);
 
             return table.Roll(profile.LootQualityMod);
         }

--- a/Source/ACE.Server/Factories/Tables/SpellLevelChance.cs
+++ b/Source/ACE.Server/Factories/Tables/SpellLevelChance.cs
@@ -108,7 +108,7 @@ namespace ACE.Server.Factories.Tables
         {
             tier = Math.Clamp(tier, 1, 10);
 
-            return spellLevelChances[tier - 1].Roll();
+            return TierTable.Entry(spellLevelChances, tier).Roll();
         }
     }
 }

--- a/Source/ACE.Server/Factories/Tables/TierTable.cs
+++ b/Source/ACE.Server/Factories/Tables/TierTable.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+
+namespace ACE.Server.Factories.Tables
+{
+    /// <summary>
+    /// Tier-indexed table access with clamp-to-last-authored-tier semantics.
+    ///
+    /// Loot tables are authored per tier (index = tier - 1). Content tiers above the last
+    /// authored entry (e.g. tier 11+ zones while tables are only authored through tier 10)
+    /// clamp to the highest authored entry instead of throwing IndexOutOfRange, so a
+    /// treasure_death profile may use ANY tier >= 1 and behaves as the best authored data.
+    /// When a table later gains a real entry for a higher tier, that entry takes effect
+    /// automatically — each table grows independently, no global max-tier constant.
+    /// </summary>
+    public static class TierTable
+    {
+        /// <summary>
+        /// Returns the entry for a 1-based tier, clamped to [1, table.Count].
+        /// </summary>
+        public static T Entry<T>(IReadOnlyList<T> table, int tier)
+        {
+            return table[Math.Clamp(tier, 1, table.Count) - 1];
+        }
+    }
+}

--- a/Source/ACE.Server/Factories/Tables/Wcids/AetheriaWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/AetheriaWcids.cs
@@ -36,6 +36,15 @@ namespace ACE.Server.Factories.Tables
                 case 10:
                     rng = ThreadSafeRandom.Next(0, 2);
                     return aetheriaColors[rng];
+
+                default:
+                    // tiers above the last authored case clamp to the highest; below tier 5 = no aetheria
+                    if (tier > 10)
+                    {
+                        rng = ThreadSafeRandom.Next(0, 2);
+                        return aetheriaColors[rng];
+                    }
+                    break;
             }
             return WeenieClassName.undef;
         }

--- a/Source/ACE.Server/Factories/Tables/Wcids/CoalescedManaWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/CoalescedManaWcids.cs
@@ -39,7 +39,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             if (profile.Tier > 4)
                 return WeenieClassName.undef;
 
-            var table = tierChances[profile.Tier - 1];
+            var table = TierTable.Entry(tierChances, profile.Tier);
 
             return table.Roll(profile.LootQualityMod);
         }

--- a/Source/ACE.Server/Factories/Tables/Wcids/ConsumeWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/ConsumeWcids.cs
@@ -128,7 +128,7 @@ namespace ACE.Server.Factories.Tables.Wcids
         {
             var tier = Math.Clamp(profile.Tier, 1, 10);
             // todo: verify t7 / t8 chances
-            var table = consumeTiers[tier - 1];
+            var table = TierTable.Entry(consumeTiers, tier);
 
             // quality mod?
             return table.Roll(profile.LootQualityMod);

--- a/Source/ACE.Server/Factories/Tables/Wcids/GenericWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/GenericWcids.cs
@@ -71,7 +71,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             // todo: add unique profiles for t7 / t8?
             tier = Math.Clamp(tier, 1, 6);
 
-            return tierChances[tier - 1].Roll();
+            return TierTable.Entry(tierChances, tier).Roll();
         }
 
         private static readonly HashSet<WeenieClassName> _combined = new HashSet<WeenieClassName>();

--- a/Source/ACE.Server/Factories/Tables/Wcids/HealKitWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/HealKitWcids.cs
@@ -79,7 +79,7 @@ namespace ACE.Server.Factories.Tables.Wcids
         {
             var tier = Math.Clamp(profile.Tier, 1, 10);
             // todo: verify t7 / t8 chances
-            var table = healKitTiers[tier - 1];
+            var table = TierTable.Entry(healKitTiers, tier);
 
             return table.Roll(profile.LootQualityMod);
         }

--- a/Source/ACE.Server/Factories/Tables/Wcids/JewelryWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/JewelryWcids.cs
@@ -100,7 +100,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             // todo: add unique profiles for t7 / t8?
             tier = Math.Clamp(tier, 1, 6);
 
-            return tierChances[tier - 1].Roll();
+            return TierTable.Entry(tierChances, tier).Roll();
         }
 
         private static readonly HashSet<WeenieClassName> _combined = new HashSet<WeenieClassName>();

--- a/Source/ACE.Server/Factories/Tables/Wcids/LockpickWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/LockpickWcids.cs
@@ -78,7 +78,7 @@ namespace ACE.Server.Factories.Tables.Wcids
         {
             var tier = Math.Clamp(profile.Tier, 1, 10);
             // todo: verify t7 / t8 chances
-            var table = lockpickTiers[tier - 1];
+            var table = TierTable.Entry(lockpickTiers, tier);
 
             return table.Roll(profile.LootQualityMod);
         }

--- a/Source/ACE.Server/Factories/Tables/Wcids/ManaStoneWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/ManaStoneWcids.cs
@@ -78,7 +78,7 @@ namespace ACE.Server.Factories.Tables.Wcids
         {
             var tier = Math.Clamp(profile.Tier, 1, 10);
             // todo: verify t7 / t8 chances
-            var table = manaStoneTiers[tier - 1];
+            var table = TierTable.Entry(manaStoneTiers, tier);
 
             return table.Roll(profile.LootQualityMod);
         }

--- a/Source/ACE.Server/Factories/Tables/Wcids/SpellComponentWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/SpellComponentWcids.cs
@@ -95,7 +95,7 @@ namespace ACE.Server.Factories.Tables.Wcids
                     return Roll_Level8SpellComponent(profile);
             }
             var tier = Math.Clamp(profile.Tier, 1, 10);
-            var table = peaTiers[tier - 1];
+            var table = TierTable.Entry(peaTiers, tier);
 
             return table.Roll(profile.LootQualityMod);
         }

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/AtlatlWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/AtlatlWcids.cs
@@ -105,7 +105,7 @@ namespace ACE.Server.Factories.Tables.Wcids
 
         public static WeenieClassName Roll(int tier)
         {
-            return atlatlTiers[tier - 1].Roll();
+            return TierTable.Entry(atlatlTiers, tier).Roll();
         }
 
         private static readonly Dictionary<WeenieClassName, TreasureWeaponType> _combined = new Dictionary<WeenieClassName, TreasureWeaponType>();

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/BowWcids_Aluvian.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/BowWcids_Aluvian.cs
@@ -107,7 +107,7 @@ namespace ACE.Server.Factories.Tables.Wcids
 
         public static WeenieClassName Roll(int tier)
         {
-            return bowTiers[tier - 1].Roll();
+            return TierTable.Entry(bowTiers, tier).Roll();
         }
 
         private static readonly Dictionary<WeenieClassName, TreasureWeaponType> _combined = new Dictionary<WeenieClassName, TreasureWeaponType>();

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/BowWcids_Gharundim.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/BowWcids_Gharundim.cs
@@ -107,7 +107,7 @@ namespace ACE.Server.Factories.Tables.Wcids
 
         public static WeenieClassName Roll(int tier)
         {
-            return bowTiers[tier - 1].Roll();
+            return TierTable.Entry(bowTiers, tier).Roll();
         }
 
         private static readonly Dictionary<WeenieClassName, TreasureWeaponType> _combined = new Dictionary<WeenieClassName, TreasureWeaponType>();

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/BowWcids_Sho.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/BowWcids_Sho.cs
@@ -107,7 +107,7 @@ namespace ACE.Server.Factories.Tables.Wcids
 
         public static WeenieClassName Roll(int tier)
         {
-            return bowTiers[tier - 1].Roll();
+            return TierTable.Entry(bowTiers, tier).Roll();
         }
 
         private static readonly Dictionary<WeenieClassName, TreasureWeaponType> _combined = new Dictionary<WeenieClassName, TreasureWeaponType>();

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/CasterWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/CasterWcids.cs
@@ -184,36 +184,48 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace43383_netherstaff,   0.035f ),
         };
 
+        // T10 is the LAST authored row, so it is what every T11-T25 zone actually rolls: Roll() clamps the
+        // tier to 1-10 and TierTable.Entry clamps again to the table length. Everything endgame sees is here.
+        //
+        // NO PLAIN CASTERS (owner 2026-08-26, "remove all plain orbs and wands from our loot table").
+        // orb / sceptre / staff / wand (2366 / 2548 / 2547 / 2472) carry no W_DamageType at all, so
+        // ZoneLootMutator's Rending card finds an empty candidate pool and they can NEVER take a rend -
+        // they drop at T11+ as strictly worse versions of the elemental casters below. Only this T10 row
+        // was touched; T1-T9 keep their plain casters, which is the low-tier levelling content and is
+        // unreachable from T11+ by the clamp above.
+        //
+        // WEIGHTS: ChanceTable.VerifyTable logs an error unless the table sums to 1.0, and a short table
+        // does NOT throw - Roll() falls through its loop and returns the LAST entry with chance > 0, so a
+        // 0.144 gap would have silently dumped 14.4 pct of all caster drops onto netherstaff. The removed
+        // 0.144 is therefore redistributed in the original 0.036 : 0.035 proportion, rounded to values that
+        // sum EXACTLY to 1.0 in the decimal arithmetic VerifyTable uses: the sixteen wands/batons go
+        // 0.036 -> 0.042 (16 x 0.042 = 0.672) and the eight staves 0.035 -> 0.041 (8 x 0.041 = 0.328).
         private static readonly ChanceTable<WeenieClassName> T10_Chances = new ChanceTable<WeenieClassName>()
         {
-            ( WeenieClassName.orb,                    0.036f ),
-            ( WeenieClassName.sceptre,                0.036f ),
-            ( WeenieClassName.staff,                  0.036f ),
-            ( WeenieClassName.wand,                   0.036f ),
-            ( WeenieClassName.wandslashing,           0.036f ),
-            ( WeenieClassName.wandpiercing,           0.036f ),
-            ( WeenieClassName.wandblunt,              0.036f ),
-            ( WeenieClassName.wandacid,               0.036f ),
-            ( WeenieClassName.wandfire,               0.036f ),
-            ( WeenieClassName.wandfrost,              0.036f ),
-            ( WeenieClassName.wandelectric,           0.036f ),
-            ( WeenieClassName.ace43381_nethersceptre, 0.036f ),
-            ( WeenieClassName.ace31819_slashingbaton, 0.036f ),
-            ( WeenieClassName.ace31825_piercingbaton, 0.036f ),
-            ( WeenieClassName.ace31821_bluntbaton,    0.036f ),
-            ( WeenieClassName.ace31820_acidbaton,     0.036f ),
-            ( WeenieClassName.ace31823_firebaton,     0.036f ),
-            ( WeenieClassName.ace31824_frostbaton,    0.036f ),
-            ( WeenieClassName.ace31822_electricbaton, 0.036f ),
-            ( WeenieClassName.ace43382_netherbaton,   0.036f ),
-            ( WeenieClassName.ace37223_slashingstaff, 0.035f ),
-            ( WeenieClassName.ace37222_piercingstaff, 0.035f ),
-            ( WeenieClassName.ace37225_bluntstaff,    0.035f ),
-            ( WeenieClassName.ace37224_acidstaff,     0.035f ),
-            ( WeenieClassName.ace37220_firestaff,     0.035f ),
-            ( WeenieClassName.ace37221_froststaff,    0.035f ),
-            ( WeenieClassName.ace37219_electricstaff, 0.035f ),
-            ( WeenieClassName.ace43383_netherstaff,   0.035f ),
+            ( WeenieClassName.wandslashing,           0.042f ),
+            ( WeenieClassName.wandpiercing,           0.042f ),
+            ( WeenieClassName.wandblunt,              0.042f ),
+            ( WeenieClassName.wandacid,               0.042f ),
+            ( WeenieClassName.wandfire,               0.042f ),
+            ( WeenieClassName.wandfrost,              0.042f ),
+            ( WeenieClassName.wandelectric,           0.042f ),
+            ( WeenieClassName.ace43381_nethersceptre, 0.042f ),
+            ( WeenieClassName.ace31819_slashingbaton, 0.042f ),
+            ( WeenieClassName.ace31825_piercingbaton, 0.042f ),
+            ( WeenieClassName.ace31821_bluntbaton,    0.042f ),
+            ( WeenieClassName.ace31820_acidbaton,     0.042f ),
+            ( WeenieClassName.ace31823_firebaton,     0.042f ),
+            ( WeenieClassName.ace31824_frostbaton,    0.042f ),
+            ( WeenieClassName.ace31822_electricbaton, 0.042f ),
+            ( WeenieClassName.ace43382_netherbaton,   0.042f ),
+            ( WeenieClassName.ace37223_slashingstaff, 0.041f ),
+            ( WeenieClassName.ace37222_piercingstaff, 0.041f ),
+            ( WeenieClassName.ace37225_bluntstaff,    0.041f ),
+            ( WeenieClassName.ace37224_acidstaff,     0.041f ),
+            ( WeenieClassName.ace37220_firestaff,     0.041f ),
+            ( WeenieClassName.ace37221_froststaff,    0.041f ),
+            ( WeenieClassName.ace37219_electricstaff, 0.041f ),
+            ( WeenieClassName.ace43383_netherstaff,   0.041f ),
         };
 
         private static readonly List<ChanceTable<WeenieClassName>> casterTiers = new List<ChanceTable<WeenieClassName>>()
@@ -233,7 +245,7 @@ namespace ACE.Server.Factories.Tables.Wcids
         public static WeenieClassName Roll(int tier)
         {
             tier = Math.Clamp(tier, 1, 10);
-            return casterTiers[tier - 1].Roll();
+            return TierTable.Entry(casterTiers, tier).Roll();
         }
 
         private static readonly HashSet<WeenieClassName> _combined = new HashSet<WeenieClassName>();

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/CrossbowWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/CrossbowWcids.cs
@@ -107,7 +107,7 @@ namespace ACE.Server.Factories.Tables.Wcids
 
         public static WeenieClassName Roll(int tier)
         {
-            return crossbowTiers[tier - 1].Roll();
+            return TierTable.Entry(crossbowTiers, tier).Roll();
         }
 
         private static readonly Dictionary<WeenieClassName, TreasureWeaponType> _combined = new Dictionary<WeenieClassName, TreasureWeaponType>();

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/FinesseWeaponWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/FinesseWeaponWcids.cs
@@ -259,6 +259,27 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( HandWraps,       TreasureWeaponType.Unarmed ),
         };
 
+
+        /// <summary>
+        /// Rolls a wcid restricted to a single weapon subtype (Zone Control structured loot set).
+        /// Returns undef when this skill has no tables for that subtype.
+        /// </summary>
+        public static WeenieClassName RollForWeaponType(TreasureWeaponType requestedType)
+        {
+            var matching = new List<ChanceTable<WeenieClassName>>();
+
+            foreach (var entry in finesseWeaponsTables)
+            {
+                if (entry.weaponType == requestedType)
+                    matching.Add(entry.table);
+            }
+
+            if (matching.Count == 0)
+                return WeenieClassName.undef;
+
+            return matching[ThreadSafeRandom.Next(0, matching.Count - 1)].Roll();
+        }
+
         public static WeenieClassName Roll(out TreasureWeaponType weaponType)
         {
             // even chance of selecting each weapon table

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/HeavyWeaponWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/HeavyWeaponWcids.cs
@@ -279,6 +279,27 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( Nekodes,       TreasureWeaponType.Unarmed ),
         };
 
+
+        /// <summary>
+        /// Rolls a wcid restricted to a single weapon subtype (Zone Control structured loot set).
+        /// Returns undef when this skill has no tables for that subtype.
+        /// </summary>
+        public static WeenieClassName RollForWeaponType(TreasureWeaponType requestedType)
+        {
+            var matching = new List<ChanceTable<WeenieClassName>>();
+
+            foreach (var entry in heavyWeaponsTables)
+            {
+                if (entry.weaponType == requestedType)
+                    matching.Add(entry.table);
+            }
+
+            if (matching.Count == 0)
+                return WeenieClassName.undef;
+
+            return matching[ThreadSafeRandom.Next(0, matching.Count - 1)].Roll();
+        }
+
         public static WeenieClassName Roll(out TreasureWeaponType weaponType)
         {
             // even chance of selecting each weapon table

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/Legacy/DaggerWcids_Aluvian_Sho.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/Legacy/DaggerWcids_Aluvian_Sho.cs
@@ -80,7 +80,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             // todo: add unique profiles for t7 / t8?
             tier = Math.Clamp(tier, 1, 6);
 
-            return weaponTiers[tier - 1].Roll();
+            return TierTable.Entry(weaponTiers, tier).Roll();
         }
     }
 }

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/Legacy/DaggerWcids_Gharundim.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/Legacy/DaggerWcids_Gharundim.cs
@@ -80,7 +80,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             // todo: add unique profiles for t7 / t8?
             tier = Math.Clamp(tier, 1, 6);
 
-            return weaponTiers[tier - 1].Roll();
+            return TierTable.Entry(weaponTiers, tier).Roll();
         }
     }
 }

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/Legacy/SwordWcids_Aluvian.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/Legacy/SwordWcids_Aluvian.cs
@@ -98,7 +98,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             // todo: add unique profiles for t7 / t8?
             tier = Math.Clamp(tier, 1, 6);
 
-            return weaponTiers[tier - 1].Roll();
+            return TierTable.Entry(weaponTiers, tier).Roll();
         }
     }
 }

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/Legacy/SwordWcids_Gharundim.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/Legacy/SwordWcids_Gharundim.cs
@@ -98,7 +98,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             // todo: add unique profiles for t7 / t8?
             tier = Math.Clamp(tier, 1, 6);
 
-            return weaponTiers[tier - 1].Roll();
+            return TierTable.Entry(weaponTiers, tier).Roll();
         }
     }
 }

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/Legacy/SwordWcids_Sho.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/Legacy/SwordWcids_Sho.cs
@@ -98,7 +98,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             // todo: add unique profiles for t7 / t8?
             tier = Math.Clamp(tier, 1, 6);
 
-            return weaponTiers[tier - 1].Roll();
+            return TierTable.Entry(weaponTiers, tier).Roll();
         }
     }
 }

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/LightWeaponWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/LightWeaponWcids.cs
@@ -235,6 +235,27 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( Knuckles,       TreasureWeaponType.Unarmed ),
         };
 
+
+        /// <summary>
+        /// Rolls a wcid restricted to a single weapon subtype (Zone Control structured loot set).
+        /// Returns undef when this skill has no tables for that subtype.
+        /// </summary>
+        public static WeenieClassName RollForWeaponType(TreasureWeaponType requestedType)
+        {
+            var matching = new List<ChanceTable<WeenieClassName>>();
+
+            foreach (var entry in lightWeaponsTables)
+            {
+                if (entry.weaponType == requestedType)
+                    matching.Add(entry.table);
+            }
+
+            if (matching.Count == 0)
+                return WeenieClassName.undef;
+
+            return matching[ThreadSafeRandom.Next(0, matching.Count - 1)].Roll();
+        }
+
         public static WeenieClassName Roll(out TreasureWeaponType weaponType)
         {
             // even chance of selecting each weapon table

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/TwoHandedWeaponWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/TwoHandedWeaponWcids.cs
@@ -146,6 +146,27 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( Spadones,           TreasureWeaponType.TwoHandedSword ),
         };
 
+
+        /// <summary>
+        /// Rolls a wcid restricted to a single weapon subtype (Zone Control structured loot set).
+        /// Returns undef when this skill has no tables for that subtype.
+        /// </summary>
+        public static WeenieClassName RollForWeaponType(TreasureWeaponType requestedType)
+        {
+            var matching = new List<ChanceTable<WeenieClassName>>();
+
+            foreach (var entry in twoHandedWeaponTables)
+            {
+                if (entry.weaponType == requestedType)
+                    matching.Add(entry.table);
+            }
+
+            if (matching.Count == 0)
+                return WeenieClassName.undef;
+
+            return matching[ThreadSafeRandom.Next(0, matching.Count - 1)].Roll();
+        }
+
         public static WeenieClassName Roll(out TreasureWeaponType weaponType)
         {
             // even chance of selecting each weapon table

--- a/Source/ACE.Server/Factories/Tables/WorkmanshipChance.cs
+++ b/Source/ACE.Server/Factories/Tables/WorkmanshipChance.cs
@@ -84,7 +84,7 @@ namespace ACE.Server.Factories.Tables
             // todo: add t7 / t8
             tier = Math.Clamp(tier, 1, 6);
 
-            var workmanshipChance = workmanshipChances[tier - 1];
+            var workmanshipChance = TierTable.Entry(workmanshipChances, tier);
 
             return workmanshipChance.Roll();
         }


### PR DESCRIPTION
## T11 part 1 of N: loot tables and mutation data

First of a series of sub-100-file PRs that together deliver the Zone Control / T11 (Tou Tou) branch (`T11-Stuff`, 148 commits, 312 files). This part is data only: 81 files under `Entity/Mutations` and `Factories/Tables`. It builds clean on master by itself and changes nothing for tiers 1-10 except the one item called out below.

### What is in it
- **Tier 11 rows** added to every per-tier loot table: weapon, bow, atlatl, crossbow, caster, jewelry, mana stone, lockpick, spell component, gem, cloak, pet, scroll, spell level, heal kit, consumable, quality, workmanship, cantrip count and level, armor mod chance.
- **Mutation scripts** (`Entity/Mutations/**`): the tier-chance header rows grow from 10 to 11 entries, with the tier-11 column authored as a double step over T10 (damage / wield difficulty / variance, offense / defense, missile, casters, armor level).
- **`Factories/Tables/TierTable.cs`** (new): `TierTable.Entry(table, tier)` replaces the raw `table[tier - 1]` index in every table. It clamps to the last authored row, so a tier above what a table authors reads that table's last row instead of throwing. Tiers 1-10 resolve exactly as before.

### The one behaviour change for live
`CasterWcids.cs`, T10 row only: the plain orb / sceptre / staff / wand entries are removed and their weight redistributed over the elemental casters (16 wands and batons 0.036 -> 0.042, 8 staves 0.035 -> 0.041, sum exactly 1.0 for `VerifyTable`). Owner ruling 2026-08-26: plain casters carry no damage type and can never take a rend, so at T11+ they are strictly worse drops. Because T10 is the last authored caster row it is what T11+ rolls, and T10 itself loses the plain casters as a side effect. T1-T9 keep theirs.

### Why this order
Data first: it is inert on master (nothing asks for tier 11 yet), it is the largest reviewable chunk, and the later code parts depend on `TierTable` and the T11 rows existing.

### Still to come
Part 2: Zone Control / Weapon Scaling / Rift managers, commands, entity enums and properties. Part 3: WorldObjects wiring, physics and landblock fixes. Last part: the database update files (shard store + world content), which must land after the code that reads them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for an 11th loot tier across armor, caster, melee, missile, and weapon mutation tables.
  * Added new tier-11 bonuses for armor, damage, offense, defense, mana conversion, elemental effects, and weapon ratings.
  * Added tier-11 gear-rating and item-quality outcomes.
  * Added weapon-type-specific random selection for light, heavy, finesse, and two-handed weapons.
  * Improved handling of loot tiers above the previously supported range.

* **Bug Fixes**
  * Corrected high-tier caster weapon selection probabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->