### PR TITLE
T11 part 3: Zone Control core (managers, commands, loot factories, Wo…

### DIFF
--- a/Source/ACE.Server.Tests/EndgameVariationTests.cs
+++ b/Source/ACE.Server.Tests/EndgameVariationTests.cs
@@ -1,0 +1,163 @@
+using ACE.Entity;
+using ACE.Entity.Enum;
+using ACE.Entity.Enum.Properties;
+using ACE.Entity.Models;
+using ACE.Server.Managers;
+using ACE.Server.WorldObjects;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ACE.Server.Tests
+{
+    /// <summary>
+    /// Coverage for <see cref="VariationManager.GetEffectiveEndgameVariation"/> — the v11+ endgame-content
+    /// layer resolver behind the %HP floor, vuln compression, damage-taken mitigation, the attack-skill floor
+    /// and Zone Control's zone matching.
+    ///
+    /// This function had ZERO coverage until 2026-07-30, which is how it stayed broken for weeks: it used to
+    /// floor the ForceEndgameSystems test hook on PRESTIGE_BASE_VARIATION, so when PRESTIGE_VAR_OFFSET moved
+    /// 10 -> 1000 every test dummy silently reported variation 1001. Downstream, the %HP floor computes
+    /// growth^(variation - min), and 1.22^990 overflows to Infinity — the NaN/Infinity guard then returned
+    /// 0 damage, i.e. the dummy looked alive and well while dealing nothing.
+    /// </summary>
+    [TestClass]
+    public class EndgameVariationTests
+    {
+        private static GenericObject CreateTestObject(int? locationVariation)
+        {
+            var weenie = new Weenie
+            {
+                WeenieClassId = 424243,
+                ClassName = "TestEndgameVariationWeenie",
+                WeenieType = WeenieType.Generic
+            };
+            var wo = new GenericObject(weenie, new ObjectGuid(0xF0004243));
+            wo.SetPosition(PositionType.Location,
+                new Position(0x00A80101, 12f, 12f, 12f, 0f, 0f, 0f, 1f, false, locationVariation));
+            return wo;
+        }
+
+        // ── real mobs: the flag is absent, so the real variation always passes through ──
+
+        [TestMethod]
+        public void RealEndgameVariation_PassesThrough()
+        {
+            Assert.AreEqual(11, VariationManager.GetEffectiveEndgameVariation(CreateTestObject(11)));
+            Assert.AreEqual(25, VariationManager.GetEffectiveEndgameVariation(CreateTestObject(25)));
+        }
+
+        [TestMethod]
+        public void RealNonEndgameVariation_PassesThroughUnchanged()
+        {
+            Assert.AreEqual(0, VariationManager.GetEffectiveEndgameVariation(CreateTestObject(0)));
+            Assert.AreEqual(5, VariationManager.GetEffectiveEndgameVariation(CreateTestObject(5)));
+            Assert.AreEqual(10, VariationManager.GetEffectiveEndgameVariation(CreateTestObject(10)));
+        }
+
+        [TestMethod]
+        public void BaseWorld_NullVariation_ResolvesToZero()
+        {
+            Assert.AreEqual(0, VariationManager.GetEffectiveEndgameVariation(CreateTestObject(null)));
+        }
+
+        [TestMethod]
+        public void RiftVariation_NegativePassesThroughUnchanged()
+        {
+            // rift run instances live at <= -1000; RiftScaling strips ForceEndgameSystems from rift
+            // creatures, so the flag branch is unreachable there and the negative must survive intact
+            Assert.AreEqual(-1000, VariationManager.GetEffectiveEndgameVariation(CreateTestObject(-1000)));
+            Assert.AreEqual(-7, VariationManager.GetEffectiveEndgameVariation(CreateTestObject(-7)));
+        }
+
+        [TestMethod]
+        public void NullWorldObject_ResolvesToZero()
+        {
+            Assert.AreEqual(0, VariationManager.GetEffectiveEndgameVariation(null));
+        }
+
+        // ── ForceEndgameSystems test hook ──
+
+        [TestMethod]
+        public void Forced_Unset_ResolvesToEndgameMinimum()
+        {
+            var wo = CreateTestObject(0);
+            wo.SetProperty(PropertyBool.ForceEndgameSystems, true);
+
+            Assert.AreEqual(VariationManager.EndgameMinVariation,
+                VariationManager.GetEffectiveEndgameVariation(wo));
+            Assert.AreEqual(11, VariationManager.GetEffectiveEndgameVariation(wo));
+        }
+
+        [TestMethod]
+        public void Forced_ExplicitVariation_IsHonoured()
+        {
+            var wo = CreateTestObject(0);
+            wo.SetProperty(PropertyBool.ForceEndgameSystems, true);
+            wo.SetProperty(PropertyInt.EndgameForcedVariation, 20);
+
+            // REGRESSION: this returned PRESTIGE_BASE_VARIATION (1001) while the offset was 1000,
+            // making the documented "simulate a deeper tier" knob completely inert.
+            Assert.AreEqual(20, VariationManager.GetEffectiveEndgameVariation(wo));
+        }
+
+        [TestMethod]
+        public void Forced_BelowMinimum_IsFlooredNotPassedThrough()
+        {
+            var wo = CreateTestObject(0);
+            wo.SetProperty(PropertyBool.ForceEndgameSystems, true);
+            wo.SetProperty(PropertyInt.EndgameForcedVariation, 5);
+
+            Assert.AreEqual(11, VariationManager.GetEffectiveEndgameVariation(wo));
+        }
+
+        [TestMethod]
+        public void Forced_DoesNotOverrideARealEndgameVariation()
+        {
+            // a real v11+ mob short-circuits before the flag is ever read
+            var wo = CreateTestObject(14);
+            wo.SetProperty(PropertyBool.ForceEndgameSystems, true);
+            wo.SetProperty(PropertyInt.EndgameForcedVariation, 20);
+
+            Assert.AreEqual(14, VariationManager.GetEffectiveEndgameVariation(wo));
+        }
+
+        [TestMethod]
+        public void FlagFalse_IsIgnored()
+        {
+            var wo = CreateTestObject(0);
+            wo.SetProperty(PropertyBool.ForceEndgameSystems, false);
+            wo.SetProperty(PropertyInt.EndgameForcedVariation, 20);
+
+            Assert.AreEqual(0, VariationManager.GetEffectiveEndgameVariation(wo));
+        }
+
+        // ── the decouple invariant ──
+
+        [TestMethod]
+        public void EndgameMinimum_IsIndependentOfPrestigeTiering()
+        {
+            // The whole point of the 2026-07-30 decouple: moving PRESTIGE_VAR_OFFSET must never move the
+            // endgame content floor again. If someone re-derives one from the other, this fails.
+            // (Read through locals so the analyzer doesn't fold the const comparison away — the guard is
+            // meant to trip at COMPILE time on the next edit, which it still does.)
+            var endgameMin = VariationManager.EndgameMinVariation;
+            var prestigeBase = PrestigeManager.PRESTIGE_BASE_VARIATION;
+
+            Assert.AreEqual(11, endgameMin);
+            Assert.AreNotEqual(prestigeBase, endgameMin);
+        }
+
+        [TestMethod]
+        public void ZoneControlDelegatesToTheSharedResolver()
+        {
+            // ZoneControlManager.GetEffectiveVariation kept its name but must not keep its own copy —
+            // the duplicate is what drifted and broke the test hook.
+            var wo = CreateTestObject(0);
+            wo.SetProperty(PropertyBool.ForceEndgameSystems, true);
+            wo.SetProperty(PropertyInt.EndgameForcedVariation, 20);
+
+            Assert.AreEqual(VariationManager.GetEffectiveEndgameVariation(wo),
+                ACE.Server.Managers.ZoneControl.ZoneControlManager.GetEffectiveVariation(wo));
+        }
+    }
+}

--- a/Source/ACE.Server.Tests/WeaponScalingConfigTests.cs
+++ b/Source/ACE.Server.Tests/WeaponScalingConfigTests.cs
@@ -1,0 +1,707 @@
+using System.Linq;
+
+using ACE.Server.Managers.WeaponScaling;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Newtonsoft.Json;
+
+namespace ACE.Server.Tests
+{
+    /// <summary>
+    /// Weapon aug-scaling config (T11_WeaponRelevance_Plan_2026-07-31.md): the locked launch
+    /// defaults, the quality->k lerp the combat wire-in will lean on, and store round-trip safety.
+    /// Pure config/math only — no DB, no combat (the wire-in ships in a later step).
+    /// </summary>
+    [TestClass]
+    public class WeaponScalingConfigTests
+    {
+        // ── Locked defaults (plan §4 / §7) ──
+
+        [TestMethod]
+        public void Defaults_SystemStartsDisabled()
+        {
+            Assert.IsFalse(WeaponScalingManager.BuildDefaults().Enabled,
+                "The master switch must default OFF — deploy-cold guarantee.");
+        }
+
+        [TestMethod]
+        public void Defaults_TierLadder_CapAndWieldFloorRule()
+        {
+            var cfg = WeaponScalingManager.BuildDefaults();
+
+            var t11 = cfg.Tiers.Single(t => t.Tier == 11);
+            Assert.AreEqual(2500, t11.Cap);
+            Assert.AreEqual(2000, t11.MinWieldAugs,
+                "T11's floor = the pre-existing live gate (ZoneLootSetWieldItemAugs), not 0.");
+
+            // +500 cap per tier; each tier's wield floor = previous tier's cap (the economy joint:
+            // your T(n) weapon plateaus at exactly the count where T(n+1) becomes wieldable).
+            for (var tier = 12; tier <= 25; tier++)
+            {
+                var row = cfg.Tiers.Single(t => t.Tier == tier);
+                var prev = cfg.Tiers.Single(t => t.Tier == tier - 1);
+                Assert.AreEqual(prev.Cap + 500, row.Cap, $"T{tier} cap");
+                Assert.AreEqual(prev.Cap, row.MinWieldAugs, $"T{tier} minWieldAugs");
+            }
+        }
+
+        [TestMethod]
+        public void Defaults_LockedKRanges()
+        {
+            var cfg = WeaponScalingManager.BuildDefaults();
+
+            // One row per weapon family, weight subtypes merged; k EQUAL WITHIN MECHANICS GROUPS
+            // (owner 2026-08-01) — the discount rule follows what the weapon GIVES UP: multi-strike
+            // gives up nothing -> discounted by strike count for per-swing parity; two-handed gives
+            // up a SHIELD -> NO discount (k = singles per hit; both strikes carry it = the premium).
+            Assert.AreEqual(16, cfg.Scripts.Count);
+            var expected = new (string Key, double KMin, double KMax)[]
+            {
+                ("sword", 0.90, 1.15), ("axe", 0.90, 1.15), ("dagger", 0.90, 1.15),
+                ("mace", 0.90, 1.15), ("spear", 0.90, 1.15), ("staff", 0.90, 1.15),
+                ("unarmed", 0.90, 1.15),
+                ("sword_ms", 0.40, 0.51), ("dagger_ms", 0.40, 0.51),
+                ("cleaver", 0.90, 1.15), ("two_handed_spear", 0.90, 1.15),
+                // Launchers: kMin/kMax = the EFFECTIVE DAMAGE MODIFIER band (replace semantics,
+                // owner 2026-08-01), not a flat-term coefficient. Band FINAL 2026-08-02: S = 4.00
+                // (owner pick), KMin = 4.00 x (0.90/1.15) = 3.13 so grades ladder at the same
+                // F->S ratio as melee; floor still clears the real T10 roll ceiling (3.08).
+                ("bow", 3.13, 4.00), ("crossbow", 3.13, 4.00), ("atlatl", 3.13, 4.00),
+                // Casters: same reinterpretation, on ELEMENTAL damage mod (owner 2026-08-06,
+                // "keep bow and caster weapons scaling identical"). S = 1.58 = the real T10
+                // ceiling 1.22 x the launcher's own +29.9 pct bump; KMin = 1.58 x (0.90/1.15).
+                // NON-elemental stays on the old band ON PURPOSE — a plain caster has no element
+                // to match, so its modifier is pinned at 1.0 and nothing there can scale.
+                ("caster_elemental", 1.24, 1.58), ("caster_non_elemental", 0.90, 1.15),
+            };
+            foreach (var e in expected)
+            {
+                Assert.AreEqual(e.KMin, cfg.Scripts[e.Key].KMin, 1e-9, e.Key);
+                Assert.AreEqual(e.KMax, cfg.Scripts[e.Key].KMax, 1e-9, e.Key);
+            }
+            Assert.AreEqual(0.60, cfg.KcMin, 1e-9);
+            Assert.AreEqual(0.80, cfg.KcMax, 1e-9);
+        }
+
+        // ── Grade ladder (owner 2026-08-03, WeaponGradeLadder_Plan) ──
+
+        [TestMethod]
+        public void Ladder_SeededOnMeleeFamiliesOnly()
+        {
+            var cfg = WeaponScalingManager.BuildDefaults();
+
+            foreach (var melee in new[] { "sword", "axe", "dagger", "mace", "spear", "staff",
+                                          "unarmed", "cleaver", "two_handed_spear", "sword_ms", "dagger_ms" })
+                Assert.IsTrue(cfg.Scripts[melee].HasLadder, $"{melee} should resolve off the authored ladder.");
+
+            // Launchers resolve their rows as a damage MOD band and casters are inert — both stay
+            // on the KMin/KMax lerp until the missile/magic passes.
+            foreach (var lerp in new[] { "bow", "crossbow", "atlatl", "caster_elemental", "caster_non_elemental" })
+                Assert.IsFalse(cfg.Scripts[lerp].HasLadder, $"{lerp} must stay on the lerp for now.");
+        }
+
+        // ── Launcher tier scaling (owner 2026-08-06, LauncherTierMod_Plan) ──
+        //
+        // Replaced the missile aug cap, which produced bow tier growth by clawing BACK over-cap
+        // Blood Drinker and so froze a T11 bow user's BD contribution no matter how many item
+        // augs they bought. BD is never touched now; T11 is the baseline and tiers only ADD.
+
+        [TestMethod]
+        public void LauncherTierSteps_TrackMinAugsAndCap_InheritingMeleesDeadZone()
+        {
+            var cfg = WeaponScalingManager.BuildDefaults();
+            WeaponScalingTier Row(int t) => cfg.Tiers.Single(x => x.Tier == t);
+
+            // A 3,500-aug player. Each tier whose cap they can actually FILL adds a step, and the
+            // count freezes the moment a tier's cap climbs past their augs.
+            Assert.AreEqual(0, WeaponScalingCombat.LauncherTierSteps(cfg, Row(11), 3500));
+            Assert.AreEqual(1, WeaponScalingCombat.LauncherTierSteps(cfg, Row(12), 3500));
+            Assert.AreEqual(2, WeaponScalingCombat.LauncherTierSteps(cfg, Row(13), 3500));
+            Assert.AreEqual(2, WeaponScalingCombat.LauncherTierSteps(cfg, Row(14), 3500));
+            Assert.AreEqual(2, WeaponScalingCombat.LauncherTierSteps(cfg, Row(25), 3500),
+                "A T25 bow in 3,500-aug hands must be worth exactly what a T13 is — the same way a "
+                + "T25 melee weapon already is, both sharing min(augs, cap). A tier you cannot fill "
+                + "is worth nothing in either lane (owner: 'Bows should track min(augs, cap) like "
+                + "melee does').");
+        }
+
+        [TestMethod]
+        public void LauncherTierSteps_BaselineTierNeverAdds_AtAnyAugCount()
+        {
+            var cfg = WeaponScalingManager.BuildDefaults();
+            var t11 = cfg.Tiers.Single(x => x.Tier == 11);
+
+            foreach (var augs in new[] { 0, 2000, 2500, 9500, 100000 })
+                Assert.AreEqual(0, WeaponScalingCombat.LauncherTierSteps(cfg, t11, augs),
+                    "T11 is the baseline and must stay 1.0x at every aug count. This is WHY the "
+                    + "bow/melee gap at T11 (melee ~20-25 pct ahead, the owner's stated target) "
+                    + "cannot be tuned with LauncherTierStep — that needs a kMin/kMax edit.");
+        }
+
+        [TestMethod]
+        public void LauncherTierSteps_AtOwnCap_IsDistanceFromBaselineTier()
+        {
+            var cfg = WeaponScalingManager.BuildDefaults();
+
+            // The progression case: a player whose augs sit at their tier's cap unlocks every step.
+            foreach (var row in cfg.Tiers)
+                Assert.AreEqual(row.Tier - 11, WeaponScalingCombat.LauncherTierSteps(cfg, row, row.Cap),
+                    $"T{row.Tier} at its own cap");
+        }
+
+        [TestMethod]
+        public void LauncherTierSteps_CountsAuthoredCaps_NotTheSeeds500Spacing()
+        {
+            // Caps are hand-authored and the store is authoritative — the live grade weights
+            // already differ from the code seed — so the step count must follow the rows AS
+            // WRITTEN. Deliberately irregular spacing here.
+            var json = @"{""Enabled"":true,
+                ""Tiers"":[{""Tier"":11,""Cap"":2500,""MinWieldAugs"":2000},
+                           {""Tier"":12,""Cap"":9000,""MinWieldAugs"":2500},
+                           {""Tier"":13,""Cap"":9400,""MinWieldAugs"":9000}],
+                ""Scripts"":{""bow"":{""KMin"":3.13,""KMax"":4.00}},
+                ""KcMin"":0.6,""KcMax"":0.8}";
+            var cfg = WeaponScalingManager.Normalize(JsonConvert.DeserializeObject<WeaponScalingConfig>(json));
+            var t13 = cfg.Tiers.Single(t => t.Tier == 13);
+
+            Assert.AreEqual(0, WeaponScalingCombat.LauncherTierSteps(cfg, t13, 8999));
+            Assert.AreEqual(1, WeaponScalingCombat.LauncherTierSteps(cfg, t13, 9000));
+            Assert.AreEqual(2, WeaponScalingCombat.LauncherTierSteps(cfg, t13, 9400));
+        }
+
+        [TestMethod]
+        public void LauncherTierStep_DefaultsOnOlderStores_ButAnExplicitZeroDisablesIt()
+        {
+            // Tuned on T11-T15, the tiers players are actually in — NOT on the T25 asymptote
+            // (owner 2026-08-06: "T25 is years away, don't need to plan around that").
+            Assert.AreEqual(0.06, WeaponScalingManager.BuildDefaults().LauncherTierStep, 1e-9);
+
+            var legacy = @"{""Enabled"":true,""Tiers"":[],""Scripts"":{},""KcMin"":0.6,""KcMax"":0.8}";
+            Assert.AreEqual(0.06, WeaponScalingManager.Normalize(
+                    JsonConvert.DeserializeObject<WeaponScalingConfig>(legacy)).LauncherTierStep, 1e-9,
+                "A store written before this field existed must still get launcher tier scaling — "
+                + "the live store predates it and would otherwise leave bows with no tier term.");
+
+            var off = @"{""Enabled"":true,""LauncherTierStep"":0,""Tiers"":[],""Scripts"":{},""KcMin"":0.6,""KcMax"":0.8}";
+            Assert.AreEqual(0.0, WeaponScalingManager.Normalize(
+                    JsonConvert.DeserializeObject<WeaponScalingConfig>(off)).LauncherTierStep, 1e-9,
+                "An explicit 0 is the off switch.");
+        }
+
+        // ── Caster scaling (owner 2026-08-06, CasterScaling_Plan) ──
+        //
+        // "Lets keep bow and caster weapons scaling identical. We will tune vs magic on mobs."
+        // Same mechanism on ElementalDamageMod instead of DamageMod, own step knob so the two
+        // lanes CAN be parted later without a code change.
+
+        [TestMethod]
+        public void CasterTierStep_DefaultsEqualToTheLauncherStep_SoBothLanesStartIdentical()
+        {
+            var cfg = WeaponScalingManager.BuildDefaults();
+
+            Assert.AreEqual(cfg.LauncherTierStep, cfg.CasterTierStep, 1e-9,
+                "The lanes must START identical (owner: 'keep bow and caster weapons scaling "
+                + "identical'). The knob exists only so they can be parted DELIBERATELY later "
+                + "('incase we want to tune caster different later') — never by drift.");
+            Assert.AreEqual(0.06, cfg.CasterTierStep, 1e-9);
+        }
+
+        [TestMethod]
+        public void CasterTierStep_DefaultsOnOlderStores_ButAnExplicitZeroDisablesIt()
+        {
+            // Same legacy-store contract the launcher step has: the LIVE store predates this
+            // field, so a missing value must inherit the default rather than silently zero out.
+            var legacy = @"{""Enabled"":true,""Tiers"":[],""Scripts"":{},""KcMin"":0.6,""KcMax"":0.8}";
+            Assert.AreEqual(0.06, WeaponScalingManager.Normalize(
+                    JsonConvert.DeserializeObject<WeaponScalingConfig>(legacy)).CasterTierStep, 1e-9,
+                "The live store was written before this field existed and would otherwise leave "
+                + "casters with no tier term at all.");
+
+            var off = @"{""Enabled"":true,""CasterTierStep"":0,""Tiers"":[],""Scripts"":{},""KcMin"":0.6,""KcMax"":0.8}";
+            Assert.AreEqual(0.0, WeaponScalingManager.Normalize(
+                    JsonConvert.DeserializeObject<WeaponScalingConfig>(off)).CasterTierStep, 1e-9,
+                "An explicit 0 is the off switch, independently of the launcher lane.");
+
+            var negative = @"{""Enabled"":true,""CasterTierStep"":-5,""Tiers"":[],""Scripts"":{},""KcMin"":0.6,""KcMax"":0.8}";
+            Assert.AreEqual(0.0, WeaponScalingManager.Normalize(
+                    JsonConvert.DeserializeObject<WeaponScalingConfig>(negative)).CasterTierStep, 1e-9,
+                "Hand-edited negatives are repaired, not honored — a negative step would SHRINK "
+                + "the mod as tiers rise.");
+        }
+
+        [TestMethod]
+        public void CasterBand_PortsTheLauncherConstruction_OverTheRealT10Ceiling()
+        {
+            var cfg = WeaponScalingManager.BuildDefaults();
+            var caster = cfg.Scripts["caster_elemental"];
+
+            // Real T10 casters roll 1.20-1.22: every wield >= 500 falls through to
+            // RollElementalDamageMod's "// 550" default, so T9/T10/T11 all roll the SAME value —
+            // casters had no generational scaling whatsoever before this wire-in.
+            const double t10CasterCeiling = 1.22;
+            const double t10BowCeiling = 3.08;   // launcher reference, Handoff_2026-08-03
+            const double bowKMax = 4.00;
+
+            Assert.AreEqual(bowKMax / t10BowCeiling, caster.KMax / t10CasterCeiling, 5e-3,
+                "S grade must clear the T10 ceiling by the SAME percentage in both lanes — that is "
+                + "what 'identical scaling' means when the two lanes drive different properties "
+                + "off different baselines. Both mods multiply their lane's whole damage "
+                + "expression, so equal percentages ARE equal damage.");
+
+            Assert.IsTrue(caster.KMin > t10CasterCeiling,
+                $"Even the WORST T11 caster ({caster.KMin}) must beat the BEST T10 roll "
+                + $"({t10CasterCeiling}) — the launcher floor 3.13 clears its 3.08 ceiling the "
+                + "same way. Otherwise a T11 drop can be a downgrade.");
+        }
+
+        [TestMethod]
+        public void CasterBand_KeepsTheSameFtoSSpreadAsEveryOtherFamily()
+        {
+            var cfg = WeaponScalingManager.BuildDefaults();
+            var caster = cfg.Scripts["caster_elemental"];
+
+            // The house ratio: kMin = kMax x 0.90/1.15, the melee F->S spread (+27.8 pct),
+            // which the launcher band also follows.
+            Assert.AreEqual(0.90 / 1.15, caster.KMin / caster.KMax, 5e-3,
+                "A caster's grade must be worth the same relative jump as a bow's or a sword's.");
+        }
+
+        // ── Caster damage share (owner GO 2026-08-06, CasterDamageShare_Plan) ──
+        //
+        // "The plan needs to solve the same thing we solved for melee and bow. Making the
+        // weapon itself contribute roughly 25-35% of total damage." Composition change:
+        // modifier = wandMod x (1 + rescale x enchantments), replacing stock wandMod + ench.
+
+        [TestMethod]
+        public void CasterAuraRescale_IsTheReciprocalOfTheBandTop_SoSGradeAnchorsExactly()
+        {
+            var cfg = WeaponScalingManager.BuildDefaults();
+
+            Assert.AreEqual(1.0 / cfg.Scripts["caster_elemental"].KMax, cfg.CasterAuraRescale, 1e-3,
+                "r = 1/kMax is the anchor derivation: kMax x (1 + r x A) = kMax + A for EVERY "
+                + "aura size A, so an S-grade wand's total is unchanged from the old additive "
+                + "math at every aug count. Retune this only in step with kMax or the anchor "
+                + "property breaks.");
+        }
+
+        [TestMethod]
+        public void ComposeCasterModifier_SGradeMatchesTheOldAdditiveMath_AtEveryAuraSize()
+        {
+            var cfg = WeaponScalingManager.BuildDefaults();
+            var kMax = cfg.Scripts["caster_elemental"].KMax;   // 1.58, the S-grade resolve at T11
+
+            // Spirit Drinker at 3,500 / 2,000 / 0 item augs (+0.005 per aug), plus a no-buff case.
+            foreach (var aura in new[] { 17.5, 10.0, 2.5, 0.0 })
+            {
+                var composed = WeaponScalingCombat.ComposeCasterModifier(kMax, aura, cfg.CasterAuraRescale);
+                var stockAdditive = kMax + aura;
+                Assert.AreEqual(stockAdditive, composed, 0.005,
+                    $"aura={aura}: the migration must be INVISIBLE to the reference build (S "
+                    + "grade, matching element). Everyone else re-grades around this anchor.");
+            }
+        }
+
+        [TestMethod]
+        public void ComposeCasterModifier_MakesTiersAndGradesFinallyMoveTheTotal()
+        {
+            var cfg = WeaponScalingManager.BuildDefaults();
+            var s = cfg.Scripts["caster_elemental"].KMax;      // 1.58
+            var fMinus = cfg.Scripts["caster_elemental"].KMin; // 1.24
+            const double aura = 17.5;                          // 3,500-aug Spirit Drinker
+            var r = cfg.CasterAuraRescale;
+
+            // Under multiplicative composition the wandMod ratio IS the damage ratio.
+            var t14 = WeaponScalingCombat.ComposeCasterModifier(s * 1.12, aura, r);   // 2 steps at 0.06
+            var t11 = WeaponScalingCombat.ComposeCasterModifier(s, aura, r);
+            Assert.AreEqual(1.12, t14 / t11, 1e-6,
+                "T11 vs T14 measured ~1 pct apart in game under additive composition — the "
+                + "owner's original complaint. Multiplicative composition must restore the full "
+                + "+12 pct the tier steps grant.");
+
+            Assert.AreEqual(s / fMinus, t11 / WeaponScalingCombat.ComposeCasterModifier(fMinus, aura, r), 1e-6,
+                "S vs F- was +1.8 pct under additive (melee's same spread is 2.288x); now it is "
+                + "the full band ratio 1.27x.");
+
+            // The owner's stated target: the weapon carries 25-35 pct of total damage. Share =
+            // what you lose dropping to a wandless/mod-1.0 baseline. S lands just above the
+            // window (36.7 pct), F- just below (19.4) — same shape as melee, where better
+            // weapons carry more.
+            var share = 1.0 - WeaponScalingCombat.ComposeCasterModifier(1.0, aura, r) / t11;
+            Assert.IsTrue(share > 0.30 && share < 0.40, $"S-grade weapon share {share:F3}");
+        }
+
+        [TestMethod]
+        public void CasterAuraRescale_DefaultsOnOlderStores_AndNegativesAreRepaired()
+        {
+            // Same legacy-store contract as both tier steps: the live store predates the field.
+            var legacy = @"{""Enabled"":true,""Tiers"":[],""Scripts"":{},""KcMin"":0.6,""KcMax"":0.8}";
+            Assert.AreEqual(0.6329, WeaponScalingManager.Normalize(
+                    JsonConvert.DeserializeObject<WeaponScalingConfig>(legacy)).CasterAuraRescale, 1e-9);
+
+            var negative = @"{""Enabled"":true,""CasterAuraRescale"":-1,""Tiers"":[],""Scripts"":{},""KcMin"":0.6,""KcMax"":0.8}";
+            Assert.AreEqual(0.0, WeaponScalingManager.Normalize(
+                    JsonConvert.DeserializeObject<WeaponScalingConfig>(negative)).CasterAuraRescale, 1e-9,
+                "A negative rescale would turn buffs into damage PENALTIES; repaired to 0 "
+                + "(= enchantments contribute nothing while the system is on — wrong, but "
+                + "visibly wrong instead of subtly inverted).");
+        }
+
+        [TestMethod]
+        public void CasterNonElemental_StaysInert_BecauseItHasNoLeverToScale()
+        {
+            var cfg = WeaponScalingManager.BuildDefaults();
+
+            // A plain Orb/Sceptre/Staff/Wand (the wield==0 loot branch) has no element, so
+            // GetCasterElementalDamageModifier's damage-type match gate returns a flat 1.0 no
+            // matter what we resolve. Scaling it would be theatre. Documented as inert here so a
+            // future reader does not "fix" the band and expect an effect.
+            Assert.AreNotEqual(cfg.Scripts["caster_elemental"].KMax,
+                               cfg.Scripts["caster_non_elemental"].KMax,
+                "caster_non_elemental is deliberately NOT on the tuned band — it cannot scale. "
+                + "If plain casters should stop dropping, that is a LOOT change (they are 25 pct "
+                + "of T10/T11 caster drops), not a scaling one.");
+        }
+
+        [TestMethod]
+        public void Ladder_EveryStepIsEvenInDEALTDamage()
+        {
+            var cfg = WeaponScalingManager.BuildDefaults();
+
+            // The rung is stored with EV normalization divided out, so evenness must be asserted
+            // on k x EvNormalization — the quantity that actually reaches the damage envelope.
+            // Asserting on raw k would pass a ladder that visibly steps +5.6 pct at the top and
+            // +4.8 pct at the bottom, which is the exact defect this system removes.
+            foreach (var kv in cfg.Scripts.Where(s => s.Value.HasLadder))
+            {
+                double? prev = null;
+                foreach (var b in WeaponScalingManager.SubGradeBands)
+                {
+                    var k = kv.Value.Grades[b.Grade];
+                    var vEff = WeaponScalingManager.EffectiveVariance(kv.Value.Variance, cfg.TightenStrength, b.QMid);
+                    var dealt = k * WeaponScalingManager.EvNormalization(vEff);
+
+                    if (prev.HasValue)
+                        Assert.AreEqual(WeaponScalingManager.LadderStep, prev.Value / dealt, 1e-3,
+                            $"{kv.Key} step into {b.Grade}");
+                    prev = dealt;
+                }
+            }
+        }
+
+        [TestMethod]
+        public void Ladder_FullGradeStepIs18Percent()
+        {
+            var cfg = WeaponScalingManager.BuildDefaults();
+            var s = cfg.Scripts["unarmed"];
+
+            double Dealt(string grade)
+            {
+                var b = WeaponScalingManager.SubGradeBands.Single(x => x.Grade == grade);
+                return s.Grades[grade] * WeaponScalingManager.EvNormalization(
+                    WeaponScalingManager.EffectiveVariance(s.Variance, cfg.TightenStrength, b.QMid));
+            }
+
+            Assert.AreEqual(1.18, Dealt("A") / Dealt("B"), 1e-3, "A -> B is one full grade");
+            Assert.AreEqual(1.18, Dealt("B") / Dealt("C"), 1e-3, "B -> C is one full grade");
+            // S vs B was the presenting complaint: +7.5 pct under the old lerp, +32 pct now.
+            Assert.AreEqual(1.318, Dealt("S") / Dealt("B"), 5e-3, "S vs B");
+        }
+
+        [TestMethod]
+        public void Ladder_InterpolatesBetweenRungs_RungsStayExact()
+        {
+            var cfg = WeaponScalingManager.BuildDefaults();
+            var s = cfg.Scripts["unarmed"];
+
+            // REPLACES Ladder_ResolvesFlatPerSubGrade_NoInterpolation (owner 2026-08-06: "those 2
+            // weapons should not be identical damage"). k now interpolates BETWEEN rungs so every
+            // distinct roll deals distinct damage and the appraisal percent means something.
+
+            // 1. Each rung is still EXACT at its own sub-grade midpoint — the authored values are
+            //    what the Damage Chart shows and what the owner tuned.
+            foreach (var b in WeaponScalingManager.SubGradeBands)
+                Assert.AreEqual(s.Grades[b.Grade], WeaponScalingManager.ResolveScriptK(s, b.QMid), 1e-12,
+                    $"rung {b.Grade} must be exact at its midpoint");
+
+            // 2. Inside a band, k now VARIES — this is the reversal.
+            var atLow = WeaponScalingManager.ResolveScriptK(s, 867);
+            var atMid = WeaponScalingManager.ResolveScriptK(s, 883);
+            Assert.IsTrue(atMid > atLow, "a higher roll inside B+ must deal more than a lower one");
+
+            // 3. ...and it is MONOTONIC across the whole range, with no discontinuity at any band
+            //    edge (a jump there would let one quality point be worth a whole sub-grade).
+            var prev = -1.0;
+            for (var q = 0; q <= WeaponScalingManager.QualityMax; q++)
+            {
+                var k = WeaponScalingManager.ResolveScriptK(s, q);
+                Assert.IsTrue(k >= prev - 1e-12, $"k must never decrease as quality rises (q{q})");
+                prev = k;
+            }
+
+            // 4. Endpoints clamp to the S and F- rungs rather than running off the ladder.
+            Assert.AreEqual(s.Grades["S"], WeaponScalingManager.ResolveScriptK(s, 1000), 1e-12);
+            Assert.AreEqual(s.Grades["F-"], WeaponScalingManager.ResolveScriptK(s, 0), 1e-12);
+        }
+
+        [TestMethod]
+        public void RelativeDamagePercent_MeasuresDamageNotQualityPercentile()
+        {
+            var cfg = WeaponScalingManager.BuildDefaults();
+            var s = cfg.Scripts["unarmed"];
+
+            int Pct(int q) => WeaponScalingManager.RelativeDamagePercent(s, cfg.TightenStrength, q);
+
+            // A perfect roll is by definition 100 pct of max.
+            Assert.AreEqual(100, Pct(1000));
+
+            // The old display printed quality/10, so F- (q0) read "0 pct of max" while dealing a
+            // large share of an S weapon's damage. The number must reflect DAMAGE.
+            Assert.IsTrue(Pct(0) > 35 && Pct(0) < 50, $"F- deals a real share of max, got {Pct(0)} pct");
+
+            // The two weapons that started this: q867 and q883 are both B+ and must now differ.
+            Assert.AreNotEqual(Pct(867), Pct(883), "identical-looking B+ rolls must read differently");
+
+            // Monotonic, and never above 100.
+            var prev = -1;
+            for (var q = 0; q <= WeaponScalingManager.QualityMax; q++)
+            {
+                var p = Pct(q);
+                Assert.IsTrue(p >= prev, $"percent must not decrease as quality rises (q{q})");
+                Assert.IsTrue(p <= 100, $"percent must never exceed 100 (q{q})");
+                prev = p;
+            }
+        }
+
+        [TestMethod]
+        public void Ladder_LerpFamiliesStillUseKMinKMax()
+        {
+            var cfg = WeaponScalingManager.BuildDefaults();
+            var bow = cfg.Scripts["bow"];
+
+            Assert.AreEqual(4.00, WeaponScalingManager.ResolveScriptK(bow, 1000), 1e-9);
+            Assert.AreEqual(3.13, WeaponScalingManager.ResolveScriptK(bow, 0), 1e-9);
+            // Continuous, not stepped — proof the ladder path is genuinely bypassed.
+            Assert.AreNotEqual(WeaponScalingManager.ResolveScriptK(bow, 500),
+                               WeaponScalingManager.ResolveScriptK(bow, 600), 1e-6);
+        }
+
+        [TestMethod]
+        public void SubGrade_BandLabelsAndEdges()
+        {
+            Assert.AreEqual("S", WeaponScalingManager.GetQualitySubGrade(1000));
+            Assert.AreEqual("A+", WeaponScalingManager.GetQualitySubGrade(999));
+            Assert.AreEqual("A+", WeaponScalingManager.GetQualitySubGrade(967));
+            Assert.AreEqual("A", WeaponScalingManager.GetQualitySubGrade(966));
+            Assert.AreEqual("A-", WeaponScalingManager.GetQualitySubGrade(900));
+            Assert.AreEqual("B+", WeaponScalingManager.GetQualitySubGrade(899));
+            Assert.AreEqual("B-", WeaponScalingManager.GetQualitySubGrade(800));
+            Assert.AreEqual("C+", WeaponScalingManager.GetQualitySubGrade(799));
+            Assert.AreEqual("D-", WeaponScalingManager.GetQualitySubGrade(500));
+            Assert.AreEqual("F+", WeaponScalingManager.GetQualitySubGrade(499));
+            Assert.AreEqual("F-", WeaponScalingManager.GetQualitySubGrade(0));
+
+            // Sub-grades must TILE their parent grade exactly — a gap or overlap would mean a
+            // drop rolled inside GradeWeights lands on a rung from a different letter.
+            foreach (var g in WeaponScalingManager.GradeBands)
+            {
+                var subs = WeaponScalingManager.SubGradeBands.Where(b => b.Grade.TrimEnd('+', '-') == g.Grade).ToList();
+                Assert.AreEqual(g.QMin, subs.Min(b => b.QMin), $"{g.Grade} sub-grades must start at the grade floor");
+                Assert.AreEqual(g.QMax, subs.Max(b => b.QMax), $"{g.Grade} sub-grades must end at the grade ceiling");
+            }
+        }
+
+        [TestMethod]
+        public void Normalize_CompletesAPartialLadderFromTheLerp()
+        {
+            var cfg = new WeaponScalingConfig { TightenStrength = 0.7 };
+            cfg.Scripts["x"] = new WeaponScalingScript
+            {
+                KMin = 0.40,
+                KMax = 0.90,
+                Grades = new System.Collections.Generic.Dictionary<string, double> { ["S"] = 0.90 },
+            };
+
+            WeaponScalingManager.Normalize(cfg);
+
+            // A half-authored ladder would silently mix ladder rungs with lerp rungs.
+            Assert.AreEqual(WeaponScalingManager.SubGradeBands.Length, cfg.Scripts["x"].Grades.Count);
+            Assert.AreEqual(0.90, cfg.Scripts["x"].Grades["S"], 1e-9, "authored rung preserved");
+        }
+
+        [TestMethod]
+        public void Normalize_EmptyLadderBecomesNoLadder()
+        {
+            var cfg = new WeaponScalingConfig();
+            cfg.Scripts["x"] = new WeaponScalingScript
+            {
+                KMin = 0.40,
+                KMax = 0.90,
+                Grades = new System.Collections.Generic.Dictionary<string, double>(),
+            };
+
+            WeaponScalingManager.Normalize(cfg);
+
+            Assert.IsFalse(cfg.Scripts["x"].HasLadder, "An empty dictionary must read as 'no ladder'.");
+        }
+
+        [TestMethod]
+        public void RebaseLadder_HoldsDealtDamageFlatAcrossAVarianceEdit()
+        {
+            var cfg = WeaponScalingManager.BuildDefaults();
+            var s = cfg.Scripts["unarmed"];
+            const double oldVar = 0.55, newVar = 0.20;
+
+            double Dealt(double variance, string grade)
+            {
+                var b = WeaponScalingManager.SubGradeBands.Single(x => x.Grade == grade);
+                return s.Grades[grade] * WeaponScalingManager.EvNormalization(
+                    WeaponScalingManager.EffectiveVariance(variance, cfg.TightenStrength, b.QMid));
+            }
+
+            var before = WeaponScalingManager.SubGradeBands.Select(b => Dealt(oldVar, b.Grade)).ToList();
+            WeaponScalingManager.RebaseLadder(s, oldVar, cfg.TightenStrength, newVar, cfg.TightenStrength);
+            var after = WeaponScalingManager.SubGradeBands.Select(b => Dealt(newVar, b.Grade)).ToList();
+
+            // The owner's standing invariant: editing a Variance knob rebalances rather than
+            // silently changing how hard the family hits.
+            for (var i = 0; i < before.Count; i++)
+                Assert.AreEqual(before[i], after[i], before[i] * 1e-3,
+                    $"{WeaponScalingManager.SubGradeBands[i].Grade} dealt damage moved on a variance edit");
+        }
+
+        [TestMethod]
+        public void Defaults_ScriptLookupIsCaseInsensitive()
+        {
+            var cfg = WeaponScalingManager.BuildDefaults();
+            Assert.IsTrue(cfg.Scripts.ContainsKey("Sword"));
+        }
+
+        // ── Quality lerp (the swing-time resolve) ──
+
+        [TestMethod]
+        public void ResolveFromQuality_EndpointsAndMidpoint()
+        {
+            Assert.AreEqual(0.90, WeaponScalingManager.ResolveFromQuality(0.90, 1.15, 0), 1e-9);
+            Assert.AreEqual(1.15, WeaponScalingManager.ResolveFromQuality(0.90, 1.15, 1000), 1e-9);
+            Assert.AreEqual(1.025, WeaponScalingManager.ResolveFromQuality(0.90, 1.15, 500), 1e-9);
+        }
+
+        [TestMethod]
+        public void ResolveFromQuality_OutOfRangeQualityClamps()
+        {
+            Assert.AreEqual(0.90, WeaponScalingManager.ResolveFromQuality(0.90, 1.15, -50), 1e-9);
+            Assert.AreEqual(1.15, WeaponScalingManager.ResolveFromQuality(0.90, 1.15, 99999), 1e-9);
+        }
+
+        [TestMethod]
+        public void QualityGrade_SchoolStyleBandsAndEdges()
+        {
+            // S = a literally perfect roll only (1 in 1,001); the rest are school-style.
+            Assert.AreEqual("S", WeaponScalingManager.GetQualityGrade(1000));
+            Assert.AreEqual("A", WeaponScalingManager.GetQualityGrade(999));
+            Assert.AreEqual("A", WeaponScalingManager.GetQualityGrade(900));
+            Assert.AreEqual("B", WeaponScalingManager.GetQualityGrade(899));
+            Assert.AreEqual("B", WeaponScalingManager.GetQualityGrade(800));
+            Assert.AreEqual("C", WeaponScalingManager.GetQualityGrade(799));
+            Assert.AreEqual("C", WeaponScalingManager.GetQualityGrade(650));
+            Assert.AreEqual("D", WeaponScalingManager.GetQualityGrade(649));
+            Assert.AreEqual("D", WeaponScalingManager.GetQualityGrade(500));
+            Assert.AreEqual("F", WeaponScalingManager.GetQualityGrade(499));
+            Assert.AreEqual("F", WeaponScalingManager.GetQualityGrade(0));
+        }
+
+        // ── Normalize (hand-edited / legacy store repair) ──
+
+        [TestMethod]
+        public void Normalize_RepairsInvertedRangesAndNegatives()
+        {
+            var cfg = new WeaponScalingConfig
+            {
+                KcMin = 0.9,
+                KcMax = 0.5,
+            };
+            cfg.Scripts["x"] = new WeaponScalingScript { KMin = 1.2, KMax = 0.8 };
+            cfg.Tiers.Add(new WeaponScalingTier { Tier = 11, Cap = -5, MinWieldAugs = -1 });
+
+            WeaponScalingManager.Normalize(cfg);
+
+            Assert.AreEqual(0.5, cfg.KcMin, 1e-9);
+            Assert.AreEqual(0.9, cfg.KcMax, 1e-9);
+            Assert.AreEqual(0.8, cfg.Scripts["x"].KMin, 1e-9);
+            Assert.AreEqual(1.2, cfg.Scripts["x"].KMax, 1e-9);
+            Assert.AreEqual(0, cfg.Tiers[0].Cap);
+            Assert.AreEqual(0, cfg.Tiers[0].MinWieldAugs);
+        }
+
+        [TestMethod]
+        public void Normalize_DedupesTiersAndRestoresCaseInsensitivity()
+        {
+            var json = @"{""Enabled"":true,
+                ""Tiers"":[{""Tier"":12,""Cap"":3000,""MinWieldAugs"":2500},{""Tier"":12,""Cap"":9999,""MinWieldAugs"":0},{""Tier"":11,""Cap"":2500,""MinWieldAugs"":0}],
+                ""Scripts"":{""heavy_sword"":{""KMin"":0.9,""KMax"":1.15}},
+                ""KcMin"":0.6,""KcMax"":0.8}";
+            var cfg = WeaponScalingManager.Normalize(JsonConvert.DeserializeObject<WeaponScalingConfig>(json));
+
+            Assert.AreEqual(2, cfg.Tiers.Count);
+            Assert.AreEqual(11, cfg.Tiers[0].Tier, "tiers sort ascending");
+            Assert.AreEqual(3000, cfg.Tiers.Single(t => t.Tier == 12).Cap, "first entry wins on dupes");
+            Assert.IsTrue(cfg.Scripts.ContainsKey("HEAVY_SWORD"), "deserialized dictionary must regain case-insensitive lookup");
+        }
+
+        [TestMethod]
+        public void Normalize_MigratesFlatEraLauncherRowsToModifierBand()
+        {
+            // Pre-2026-08-01 stores carry launcher rows as flat-term coefficients (~0.9-1.15);
+            // under replace semantics those would resolve AS the damage modifier and ~quarter
+            // launcher damage. Normalize must bump any launcher row entirely below 2.0 to the
+            // modifier-band defaults, while respecting deliberate values >= 2.0.
+            var cfg = new WeaponScalingConfig();
+            cfg.Scripts["bow"] = new WeaponScalingScript { KMin = 0.90, KMax = 1.15 };
+            cfg.Scripts["crossbow"] = new WeaponScalingScript { KMin = 0.40, KMax = 0.51 };
+            cfg.Scripts["atlatl"] = new WeaponScalingScript { KMin = 2.80, KMax = 3.10 };
+            cfg.Scripts["sword"] = new WeaponScalingScript { KMin = 0.90, KMax = 1.15 };
+
+            WeaponScalingManager.Normalize(cfg);
+
+            // Migration target follows the CURRENT band (retuned to 3.13/4.00 on 2026-08-02).
+            Assert.AreEqual(3.13, cfg.Scripts["bow"].KMin, 1e-9);
+            Assert.AreEqual(4.00, cfg.Scripts["bow"].KMax, 1e-9);
+            Assert.AreEqual(3.13, cfg.Scripts["crossbow"].KMin, 1e-9);
+            Assert.AreEqual(4.00, cfg.Scripts["crossbow"].KMax, 1e-9);
+            Assert.AreEqual(2.80, cfg.Scripts["atlatl"].KMin, 1e-9, "deliberate >= 2.0 band must survive");
+            Assert.AreEqual(3.10, cfg.Scripts["atlatl"].KMax, 1e-9);
+            Assert.AreEqual(0.90, cfg.Scripts["sword"].KMin, 1e-9, "melee rows untouched");
+            Assert.AreEqual(1.15, cfg.Scripts["sword"].KMax, 1e-9);
+        }
+
+        // ── Store round-trip ──
+
+        [TestMethod]
+        public void Store_JsonRoundTripPreservesEverything()
+        {
+            var cfg = WeaponScalingManager.BuildDefaults();
+            cfg.Enabled = true;
+
+            var back = WeaponScalingManager.Normalize(
+                JsonConvert.DeserializeObject<WeaponScalingConfig>(JsonConvert.SerializeObject(cfg)));
+
+            Assert.IsTrue(back.Enabled);
+            Assert.AreEqual(cfg.Tiers.Count, back.Tiers.Count);
+            Assert.AreEqual(cfg.Scripts.Count, back.Scripts.Count);
+            foreach (var t in cfg.Tiers)
+            {
+                var bt = back.Tiers.Single(x => x.Tier == t.Tier);
+                Assert.AreEqual(t.Cap, bt.Cap);
+                Assert.AreEqual(t.MinWieldAugs, bt.MinWieldAugs);
+            }
+            foreach (var s in cfg.Scripts)
+            {
+                Assert.AreEqual(s.Value.KMin, back.Scripts[s.Key].KMin, 1e-9);
+                Assert.AreEqual(s.Value.KMax, back.Scripts[s.Key].KMax, 1e-9);
+            }
+            Assert.AreEqual(cfg.KcMin, back.KcMin, 1e-9);
+            Assert.AreEqual(cfg.KcMax, back.KcMax, 1e-9);
+        }
+    }
+}

--- a/Source/ACE.Server.Tests/ZoneDefaultLayerTests.cs
+++ b/Source/ACE.Server.Tests/ZoneDefaultLayerTests.cs
@@ -1,0 +1,269 @@
+using ACE.Server.Managers.ZoneControl;
+using ACE.Server.Managers.ZoneScaling;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ACE.Server.Tests
+{
+    /// <summary>
+    /// The per-variation Default layer (2026-07-30): resolution is
+    /// <c>VariationDefault -&gt; zone -&gt; wcid</c>, merged PER STAT, never wholesale.
+    ///
+    /// These cover the merge primitives directly — they are pure static functions with no DB or DAT
+    /// dependency. The merge runs once at snapshot-build time (ZoneControlManager.BuildZoneRef), so a bug
+    /// here silently mis-resolves every governed monster's stats with no other symptom.
+    /// </summary>
+    [TestClass]
+    public class ZoneDefaultLayerTests
+    {
+        private static ZoneVariantProfile Profile(params (string stat, double val)[] stats)
+        {
+            var p = new ZoneVariantProfile();
+            foreach (var (stat, val) in stats)
+                p.Stats[stat] = new StatCurve { Base = val };
+            return p;
+        }
+
+        private static double Stat(ZoneVariantProfile p, string key) => p.Stats[key].Base;
+
+        // ── stat layering ──
+
+        [TestMethod]
+        public void Merge_NoLayers_IsEmpty()
+        {
+            Assert.IsTrue(ZoneVariantProfile.Merge().IsEmpty);
+            Assert.IsTrue(ZoneVariantProfile.Merge(null, null).IsEmpty);
+        }
+
+        [TestMethod]
+        public void Merge_ZoneOverridesDefault_PerStat()
+        {
+            var def = Profile(("max_health", 1100), ("melee_defense", 1100));
+            var zone = Profile(("max_health", 5000));
+
+            var merged = ZoneVariantProfile.Merge(def, zone);
+
+            Assert.AreEqual(5000, Stat(merged, "max_health"), "zone wins where it authors");
+            Assert.AreEqual(1100, Stat(merged, "melee_defense"), "unauthored falls through to the Default");
+        }
+
+        [TestMethod]
+        public void Merge_WcidIsMostSpecific()
+        {
+            var def = Profile(("max_health", 1100), ("melee_defense", 1100), ("attack_damage", 1100));
+            var zone = Profile(("max_health", 5000), ("melee_defense", 2000));
+            var wcid = Profile(("max_health", 9999));
+
+            var merged = ZoneVariantProfile.Merge(def, zone, wcid);
+
+            Assert.AreEqual(9999, Stat(merged, "max_health"), "wcid beats zone and default");
+            Assert.AreEqual(2000, Stat(merged, "melee_defense"), "zone beats default");
+            Assert.AreEqual(1100, Stat(merged, "attack_damage"), "default survives when nothing overrides");
+        }
+
+        [TestMethod]
+        public void Merge_WcidSettingOneStat_DoesNotWipeTheRest()
+        {
+            // THE regression this layer exists to fix: a per-WCID bucket used to REPLACE the whole
+            // profile, so a boss with one authored stat lost every other zone/default value.
+            var def = Profile(("max_health", 1100), ("melee_defense", 1100), ("armor_level", 1100));
+            var zone = Profile(("max_health", 5000));
+            var wcid = Profile(("attack_damage", 7777));
+
+            var merged = ZoneVariantProfile.Merge(def, zone, wcid);
+
+            Assert.AreEqual(7777, Stat(merged, "attack_damage"));
+            Assert.AreEqual(5000, Stat(merged, "max_health"));
+            Assert.AreEqual(1100, Stat(merged, "melee_defense"));
+            Assert.AreEqual(1100, Stat(merged, "armor_level"));
+        }
+
+        [TestMethod]
+        public void Merge_NullLayersAreSkipped()
+        {
+            var zone = Profile(("max_health", 5000));
+
+            var merged = ZoneVariantProfile.Merge(null, zone, null);
+
+            Assert.AreEqual(5000, Stat(merged, "max_health"));
+            Assert.AreEqual(1, merged.Stats.Count);
+        }
+
+        [TestMethod]
+        public void Merge_DoesNotMutateItsInputs()
+        {
+            // The layers handed in are the LIVE admin-mutable objects behind the lock; mutating them
+            // would corrupt the store and leak edits across zones.
+            var def = Profile(("max_health", 1100));
+            var zone = Profile(("max_health", 5000));
+
+            ZoneVariantProfile.Merge(def, zone);
+
+            Assert.AreEqual(1100, Stat(def, "max_health"));
+            Assert.AreEqual(5000, Stat(zone, "max_health"));
+            Assert.AreEqual(1, def.Stats.Count);
+            Assert.AreEqual(1, zone.Stats.Count);
+        }
+
+        [TestMethod]
+        public void Merge_Props_LayerPerKey()
+        {
+            var def = new ZoneVariantProfile();
+            def.PropInts[1234] = 10;
+            def.PropFloats[99] = 1.5;
+            def.PropBools[7] = true;
+
+            var zone = new ZoneVariantProfile();
+            zone.PropInts[1234] = 20;
+
+            var merged = ZoneVariantProfile.Merge(def, zone);
+
+            Assert.AreEqual(20, merged.PropInts[1234]);
+            Assert.AreEqual(1.5, merged.PropFloats[99]);
+            Assert.IsTrue(merged.PropBools[7]);
+        }
+
+        // ── list-valued fields: UNION, most specific wins on collision ──
+
+        [TestMethod]
+        public void Merge_Modifiers_UnionAndDeduped()
+        {
+            var def = new ZoneVariantProfile();
+            def.CustomModifiers.AddRange(new[] { 1, 2 });
+            var zone = new ZoneVariantProfile();
+            zone.CustomModifiers.AddRange(new[] { 2, 3 });
+
+            var merged = ZoneVariantProfile.Merge(def, zone);
+
+            CollectionAssert.AreEquivalent(new[] { 1, 2, 3 }, merged.CustomModifiers);
+        }
+
+        [TestMethod]
+        public void Merge_CurrencyDrops_UnionKeyedByWcid()
+        {
+            var def = new ZoneVariantProfile();
+            def.CurrencyDrops.Add(new ZoneCurrencyDrop { Wcid = 100, Amount = 1 });
+            def.CurrencyDrops.Add(new ZoneCurrencyDrop { Wcid = 200, Amount = 5 });
+
+            var zone = new ZoneVariantProfile();
+            zone.CurrencyDrops.Add(new ZoneCurrencyDrop { Wcid = 100, Amount = 50 });   // collision
+            zone.CurrencyDrops.Add(new ZoneCurrencyDrop { Wcid = 300, Amount = 7 });    // addition
+
+            var merged = ZoneVariantProfile.Merge(def, zone);
+
+            Assert.AreEqual(3, merged.CurrencyDrops.Count, "a zone adds a drop without restating the Default's");
+            Assert.AreEqual(50, merged.CurrencyDrops.Find(d => d.Wcid == 100).Amount, "zone wins the collision");
+            Assert.AreEqual(5, merged.CurrencyDrops.Find(d => d.Wcid == 200).Amount);
+            Assert.AreEqual(7, merged.CurrencyDrops.Find(d => d.Wcid == 300).Amount);
+        }
+
+        [TestMethod]
+        public void Merge_CurrencyDrops_AreClonedNotShared()
+        {
+            var def = new ZoneVariantProfile();
+            def.CurrencyDrops.Add(new ZoneCurrencyDrop { Wcid = 100, Amount = 1 });
+
+            var merged = ZoneVariantProfile.Merge(def);
+            merged.CurrencyDrops[0].Amount = 999;
+
+            Assert.AreEqual(1, def.CurrencyDrops[0].Amount, "merging must not alias the live entry");
+        }
+
+        [TestMethod]
+        public void Merge_SpellRules_UnionKeyedBySpellId()
+        {
+            var def = new ZoneVariantProfile();
+            def.SpellRules.Add(new ZoneSpellRule { SpellId = 10, Chance = 2.0 });
+
+            var zone = new ZoneVariantProfile();
+            zone.SpellRules.Add(new ZoneSpellRule { SpellId = 10, Chance = 25.0 });
+            zone.SpellRules.Add(new ZoneSpellRule { SpellId = 20, Disabled = true });
+
+            var merged = ZoneVariantProfile.Merge(def, zone);
+
+            Assert.AreEqual(2, merged.SpellRules.Count);
+            Assert.AreEqual(25.0, merged.SpellRules.Find(r => r.SpellId == 10).Chance);
+            Assert.IsTrue(merged.SpellRules.Find(r => r.SpellId == 20).Disabled);
+        }
+
+        // ── body parts: per part, then per field within the part ──
+
+        [TestMethod]
+        public void Merge_BodyParts_LayerPerField()
+        {
+            var def = new ZoneVariantProfile();
+            def.BodyParts[16] = new ZoneBodyPart { Armor = 500, Damage = 100 };
+
+            var zone = new ZoneVariantProfile();
+            zone.BodyParts[16] = new ZoneBodyPart { Damage = 250 };   // armor unset -> inherits
+
+            var merged = ZoneVariantProfile.Merge(def, zone);
+
+            Assert.AreEqual(500, merged.BodyParts[16].Armor, "unset field falls through");
+            Assert.AreEqual(250, merged.BodyParts[16].Damage, "set field wins");
+        }
+
+        [TestMethod]
+        public void BodyPart_Merge_HandlesNulls()
+        {
+            var only = new ZoneBodyPart { Armor = 1 };
+            Assert.AreEqual(1, ZoneBodyPart.Merge(null, only).Armor);
+            Assert.AreEqual(1, ZoneBodyPart.Merge(only, null).Armor);
+            Assert.IsNull(ZoneBodyPart.Merge(null, null));
+        }
+
+        // ── effects: nullable so they can layer ──
+
+        [TestMethod]
+        public void Effects_MergePerField()
+        {
+            var def = new ZoneEffects { DotEnabled = true, DotDamage = 5, DotDamageType = 0x10, DotIntervalSeconds = 3 };
+            var zone = new ZoneEffects { DotDamage = 12 };   // only the number, inherits the rest
+
+            var merged = ZoneEffects.Merge(def, zone);
+
+            Assert.IsTrue(merged.EffectiveDotEnabled);
+            Assert.AreEqual(12, merged.EffectiveDotDamage);
+            Assert.AreEqual(0x10, merged.EffectiveDotDamageType);
+            Assert.AreEqual(3, merged.EffectiveDotIntervalSeconds);
+        }
+
+        [TestMethod]
+        public void Effects_UnauthoredDefaultsMatchThePreNullableBehaviour()
+        {
+            // The field initializers that used to live on the class (interval 5s, Fire) must survive
+            // as the Effective* fallbacks, or every zone silently changes DoT type/cadence.
+            var empty = new ZoneEffects();
+
+            Assert.IsTrue(empty.IsEmpty);
+            Assert.IsFalse(empty.EffectiveDotEnabled);
+            Assert.AreEqual(0.0, empty.EffectiveDotDamage);
+            Assert.AreEqual(5.0, empty.EffectiveDotIntervalSeconds);
+            Assert.AreEqual(0x10, empty.EffectiveDotDamageType);
+            Assert.IsFalse(empty.AnyActive);
+        }
+
+        [TestMethod]
+        public void Effects_AnyActive_OnlyWhenExplicitlyEnabled()
+        {
+            Assert.IsFalse(new ZoneEffects { DotEnabled = null }.AnyActive);
+            Assert.IsFalse(new ZoneEffects { DotEnabled = false }.AnyActive);
+            Assert.IsTrue(new ZoneEffects { DotEnabled = true }.AnyActive);
+        }
+
+        // ── the "zone with nothing authored IS its variation's Default" property ──
+
+        [TestMethod]
+        public void ZoneAuthoringNothing_ResolvesToTheDefaultExactly()
+        {
+            var def = Profile(("max_health", 1100), ("melee_defense", 1100), ("attack_damage", 1100));
+
+            var merged = ZoneVariantProfile.Merge(def, new ZoneVariantProfile());
+
+            Assert.AreEqual(3, merged.Stats.Count);
+            Assert.AreEqual(1100, Stat(merged, "max_health"));
+            Assert.AreEqual(1100, Stat(merged, "melee_defense"));
+            Assert.AreEqual(1100, Stat(merged, "attack_damage"));
+        }
+    }
+}

--- a/Source/ACE.Server.Tests/ZoneSpawnResolutionTests.cs
+++ b/Source/ACE.Server.Tests/ZoneSpawnResolutionTests.cs
@@ -75,10 +75,14 @@ namespace ACE.Server.Tests
 
             var applyIdx = src.IndexOf("public static void ApplyToSpawn(", StringComparison.Ordinal);
             Assert.IsTrue(applyIdx > 0, "ApplyToSpawn not found in ZoneSpawnScaler");
+            // bound the search to THIS method: a guard or a resolve in a later method must not satisfy the test
+            var bodyEnd = src.IndexOf("\n        public static ", applyIdx + 1, StringComparison.Ordinal);
+            if (bodyEnd < 0) bodyEnd = src.Length;
+            var body = src.Substring(applyIdx, bodyEnd - applyIdx);
 
             // the guard must sit before the first resolve, or it guards nothing
-            var resolveIdx = src.IndexOf("ResolveForCreature", applyIdx, StringComparison.Ordinal);
-            var guardIdx = src.IndexOf("creature.Location == null", applyIdx, StringComparison.Ordinal);
+            var resolveIdx = body.IndexOf("ResolveForCreature", StringComparison.Ordinal);
+            var guardIdx = body.IndexOf("creature.Location == null", StringComparison.Ordinal);
 
             Assert.IsTrue(guardIdx > 0,
                 "ApplyToSpawn must reject a null Location loudly - a silent no-op here is invisible for months.");

--- a/Source/ACE.Server.Tests/ZoneSpawnResolutionTests.cs
+++ b/Source/ACE.Server.Tests/ZoneSpawnResolutionTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ACE.Server.Tests
+{
+    /// <summary>
+    /// Regression cover for the 2026-07-30 generator spawn-snapshot bug.
+    ///
+    /// THE BUG: <c>GeneratorProfile.Spawn()</c> called <c>ZoneSpawnScaler.ApplyToSpawn(creature)</c>
+    /// BEFORE the <c>Spawn_*</c> handlers assigned the creature a Location. Zone resolution keys on
+    /// <c>Location.LandblockId.Landblock</c>, so every generator-spawned mob resolved landblock 0, matched
+    /// no zone, and silently received no spawn snapshot at all — attributes, max health/stamina/mana, crit
+    /// resist ratings, prop stamps and appearance were ALL skipped. Placed (landblock_instance) mobs were
+    /// unaffected, because WorldObjectFactory sets Location before calling the same method.
+    ///
+    /// It hid for months because the only stats Tou Tou authored were live per-hit ones (attack_skill,
+    /// damage_rating, attack_damage, percent_hp_base), which resolve during combat when Location IS set.
+    /// The first per-variation Default to author attributes exposed it immediately.
+    ///
+    /// WHY THIS IS A SOURCE TEST, which is otherwise a smell: the bug is a statement-ORDERING contract
+    /// that C# cannot express and no unit test can reach here — constructing a live <c>Creature</c> calls
+    /// <c>GenerateNewFace()</c>, which dereferences <c>DatManager.PortalDat</c> and NREs without the DAT
+    /// files this test environment does not have (the same reason GetCellTest/GetLandblockTest fail).
+    /// The runtime defence is the null-Location guard inside ApplyToSpawn, which now logs loudly instead
+    /// of doing nothing; this test is the cheap belt-and-braces that pins the ordering itself.
+    /// </summary>
+    [TestClass]
+    public class ZoneSpawnResolutionTests
+    {
+        private static string ReadServerSource(string relativePath)
+        {
+            // walk up from the test bin dir to the repo root
+            var dir = AppContext.BaseDirectory;
+            for (var i = 0; i < 8 && dir != null; i++)
+            {
+                var candidate = Path.Combine(dir, "Source", "ACE.Server", relativePath);
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate);
+                dir = Path.GetDirectoryName(dir);
+            }
+            Assert.Inconclusive($"Could not locate Source/ACE.Server/{relativePath} from {AppContext.BaseDirectory}");
+            return null;
+        }
+
+        [TestMethod]
+        public void GeneratorSpawn_AssignsLocationBeforeApplyingTheZoneSnapshot()
+        {
+            var src = ReadServerSource(Path.Combine("Entity", "GeneratorProfile.cs"));
+
+            // isolate the creature-scaling block inside Spawn()
+            var applyIdx = src.IndexOf("ZoneSpawnScaler.ApplyToSpawn(creature)", StringComparison.Ordinal);
+            Assert.IsTrue(applyIdx > 0, "ApplyToSpawn call not found in GeneratorProfile - has the spawn path moved?");
+
+            // the guard block opens the `if (wo is Creature creature ...)` body
+            var blockIdx = src.LastIndexOf("wo is Creature creature", applyIdx, StringComparison.Ordinal);
+            Assert.IsTrue(blockIdx > 0, "creature-scaling block not found ahead of the ApplyToSpawn call");
+
+            var block = src.Substring(blockIdx, applyIdx - blockIdx);
+
+            Assert.IsTrue(
+                Regex.IsMatch(block, @"wo\.Location\s*=\s*new\s+ACE\.Entity\.Position\(\s*Generator\.Location\s*\)"),
+                "GeneratorProfile.Spawn must assign a provisional Location from the generator BEFORE calling " +
+                "ZoneSpawnScaler.ApplyToSpawn. Without it the creature resolves landblock 0, matches no zone, " +
+                "and silently receives NO spawn snapshot (attributes, vitals, prop stamps, appearance). " +
+                "The Spawn_* handlers overwrite this Location immediately, so it costs nothing.");
+        }
+
+        [TestMethod]
+        public void ApplyToSpawn_HasTheNullLocationGuard()
+        {
+            var src = ReadServerSource(Path.Combine("Managers", "ZoneControl", "ZoneSpawnScaler.cs"));
+
+            var applyIdx = src.IndexOf("public static void ApplyToSpawn(", StringComparison.Ordinal);
+            Assert.IsTrue(applyIdx > 0, "ApplyToSpawn not found in ZoneSpawnScaler");
+
+            // the guard must sit before the first resolve, or it guards nothing
+            var resolveIdx = src.IndexOf("ResolveForCreature", applyIdx, StringComparison.Ordinal);
+            var guardIdx = src.IndexOf("creature.Location == null", applyIdx, StringComparison.Ordinal);
+
+            Assert.IsTrue(guardIdx > 0,
+                "ApplyToSpawn must reject a null Location loudly - a silent no-op here is invisible for months.");
+            Assert.IsTrue(resolveIdx < 0 || guardIdx < resolveIdx,
+                "the null-Location guard must come BEFORE the first zone resolve, or it guards nothing.");
+        }
+    }
+}

--- a/Source/ACE.Server.Tests/ZoneStoreCompatTests.cs
+++ b/Source/ACE.Server.Tests/ZoneStoreCompatTests.cs
@@ -1,0 +1,167 @@
+using ACE.Server.Managers.ZoneControl;
+using ACE.Server.Managers.ZoneScaling;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Newtonsoft.Json;
+
+namespace ACE.Server.Tests
+{
+    /// <summary>
+    /// Store round-trip compatibility for the 2026-07-30 Default-layer change.
+    ///
+    /// The zone store is a single JSON blob in shard config (`zonecontrol_data`). Two things in that change
+    /// could silently destroy authored data on load rather than failing loudly:
+    ///   * the `Boss` slot was DELETED — stored profiles still carry a "Boss" key
+    ///   * the zone layer is still serialized under the legacy key "Minion"
+    /// If either mis-binds, every zone loads with no stats and the only symptom is monsters quietly
+    /// reverting to weenie baselines. Hence a test rather than an assumption.
+    ///
+    /// The JSON below is shaped exactly like the live store read on 2026-07-30.
+    /// </summary>
+    [TestClass]
+    public class ZoneStoreCompatTests
+    {
+        private const string LegacyAreaJson = @"{
+            ""Name"": ""Tou Tou"",
+            ""Landblocks"": [62809, 62810],
+            ""Variation"": 11,
+            ""Enabled"": true,
+            ""Bounded"": true,
+            ""Notes"": null,
+            ""TerrainOverrides"": { ""62809"": ""obsidian"" },
+            ""Profile"": {
+                ""ScopeType"": 0,
+                ""Landblock"": null,
+                ""Variation"": null,
+                ""ZoneName"": null,
+                ""Enabled"": true,
+                ""Notes"": null,
+                ""Minion"": {
+                    ""Stats"": {
+                        ""percent_hp_base"": { ""Base"": 10.0, ""Growth"": 1.0, ""Additive"": false, ""Overrides"": null },
+                        ""max_health"": { ""Base"": 5000.0, ""Growth"": 1.0, ""Additive"": false, ""Overrides"": null }
+                    },
+                    ""BodyParts"": {},
+                    ""CustomCantrips"": [],
+                    ""CurrencyDrops"": [],
+                    ""SpellRules"": [],
+                    ""PropInts"": {},
+                    ""PropInt64s"": {},
+                    ""PropFloats"": {},
+                    ""PropBools"": {}
+                },
+                ""Boss"": {
+                    ""Stats"": { ""max_health"": { ""Base"": 999999.0, ""Growth"": 1.0, ""Additive"": false, ""Overrides"": null } },
+                    ""BodyParts"": {}
+                },
+                ""WcidOverrides"": {
+                    ""730000116"": {
+                        ""Stats"": { ""attack_damage"": { ""Base"": 1234.0, ""Growth"": 1.0, ""Additive"": false, ""Overrides"": null } },
+                        ""BodyParts"": {}
+                    }
+                }
+            },
+            ""Effects"": { ""DotEnabled"": true, ""DotDamage"": 5.0, ""DotPercent"": false, ""DotIntervalSeconds"": 3.0, ""DotDamageType"": 16 },
+            ""AppearanceDefault"": {},
+            ""AppearanceByWcid"": {}
+        }";
+
+        [TestMethod]
+        public void LegacyStore_ZoneStatsStillLoad()
+        {
+            var area = JsonConvert.DeserializeObject<ControlledArea>(LegacyAreaJson);
+
+            Assert.IsNotNull(area);
+            Assert.AreEqual("Tou Tou", area.Name);
+            Assert.AreEqual(11, area.Variation);
+            Assert.IsTrue(area.Bounded);
+            Assert.AreEqual(2, area.Landblocks.Count);
+            Assert.AreEqual("obsidian", area.TerrainOverrides[62809]);
+
+            // the zone layer still binds from the legacy "Minion" key
+            Assert.AreEqual(2, area.Profile.Minion.Stats.Count);
+            Assert.AreEqual(5000.0, area.Profile.Minion.Stats["max_health"].Base);
+            Assert.AreEqual(10.0, area.Profile.Minion.Stats["percent_hp_base"].Base);
+        }
+
+        [TestMethod]
+        public void LegacyStore_DeletedBossSlotIsIgnoredNotFatal()
+        {
+            // Newtonsoft ignores unknown members by default, so a stored "Boss" key simply drops.
+            var area = JsonConvert.DeserializeObject<ControlledArea>(LegacyAreaJson);
+
+            Assert.IsNotNull(area);
+            Assert.AreEqual(5000.0, area.Profile.Minion.Stats["max_health"].Base,
+                "the Boss block must not bleed into the zone layer");
+        }
+
+        [TestMethod]
+        public void LegacyStore_WcidOverridesStillLoad()
+        {
+            var area = JsonConvert.DeserializeObject<ControlledArea>(LegacyAreaJson);
+
+            Assert.AreEqual(1, area.Profile.WcidOverrides.Count);
+            var bucket = area.Profile.VariantForWcid(730000116);
+            Assert.IsNotNull(bucket);
+            Assert.AreEqual(1234.0, bucket.Stats["attack_damage"].Base);
+        }
+
+        [TestMethod]
+        public void VariantForWcid_ReturnsNullForAnUnauthoredMonster()
+        {
+            // Changed 2026-07-30: it used to fall back to the zone profile, which is wrong now that
+            // resolution LAYERS — the bucket accessor reports only what this monster authors.
+            var area = JsonConvert.DeserializeObject<ControlledArea>(LegacyAreaJson);
+
+            Assert.IsNull(area.Profile.VariantForWcid(999999));
+            Assert.IsNotNull(area.Profile.VariantForWcid(999999, create: true));
+        }
+
+        [TestMethod]
+        public void LegacyStore_EffectsBindToNullableFields()
+        {
+            var area = JsonConvert.DeserializeObject<ControlledArea>(LegacyAreaJson);
+
+            Assert.IsTrue(area.Effects.EffectiveDotEnabled);
+            Assert.AreEqual(5.0, area.Effects.EffectiveDotDamage);
+            Assert.AreEqual(3.0, area.Effects.EffectiveDotIntervalSeconds);
+            Assert.AreEqual(16, area.Effects.EffectiveDotDamageType);
+            Assert.IsFalse(area.Effects.EffectiveDotPercent);
+
+            // unauthored reserved fields stay null so they can inherit
+            Assert.IsNull(area.Effects.SlowEnabled);
+            Assert.IsNull(area.Effects.CharmEnabled);
+        }
+
+        [TestMethod]
+        public void RoundTrip_SurvivesSerializeAndReload()
+        {
+            var area = JsonConvert.DeserializeObject<ControlledArea>(LegacyAreaJson);
+            var again = JsonConvert.DeserializeObject<ControlledArea>(JsonConvert.SerializeObject(area));
+
+            Assert.AreEqual(5000.0, again.Profile.Minion.Stats["max_health"].Base);
+            Assert.AreEqual(1234.0, again.Profile.WcidOverrides[730000116].Stats["attack_damage"].Base);
+            Assert.IsTrue(again.Effects.EffectiveDotEnabled);
+            Assert.AreEqual(3.0, again.Effects.EffectiveDotIntervalSeconds);
+            Assert.IsTrue(again.Bounded);
+            Assert.AreEqual("obsidian", again.TerrainOverrides[62809]);
+        }
+
+        [TestMethod]
+        public void NewStore_VariationDefaultRoundTrips()
+        {
+            var def = new VariationDefault();
+            def.Profile.Stats["max_health"] = new StatCurve { Base = 1100 };
+            def.Effects.DotEnabled = true;
+            def.Effects.DotDamage = 4;
+
+            var back = JsonConvert.DeserializeObject<VariationDefault>(JsonConvert.SerializeObject(def));
+
+            Assert.AreEqual(1100.0, back.Profile.Stats["max_health"].Base);
+            Assert.IsTrue(back.Effects.EffectiveDotEnabled);
+            Assert.AreEqual(4.0, back.Effects.EffectiveDotDamage);
+            Assert.IsFalse(back.IsEmpty);
+        }
+    }
+}

--- a/Source/ACE.Server.Tests/ZoneStoreCompatTests.cs
+++ b/Source/ACE.Server.Tests/ZoneStoreCompatTests.cs
@@ -119,6 +119,20 @@ namespace ACE.Server.Tests
         }
 
         [TestMethod]
+        public void VariantForWcid_SurvivesNullMapAndNullBucket()
+        {
+            // persisted JSON can carry an explicit null map, or a null bucket inside the map; neither may throw,
+            // both read as "absent", and create still hands back a fresh bucket
+            var nullMap = JsonConvert.DeserializeObject<ZoneScalingProfile>("{\"WcidOverrides\": null}");
+            Assert.IsNull(nullMap.VariantForWcid(12345));
+            Assert.IsNotNull(nullMap.VariantForWcid(12345, create: true));
+
+            var nullBucket = JsonConvert.DeserializeObject<ZoneScalingProfile>("{\"WcidOverrides\": {\"5\": null}}");
+            Assert.IsNull(nullBucket.VariantForWcid(5));
+            Assert.IsNotNull(nullBucket.VariantForWcid(5, create: true));
+        }
+
+        [TestMethod]
         public void LegacyStore_EffectsBindToNullableFields()
         {
             var area = JsonConvert.DeserializeObject<ControlledArea>(LegacyAreaJson);

--- a/Source/ACE.Server.Tests/ZoneStoreCompatTests.cs
+++ b/Source/ACE.Server.Tests/ZoneStoreCompatTests.cs
@@ -122,14 +122,31 @@ namespace ACE.Server.Tests
         public void VariantForWcid_SurvivesNullMapAndNullBucket()
         {
             // persisted JSON can carry an explicit null map, or a null bucket inside the map; neither may throw,
-            // both read as "absent", and create still hands back a fresh bucket
+            // and both read as "absent"
             var nullMap = JsonConvert.DeserializeObject<ZoneScalingProfile>("{\"WcidOverrides\": null}");
             Assert.IsNull(nullMap.VariantForWcid(12345));
-            Assert.IsNotNull(nullMap.VariantForWcid(12345, create: true));
 
             var nullBucket = JsonConvert.DeserializeObject<ZoneScalingProfile>("{\"WcidOverrides\": {\"5\": null}}");
             Assert.IsNull(nullBucket.VariantForWcid(5));
-            Assert.IsNotNull(nullBucket.VariantForWcid(5, create: true));
+        }
+
+        [TestMethod]
+        public void VariantForWcid_CreatesAndStoresFromNullMapAndNullBucket()
+        {
+            // Fresh instances: the create call must be the FIRST touch, so the null map is what it
+            // normalizes - a prior non-creating lookup would have done that already and hidden the path.
+            var nullMap = JsonConvert.DeserializeObject<ZoneScalingProfile>("{\"WcidOverrides\": null}");
+            var created = nullMap.VariantForWcid(12345, create: true);
+            Assert.IsNotNull(created);
+            Assert.IsNotNull(nullMap.WcidOverrides, "create must materialize the map");
+            Assert.AreSame(created, nullMap.VariantForWcid(12345), "a later non-creating lookup must return the stored bucket");
+            Assert.AreEqual(1, nullMap.WcidOverrides.Count);
+
+            var nullBucket = JsonConvert.DeserializeObject<ZoneScalingProfile>("{\"WcidOverrides\": {\"5\": null}}");
+            var replaced = nullBucket.VariantForWcid(5, create: true);
+            Assert.IsNotNull(replaced);
+            Assert.AreSame(replaced, nullBucket.VariantForWcid(5), "the null bucket must be replaced in the map, not just returned");
+            Assert.AreSame(replaced, nullBucket.WcidOverrides[5]);
         }
 
         [TestMethod]

--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -28,6 +28,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using Position = ACE.Entity.Position;
@@ -242,6 +243,7 @@ namespace ACE.Server.Command.Handlers
                         PrestigeManager.RemovePrestigeScaling(creature);
                         var variationForTier = tier + PrestigeManager.PRESTIGE_VAR_OFFSET;
                         PrestigeManager.ApplyPrestigeScaling(creature, variationForTier);
+                        Managers.ZoneControl.ZoneSpawnScaler.ApplyToSpawn(creature);
                         CommandHandlerHelper.WriteOutputInfo(session,
                             $"Replaced prestige scaling on {creature.Name} for tier {tier} (variation {variationForTier}).");
                         PlayerManager.BroadcastToAuditChannel(session.Player,
@@ -2200,7 +2202,8 @@ namespace ACE.Server.Command.Handlers
         }
 
         // draw
-        [CommandHandler("draw", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 0)]
+        // CUT 2026-07-07: empty retail no-op stub ("draws undrawable things"), no known purpose. De-registered.
+        // [CommandHandler("draw", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 0)]
         public static void HandleDraw(Session session, params string[] parameters)
         {
             // @draw - Draws undrawable things.
@@ -2860,31 +2863,37 @@ namespace ACE.Server.Command.Handlers
         // televariant variation (other /tele* live in TeleportCommands on master)
         [CommandHandler("televariant", AccessLevel.Admin, CommandHandlerFlag.RequiresWorld, 1,
             "Teleport yourself to the specified variation at your current location.",
-            "variation — retail | default | null (unlayered base, same as omitting variation), or an integer id (use 0 for variation 0)\n" +
+            "variation — retail | default | null | 0 (all mean the unlayered base world), or an integer id (-1..-999 = rift design variations)\n" +
             "Example: @televariant 1\n" +
+            "Example: @televariant -1\n" +
             "Example: @televariant retail")]
         public static void HandleTelevariant(Session session, params string[] parameters)
         {
             int? variation = null;
             var param = parameters[0].ToLower();
 
-            // retail / default / null => true base (unlayered); 0 is explicit variation id 0, not base
-            if (param == "retail" || param == "null" || param == "default")
+            // retail / default / null / 0 => the unlayered base world. Explicit "layer 0" was a trap:
+            // the landblock cache keys 0 and null as separate instances, so @tv 0 stranded players in an
+            // empty parallel copy of the landblock (invisible/unattackable mobs), and that 0 persisted
+            // into the character's saved Location, re-breaking them on every login.
+            if (param == "retail" || param == "null" || param == "default" || param == "0")
             {
                 variation = null;
             }
             else if (int.TryParse(parameters[0], out int varId))
             {
-                if (varId < 0)
+                // -1..-999 = rift DESIGN variations (author rift layouts there; prestige ignores all
+                // negatives). -1000 and below are ephemeral rift RUN instances — no manual entry.
+                if (varId <= -1000)
                 {
-                    CommandHandlerHelper.WriteOutputInfo(session, "Invalid variation ID. Use 'retail', 'default', 'null' for base, or a non-negative integer (0 = variation 0).");
+                    CommandHandlerHelper.WriteOutputInfo(session, "Variations -1000 and below are reserved for live rift run instances. Use -1..-999 for rift design variations.");
                     return;
                 }
-                variation = varId;
+                variation = varId == 0 ? null : varId;
             }
             else
             {
-                CommandHandlerHelper.WriteOutputInfo(session, "Invalid variation ID. Use 'retail', 'default', 'null' for base, or a non-negative integer (0 = variation 0).");
+                CommandHandlerHelper.WriteOutputInfo(session, "Invalid variation ID. Use 'retail', 'default', 'null' or 0 for base, or an integer variation id.");
                 return;
             }
 
@@ -2900,11 +2909,113 @@ namespace ACE.Server.Command.Handlers
             CommandHandlerHelper.WriteOutputInfo(session, $"Teleporting to variation {variationLabel}.");
         }
 
+        // bossgroup - boss-group status + runtime tuning (BossGroupManager / PropertyInt.BossGroupId gens)
+        [CommandHandler("bossgroup", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 0,
+            "Boss-group status + runtime tuning (generators sharing a BossGroupId).",
+            "status [--wire] | set <group> delay|radius <value> | clear <group> delay|radius | enable <group> | disable <group> | respawn <group>\n" +
+            "Overrides are RUNTIME (shard store, instant); the weenie values stay the defaults.\n" +
+            "Example: @bossgroup set 1 delay 1800")]
+        public static void HandleBossGroup(Session session, params string[] parameters)
+        {
+            var sub = parameters.Length > 0 ? parameters[0].ToLowerInvariant() : "status";
+
+            if (sub == "status")
+            {
+                if (parameters.Length > 1 && parameters[1].Equals("--wire", StringComparison.OrdinalIgnoreCase))
+                {
+                    foreach (var line in Managers.BossGroupManager.GetWireLines())
+                        ChatPacket.SendServerMessage(session, line, ChatMessageType.Broadcast);
+                    return;
+                }
+                foreach (var line in Managers.BossGroupManager.GetStatusLines())
+                    CommandHandlerHelper.WriteOutputInfo(session, line);
+                return;
+            }
+
+            if (parameters.Length < 2 || !int.TryParse(parameters[1], out var group))
+            {
+                CommandHandlerHelper.WriteOutputInfo(session, "Usage: /bossgroup status [--wire] | set <group> delay|radius <value> | clear <group> delay|radius | enable|disable <group> | respawn <group>");
+                return;
+            }
+
+            switch (sub)
+            {
+                case "set":
+                {
+                    if (parameters.Length < 4 || !float.TryParse(parameters[3], out var value) || value < 0)
+                    {
+                        CommandHandlerHelper.WriteOutputInfo(session, "Usage: /bossgroup set <group> delay|radius <value>");
+                        return;
+                    }
+                    var field = parameters[2].ToLowerInvariant();
+                    if (field == "delay")
+                        Managers.BossGroupManager.MutateOverride(group, ov => ov.Delay = value);
+                    else if (field == "radius")
+                        Managers.BossGroupManager.MutateOverride(group, ov => ov.Radius = value);
+                    else
+                    {
+                        CommandHandlerHelper.WriteOutputInfo(session, "Field must be delay or radius.");
+                        return;
+                    }
+                    CommandHandlerHelper.WriteOutputInfo(session, $"Boss group {group}: {field} override = {value:0.#} (runtime, instant; weenie default untouched).");
+                    return;
+                }
+                case "clear":
+                {
+                    if (parameters.Length < 3)
+                    {
+                        CommandHandlerHelper.WriteOutputInfo(session, "Usage: /bossgroup clear <group> delay|radius");
+                        return;
+                    }
+                    var field = parameters[2].ToLowerInvariant();
+                    if (field == "delay")
+                        Managers.BossGroupManager.MutateOverride(group, ov => ov.Delay = null);
+                    else if (field == "radius")
+                        Managers.BossGroupManager.MutateOverride(group, ov => ov.Radius = null);
+                    else
+                    {
+                        CommandHandlerHelper.WriteOutputInfo(session, "Field must be delay or radius.");
+                        return;
+                    }
+                    CommandHandlerHelper.WriteOutputInfo(session, $"Boss group {group}: {field} override cleared (weenie default applies).");
+                    return;
+                }
+                case "enable":
+                    Managers.BossGroupManager.MutateOverride(group, ov => ov.Enabled = true);
+                    CommandHandlerHelper.WriteOutputInfo(session, $"Boss group {group} ENABLED.");
+                    return;
+                case "disable":
+                    Managers.BossGroupManager.MutateOverride(group, ov => ov.Enabled = false);
+                    CommandHandlerHelper.WriteOutputInfo(session, $"Boss group {group} DISABLED - a live boss is left alone; it just never respawns until re-enabled.");
+                    return;
+                case "respawn":
+                {
+                    // clock/flag first: the smite's death event lands async and must see the pending flag
+                    var kicked = Managers.BossGroupManager.ForceRespawn(group);
+                    var boss = Managers.BossGroupManager.GetAliveBoss(group);
+                    if (boss is Creature c && !c.IsDestroyed)
+                    {
+                        c.Smite(session.Player);
+                        CommandHandlerHelper.WriteOutputInfo(session, $"Boss group {group}: current boss smitten; a new boss is spawning at a re-elected generator.");
+                    }
+                    else if (kicked)
+                        CommandHandlerHelper.WriteOutputInfo(session, $"Boss group {group}: spawning now at a re-elected generator.");
+                    else
+                        CommandHandlerHelper.WriteOutputInfo(session, $"Boss group {group}: no loaded generator is polling this group yet - it spawns as soon as one loads.");
+                    return;
+                }
+                default:
+                    CommandHandlerHelper.WriteOutputInfo(session, "Usage: /bossgroup status [--wire] | set <group> delay|radius <value> | clear <group> delay|radius | enable|disable <group> | respawn <group>");
+                    return;
+            }
+        }
+
         // tv {variation} - Alias for televariant
         [CommandHandler("tv", AccessLevel.Admin, CommandHandlerFlag.RequiresWorld, 1,
             "Teleport yourself to the specified variation at your current location (alias for televariant).",
-            "variation — retail | default | null (unlayered base), or an integer id (use 0 for variation 0)\n" +
+            "variation — retail | default | null (unlayered base), or an integer id (use 0 for variation 0; -1..-999 = rift design variations)\n" +
             "Example: @tv 1\n" +
+            "Example: @tv -1\n" +
             "Example: @tv retail")]
         public static void HandleTV(Session session, params string[] parameters)
         {
@@ -4753,6 +4864,23 @@ namespace ACE.Server.Command.Handlers
             }
 
             obj.Location.LandblockId = new LandblockId(obj.Location.GetCell());
+
+            // ZONE SCALING for admin-spawned creatures (owner 2026-09-01, found while testing at v12).
+            // ZoneSpawnScaler.ApplyToSpawn is otherwise only reached from the landblock-instance path
+            // (WorldObjectFactory), so /create and /createliveops produced a HALF-scaled monster: the
+            // live-read stats applied (ratings read 1100) while the spawn-STAMPED ones did not (a retail
+            // lich stood in a v12 zone with 89 health and its own 161/178/135 attributes instead of
+            // 1,000,000 and 1100s). Generators, landblock instances and summons were always fine - this
+            // was purely the admin direct-spawn path, which is the one a dev reaches for when testing a
+            // new mob, so it failed in the most confusing possible direction.
+            //
+            // Placement HAS to come first: the scaler resolves the zone from Location (and Position
+            // carries Variation through InFrontOf), so calling this before the two assignments above
+            // would resolve nothing and silently no-op again. Prestige and Rift scaling are deliberately
+            // NOT added here - they are separate systems with their own entry points, and this fixes
+            // only the gap that was actually observed.
+            if (obj is Creature spawnedCreature)
+                Managers.ZoneControl.ZoneSpawnScaler.ApplyToSpawn(spawnedCreature);
 
             LastSpawnPos = obj.Location;
 
@@ -6769,7 +6897,8 @@ namespace ACE.Server.Command.Handlers
         }
 
         // raise
-        [CommandHandler("raise", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 2)]
+        // CUT 2026-07-07: empty retail no-op stub; redundant with working /grantxp and /spendxp. De-registered.
+        // [CommandHandler("raise", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 2)]
         public static void HandleRaise(Session session, params string[] parameters)
         {
             // @raise - Raises your experience (or the experience in a skill) by the given amount.
@@ -7040,7 +7169,8 @@ namespace ACE.Server.Command.Handlers
         }
 
         // lbinterval
-        [CommandHandler("lbinterval", AccessLevel.Admin, CommandHandlerFlag.RequiresWorld, 1)]
+        // CUT 2026-07-07: empty no-op stub; Turbine multi-server-farm load balancing, N/A on single-shard ACE. De-registered.
+        // [CommandHandler("lbinterval", AccessLevel.Admin, CommandHandlerFlag.RequiresWorld, 1)]
         public static void Handlelbinterval(Session session, params string[] parameters)
         {
             // @lbinterval - Sets how often in seconds the server farm will rebalance the server farm load.
@@ -7049,7 +7179,8 @@ namespace ACE.Server.Command.Handlers
         }
 
         // lbthresh
-        [CommandHandler("lbthresh", AccessLevel.Admin, CommandHandlerFlag.RequiresWorld, 1)]
+        // CUT 2026-07-07: empty no-op stub; Turbine multi-server-farm load balancing, N/A on single-shard ACE. De-registered.
+        // [CommandHandler("lbthresh", AccessLevel.Admin, CommandHandlerFlag.RequiresWorld, 1)]
         public static void Handlelbthresh(Session session, params string[] parameters)
         {
             // the @lbthresh command sets the maximum amount of load servers can trade at each balance. Large load transfers at once can cause poor server performance.  (Large would be about 400, small is about 20.)
@@ -7059,7 +7190,8 @@ namespace ACE.Server.Command.Handlers
         }
 
         // radar
-        [CommandHandler("radar", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 0)]
+        // CUT 2026-07-07: empty retail no-op stub; radar is client-side, per-object hiding available via /setproperty radarbehavior. De-registered.
+        // [CommandHandler("radar", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 0)]
         public static void Handleradar(Session session, params string[] parameters)
         {
             // @radar - Toggles your radar on and off.
@@ -7068,16 +7200,54 @@ namespace ACE.Server.Command.Handlers
         }
 
         // rares dump
-        [CommandHandler("rares dump", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 0)]
+        [CommandHandler("rares dump", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 0,
+            "Lists the rare item pool by tier.",
+            "[tier]\nWith no argument, shows a summary of each tier (rare count + drop chance).\nWith a tier number (1-6), lists every rare WCID and name in that tier.")]
         public static void HandleRaresDump(Session session, params string[] parameters)
         {
             // @rares dump - Lists all tiers of rare items.
 
-            // TODO: output
+            if (LootGenerationFactory.RareWCIDs == null || LootGenerationFactory.RareWCIDs.Count == 0)
+            {
+                CommandHandlerHelper.WriteOutputInfo(session, "Rare tables are not initialized.");
+                return;
+            }
+
+            // Optional tier argument: "rares dump" is a two-word command, so the tier (if any) arrives as parameters[0].
+            if (parameters != null && parameters.Length > 0 && int.TryParse(parameters[0], out var reqTier))
+            {
+                if (!LootGenerationFactory.RareWCIDs.TryGetValue(reqTier, out var wcids))
+                {
+                    CommandHandlerHelper.WriteOutputInfo(session, $"No rare tier {reqTier}. Valid tiers: {string.Join(", ", LootGenerationFactory.RareWCIDs.Keys.OrderBy(k => k))}");
+                    return;
+                }
+
+                var sb = new StringBuilder();
+                sb.AppendLine($"=== Rare Tier {reqTier} ({wcids.Count} items) ===");
+                foreach (var wcid in wcids.OrderBy(w => w))
+                {
+                    var weenie = DatabaseManager.World.GetCachedWeenie((uint)wcid);
+                    sb.AppendLine(weenie == null ? $"{wcid} - <not in database>" : $"{wcid} - {weenie.GetName()}");
+                }
+                CommandHandlerHelper.WriteOutputInfo(session, sb.ToString());
+                return;
+            }
+
+            // Summary view: tier, count, and the 1-in-N drop chance.
+            var summary = new StringBuilder();
+            summary.AppendLine("=== Rare Item Pool (use 'rares dump <tier>' for the full list) ===");
+            foreach (var tier in LootGenerationFactory.RareWCIDs.Keys.OrderBy(k => k))
+            {
+                var count = LootGenerationFactory.RareWCIDs[tier].Count;
+                var chance = LootGenerationFactory.RareChances.TryGetValue(tier, out var c) ? $"1 in {c:N0}" : "unknown";
+                summary.AppendLine($"Tier {tier}: {count} rares  (base chance {chance})");
+            }
+            CommandHandlerHelper.WriteOutputInfo(session, summary.ToString());
         }
 
         // stormnumstormed
-        [CommandHandler("stormnumstormed", AccessLevel.Admin, CommandHandlerFlag.RequiresWorld, 1)]
+        // CUT 2026-07-07: empty no-op stub; automatic portal storms not used on this shard. De-registered.
+        // [CommandHandler("stormnumstormed", AccessLevel.Admin, CommandHandlerFlag.RequiresWorld, 1)]
         public static void Handlestormnumstormed(Session session, params string[] parameters)
         {
             // @stormnumstormed - Sets how many characters are teleported away during a portal storm.
@@ -7086,7 +7256,8 @@ namespace ACE.Server.Command.Handlers
         }
 
         // stormthresh
-        [CommandHandler("stormthresh", AccessLevel.Admin, CommandHandlerFlag.RequiresWorld, 1)]
+        // CUT 2026-07-07: empty no-op stub; automatic portal storms not used on this shard. De-registered.
+        // [CommandHandler("stormthresh", AccessLevel.Admin, CommandHandlerFlag.RequiresWorld, 1)]
         public static void Handlestormthresh(Session session, params string[] parameters)
         {
             // @stormthresh - Sets how many character can be in a landblock before we do a portal storm.
@@ -7256,6 +7427,231 @@ namespace ACE.Server.Command.Handlers
                 floatProp != null ?
                     $"{parameters[0]}: {floatProp.Value}" :
                     $"{parameters[0]} not found.  Type /showprops for a list of properties.");
+        }
+
+        /// <summary>
+        /// /nolog - edit the no-log areas (log out inside one, log back in at your lifestone).
+        ///
+        /// This is a thin editor over ONE ordinary server property, ServerConfig.nolog_landblocks.
+        /// Everything it does can also be done with /modifystring by hand; the command exists so nobody
+        /// has to hand-write the token format. The built-in retail list in Player_Location stays the
+        /// seed and needs no property at all - a server that authors nothing behaves exactly as before.
+        ///
+        /// A landblock+variation pair can be turned OFF as well as on, including a pair that comes from
+        /// the retail seed, which is why removal writes a suppress token rather than just deleting one.
+        /// </summary>
+        [CommandHandler("nolog", AccessLevel.Developer, CommandHandlerFlag.None, 0,
+            "List or edit the no-log areas - log out in one and you log back in at your lifestone.",
+            "nolog list | add <where> [scope] | remove <where> [scope] | check [where] | help")]
+        public static void HandleNoLog(Session session, params string[] parameters)
+        {
+            void Msg(string s) => CommandHandlerHelper.WriteOutputInfo(session, s);
+
+            var sub = parameters.Length > 0 ? parameters[0].ToLowerInvariant() : "list";
+
+            if (sub == "help")
+            {
+                // Kept SHORT and column-aligned on purpose - the previous block wrapped in the chat
+                // window and read as a wall. Lines stay under ~66 chars so they do not fold.
+                Msg("No-Log Areas - log out in one, log back in at your lifestone.");
+                Msg("");
+                Msg("  /nolog list            - show every area in force");
+                Msg("  /nolog add <where>     - make one a no-log area");
+                Msg("  /nolog remove <where>  - stop one being one");
+                Msg("  /nolog check [where]   - does logging out here bounce me?");
+                Msg("");
+                Msg("  <where>");
+                Msg("    here                 - the landblock you stand in");
+                Msg("    016C                 - a hex landblock");
+                Msg("    016C,016D,016E       - a list, sent as one write");
+                Msg("");
+                Msg("  scope - optional, after <where>");
+                Msg("    base                 - normal world; default for a hex");
+                Msg("    11                   - one variation");
+                Msg("    all                  - base and every variation");
+                Msg("    'here' alone uses the layer you stand in.");
+                Msg("");
+                Msg("  Stored in the nolog_landblocks property.");
+                Msg("  The built-in retail list is the seed and needs nothing.");
+                return;
+            }
+
+            if (sub == "list")
+            {
+                var entries = Player.NoLogEntries();
+                Msg($"{entries.Count} no-log area(s) in force:");
+                // Built-in rows show their NAME; rows you added show "(added)". No "(built-in)" tag -
+                // with no overrides every row wore it and it said nothing. The plugin keys off the
+                // "(added)" marker to decide which rows are removable.
+                foreach (var (lb, key) in entries)
+                {
+                    var seed = Player.IsNoLogSeed(lb, key);
+                    var tail = seed ? Player.NoLogSeedName(lb) : "(added)";
+                    Msg($"  {lb:X4}  {Player.NoLogScopeName(key),-13} {tail}");
+                }
+                var raw = ServerConfig.nolog_landblocks?.Value ?? "";
+                Msg(string.IsNullOrWhiteSpace(raw) ? "Overrides: none (built-in list only)." : "Overrides: " + raw);
+                return;
+            }
+
+            if (sub == "check")
+            {
+                if (!TryNoLogTarget(session, parameters, 1, out var lb, out var variation, out var err)) { Msg(err); return; }
+                var key = Player.NoLogVariationKey(variation);
+                var on = Player.IsNoLogArea(lb, variation);
+                var scope = Player.NoLogScopeName(key);
+                Msg($"{lb:X4} at {scope}: {(on ? "NO-LOG - logging out here returns you to your lifestone." : "normal - you log back in where you left.")}");
+                if (on && Player.IsNoLogSeed(lb, key))
+                    Msg("  Source: the built-in retail list.");
+                return;
+            }
+
+            if (sub != "add" && sub != "remove")
+            {
+                Msg($"Unknown subcommand '{sub}'. Try /nolog help.");
+                return;
+            }
+
+            // A COMMA LIST is accepted so a whole zone is one command, not one per landblock. That
+            // matters: Tou Tou alone is 90 landblocks, and every write flushes to the database, so
+            // ninety separate commands would be ninety flushes off one button press.
+            if (!TryNoLogTargets(session, parameters, 1, out var landblocks, out var rawVariation, out var error)) { Msg(error); return; }
+
+            // an explicit scope argument overrides where the caller is standing
+            var variationKey = Player.NoLogVariationKey(rawVariation);
+            var scopeArg = parameters.Length > 2 ? parameters[2] : null;
+            if (!string.IsNullOrWhiteSpace(scopeArg))
+            {
+                if (!Player.TryParseNoLogToken("0000:" + scopeArg.Trim(), out _, out variationKey, out _))
+                {
+                    Msg($"Bad scope '{scopeArg}'. Use base, all, or a variation number.");
+                    return;
+                }
+            }
+
+            var adding = sub == "add";
+            var original = ServerConfig.nolog_landblocks?.Value ?? "";
+            var tokens = SplitNoLogTokens(original);
+
+            foreach (var landblock in landblocks)
+            {
+                // Drop any existing token for this exact pair, in either direction, so an add/remove
+                // cycle is lossless rather than accumulating contradictions.
+                var lb = landblock;
+                tokens.RemoveAll(t => Player.TryParseNoLogToken(t, out var tlb, out var tkey, out _)
+                                      && tlb == lb && tkey == variationKey);
+
+                // Then author an explicit token, UNLESS the built-in seed already says exactly this on
+                // its own. The seed only ever covers the base bucket, so only a base-scope edit can be
+                // redundant with it - a variation or 'all' edit always needs its own token.
+                var seedSaysSame = variationKey == Player.NoLogBaseScopeKey
+                                   && Player.IsNoLogSeed(lb, variationKey) == adding;
+                if (!seedSaysSame)
+                    tokens.Add(Player.NoLogTokenFor(lb, variationKey, !adding));
+            }
+
+            var updated = string.Join(", ", tokens);
+            if (updated == original)
+            {
+                Msg($"{DescribeNoLogTargets(landblocks)} at {Player.NoLogScopeName(variationKey)} "
+                    + $"{(landblocks.Count == 1 ? "is" : "are")} already {(adding ? "a no-log area" : "normal")} - nothing changed.");
+                return;
+            }
+
+            if (!ServerConfig.SetValue("nolog_landblocks", updated))
+            {
+                Msg("Could not write the nolog_landblocks property.");
+                return;
+            }
+
+            // FLUSH NOW, do not wait for the property worker.
+            //
+            // SetValue only updates the in-memory value and queues the row; PropertyManager drains the
+            // queue on a 300000 ms timer (_workerThread) and StopUpdating() stops that timer WITHOUT
+            // flushing. So an edit followed by a shutdown inside five minutes is silently lost - the
+            // admin sees it working live, then it is gone on the next start. That is intolerable for a
+            // setting whose whole job is to survive a relog, and it bit exactly that way in testing.
+            ServerConfig.WriteUpdatesToDb();
+
+            Msg($"{DescribeNoLogTargets(landblocks)} at {Player.NoLogScopeName(variationKey)} "
+                + $"{(landblocks.Count == 1 ? "is" : "are")} now {(adding ? "NO-LOG" : "normal")}.");
+            Msg(string.IsNullOrWhiteSpace(updated) ? "Overrides: none (built-in list only)." : "Overrides: " + updated);
+            PlayerManager.BroadcastToAuditChannel(session?.Player,
+                $"{(adding ? "Added" : "Removed")} no-log: {DescribeNoLogTargets(landblocks)} ({Player.NoLogScopeName(variationKey)})");
+        }
+
+        /// <summary>"016C" / "here" / "F156,F157,F158" -> the landblocks to act on. Duplicates collapse.</summary>
+        private static bool TryNoLogTargets(Session session, string[] parameters, int index, out List<ushort> landblocks, out int? variation, out string error)
+        {
+            landblocks = new List<ushort>();
+            variation = null;
+            error = null;
+
+            var raw = parameters.Length > index ? parameters[index] : "here";
+
+            foreach (var piece in raw.Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries))
+            {
+                var token = piece.Trim();
+                if (token.Length == 0) continue;
+
+                if (!TryNoLogTarget(session, new[] { token }, 0, out var lb, out var v, out error))
+                    return false;
+
+                if (v.HasValue) variation = v;                 // only "here" supplies one
+                if (!landblocks.Contains(lb)) landblocks.Add(lb);
+            }
+
+            if (landblocks.Count == 0) { error = "No landblock given. Use a hex id, a comma list, or 'here'."; return false; }
+            return true;
+        }
+
+        /// <summary>Short human summary of a target list - the ids when there are few, a count when many.</summary>
+        private static string DescribeNoLogTargets(List<ushort> landblocks)
+        {
+            if (landblocks.Count == 1) return landblocks[0].ToString("X4");
+            if (landblocks.Count <= 6) return string.Join(", ", landblocks.ConvertAll(l => l.ToString("X4")));
+            return landblocks.Count + " landblocks";
+        }
+
+        private static List<string> SplitNoLogTokens(string raw)
+        {
+            var list = new List<string>();
+            foreach (var t in (raw ?? "").Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries))
+                if (!string.IsNullOrWhiteSpace(t))
+                    list.Add(t.Trim());
+            return list;
+        }
+
+        /// <summary>
+        /// Resolve the landblock (and, for "here", the caller's variation) for a /nolog subcommand.
+        /// The variation is the RAW Location.Variation, deliberately not GetEffectiveVariation - that one
+        /// also applies the ForceEndgameSystems dev override, and an entry authored from a simulated
+        /// variation could never match the real one at login.
+        /// </summary>
+        private static bool TryNoLogTarget(Session session, string[] parameters, int index, out ushort landblock, out int? variation, out string error)
+        {
+            landblock = 0;
+            variation = null;
+            error = null;
+
+            var token = parameters.Length > index ? parameters[index] : "here";
+
+            if (token.Equals("here", StringComparison.OrdinalIgnoreCase))
+            {
+                var loc = session?.Player?.Location;
+                if (loc == null) { error = "No location for 'here' - stand somewhere, or pass a hex landblock."; return false; }
+                landblock = loc.LandblockId.Landblock;
+                variation = loc.Variation;
+                return true;
+            }
+
+            var text = token.StartsWith("0x", StringComparison.OrdinalIgnoreCase) ? token.Substring(2) : token;
+            if (!ushort.TryParse(text, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out landblock))
+            {
+                error = $"'{token}' is not a hex landblock (e.g. 016C) or 'here'.";
+                return false;
+            }
+            return true;
         }
 
         [CommandHandler("modifystring", AccessLevel.Admin, CommandHandlerFlag.None, 2, "Modifies a server property that is a string", "modifystring (string) (string)")]

--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -2957,6 +2957,7 @@ namespace ACE.Server.Command.Handlers
                         CommandHandlerHelper.WriteOutputInfo(session, "Field must be delay or radius.");
                         return;
                     }
+                    PlayerManager.BroadcastToAuditChannel(session.Player, $"/bossgroup set {group} {field} {value:0.#}");
                     CommandHandlerHelper.WriteOutputInfo(session, $"Boss group {group}: {field} override = {value:0.#} (runtime, instant; weenie default untouched).");
                     return;
                 }
@@ -2977,21 +2978,25 @@ namespace ACE.Server.Command.Handlers
                         CommandHandlerHelper.WriteOutputInfo(session, "Field must be delay or radius.");
                         return;
                     }
+                    PlayerManager.BroadcastToAuditChannel(session.Player, $"/bossgroup clear {group} {field}");
                     CommandHandlerHelper.WriteOutputInfo(session, $"Boss group {group}: {field} override cleared (weenie default applies).");
                     return;
                 }
                 case "enable":
                     Managers.BossGroupManager.MutateOverride(group, ov => ov.Enabled = true);
+                    PlayerManager.BroadcastToAuditChannel(session.Player, $"/bossgroup enable {group}");
                     CommandHandlerHelper.WriteOutputInfo(session, $"Boss group {group} ENABLED.");
                     return;
                 case "disable":
                     Managers.BossGroupManager.MutateOverride(group, ov => ov.Enabled = false);
+                    PlayerManager.BroadcastToAuditChannel(session.Player, $"/bossgroup disable {group}");
                     CommandHandlerHelper.WriteOutputInfo(session, $"Boss group {group} DISABLED - a live boss is left alone; it just never respawns until re-enabled.");
                     return;
                 case "respawn":
                 {
                     // clock/flag first: the smite's death event lands async and must see the pending flag
                     var kicked = Managers.BossGroupManager.ForceRespawn(group);
+                    PlayerManager.BroadcastToAuditChannel(session.Player, $"/bossgroup respawn {group} -> {kicked}");
                     var boss = Managers.BossGroupManager.GetAliveBoss(group);
                     if (boss is Creature c && !c.IsDestroyed)
                     {

--- a/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
@@ -1915,6 +1915,38 @@ namespace ACE.Server.Command.Handlers
         }
 
 
+        /// <summary>Launch-day readout (2026-08-23): how Max Health is composed, incl. the Zone Control cantrip
+        /// cache (Fortify Vitals / Max Health Pct) and the worn GearMaxHealth sum. Diagnoses "helm on/off".</summary>
+        [CommandHandler("zcvitals", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, "Shows the Max Health composition incl. Zone Control cantrip contributions")]
+        public static void HandleZcVitals(Session session, params string[] parameters)
+        {
+            var p = session.Player;
+            var hp = p.Health;
+            void Msg(string m) => session.Network.EnqueueSend(new GameMessageSystemChat(m, ChatMessageType.Broadcast));
+            var formula = AttributeFormula.GetFormula(p, hp.Vital, true);
+            var fortify = p.GetZoneModifierMax(ACE.Server.Managers.ZoneControl.ZoneModifiers.FortifyVitalsPct);
+            var pctHp = p.GetZoneModifierBonus(ACE.Server.Managers.ZoneControl.ZoneModifiers.PctMaxHealthPct);
+            var worn = 0; var wornWithRecord = 0; var rawFortifyMax = 0; var rawPct = 0; var rawGearHp = 0;
+            foreach (var wo in p.EquippedObjects.Values)
+            {
+                worn++;
+                if (ACE.Server.Managers.ZoneControl.ZoneStatResolver.HasRecord(wo)) wornWithRecord++;
+                rawFortifyMax = Math.Max(rawFortifyMax, wo.GetProperty((PropertyInt)ACE.Server.Managers.ZoneControl.ZoneModifiers.FortifyVitalsPct) ?? 0);
+                rawPct += wo.GetProperty((PropertyInt)ACE.Server.Managers.ZoneControl.ZoneModifiers.PctMaxHealthPct) ?? 0;
+                rawGearHp += wo.GearMaxHealth ?? 0;
+            }
+            Msg($"Max Health {hp.MaxValue:N0} = (starting {hp.StartingValue:N0} + formula {formula:N0} + enl {p.Enlightenment * 2:N0} + ranks {hp.Ranks:N0} + gear {p.GetGearMaxHealth():N0}) x ench {p.EnchantmentManager.GetVitalMod_Multiplier(hp):0.###} x fortify (1 + ({fortify} + {pctHp}) / 100) x vitae {p.Vitae:0.###} + additives {p.EnchantmentManager.GetVitalMod_Additives(hp):N0}");
+            Msg($"Worn: {worn} items, {wornWithRecord} with a ZcModifiers record. Raw on items: Fortify max {rawFortifyMax}, Max Health Pct sum {rawPct}, GearMaxHealth sum {rawGearHp:N0}. Cache says: Fortify {fortify}, Pct {pctHp}, GearMaxHealth {p.GetGearMaxHealth():N0}.");
+            if (rawFortifyMax != fortify || rawPct != pctHp)
+                Msg("MISMATCH: the cantrip cache does not match what is worn - equip/dequip hook missed (report this).");
+
+            // Regeneration (key 46, bracers): prop 50231 = FLAT pct of max vital added per natural tick (2026-08-23)
+            var regenSpecial = p.GetZoneModifierMax(ACE.Server.Managers.ZoneControl.ZoneModifiers.RegenSpecialMult);
+            var augRegen = 1.0f + p.AugmentationFasterRegen;
+            var ench = p.EnchantmentManager.GetRegenerationMod(hp);
+            Msg($"Health regen per tick = base {hp.RegenRate:0.###} x attribute mod x stance mod x enchant {ench:0.##} x Faster Regen aug {augRegen:0.##} (x zone tuner) + bracers flat {regenSpecial} pct of max = +{hp.MaxValue * regenSpecial / 100.0:N0}.");
+        }
+
         [CommandHandler("lbworldobjs", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, "Shows the current landblock's world objects")]
         public static void HandleLBWorldObjects(Session session, params string[] parameters)
         {

--- a/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
@@ -1937,8 +1937,14 @@ namespace ACE.Server.Command.Handlers
             }
             Msg($"Max Health {hp.MaxValue:N0} = (starting {hp.StartingValue:N0} + formula {formula:N0} + enl {p.Enlightenment * 2:N0} + ranks {hp.Ranks:N0} + gear {p.GetGearMaxHealth():N0}) x ench {p.EnchantmentManager.GetVitalMod_Multiplier(hp):0.###} x fortify (1 + ({fortify} + {pctHp}) / 100) x vitae {p.Vitae:0.###} + additives {p.EnchantmentManager.GetVitalMod_Additives(hp):N0}");
             Msg($"Worn: {worn} items, {wornWithRecord} with a ZcModifiers record. Raw on items: Fortify max {rawFortifyMax}, Max Health Pct sum {rawPct}, GearMaxHealth sum {rawGearHp:N0}. Cache says: Fortify {fortify}, Pct {pctHp}, GearMaxHealth {p.GetGearMaxHealth():N0}.");
-            if (rawFortifyMax != fortify || rawPct != pctHp)
+            // the cache applies two rules the raw item sums do not: zone-lock suppression (everything reads 0) and the
+            // gear cap on cap-line props (the cache may be LOWER than the raw sum, never higher)
+            if (ACE.Server.Managers.ZoneControl.ZoneControlManager.WornPowerSuppressed(p))
+                Msg("Zone lock: worn power is SUPPRESSED here (outside an authored zone) - the cache reads 0 by design.");
+            else if (rawFortifyMax != fortify || pctHp > rawPct)
                 Msg("MISMATCH: the cantrip cache does not match what is worn - equip/dequip hook missed (report this).");
+            else if (pctHp < rawPct)
+                Msg($"Max Health Pct clamped by the gear cap: raw {rawPct} -> effective {pctHp}.");
 
             // Regeneration (key 46, bracers): prop 50231 = FLAT pct of max vital added per natural tick (2026-08-23)
             var regenSpecial = p.GetZoneModifierMax(ACE.Server.Managers.ZoneControl.ZoneModifiers.RegenSpecialMult);

--- a/Source/ACE.Server/Command/Handlers/DeveloperContentCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperContentCommands.cs
@@ -1207,7 +1207,7 @@ namespace ACE.Server.Command.Handlers.Processors
             public List<int> ExplicitTargetVariations { get; } = new();
         }
 
-        [CommandHandler("createinst", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 1, "Spawns landblock instance. Prestige mirroring (extra landblock_instance rows for other prestige layers) never runs on retail/base (variation null or 1–10); it only runs when your current layer is prestige (11+). Flags: -nomirror|-nm skips mirroring. -mirror|-mv <list> targets only prestige variants: comma list and/or ranges (11,15,20 or 11-15), all|* = 11..max configured, spaces after commas OK (e.g. -mv 11, 15, 20). Retail IDs in -mv are rejected. Auto-mirror 11→12..max only if createinst_auto_mirror_higher_prestige_variants=true and no explicit -mv/-mirror.", "<wcid or classname> [flags]")]
+        [CommandHandler("createinst", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 1, "Spawns landblock instance. Prestige mirroring (extra landblock_instance rows for other prestige layers) only runs when your current layer is a PRESTIGE variation, i.e. above PrestigeManager.PRESTIGE_VAR_OFFSET (1000) - NOT at variations 11-25, where the mirror flags below are inert and you get exactly one row. Flags: -nomirror|-nm skips mirroring. -mirror|-mv <list> targets only prestige variants: comma list and/or ranges (11,15,20 or 11-15), all|* = 11..max configured, spaces after commas OK (e.g. -mv 11, 15, 20). Retail IDs in -mv are rejected. Auto-mirror 11→12..max only if createinst_auto_mirror_higher_prestige_variants=true and no explicit -mv/-mirror.", "<wcid or classname> [flags]")]
         public static void HandleCreateInst(Session session, params string[] parameters)
         {
             var loc = new Position(session.Player.Location);
@@ -1394,6 +1394,15 @@ namespace ACE.Server.Command.Handlers.Processors
                 return;
             }
 
+            // Prestige/Zone Scaler HP+damage scaling is normally applied when landblock instances are
+            // loaded from the world DB (WorldObjectFactory.CreateNewWorldObjects); /createinst bypasses
+            // that path entirely, so it must be applied here too or spawned mobs never pick up tier HP.
+            if (wo is Creature createdCreature)
+            {
+                PrestigeManager.ApplyPrestigeScaling(createdCreature, variation);
+                Managers.ZoneControl.ZoneSpawnScaler.ApplyToSpawn(createdCreature);
+            }
+
             // create new landblock instance
             var instance = CreateLandblockInstance(wo, isLinkChild, variation);
 
@@ -1445,6 +1454,255 @@ namespace ACE.Server.Command.Handlers.Processors
         public static void HandleCreateInstAlias(Session session, params string[] parameters)
         {
             HandleCreateInst(session, parameters);
+        }
+
+        [CommandHandler("fixinstz", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 1,
+            "Recomputes origin_Z = terrain height for landblock_instance rows of a wcid, fixing Z=0 / underground placements that fail to spawn (\"Failed to add world object ...\"). " +
+            "Default scope: the landblock you are standing in (all its variation layers). Add 'all' to fix every landblock in the world DB that contains the wcid. " +
+            "Writes to the world DB; reload the landblock or restart to respawn with the corrected Z.",
+            "<wcid> [all]")]
+        public static void HandleFixInstZ(Session session, params string[] parameters)
+        {
+            if (!uint.TryParse(parameters[0], out var wcid))
+            {
+                session.Network.EnqueueSend(new GameMessageSystemChat($"Couldn't parse wcid '{parameters[0]}'. Usage: /fixinstz <wcid> [all]", ChatMessageType.Broadcast));
+                return;
+            }
+
+            var all = parameters.Length > 1 && parameters[1].Equals("all", StringComparison.OrdinalIgnoreCase);
+            int? currentLandblock = all ? (int?)null : session.Player.CurrentLandblock.Id.Landblock;
+
+            var scanned = 0;
+            var changed = 0;
+            var failed = 0;
+            var minZ = float.MaxValue;
+            var maxZ = float.MinValue;
+            var affectedLandblocks = new HashSet<(int lb, int? var)>();
+
+            try
+            {
+                using (var ctx = new WorldDbContext())
+                {
+                    var query = ctx.LandblockInstance.Where(i => i.WeenieClassId == wcid);
+                    if (!all)
+                        query = query.Where(i => i.Landblock == currentLandblock);
+
+                    var rows = query.ToList();
+
+                    foreach (var inst in rows)
+                    {
+                        scanned++;
+
+                        var pos = new Position(inst.ObjCellId, inst.OriginX, inst.OriginY, inst.OriginZ,
+                            inst.AnglesX, inst.AnglesY, inst.AnglesZ, inst.AnglesW, false, inst.VariationId);
+
+                        float terrainZ;
+                        try
+                        {
+                            terrainZ = pos.GetTerrainZ();
+                        }
+                        catch
+                        {
+                            failed++;
+                            continue;
+                        }
+
+                        // small epsilon (matches createinst) so the object spawns just above the ground rather than clipping into it
+                        var newZ = terrainZ + 0.05f;
+
+                        if (Math.Abs(newZ - inst.OriginZ) > 0.001f)
+                        {
+                            inst.OriginZ = newZ;
+                            inst.LastModified = DateTime.Now;
+                            changed++;
+                            if (newZ < minZ) minZ = newZ;
+                            if (newZ > maxZ) maxZ = newZ;
+                            if (inst.Landblock.HasValue)
+                                affectedLandblocks.Add((inst.Landblock.Value, inst.VariationId));
+                        }
+                    }
+
+                    ctx.SaveChanges();
+                }
+            }
+            catch (Exception ex)
+            {
+                session.Network.EnqueueSend(new GameMessageSystemChat($"fixinstz failed: {ex.Message}", ChatMessageType.Broadcast));
+                return;
+            }
+
+            // drop cached instances for affected landblocks so a reload picks up the corrected Z
+            foreach (var (lb, var) in affectedLandblocks)
+                DatabaseManager.World.ClearCachedInstancesByLandblock((ushort)lb, var);
+
+            var scopeLabel = all ? "ALL landblocks" : $"landblock 0x{currentLandblock:X4}";
+            var zRange = changed > 0 ? $" Z range now {minZ:F2}..{maxZ:F2}." : "";
+            session.Network.EnqueueSend(new GameMessageSystemChat(
+                $"fixinstz wcid {wcid} ({scopeLabel}): scanned {scanned}, updated {changed}, unresolved terrain {failed}.{zRange} " +
+                $"Reload the landblock (or restart) to respawn. Rows live in ace_world only - there is no instance export command.", ChatMessageType.Broadcast));
+            PlayerManager.BroadcastToAuditChannel(session.Player,
+                $"{session.Player.Name} ran /fixinstz wcid {wcid} ({scopeLabel}): updated {changed}/{scanned}, failed {failed}.");
+        }
+
+        [CommandHandler("spreadinst", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 2,
+            "Bulk-generates <count> randomly-positioned static landblock_instance rows of <wcid> per prestige landblock, mirrored across variation layers [minVar..maxVar] (default 11..25), with terrain-snapped Z. " +
+            "By default only fills landblocks that do NOT already have that wcid (add 'force' to also add to populated ones). Targets the prestige_allowed_landblocks set. Writes the world DB; restart/reload to spawn.",
+            "<wcid> <count> [minVar] [maxVar] [force]")]
+        public static void HandleSpreadInst(Session session, params string[] parameters)
+        {
+            if (!uint.TryParse(parameters[0], out var wcid))
+            {
+                session.Network.EnqueueSend(new GameMessageSystemChat($"Couldn't parse wcid '{parameters[0]}'. Usage: /spreadinst <wcid> <count> [minVar] [maxVar] [force]", ChatMessageType.Broadcast));
+                return;
+            }
+            if (!int.TryParse(parameters[1], out var count) || count <= 0)
+            {
+                session.Network.EnqueueSend(new GameMessageSystemChat($"Couldn't parse count '{parameters[1]}' (must be > 0).", ChatMessageType.Broadcast));
+                return;
+            }
+
+            var minVar = 11;
+            var maxVar = 25;
+            var force = false;
+            var numericArgs = new List<int>();
+            for (var p = 2; p < parameters.Length; p++)
+            {
+                if (parameters[p].Equals("force", StringComparison.OrdinalIgnoreCase))
+                    force = true;
+                else if (int.TryParse(parameters[p], out var num))
+                    numericArgs.Add(num);
+            }
+            if (numericArgs.Count >= 1) minVar = numericArgs[0];
+            if (numericArgs.Count >= 2) maxVar = numericArgs[1];
+            if (minVar < 11 || maxVar < minVar)
+            {
+                session.Network.EnqueueSend(new GameMessageSystemChat($"Invalid variation range {minVar}..{maxVar} (min 11, max >= min).", ChatMessageType.Broadcast));
+                return;
+            }
+
+            // verify the weenie exists so we don't scatter bad rows
+            if (DatabaseManager.World.GetWeenie(wcid) == null)
+            {
+                session.Network.EnqueueSend(new GameMessageSystemChat($"Weenie {wcid} not found.", ChatMessageType.Broadcast));
+                return;
+            }
+
+            // valid prestige zones = union of all configured allowed-landblock sets
+            var allowed = new HashSet<ushort>();
+            foreach (var kvp in PrestigeManager.GetAllAllowedLandblocks())
+                allowed.UnionWith(kvp.Value);
+
+            if (allowed.Count == 0)
+            {
+                session.Network.EnqueueSend(new GameMessageSystemChat("No prestige-allowed landblocks are configured; nothing to do.", ChatMessageType.Broadcast));
+                return;
+            }
+
+            var totalRows = 0;
+            var landblocksFilled = 0;
+            var terrainFails = 0;
+            var guidExhausted = 0;
+
+            try
+            {
+                using (var ctx = new WorldDbContext())
+                {
+                    foreach (var lb in allowed.OrderBy(x => x))
+                    {
+                        var existing = ctx.LandblockInstance.Where(i => i.Landblock == lb).ToList();
+
+                        // which variations in range already have this wcid (skip unless force)
+                        var haveVars = existing.Where(i => i.WeenieClassId == wcid && i.VariationId.HasValue)
+                                               .Select(i => i.VariationId.Value).ToHashSet();
+
+                        var targetVars = Enumerable.Range(minVar, maxVar - minVar + 1)
+                                                   .Where(v => force || !haveVars.Contains(v)).ToList();
+                        if (targetVars.Count == 0)
+                            continue;
+
+                        // proper per-landblock static guid range: 0x70000000 | landblock<<12 | index (0..0xFFF)
+                        var firstGuid = ObjectGuid.LandblockInstanceGuidBase | ((uint)lb << 12);
+                        var lastGuid = firstGuid | 0xFFF;
+                        var maxUsed = existing.Where(i => i.Guid >= firstGuid && i.Guid <= lastGuid)
+                                              .Select(i => i.Guid).DefaultIfEmpty(firstGuid - 1).Max();
+                        var nextGuid = maxUsed + 1;
+
+                        // generate 'count' shared positions once, mirror them across the target variations
+                        var positions = new List<(uint cell, float x, float y, float z)>();
+                        for (var i = 0; i < count; i++)
+                        {
+                            var x = (float)ThreadSafeRandom.Next(0f, 191.9f);
+                            var y = (float)ThreadSafeRandom.Next(0f, 191.9f);
+                            var cellX = Math.Min(7, (int)(x / 24f));
+                            var cellY = Math.Min(7, (int)(y / 24f));
+                            var objCell = ((uint)lb << 16) | (uint)(cellX * 8 + cellY + 1);
+
+                            float z;
+                            try
+                            {
+                                var probe = new Position(objCell, x, y, 0f, 0f, 0f, 0f, 1f, false, minVar);
+                                z = probe.GetTerrainZ() + 0.05f;
+                            }
+                            catch
+                            {
+                                z = 0f;
+                                terrainFails++;
+                            }
+                            positions.Add((objCell, x, y, z));
+                        }
+
+                        var filledThisLb = false;
+                        foreach (var v in targetVars)
+                        {
+                            foreach (var pos in positions)
+                            {
+                                if (nextGuid > lastGuid)
+                                {
+                                    guidExhausted++;
+                                    break;
+                                }
+
+                                ctx.LandblockInstance.Add(new LandblockInstance
+                                {
+                                    Guid = nextGuid++,
+                                    Landblock = lb,
+                                    WeenieClassId = wcid,
+                                    ObjCellId = pos.cell,
+                                    OriginX = pos.x,
+                                    OriginY = pos.y,
+                                    OriginZ = pos.z,
+                                    AnglesW = 1f,
+                                    AnglesX = 0f,
+                                    AnglesY = 0f,
+                                    AnglesZ = 0f,
+                                    IsLinkChild = false,
+                                    LastModified = DateTime.Now,
+                                    VariationId = v
+                                });
+                                totalRows++;
+                                filledThisLb = true;
+                            }
+                        }
+
+                        if (filledThisLb)
+                            landblocksFilled++;
+                    }
+
+                    ctx.SaveChanges();
+                }
+            }
+            catch (Exception ex)
+            {
+                session.Network.EnqueueSend(new GameMessageSystemChat($"spreadinst failed: {ex.Message}", ChatMessageType.Broadcast));
+                return;
+            }
+
+            var msg = $"spreadinst wcid {wcid}: added {totalRows} rows across {landblocksFilled} landblocks, variations {minVar}..{maxVar}, {count}/landblock/variation." +
+                      (terrainFails > 0 ? $" ({terrainFails} positions had no terrain -> Z=0, run /fixinstz {wcid} all)" : "") +
+                      (guidExhausted > 0 ? $" ({guidExhausted} landblocks hit the 4096 static-guid cap)" : "") +
+                      " Restart/reload to spawn.";
+            session.Network.EnqueueSend(new GameMessageSystemChat(msg, ChatMessageType.Broadcast));
+            PlayerManager.BroadcastToAuditChannel(session.Player, $"{session.Player.Name} ran /spreadinst wcid {wcid}: {totalRows} rows / {landblocksFilled} landblocks.");
         }
 
         /// <summary>
@@ -1819,9 +2077,25 @@ namespace ACE.Server.Command.Handlers.Processors
             return null;
         }
 
-        [CommandHandler("removeinst", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, "Removes the last appraised object from the current landblock instances")]
+        [CommandHandler("removeinst", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, "Removes the last appraised object from the current landblock instances. Optional: /removeinst <wcid> removes the NEAREST instance of that weenie in your current landblock at your variation (Zone Control plugin button support).")]
         public static void HandleRemoveInst(Session session, params string[] parameters)
         {
+            if (parameters.Length > 0)
+            {
+                var wcidStr = parameters[0];
+                if (wcidStr.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+                    wcidStr = wcidStr.Substring(2);
+
+                if (uint.TryParse(wcidStr, out var wcid) ||
+                    uint.TryParse(wcidStr, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out wcid))
+                {
+                    RemoveInstanceByWcid(session, wcid);
+                    return;
+                }
+
+                session.Network.EnqueueSend(new GameMessageSystemChat($"Couldn't parse wcid {parameters[0]} - usage: /removeinst [wcid]", ChatMessageType.Broadcast));
+                return;
+            }
             RemoveInstance(session);
         }
 
@@ -1829,7 +2103,52 @@ namespace ACE.Server.Command.Handlers.Processors
         {
             var wo = CommandHandlerHelper.GetLastAppraisedObject(session);
 
-            if (wo?.Location == null) return;
+            if (wo == null)
+                return; // GetLastAppraisedObject already reported the reason to the player
+
+            RemoveInstanceWorldObject(session, wo, confirmed, () => RemoveInstance(session, true));
+        }
+
+        /// <summary>
+        /// /removeinst <wcid>: removes the nearest live instance of the weenie in the player's current
+        /// landblock (the landblock is already variation-specific). Generator children resolve to their
+        /// generator's static row exactly like the appraisal path.
+        /// </summary>
+        public static void RemoveInstanceByWcid(Session session, uint wcid, bool confirmed = false)
+        {
+            var player = session.Player;
+            var landblock = player?.CurrentLandblock;
+
+            if (landblock == null)
+                return;
+
+            var wo = landblock.GetAllWorldObjectsForDiagnostics()
+                .Where(o => o.WeenieClassId == wcid && o.Location != null && !(o is Player))
+                .OrderBy(o => o.Location.SquaredDistanceTo(player.Location))
+                .FirstOrDefault();
+
+            if (wo == null)
+            {
+                session.Network.EnqueueSend(new GameMessageSystemChat($"No live instance of wcid {wcid} found in this landblock at your variation.", ChatMessageType.Broadcast));
+                return;
+            }
+
+            RemoveInstanceWorldObject(session, wo, confirmed, () => RemoveInstanceByWcid(session, wcid, true));
+        }
+
+        private static void RemoveInstanceWorldObject(Session session, WorldObject wo, bool confirmed, Action reconfirm)
+        {
+            if (wo.Location == null)
+            {
+                // Previously a SILENT return, which read as "removeinst does nothing" -- almost always because the
+                // stale appraisal target is a location-less object (e.g. a dynamic loot item), not the intended
+                // landblock instance. Tell the player instead of failing quietly.
+                session.Network.EnqueueSend(new GameMessageSystemChat(
+                    $"Cannot remove {wo.WeenieClassId} - {wo.Name} (0x{wo.Guid.Full:X8}): object has no Location " +
+                    $"(IsDestroyed={wo.IsDestroyed}, inLandblock={(wo.CurrentLandblock != null)}). Re-appraise it or reload the landblock, then retry.",
+                    ChatMessageType.Broadcast));
+                return;
+            }
 
             var landblock = (ushort)wo.Location.Landblock;
             int? variation = wo.Location.Variation;
@@ -1849,6 +2168,22 @@ namespace ACE.Server.Command.Handlers.Processors
 
             if (instance == null)
             {
+                // Fallback: the per-(landblock, variation) cache can miss the row -- e.g. a stale cache, or the
+                // runtime object's Location.Variation not matching the stored variation_Id. guid is the primary key,
+                // so look the row up directly (bypassing the variation cache) across every variation of this
+                // landblock. This is what previously forced manual DB deletes for createinst'd generators in a variation.
+                var bypass = DatabaseManager.World.GetLandblockInstancesByLandblockBypassCache(landblock);
+                instance = bypass.FirstOrDefault(i => i.Guid == guid);
+
+                if (instance != null)
+                {
+                    instances = bypass;
+                    variation = instance.VariationId;   // use the stored variation for the post-delete cache clear
+                }
+            }
+
+            if (instance == null)
+            {
                 session.Network.EnqueueSend(new GameMessageSystemChat($"Couldn't find landblock_instance for {wo.WeenieClassId} - {wo.Name} (0x{guid:X8})", ChatMessageType.Broadcast));
                 return;
             }
@@ -1864,7 +2199,7 @@ namespace ACE.Server.Command.Handlers.Processors
 
                 // require confirmation for parent objects
                 var msg = $"Are you sure you want to delete this parent object, and {numChilds} child object{(numChilds != 1 ? "s" : "")}?";
-                void onResponse(bool response, bool _) { if (response) { RemoveInstance(session, true); } };
+                void onResponse(bool response, bool _) { if (response) { reconfirm(); } };
                 if (!session.Player.ConfirmationManager.EnqueueSend(new Confirmation_Custom(session.Player.Guid, onResponse), msg))
                     session.Player.SendWeenieError(WeenieError.ConfirmationInProgress);
                 return;
@@ -1900,6 +2235,10 @@ namespace ACE.Server.Command.Handlers.Processors
 
             //SyncInstances(session, landblock, instances, variation);
             DeleteInstanceFromWorldDatabase(instance);
+
+            // invalidate the variation cache so a reload re-queries fresh (esp. when the bypass fallback was used,
+            // where 'instances' is not the cached list reference)
+            DatabaseManager.World.ClearCachedInstancesByLandblock(landblock, variation);
 
             session.Network.EnqueueSend(new GameMessageSystemChat($"Removed {(instance.IsLinkChild ? "child " : "")}{wo.WeenieClassId} - {wo.Name} (0x{guid:X8}) from landblock instances", ChatMessageType.Broadcast));
             PlayerManager.BroadcastToAuditChannel(session.Player, $"{session.Player.Name} has removed {(instance.IsLinkChild ? "child " : "")}[WeenieID]: {wo.WeenieClassId} - {wo.Name} [GUID]: (0x{guid:X8}) from landblock instances");
@@ -4219,6 +4558,57 @@ namespace ACE.Server.Command.Handlers.Processors
 
 
             CommandHandlerHelper.WriteOutputInfo(session, $"Next available weenie id in range {start}: {weenies}");
+        }
+
+        [CommandHandler("findwcid", AccessLevel.Developer, CommandHandlerFlag.None, 1,
+            "Searches weenies by display name or classname (case-insensitive substring).",
+            "<partial name>  e.g. @findwcid galaeral")]
+        public static void HandleFindWcid(Session session, params string[] parameters)
+        {
+            var search = string.Join(" ", parameters).Trim();
+
+            if (search.Length < 3)
+            {
+                CommandHandlerHelper.WriteOutputInfo(session, "Search term must be at least 3 characters.");
+                return;
+            }
+
+            const int maxResults = 25;
+
+            using var ctx = new WorldDbContext();
+
+            // left-join the display name (weenie_properties_string type 1); match on either it or the classname
+            var matches = (from w in ctx.Weenie
+                           join s in ctx.WeeniePropertiesString.Where(s => s.Type == (ushort)PropertyString.Name)
+                               on w.ClassId equals s.ObjectId into names
+                           from n in names.DefaultIfEmpty()
+                           where EF.Functions.Like(w.ClassName, $"%{search}%") ||
+                                 (n != null && EF.Functions.Like(n.Value, $"%{search}%"))
+                           orderby w.ClassId
+                           select new { w.ClassId, w.ClassName, w.Type, DisplayName = n != null ? n.Value : null })
+                          .Take(maxResults + 1)
+                          .ToList();
+
+            if (matches.Count == 0)
+            {
+                CommandHandlerHelper.WriteOutputInfo(session, $"No weenies found matching '{search}'.");
+                return;
+            }
+
+            var lines = matches.Take(maxResults)
+                .Select(m => $"{m.ClassId,7} | {(WeenieType)m.Type,-14} | {m.ClassName}{(m.DisplayName != null ? $" | {m.DisplayName}" : "")}");
+
+            CommandHandlerHelper.WriteOutputInfo(session,
+                $"Weenies matching '{search}':\n   wcid | type           | classname | name\n" + string.Join("\n", lines) +
+                (matches.Count > maxResults ? $"\n...more than {maxResults} matches, narrow the search." : ""));
+        }
+
+        [CommandHandler("findnpc", AccessLevel.Developer, CommandHandlerFlag.None, 1,
+            "Alias for findwcid - searches weenies by display name or classname.",
+            "<partial name>")]
+        public static void HandleFindNpc(Session session, params string[] parameters)
+        {
+            HandleFindWcid(session, parameters);
         }
 
         [CommandHandler("generate-classnames", AccessLevel.Developer, CommandHandlerFlag.None, "Generates WeenieClassName.cs from current world database")]

--- a/Source/ACE.Server/Command/Handlers/DeveloperContentCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperContentCommands.cs
@@ -1506,6 +1506,13 @@ namespace ACE.Server.Command.Handlers.Processors
                             failed++;
                             continue;
                         }
+                        // GetTerrainZ returns the probe's own Z when there is no land cell / terrain polygon; that is a
+                        // failure to resolve, not a height - skip the row rather than nudge it by the epsilon every run
+                        if (terrainZ == pos.Pos.Z)
+                        {
+                            failed++;
+                            continue;
+                        }
 
                         // small epsilon (matches createinst) so the object spawns just above the ground rather than clipping into it
                         var newZ = terrainZ + 0.05f;
@@ -1555,9 +1562,9 @@ namespace ACE.Server.Command.Handlers.Processors
                 session.Network.EnqueueSend(new GameMessageSystemChat($"Couldn't parse wcid '{parameters[0]}'. Usage: /spreadinst <wcid> <count> [minVar] [maxVar] [force]", ChatMessageType.Broadcast));
                 return;
             }
-            if (!int.TryParse(parameters[1], out var count) || count <= 0)
+            if (!int.TryParse(parameters[1], out var count) || count <= 0 || count > 200)
             {
-                session.Network.EnqueueSend(new GameMessageSystemChat($"Couldn't parse count '{parameters[1]}' (must be > 0).", ChatMessageType.Broadcast));
+                session.Network.EnqueueSend(new GameMessageSystemChat($"Couldn't parse count '{parameters[1]}' (must be 1-200).", ChatMessageType.Broadcast));
                 return;
             }
 
@@ -1652,13 +1659,16 @@ namespace ACE.Server.Command.Handlers.Processors
                         }
 
                         var filledThisLb = false;
+                        var lbExhausted = false;   // counted once per LANDBLOCK, not once per variation
                         foreach (var v in targetVars)
                         {
+                            if (lbExhausted)
+                                break;
                             foreach (var pos in positions)
                             {
                                 if (nextGuid > lastGuid)
                                 {
-                                    guidExhausted++;
+                                    lbExhausted = true;
                                     break;
                                 }
 
@@ -1684,8 +1694,13 @@ namespace ACE.Server.Command.Handlers.Processors
                             }
                         }
 
+                        if (lbExhausted)
+                            guidExhausted++;
                         if (filledThisLb)
                             landblocksFilled++;
+                        // persist per landblock: one transaction per block instead of one giant tracked change set
+                        ctx.SaveChanges();
+                        ctx.ChangeTracker.Clear();
                     }
 
                     ctx.SaveChanges();
@@ -2177,7 +2192,8 @@ namespace ACE.Server.Command.Handlers.Processors
 
                 if (instance != null)
                 {
-                    instances = bypass;
+                    // stay on the row's own variation: the later parent-link fix-up must not mutate a sibling variation's parent
+                    instances = bypass.Where(i => i.VariationId == instance.VariationId).ToList();
                     variation = instance.VariationId;   // use the stored variation for the post-delete cache clear
                 }
             }
@@ -4576,14 +4592,15 @@ namespace ACE.Server.Command.Handlers.Processors
             const int maxResults = 25;
 
             using var ctx = new WorldDbContext();
+            var pattern = ACE.Server.Web.WeenieSearchOrdering.ContainsLikePattern(search);   // % and _ in the search are literal
 
             // left-join the display name (weenie_properties_string type 1); match on either it or the classname
             var matches = (from w in ctx.Weenie
                            join s in ctx.WeeniePropertiesString.Where(s => s.Type == (ushort)PropertyString.Name)
                                on w.ClassId equals s.ObjectId into names
                            from n in names.DefaultIfEmpty()
-                           where EF.Functions.Like(w.ClassName, $"%{search}%") ||
-                                 (n != null && EF.Functions.Like(n.Value, $"%{search}%"))
+                           where EF.Functions.Like(w.ClassName, pattern, "\\") ||
+                                 (n != null && EF.Functions.Like(n.Value, pattern, "\\"))
                            orderby w.ClassId
                            select new { w.ClassId, w.ClassName, w.Type, DisplayName = n != null ? n.Value : null })
                           .Take(maxResults + 1)

--- a/Source/ACE.Server/Command/Handlers/PlayerCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/PlayerCommands.cs
@@ -1934,18 +1934,54 @@ namespace ACE.Server.Command.Handlers
         [CommandHandler("instance", AccessLevel.Player, CommandHandlerFlag.RequiresWorld, "Shows the current instance")]
         public static void HandleInstanceInfo(Session session, params string[] parameters)
         {
-            var physicsObj = session.Player.PhysicsObj;
+            var player = session.Player;
+            var physicsObj = player.PhysicsObj;
 
-            var physInstance = physicsObj.Position.Variation;
-            var locInstance = session.Player.Location.Variation;
+            static string V(int? v) => v?.ToString() ?? "null";
 
-            session.Network.EnqueueSend(new GameMessageSystemChat($"Physics Instance: {physInstance}\nLocation Instance: {locInstance}", ChatMessageType.Broadcast));
-            if (session.Player.CurrentLandblock != null)
+            var physInstance = physicsObj?.Position.Variation;
+            var locInstance = player.Location.Variation;
+            var curCell = physicsObj?.CurCell;
+
+            session.Network.EnqueueSend(new GameMessageSystemChat(
+                $"Physics Instance: {V(physInstance)}\nLocation Instance: {V(locInstance)}\n" +
+                $"Physics Cell: 0x{curCell?.ID ?? 0:X8} (v={V(curCell?.VariationId)})", ChatMessageType.Broadcast));
+
+            var lb = player.CurrentLandblock;
+            if (lb != null)
             {
-                session.Network.EnqueueSend(new GameMessageSystemChat($"Landblock World Object Count: {session.Player.CurrentLandblock.WorldObjectCount}", ChatMessageType.Broadcast));
-                session.Network.EnqueueSend(new GameMessageSystemChat($"Landblock Physics Object Count: {session.Player.CurrentLandblock.PhysicsObjectCount}", ChatMessageType.Broadcast));
+                var matches = lb.Id.Landblock == player.Location.LandblockId.Landblock && lb.VariationId == player.Location.Variation;
+                session.Network.EnqueueSend(new GameMessageSystemChat(
+                    $"CurrentLandblock: 0x{lb.Id.Landblock:X4} (v={V(lb.VariationId)}) — {(matches ? "matches Location" : "STALE: does NOT match Location!")}", ChatMessageType.Broadcast));
+                session.Network.EnqueueSend(new GameMessageSystemChat($"Landblock World Object Count: {lb.WorldObjectCount}", ChatMessageType.Broadcast));
+                session.Network.EnqueueSend(new GameMessageSystemChat($"Landblock Physics Object Count: {lb.PhysicsObjectCount}", ChatMessageType.Broadcast));
             }
+            else
+                session.Network.EnqueueSend(new GameMessageSystemChat("CurrentLandblock: NULL (not resident in any landblock instance!)", ChatMessageType.Broadcast));
 
+            if (player.Attacking || player.MeleeTarget != null || player.MissileTarget != null)
+                session.Network.EnqueueSend(new GameMessageSystemChat(
+                    $"Combat state: Attacking={player.Attacking} MeleeTarget={player.MeleeTarget?.Name ?? "null"} MissileTarget={player.MissileTarget?.Name ?? "null"}", ChatMessageType.Broadcast));
+        }
+
+        [CommandHandler("fixvariation", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld,
+            "Re-homes you into the landblock instance matching your current location (repairs variation/instance desync).")]
+        public static void HandleFixVariation(Session session, params string[] parameters)
+        {
+            var player = session.Player;
+
+            // clear any stale attack-loop state that silently swallows new attack requests
+            player.OnAttackDone();
+
+            // re-home CurrentLandblock to the instance matching Location (landblock + variation)
+            LandblockManager.RelocateObjectForPhysics(player, true);
+
+            // refresh client-side visibility from the current cell PVS
+            player.ReconcileVisibilityAfterArrival();
+
+            var lb = player.CurrentLandblock;
+            session.Network.EnqueueSend(new GameMessageSystemChat(
+                $"Re-homed to landblock 0x{lb?.Id.Landblock:X4} (v={lb?.VariationId?.ToString() ?? "null"}), Location v={player.Location.Variation?.ToString() ?? "null"}.", ChatMessageType.Broadcast));
         }
 
         [CommandHandler("knownobjects", AccessLevel.Player, CommandHandlerFlag.RequiresWorld, "Shows the current known objects")]

--- a/Source/ACE.Server/Command/Handlers/RiftCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/RiftCommands.cs
@@ -1,0 +1,466 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+using ACE.Database;
+using ACE.Entity.Enum;
+using ACE.Entity.Models;
+using ACE.Server.Managers;
+using ACE.Server.Managers.Rifts;
+using ACE.Server.Managers.ZoneScaling;
+using ACE.Server.Network;
+using ACE.Server.Network.GameMessages.Messages;
+
+namespace ACE.Server.Command.Handlers
+{
+    /// <summary>
+    /// /rift — Greater Rifts. Player-facing: status / leave / return / abandon. Everything else
+    /// (open, close, pool, guardian, set, setloot, show, reload) is gated to Developer+ inside the handler
+    /// so the one command serves both audiences.
+    /// </summary>
+    public static class RiftCommands
+    {
+        [CommandHandler("rift", AccessLevel.Player, CommandHandlerFlag.RequiresWorld, 0,
+            "Greater Rifts.",
+            "(blank = status) | leave | return | abandon"
+            + " || DEV: open <tier> [lbHex] | close [player] | list | pool add here <name> | pool guardianpos | pool remove <hex> | pool list | "
+            + "guardian add <minTier> <maxTier> <wcid> | guardian remove <wcid> | guardian list | "
+            + "set <key> <value> | setloot <stat> <base> <perTier> | setloot <stat> clear | show | reload")]
+        public static void HandleRift(Session session, params string[] parameters)
+        {
+            var player = session?.Player;
+            if (player == null)
+                return;
+
+            var sub = parameters.Length > 0 ? parameters[0].ToLowerInvariant() : "status";
+
+            switch (sub)
+            {
+                // ── player-facing ──
+                case "status":
+                    Reply(session, RiftManager.BuildStatus(player));
+                    return;
+
+                case "leave":
+                    Reply(session, RiftManager.Leave(player) ?? "You step out of the rift.");
+                    return;
+
+                case "return":
+                    Reply(session, RiftManager.ReEnter(player) ?? "You return to your rift.");
+                    return;
+
+                case "abandon":
+                    Reply(session, RiftManager.Abandon(player) ?? "Rift abandoned.");
+                    return;
+            }
+
+            if (session.AccessLevel < AccessLevel.Developer)
+            {
+                Reply(session, "Usage: /rift (status) | leave | return | abandon");
+                return;
+            }
+
+            switch (sub)
+            {
+                case "open":
+                    HandleOpen(session, parameters);
+                    return;
+                case "close":
+                    HandleClose(session, parameters);
+                    return;
+                case "list":
+                    HandleList(session);
+                    return;
+                case "pool":
+                    HandlePool(session, parameters);
+                    return;
+                case "guardian":
+                    HandleGuardian(session, parameters);
+                    return;
+                case "set":
+                    HandleSet(session, parameters);
+                    return;
+                case "setloot":
+                    HandleSetLoot(session, parameters);
+                    return;
+                case "show":
+                    HandleShow(session);
+                    return;
+                case "reload":
+                    RiftManager.ReloadConfig();
+                    Reply(session, "Rift config reloaded from the shard store.");
+                    return;
+                default:
+                    Reply(session, "Unknown /rift subcommand. See /rift help in the command usage.");
+                    return;
+            }
+        }
+
+        private static void HandleOpen(Session session, string[] p)
+        {
+            if (p.Length < 2 || !int.TryParse(p[1], out var tier))
+            {
+                Reply(session, "Usage: /rift open <tier> [lbHex]");
+                return;
+            }
+
+            ushort? lb = null;
+            if (p.Length >= 3)
+            {
+                if (!TryParseLandblock(p[2], out var parsed))
+                {
+                    Reply(session, $"Could not parse landblock '{p[2]}' (expected hex, e.g. 01AB).");
+                    return;
+                }
+                lb = parsed;
+            }
+
+            var err = RiftManager.OpenRun(session.Player, tier, lb);
+            if (err != null)
+                Reply(session, err);
+        }
+
+        private static void HandleClose(Session session, string[] p)
+        {
+            RiftRun run;
+            if (p.Length >= 2)
+            {
+                var target = PlayerManager.GetOnlinePlayer(string.Join(" ", p.Skip(1)));
+                if (target == null)
+                {
+                    Reply(session, "Player not found online.");
+                    return;
+                }
+                run = RiftManager.GetRunByOwner(target.Guid.Full);
+            }
+            else
+            {
+                run = RiftManager.GetRunByOwner(session.Player.Guid.Full);
+            }
+
+            if (run == null)
+            {
+                Reply(session, "No open rift found for that player.");
+                return;
+            }
+
+            RiftManager.ForceClose(run);
+            Reply(session, $"Closed rift run {run.RunId} (tier {run.Tier}, {run.OwnerName}).");
+        }
+
+        private static void HandleList(Session session)
+        {
+            var runs = RiftManager.GetActiveRuns();
+            if (runs.Count == 0)
+            {
+                Reply(session, "No rifts are open.");
+                return;
+            }
+
+            var sb = new StringBuilder($"Open rifts ({runs.Count}):\n");
+            foreach (var run in runs.OrderBy(r => r.RunId))
+                sb.AppendLine($"  #{run.RunId} {run.OwnerName} - tier {run.Tier} {run.DungeonName} ({run.DungeonLb:X4} v{run.Variation}) {run.State} {run.ProgressPercent}%");
+            Reply(session, sb.ToString().TrimEnd());
+        }
+
+        private static void HandlePool(Session session, string[] p)
+        {
+            var cfg = RiftManager.Config;
+            var action = p.Length > 1 ? p[1].ToLowerInvariant() : "list";
+
+            switch (action)
+            {
+                case "add":
+                {
+                    // /rift pool add here <name...>
+                    if (p.Length < 3 || !p[2].Equals("here", StringComparison.OrdinalIgnoreCase))
+                    {
+                        Reply(session, "Usage: /rift pool add here <name> (stand at the desired entry point inside the dungeon)");
+                        return;
+                    }
+
+                    var loc = session.Player.Location;
+                    var lbObj = session.Player.CurrentLandblock;
+                    if (loc == null || lbObj == null)
+                        return;
+
+                    if (!loc.Indoors || lbObj.PhysicsLandblock?.IsDungeon != true)
+                    {
+                        Reply(session, "Rift pool dungeons must be added from INSIDE a dungeon landblock.");
+                        return;
+                    }
+
+                    var lb = loc.LandblockId.Landblock;
+                    var name = p.Length > 3 ? string.Join(" ", p.Skip(3)) : lb.ToString("X4");
+
+                    // population source = the variation you're standing in (0 normalizes to the base rows);
+                    // instance rows are per-variation exact-match, so this decides which copy's monsters
+                    // populate rift runs of this dungeon
+                    var sourceVariation = loc.Variation is int v && v != 0 ? loc.Variation : null;
+                    var sourceLabel = sourceVariation?.ToString() ?? "base";
+
+                    var existing = cfg.DungeonPool.FirstOrDefault(d => d.Landblock == lb);
+                    if (existing != null)
+                    {
+                        existing.Name = name;
+                        existing.Entry = RiftPos.FromPosition(loc);
+                        existing.SourceVariation = sourceVariation;
+                        RiftManager.SaveConfig();
+                        Reply(session, $"Updated pool dungeon {name} ({lb:X4}): entry point set to your position, population source v:{sourceLabel}.");
+                        return;
+                    }
+
+                    cfg.DungeonPool.Add(new RiftDungeonEntry
+                    {
+                        Landblock = lb,
+                        Name = name,
+                        Entry = RiftPos.FromPosition(loc),
+                        SourceVariation = sourceVariation,
+                    });
+                    RiftManager.SaveConfig();
+                    Reply(session, $"Added pool dungeon {name} ({lb:X4}), entry at your position, population source v:{sourceLabel}. Now stand at the guardian spot and run: /rift pool guardianpos");
+                    return;
+                }
+
+                case "guardianpos":
+                {
+                    var loc = session.Player.Location;
+                    if (loc == null)
+                        return;
+
+                    var lb = loc.LandblockId.Landblock;
+                    var entry = cfg.DungeonPool.FirstOrDefault(d => d.Landblock == lb);
+                    if (entry == null)
+                    {
+                        Reply(session, $"Landblock {lb:X4} is not in the pool. Add it first: /rift pool add here <name>");
+                        return;
+                    }
+
+                    entry.Guardian = RiftPos.FromPosition(loc);
+                    RiftManager.SaveConfig();
+                    Reply(session, $"Guardian spawn for {entry.Name} ({lb:X4}) set to your position.");
+                    return;
+                }
+
+                case "remove":
+                {
+                    if (p.Length < 3 || !TryParseLandblock(p[2], out var lb))
+                    {
+                        Reply(session, "Usage: /rift pool remove <lbHex>");
+                        return;
+                    }
+
+                    var removed = cfg.DungeonPool.RemoveAll(d => d.Landblock == lb);
+                    if (removed > 0)
+                        RiftManager.SaveConfig();
+                    Reply(session, removed > 0 ? $"Removed {lb:X4} from the pool." : $"{lb:X4} was not in the pool.");
+                    return;
+                }
+
+                case "list":
+                default:
+                {
+                    if (cfg.DungeonPool.Count == 0)
+                    {
+                        Reply(session, "The rift dungeon pool is empty. Stand inside a dungeon and use: /rift pool add here <name>");
+                        return;
+                    }
+
+                    var sb = new StringBuilder($"Rift dungeon pool ({cfg.DungeonPool.Count}):\n");
+                    foreach (var d in cfg.DungeonPool)
+                        sb.AppendLine($"  {d.Name} ({d.Landblock:X4}) source v:{d.SourceVariation?.ToString() ?? "base"} entry:{(d.Entry != null ? "set" : "MISSING")} guardian:{(d.Guardian != null ? "set" : "entry fallback")}");
+                    Reply(session, sb.ToString().TrimEnd());
+                    return;
+                }
+            }
+        }
+
+        private static void HandleGuardian(Session session, string[] p)
+        {
+            var cfg = RiftManager.Config;
+            var action = p.Length > 1 ? p[1].ToLowerInvariant() : "list";
+
+            switch (action)
+            {
+                case "add":
+                {
+                    if (p.Length < 5 || !int.TryParse(p[2], out var min) || !int.TryParse(p[3], out var max) || !uint.TryParse(p[4], out var wcid))
+                    {
+                        Reply(session, "Usage: /rift guardian add <minTier> <maxTier> <wcid>");
+                        return;
+                    }
+
+                    var weenie = DatabaseManager.World.GetCachedWeenie(wcid);
+                    if (weenie == null)
+                    {
+                        Reply(session, $"No weenie {wcid} exists.");
+                        return;
+                    }
+
+                    var pool = cfg.GuardianPools.FirstOrDefault(g => g.MinTier == min && g.MaxTier == max);
+                    if (pool == null)
+                    {
+                        pool = new RiftGuardianPool { MinTier = min, MaxTier = max };
+                        cfg.GuardianPools.Add(pool);
+                    }
+
+                    if (!pool.Wcids.Contains(wcid))
+                        pool.Wcids.Add(wcid);
+
+                    RiftManager.SaveConfig();
+                    Reply(session, $"Added guardian {weenie.GetName()} ({wcid}) for tiers {min}-{max}.");
+                    return;
+                }
+
+                case "remove":
+                {
+                    if (p.Length < 3 || !uint.TryParse(p[2], out var wcid))
+                    {
+                        Reply(session, "Usage: /rift guardian remove <wcid>");
+                        return;
+                    }
+
+                    var removed = 0;
+                    foreach (var pool in cfg.GuardianPools)
+                        removed += pool.Wcids.RemoveAll(w => w == wcid);
+                    cfg.GuardianPools.RemoveAll(g => g.Wcids.Count == 0);
+
+                    if (removed > 0)
+                        RiftManager.SaveConfig();
+                    Reply(session, removed > 0 ? $"Removed wcid {wcid} from {removed} guardian pool(s)." : $"Wcid {wcid} was not in any guardian pool.");
+                    return;
+                }
+
+                case "list":
+                default:
+                {
+                    if (cfg.GuardianPools.Count == 0)
+                    {
+                        Reply(session, "No guardian pools configured. Use: /rift guardian add <minTier> <maxTier> <wcid>");
+                        return;
+                    }
+
+                    var sb = new StringBuilder($"Guardian pools ({cfg.GuardianPools.Count}):\n");
+                    foreach (var g in cfg.GuardianPools.OrderBy(g => g.MinTier))
+                        sb.AppendLine($"  tiers {g.MinTier}-{g.MaxTier}: {string.Join(", ", g.Wcids)}");
+                    Reply(session, sb.ToString().TrimEnd());
+                    return;
+                }
+            }
+        }
+
+        private static void HandleSet(Session session, string[] p)
+        {
+            if (p.Length < 3)
+            {
+                Reply(session, "Usage: /rift set <key> <value>. Keys: timer grace maxruns progressbase progresspertier progressperkill hpgrowth dmgratingpertier guardianhpmult guardiandmgbonus currencywcid currencybase currencypertier");
+                return;
+            }
+
+            var cfg = RiftManager.Config;
+            var key = p[1].ToLowerInvariant();
+            var raw = p[2];
+
+            if (!double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out var val))
+            {
+                Reply(session, $"Could not parse value '{raw}'.");
+                return;
+            }
+
+            switch (key)
+            {
+                case "timer": cfg.TimerSeconds = (int)val; break;
+                case "grace": cfg.GraceSeconds = (int)val; break;
+                case "maxruns": cfg.MaxActiveRuns = (int)val; break;
+                case "progressbase": cfg.ProgressBase = val; break;
+                case "progresspertier": cfg.ProgressPerTier = val; break;
+                case "progressperkill": cfg.ProgressPerKill = val; break;
+                case "hpgrowth": cfg.HpGrowth = val; break;
+                case "dmgratingpertier": cfg.DamageRatingPerTier = val; break;
+                case "guardianhpmult": cfg.GuardianHpMult = val; break;
+                case "guardiandmgbonus": cfg.GuardianDamageRatingBonus = val; break;
+                case "currencywcid": cfg.CurrencyWcid = (uint)val; break;
+                case "currencybase": cfg.CurrencyBase = val; break;
+                case "currencypertier": cfg.CurrencyPerTier = val; break;
+                default:
+                    Reply(session, $"Unknown key '{key}'.");
+                    return;
+            }
+
+            RiftManager.SaveConfig();
+            Reply(session, $"Set {key} = {val}. (Applies to runs opened from now on.)");
+        }
+
+        private static void HandleSetLoot(Session session, string[] p)
+        {
+            if (p.Length < 3)
+            {
+                Reply(session, "Usage: /rift setloot <stat> <base> <perTier>  |  /rift setloot <stat> clear");
+                return;
+            }
+
+            var cfg = RiftManager.Config;
+            var stat = p[1].ToLowerInvariant();
+
+            if (!ZoneStat.All.Contains(stat, StringComparer.OrdinalIgnoreCase))
+            {
+                Reply(session, $"'{stat}' is not a known zone stat.");
+                return;
+            }
+
+            if (p[2].Equals("clear", StringComparison.OrdinalIgnoreCase))
+            {
+                var removed = cfg.LootStatBase.Remove(stat) | cfg.LootStatPerTier.Remove(stat);
+                if (removed)
+                    RiftManager.SaveConfig();
+                Reply(session, removed ? $"Cleared rift loot stat {stat}." : $"{stat} was not set.");
+                return;
+            }
+
+            if (p.Length < 4 ||
+                !double.TryParse(p[2], NumberStyles.Float, CultureInfo.InvariantCulture, out var baseVal) ||
+                !double.TryParse(p[3], NumberStyles.Float, CultureInfo.InvariantCulture, out var perTier))
+            {
+                Reply(session, "Usage: /rift setloot <stat> <base> <perTier>");
+                return;
+            }
+
+            cfg.LootStatBase[stat] = baseVal;
+            cfg.LootStatPerTier[stat] = perTier;
+            RiftManager.SaveConfig();
+            Reply(session, $"Rift loot stat {stat} = {baseVal} + {perTier} * tier. (Applies to runs opened from now on.)");
+        }
+
+        private static void HandleShow(Session session)
+        {
+            var cfg = RiftManager.Config;
+            var sb = new StringBuilder("Rift config:\n");
+            sb.AppendLine($"  timer {cfg.TimerSeconds}s | grace {cfg.GraceSeconds}s | maxruns {cfg.MaxActiveRuns}");
+            sb.AppendLine($"  progress: {cfg.ProgressBase} + {cfg.ProgressPerTier}/tier, {cfg.ProgressPerKill}/kill");
+            sb.AppendLine($"  scaling: hp x{cfg.HpGrowth}^tier | +{cfg.DamageRatingPerTier} dmg rating/tier | guardian hp x{cfg.GuardianHpMult}, +{cfg.GuardianDamageRatingBonus} rating");
+            sb.AppendLine($"  currency: wcid {cfg.CurrencyWcid}, {cfg.CurrencyBase} + {cfg.CurrencyPerTier}/tier");
+            sb.AppendLine($"  loot stats ({cfg.LootStatBase.Count}):");
+            foreach (var kv in cfg.LootStatBase)
+            {
+                cfg.LootStatPerTier.TryGetValue(kv.Key, out var per);
+                sb.AppendLine($"    {kv.Key} = {kv.Value} + {per}/tier");
+            }
+            sb.AppendLine($"  dungeons: {cfg.DungeonPool.Count} | guardian pools: {cfg.GuardianPools.Count} | open runs: {RiftManager.GetActiveRuns().Count}");
+            Reply(session, sb.ToString().TrimEnd());
+        }
+
+        private static bool TryParseLandblock(string s, out ushort lb)
+        {
+            s = s?.Trim() ?? "";
+            if (s.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+                s = s.Substring(2);
+            return ushort.TryParse(s, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out lb);
+        }
+
+        private static void Reply(Session session, string msg)
+        {
+            session.Network.EnqueueSend(new GameMessageSystemChat(msg, ChatMessageType.Broadcast));
+        }
+    }
+}

--- a/Source/ACE.Server/Command/Handlers/RiftCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/RiftCommands.cs
@@ -324,10 +324,11 @@ namespace ACE.Server.Command.Handlers
                     var removed = 0;
                     foreach (var pool in cfg.GuardianPools)
                         removed += pool.Wcids.RemoveAll(w => w == wcid);
-                    cfg.GuardianPools.RemoveAll(g => g.Wcids.Count == 0);
-
                     if (removed > 0)
+                    {
+                        cfg.GuardianPools.RemoveAll(g => g.Wcids.Count == 0);   // prune only when something changed, then persist
                         RiftManager.SaveConfig();
+                    }
                     Reply(session, removed > 0 ? $"Removed wcid {wcid} from {removed} guardian pool(s)." : $"Wcid {wcid} was not in any guardian pool.");
                     return;
                 }
@@ -368,6 +369,24 @@ namespace ACE.Server.Command.Handlers
                 return;
             }
 
+            // validate before anything is persisted: no negatives, integer keys must be whole and in range, and the
+            // wcid must survive its uint cast (a negative wraps to a huge value that survives a restart)
+            if (double.IsNaN(val) || double.IsInfinity(val) || val < 0)
+            {
+                Reply(session, $"'{key}' must be a number of 0 or more.");
+                return;
+            }
+            var integerKey = key is "timer" or "grace" or "maxruns" or "currencywcid";
+            if (integerKey && val != Math.Floor(val))
+            {
+                Reply(session, $"'{key}' must be a whole number.");
+                return;
+            }
+            if ((key is "timer" or "grace" or "maxruns") && val > int.MaxValue || key == "currencywcid" && val > uint.MaxValue)
+            {
+                Reply(session, $"'{key}' is out of range.");
+                return;
+            }
             switch (key)
             {
                 case "timer": cfg.TimerSeconds = (int)val; break;

--- a/Source/ACE.Server/Command/Handlers/SentinelCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/SentinelCommands.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 
 using ACE.Database;
 using ACE.Database.Models.Auth;
@@ -148,27 +149,42 @@ namespace ACE.Server.Command.Handlers
             }
         }
 
-        // portal_bypass
+        // portal_bypass [on|off]
         [CommandHandler("portal_bypass", AccessLevel.Sentinel, CommandHandlerFlag.RequiresWorld, 0,
-            "Toggles the ability to bypass portal restrictions.",
-            "")]
+            "Toggles or sets the ability to bypass portal restrictions.",
+            "[on|off|true|false|enable|disable]\n" +
+            "With no argument this toggles, as it always has. An explicit on/off sets the state outright,\n" +
+            "so a button (Zone Control plugin) can't get out of step with the flag.")]
         public static void HandlePortalBypass(Session session, params string[] parameters)
         {
             // @portal_bypass - Toggles the ability to bypass portal restrictions.
+            // Arg parsing added 2026-07-29, same shape as @unkillable: no-arg still toggles.
 
-            var param = session.Player.IgnorePortalRestrictions;
+            bool newValue;
 
-            switch (param)
+            if (parameters == null || parameters.Length == 0)
             {
-                case true:
-                    session.Player.IgnorePortalRestrictions = false;
-                    session.Network.EnqueueSend(new GameMessageSystemChat("You are once again bound by portal restrictions.", ChatMessageType.Broadcast));
-                    break;
-                case false:
-                    session.Player.IgnorePortalRestrictions = true;
-                    session.Network.EnqueueSend(new GameMessageSystemChat("You are no longer bound by portal restrictions.", ChatMessageType.Broadcast));
-                    break;
+                newValue = !session.Player.IgnorePortalRestrictions;
             }
+            else
+            {
+                var arg = parameters[0].ToLower();
+                if (arg == "on" || arg == "true" || arg == "enable")
+                    newValue = true;
+                else if (arg == "off" || arg == "false" || arg == "disable")
+                    newValue = false;
+                else
+                {
+                    session.Network.EnqueueSend(new GameMessageSystemChat("Usage: @portal_bypass [on|off|true|false|enable|disable]", ChatMessageType.Broadcast));
+                    return;
+                }
+            }
+
+            session.Player.IgnorePortalRestrictions = newValue;
+
+            session.Network.EnqueueSend(new GameMessageSystemChat(newValue
+                ? "You are no longer bound by portal restrictions."
+                : "You are once again bound by portal restrictions.", ChatMessageType.Broadcast));
         }
 
         // fellowbuff [name]
@@ -208,6 +224,32 @@ namespace ACE.Server.Command.Handlers
             Player target = CommandHandlerHelper.GetPlayerAsCommandTarget(session, string.Join(" ", parameters), fallbackToSelf: true);
             if (target == null) return;
             session.Player.CreateSentinelBuffPlayers(new Player[] { target }, target == session.Player, maxLevel);
+
+            // Owner 2026-09-01: proper test buffing includes the surges the WORN aetheria would proc.
+            // Self-targeted surges (Destruction / Protection / Regeneration) are cast now through the
+            // real proc path at 100 pct; the two that land on a monster (Affliction / Festering) cannot
+            // be pre-cast and are reported. No aetheria worn = nothing happens.
+            var surged = new List<string>();
+            var skipped = new List<string>();
+            foreach (var item in target.EquippedObjects.Values.ToList())
+            {
+                if (!Aetheria.IsAetheria(item.WeenieClassId) || item.ProcSpell == null)
+                    continue;
+                var surge = new Spell(item.ProcSpell.Value);
+                if (surge.NotFound)
+                    continue;
+                if (item.ProcSpellSelfTargeted)
+                {
+                    item.ForceProcSpell(target, target, true);
+                    surged.Add(surge.Name);
+                }
+                else
+                    skipped.Add(surge.Name);
+            }
+            if (surged.Count > 0)
+                session.Network.EnqueueSend(new GameMessageSystemChat($"Aetheria surges cast: {string.Join(", ", surged)}", ChatMessageType.Broadcast));
+            if (skipped.Count > 0)
+                session.Network.EnqueueSend(new GameMessageSystemChat($"Aetheria surges that only land on a monster (not cast): {string.Join(", ", skipped)}", ChatMessageType.Broadcast));
         }
 
         // run < on | off | toggle | check >

--- a/Source/ACE.Server/Command/Handlers/TeleportCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/TeleportCommands.cs
@@ -31,7 +31,7 @@ namespace ACE.Server.Command.Handlers
                                               "  player <name>\n" +
                                               "  dungeon <name|hex>\n" +
                                               "  poi <name>\n" +
-                                              "  variant <retail|default|null|id> (retail/default/null = base; 0 = variation 0)\n" +
+                                              "  variant <retail|default|null|id> (retail/default/null/0 = base world)\n" +
                                               "  xyz <cell> <x> <y> <z>...\n" +
                                               "  type <id>\n" +
                                               "  dist <distance>\n" +
@@ -51,7 +51,7 @@ namespace ACE.Server.Command.Handlers
                                                 "  player <name>\n" +
                                                 "  dungeon <name|hex>\n" +
                                                 "  poi <name>\n" +
-                                                "  variant <retail|default|null|id> (retail/default/null = base; 0 = variation 0)\n" +
+                                                "  variant <retail|default|null|id> (retail/default/null/0 = base world)\n" +
                                                 "  xyz <cell> <x> <y> <z>...\n" +
                                                 "  type <id>\n" +
                                                 "  dist <distance>\n" +
@@ -263,7 +263,8 @@ namespace ACE.Server.Command.Handlers
             if (args.Length > 0)
             {
                 var a = args[0].Trim();
-                // Same semantics as @televariant: retail/default/null => unlayered base; 0 is explicit variation 0
+                // Same semantics as @televariant: retail/default/null/0 all mean the unlayered base world
+                // (explicit "layer 0" is a separate empty landblock instance — never teleport anyone there)
                 if (string.Equals(a, "null", StringComparison.OrdinalIgnoreCase) ||
                     string.Equals(a, "retail", StringComparison.OrdinalIgnoreCase) ||
                     string.Equals(a, "default", StringComparison.OrdinalIgnoreCase))
@@ -274,8 +275,8 @@ namespace ACE.Server.Command.Handlers
                 }
                 if (int.TryParse(a, out var variant))
                 {
-                    pos.Variation = variant;
-                    name = $"variant {variant}";
+                    pos.Variation = variant == 0 ? null : variant;
+                    name = variant == 0 ? "variant base (0 = retail base)" : $"variant {variant}";
                     return true;
                 }
             }

--- a/Source/ACE.Server/Command/Handlers/TestCharacterCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/TestCharacterCommands.cs
@@ -21,247 +21,68 @@ namespace ACE.Server.Command.Handlers
     public static class TestCharacterCommands
     {
         [CommandHandler("testchar", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 1,
-            "Boost character stats/gear/weapons to Tier 11 or Tier 10, or reset to Tier 0.",
-            "Usage: /testchar <T11|T10|T0>  |  /testchar stats <T11|T10>  |  /testchar gear <tier>  |  /testchar weapons <tier> [style]  |  /testchar gems <tier>  |  /testchar charms")]
+            "Test-character builder: wipe to Tier 0, or set stats / apply unlocks / mint extras granularly (driven by the plugin's Character tab). Gear comes from /asforge premade and /wsforge.",
+            "Usage: /testchar T0 (wipe)  |  /testchar set attrs|vitals|level|enl|augs|charms|raugs <csv>  |  /testchar apply skills,spells,aetheria,manastone  |  /testchar extra <keys>  |  /testchar save  |  /testchar report\n" +
+            "Also: /testchar gems  |  /testchar charms  |  /testchar print <wcid>")]
         public static void HandleTestChar(Session session, params string[] parameters)
         {
             var player = session.Player;
             if (player == null) return;
 
+            // Granular setters (Admin > Character tab, 2026-08-02 — CharacterTab_Plan): the
+            // plugin applies a tier preset as a short batch of these. Dispatched BEFORE the
+            // tier parsing below, which would reject them as bad tiers.
+            var sub0 = parameters[0].ToLowerInvariant();
+            if (sub0 == "set" || sub0 == "apply" || sub0 == "save" || sub0 == "extra" || sub0 == "report")
+            {
+                HandleCharacterSetter(session, player, parameters);
+                return;
+            }
+
+            // gems / charms (plugin Extras card): the tier arg is OPTIONAL - a trailing token
+            // (older plugin sends "/testchar gems t11") is accepted and ignored.
+            if (sub0 == "gems")
+            {
+                SpawnTeleportGems(player, GetOrCreatePack(player, "Portal Gems Pack", "Booster Pack 1"));
+                player.SendMessage("Custom Teleport Gems generated in your inventory.");
+                player.SaveBiotaToDatabase();
+                return;
+            }
+            if (sub0 == "charms")
+            {
+                SpawnCharms(player);
+                player.SendMessage("All ability charms (T1) and Charm Catalysts added to your inventory.");
+                player.SaveBiotaToDatabase();
+                return;
+            }
+
+            const string usage = "Usage: /testchar T0 (wipe) | set ... | apply ... | extra ... | save | report";
+
             if (parameters.Length == 1)
             {
-                // Full booster package (stats + gear + weapons)
+                // The plugin's Wipe button (Reset to T0). The legacy T10/T11 "full booster"
+                // (stats + 24 elemental weapons + armor/jewelry/extras) was deleted 2026-08-23:
+                // characters are built through the granular setters above, gear through
+                // /asforge premade + /wsforge.
                 var tier = parameters[0].ToUpper();
                 if (tier == "T0" || tier == "0")
                 {
+                    if (!GuardWipe(session, player)) return;
                     ResetToTier0(player);
                     player.SendMessage("Character successfully reset to Tier 0 baseline! Please log out and back in to completely refresh your client spellbook.");
                     player.SaveBiotaToDatabase();
                     return;
                 }
 
-                bool isT10 = (tier == "T10" || tier == "10");
-                if (!isT10 && tier != "T11" && tier != "11")
-                {
-                    session.Network.EnqueueSend(new GameMessageSystemChat("Supported tiers: T11, T10, T0. Usage: /testchar T11 or /testchar T10 or /testchar T0", ChatMessageType.System));
-                    return;
-                }
-
-                if (isT10)
-                    ConfigureStatsAndSpellsT10(player);
-                else
-                    ConfigureStatsAndSpells(player);
-
-                CreateCustomBow(player, DamageType.Cold, true);
-                CreateCustomBow(player, DamageType.Fire, true);
-                CreateCustomBow(player, DamageType.Electric, true);
-                CreateCustomBow(player, DamageType.Acid, true);
-                CreateCustomBow(player, DamageType.Slash, true);
-                CreateCustomBow(player, DamageType.Pierce, true);
-                CreateCustomBow(player, DamageType.Bludgeon, true);
-                CreateCustomBow(player, DamageType.Nether, true);
-
-                CreateCustomUA(player, DamageType.Cold);
-                CreateCustomUA(player, DamageType.Fire);
-                CreateCustomUA(player, DamageType.Electric);
-                CreateCustomUA(player, DamageType.Acid);
-                CreateCustomUA(player, DamageType.Slash);
-                CreateCustomUA(player, DamageType.Pierce);
-                CreateCustomUA(player, DamageType.Bludgeon);
-                CreateCustomUA(player, DamageType.Nether);
-
-                CreateCustomWand(player, DamageType.Cold);
-                CreateCustomWand(player, DamageType.Fire);
-                CreateCustomWand(player, DamageType.Electric);
-                CreateCustomWand(player, DamageType.Acid);
-                CreateCustomWand(player, DamageType.Slash);
-                CreateCustomWand(player, DamageType.Pierce);
-                CreateCustomWand(player, DamageType.Bludgeon);
-                CreateCustomWand(player, DamageType.Nether);
-
-                // Spawn booster packs 7 down to 3 empty
-                for (int i = 7; i >= 3; i--)
-                {
-                    var packName = $"Booster Pack {i}";
-                    if (HasItemNamed(player, packName)) continue;
-                    var emptyBag = WorldObjectFactory.CreateNewWorldObject(310025) as Container;
-                    if (emptyBag != null)
-                    {
-                        emptyBag.Name = packName;
-                        emptyBag.SetProperty(PropertyString.Name, packName);
-                        player.TryCreateInInventoryWithNetworking(emptyBag);
-                    }
-                }
-
-                // Spawn Booster Pack 2 containing hilts
-                var bag2 = player.GetAllPossessionsDeep().OfType<Container>().FirstOrDefault(c => c.Name == "Booster Pack 2");
-                if (bag2 == null)
-                {
-                    bag2 = WorldObjectFactory.CreateNewWorldObject(310025) as Container;
-                    if (bag2 != null)
-                    {
-                        bag2.Name = "Booster Pack 2";
-                        bag2.SetProperty(PropertyString.Name, "Booster Pack 2");
-                        SpawnHilts(player, bag2);
-                        player.TryCreateInInventoryWithNetworking(bag2);
-                    }
-                }
-                else
-                {
-                    SpawnHilts(player, bag2);
-                }
-
-                // Spawn Booster Pack 1 containing portal gems
-                var bag1 = player.GetAllPossessionsDeep().OfType<Container>().FirstOrDefault(c => c.Name == "Booster Pack 1");
-                if (bag1 == null)
-                {
-                    bag1 = WorldObjectFactory.CreateNewWorldObject(310025) as Container;
-                    if (bag1 != null)
-                    {
-                        bag1.Name = "Booster Pack 1";
-                        bag1.SetProperty(PropertyString.Name, "Booster Pack 1");
-                        SpawnTeleportGems(player, bag1);
-                        player.TryCreateInInventoryWithNetworking(bag1);
-                    }
-                }
-                else
-                {
-                    SpawnTeleportGems(player, bag1);
-                }
-
-                var gearTier = "T10";
-                SpawnOlthoiShadowArmor(player, gearTier);
-                SpawnCustomUndergarmentsAndCloak(player, gearTier);
-                SpawnCustomJewelry(player, gearTier);
-
-                // Add and auto-equip Infinite Deadly Prismatic Arrow
-                bool hasArrow = player.GetAllPossessionsDeep().Any(i => i.WeenieClassId == 4395100);
-                if (!hasArrow)
-                {
-                    var arrow = WorldObjectFactory.CreateNewWorldObject(4395100);
-                    if (arrow != null)
-                    {
-                        AddItemToInventory(player, arrow);
-                    }
-                }
-
-                // Add Aetherias
-                SpawnAetherias(player);
-
-                // Add all charms (T1) + Charm Catalysts
-                SpawnCharms(player);
-
-                var tierLabel = isT10 ? "Tier 10" : "Tier 11";
-                player.SendMessage($"Character fully configured with {tierLabel} stats, elemental weapons, Olthoi Infused Shadow armor, custom undergarments, cloak, jewelry, Infinite Arrow, Aetherias, and all ability charms!");
-                player.SaveBiotaToDatabase();
+                session.Network.EnqueueSend(new GameMessageSystemChat(usage, ChatMessageType.System));
             }
             else if (parameters.Length >= 2)
             {
                 var sub = parameters[0].ToLower();
-                var tier = parameters[1].ToUpper();
 
-                if (tier == "T0" || tier == "0")
+                if (sub == "print")
                 {
-                    if (sub == "stats")
-                    {
-                        ResetToTier0(player);
-                        player.SendMessage("Character stats, skills, augmentations, and spellbook reset to Tier 0 baseline! Please log out and back in to completely refresh your client spellbook.");
-                        player.SaveBiotaToDatabase();
-                    }
-                    else if (sub == "gear")
-                    {
-                        session.Network.EnqueueSend(new GameMessageSystemChat("No gear is defined for Tier 0.", ChatMessageType.System));
-                    }
-                    else if (sub == "weapons")
-                    {
-                        session.Network.EnqueueSend(new GameMessageSystemChat("No weapons are defined for Tier 0.", ChatMessageType.System));
-                    }
-                    else
-                    {
-                        session.Network.EnqueueSend(new GameMessageSystemChat("Unknown subcommand. Usage: /testchar <tier> | /testchar [stats|gear|weapons|gems] <tier> [style]", ChatMessageType.System));
-                    }
-                    return;
-                }
-
-                bool isT10 = (tier == "T10" || tier == "10");
-                if (!isT10 && tier != "T11" && tier != "11")
-                {
-                    session.Network.EnqueueSend(new GameMessageSystemChat($"Supported tiers: T11, T10, T0. Usage: /testchar {sub} T11 or /testchar {sub} T10", ChatMessageType.System));
-                    return;
-                }
-
-                if (sub == "stats")
-                {
-                    if (isT10)
-                        ConfigureStatsAndSpellsT10(player);
-                    else
-                        ConfigureStatsAndSpells(player);
-                    var statsTierLabel = isT10 ? "Tier 10" : "Tier 11";
-                    player.SendMessage($"Character stats, skills, augmentations, and spells configured for {statsTierLabel}!");
-                    player.SaveBiotaToDatabase();
-                }
-                else if (sub == "gear")
-                {
-                    var gearTier = "T10";
-                    SpawnArmor(player);
-                    SpawnOlthoiShadowArmor(player, gearTier);
-                    SpawnCustomUndergarmentsAndCloak(player, gearTier);
-                    SpawnCustomJewelry(player, gearTier);
-
-                    // Add and auto-equip Infinite Deadly Prismatic Arrow
-                    bool hasArrow = player.GetAllPossessionsDeep().Any(i => i.WeenieClassId == 4395100);
-                    if (!hasArrow)
-                    {
-                        var arrow = WorldObjectFactory.CreateNewWorldObject(4395100);
-                        if (arrow != null)
-                        {
-                            AddItemToInventory(player, arrow);
-                        }
-                    }
-
-                    // Add Aetherias
-                    SpawnAetherias(player);
-
-                    player.SendMessage("Prismatic GSA armor, Olthoi Infused Shadow armor (No Cloak), custom undergarments, custom cloak, custom jewelry, Infinite Arrow, and Aetherias generated and equipped.");
-                    player.SaveBiotaToDatabase();
-                }
-                else if (sub == "weapons")
-                {
-                    string style = null;
-                    if (parameters.Length >= 3)
-                    {
-                        var argStyle = parameters[2].ToUpper();
-                        if (argStyle == "UA" || argStyle == "2H" || argStyle == "BOW" || argStyle == "WAND")
-                        {
-                            style = argStyle;
-                        }
-                        else
-                        {
-                            session.Network.EnqueueSend(new GameMessageSystemChat("Invalid weapon style. Supported styles: UA, 2H, Bow, Wand.", ChatMessageType.System));
-                            return;
-                        }
-                    }
-
-                    SpawnWeapons(player, style);
-                    var styleLabel = style != null ? $"{style} " : "";
-                    player.SendMessage($"Weapons generated in your inventory.");
-                    player.SaveBiotaToDatabase();
-                }
-                else if (sub == "gems")
-                {
-                    SpawnTeleportGems(player);
-                    player.SendMessage("Custom Teleport Gems generated in your inventory.");
-                    player.SaveBiotaToDatabase();
-                }
-                else if (sub == "charms")
-                {
-                    SpawnCharms(player);
-                    player.SendMessage("All ability charms (T1) and Charm Catalysts added to your inventory.");
-                    player.SaveBiotaToDatabase();
-                }
-                else if (sub == "print")
-                {
-                    if (parameters.Length >= 2 && uint.TryParse(parameters[1], out var wcid))
+                    if (uint.TryParse(parameters[1], out var wcid))
                     {
                         var wo = WorldObjectFactory.CreateNewWorldObject(wcid);
                         if (wo != null)
@@ -291,13 +112,26 @@ namespace ACE.Server.Command.Handlers
                 }
                 else
                 {
-                    session.Network.EnqueueSend(new GameMessageSystemChat("Unknown subcommand. Usage: /testchar <tier> | /testchar [stats|gear|weapons|gems|print] <tier> [style]", ChatMessageType.System));
+                    session.Network.EnqueueSend(new GameMessageSystemChat(usage + " | gems | charms | print <wcid>", ChatMessageType.System));
                 }
             }
             else
             {
-                session.Network.EnqueueSend(new GameMessageSystemChat("Usage: /testchar <tier> | /testchar [stats|gear|weapons|gems] <tier> [style]", ChatMessageType.System));
+                session.Network.EnqueueSend(new GameMessageSystemChat(usage, ChatMessageType.System));
             }
+        }
+
+        /// <summary>The T0 wipe may only ever touch an admin (plussed, "+Name") character —
+        /// never a real player character (owner 2026-08-02). Gate for BOTH wipe entry points
+        /// (/testchar T0 and /testchar stats T0).</summary>
+        private static bool GuardWipe(Session session, Player player)
+        {
+            if (player.IsPlussed)
+                return true;
+            ChatPacket.SendServerMessage(session,
+                "testchar T0: REFUSED - this is not an admin (+) character. The wipe only runs on plussed test characters.",
+                ChatMessageType.Broadcast);
+            return false;
         }
 
         private static void ResetToTier0(Player player)
@@ -377,6 +211,17 @@ namespace ACE.Server.Command.Handlers
             player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt64(player, PropertyInt64.LumAugMeleeCount, 0));
             player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt64(player, PropertyInt64.LumAugMissileCount, 0));
 
+            // 7b. Reset growth charm counters to 0 (owner 08-15: /aug kept showing charm
+            // lines after a wipe). Same PropertyInt64 set that /testchar set charms writes.
+            var charmProps = new[] { PropertyInt64.TriuneWeaveCount, PropertyInt64.BattlemagesWrathCharmCount,
+                                     PropertyInt64.NetherVeilCharmCount, PropertyInt64.CrashingSteelCharmCount,
+                                     PropertyInt64.TrueShotCharmCount };
+            foreach (var charmProp in charmProps)
+            {
+                player.SetProperty(charmProp, 0);
+                player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt64(player, charmProp, 0));
+            }
+
             // 8. Reset Retail Augmentations to 0
             foreach (var kvp in AugmentationDevice.MaxAugs)
             {
@@ -403,79 +248,65 @@ namespace ACE.Server.Command.Handlers
                 player.TryDequipObjectWithNetworking(guid, out _, Player.DequipObjectAction.ConsumeItem);
             }
 
-            // 12. Clear all remaining inventory items
-            player.ClearInventory(false);
+            // 12. Clear all remaining inventory items. NOT Container.ClearInventory: that
+            // destroys server-side without telling the client (packs looked untouched in-game,
+            // owner 2026-08-02), and one removal failure stops it destroying anything after.
+            // Per-item remove + client notify + destroy; top-level packs take their contents
+            // with them. Deliberately no ability-charm exemption — a wipe means everything.
+            var inventoryItems = new List<WorldObject>(player.Inventory.Values);
+            foreach (var invItem in inventoryItems)
+            {
+                if (player.TryRemoveFromInventory(invItem.Guid, out var removed))
+                {
+                    player.Session.Network.EnqueueSend(new GameMessageInventoryRemoveObject(removed));
+                    removed.Destroy();
+                }
+            }
+            player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt(player, PropertyInt.EncumbranceVal, player.EncumbranceVal ?? 0));
         }
 
-        private static void ConfigureStatsAndSpells(Player player)
+        // ─── Per-knob setter helpers for the granular /testchar set|apply commands
+        // (Admin > Character tab, 2026-08-02). Extracted from the legacy ConfigureStatsAndSpells
+        // booster, which was deleted 2026-08-23. ───
+
+        /// <summary>Set one base attribute to an exact target (innate 100 + ranks; a target
+        /// under 100 becomes the innate value with 0 ranks).</summary>
+        private static void SetChAttribute(Player player, PropertyAttribute attrType, uint targetValue)
         {
-            // 1. Set Base Attributes
-            // Base Attributes: Strength 450, Endurance 450, Coordination 575, Quickness 450, Focus 450, Self 450
-            var attributeTargets = new Dictionary<PropertyAttribute, uint>()
-            {
-                { PropertyAttribute.Strength, 450 },
-                { PropertyAttribute.Endurance, 450 },
-                { PropertyAttribute.Coordination, 575 },
-                { PropertyAttribute.Quickness, 450 },
-                { PropertyAttribute.Focus, 450 },
-                { PropertyAttribute.Self, 450 },
-            };
+            if (!player.Attributes.TryGetValue(attrType, out var attr))
+                return;
 
-            foreach (var kvp in attributeTargets)
-            {
-                var attrType = kvp.Key;
-                var targetValue = kvp.Value;
-                if (!player.Attributes.TryGetValue(attrType, out var attr))
-                    continue;
+            attr.StartingValue = Math.Min(targetValue, 100);
+            uint ranks = targetValue > 100 ? targetValue - 100 : 0;
+            player.SetAttributeRank(attr, ranks);
+            player.Session.Network.EnqueueSend(new GameMessagePrivateUpdateAttribute(player, attr));
+        }
 
-                // Set innate StartingValue to 100
-                attr.StartingValue = 100;
-                
-                // Ranks = Target - 100
-                uint ranks = targetValue > 100 ? targetValue - 100 : 0;
-                player.SetAttributeRank(attr, ranks);
-                
-                player.Session.Network.EnqueueSend(new GameMessagePrivateUpdateAttribute(player, attr));
-            }
+        /// <summary>Set one secondary vital's MAX to an exact target by back-solving the
+        /// starting value against the attribute formula + enl/gear bonuses. Attribute and
+        /// enlightenment setters must run BEFORE this for the solve to land on target.</summary>
+        private static void SetChVital(Player player, PropertyAttribute2nd vitalType, uint targetValue)
+        {
+            if (!player.Vitals.TryGetValue(vitalType, out var vital))
+                return;
 
-            // 2. Set Secondary Vitals (Max)
-            // Secondary Vitals: Max Health 700, Max Stamina 900, Max Mana 900
-            var vitalTargets = new Dictionary<PropertyAttribute2nd, uint>()
-            {
-                { PropertyAttribute2nd.MaxHealth, 700 },
-                { PropertyAttribute2nd.MaxStamina, 900 },
-                { PropertyAttribute2nd.MaxMana, 900 },
-            };
+            vital.Ranks = 0;
+            vital.ExperienceSpent = 0;
 
-            foreach (var kvp in vitalTargets)
-            {
-                var vitalType = kvp.Key;
-                var targetValue = kvp.Value;
-                if (!player.Vitals.TryGetValue(vitalType, out var vital))
-                    continue;
+            int baseFormula = (int)AttributeFormula.GetFormula(player, vitalType, true);
+            int enlBonus = (int)vital.EnlBonus;
+            int gearBonus = (int)vital.GearBonus;
 
-                // Clear CP ranks
-                vital.Ranks = 0;
-                vital.ExperienceSpent = 0;
+            int startingValue = (int)targetValue - baseFormula - enlBonus - gearBonus;
+            vital.StartingValue = (uint)Math.Max(1, startingValue);
 
-                // Adjust starting value based on current base attribute formulas, etc.
-                int baseFormula = (int)AttributeFormula.GetFormula(player, vitalType, true);
-                int enlBonus = (int)vital.EnlBonus;
-                int gearBonus = (int)vital.GearBonus;
-                
-                int startingValue = (int)targetValue - baseFormula - enlBonus - gearBonus;
-                vital.StartingValue = (uint)Math.Max(1, startingValue);
-                
-                // Fully restore current vital value
-                vital.Current = vital.MaxValue;
-                
-                player.Session.Network.EnqueueSend(new GameMessagePrivateUpdateVital(player, vital));
-            }
+            vital.Current = vital.MaxValue;
+            player.Session.Network.EnqueueSend(new GameMessagePrivateUpdateVital(player, vital));
+        }
 
-            // 2.5 Set Level and Maximize All Skills
-            player.Level = 1300;
-            player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt(player, PropertyInt.Level, 1300));
-
+        /// <summary>Specialize every skill and max its ranks (does NOT touch Level).</summary>
+        private static void ApplyChMaxSkills(Player player)
+        {
             foreach (var skill in player.Skills.Values)
             {
                 skill.AdvancementClass = SkillAdvancementClass.Specialized;
@@ -490,85 +321,41 @@ namespace ACE.Server.Command.Handlers
 
                 player.Session.Network.EnqueueSend(new GameMessagePrivateUpdateSkill(player, skill));
             }
+        }
 
-            // 3. Set Custom Augmentations (Luminance Augmentations)
-            player.LuminanceAugmentCreatureCount = 5000;
-            player.LuminanceAugmentItemCount = 3500;
-            player.LuminanceAugmentLifeCount = 3500;
-            player.LuminanceAugmentWarCount = 3500;
-            player.LuminanceAugmentVoidCount = 3500;
-            player.LuminanceAugmentSpellDurationCount = 3000;
-            player.LuminanceAugmentSpecializeCount = 100;
-            player.LuminanceAugmentSummonCount = 1100;
-            player.LuminanceAugmentMeleeCount = 3500;
-            player.LuminanceAugmentMissileCount = 3500;
-
-            // Sync updated custom augs to the client
-            player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt64(player, PropertyInt64.LumAugCreatureCount, player.LuminanceAugmentCreatureCount ?? 0));
-            player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt64(player, PropertyInt64.LumAugItemCount, player.LuminanceAugmentItemCount ?? 0));
-            player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt64(player, PropertyInt64.LumAugLifeCount, player.LuminanceAugmentLifeCount ?? 0));
-            player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt64(player, PropertyInt64.LumAugWarCount, player.LuminanceAugmentWarCount ?? 0));
-            player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt64(player, PropertyInt64.LumAugVoidCount, player.LuminanceAugmentVoidCount ?? 0));
-            player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt64(player, PropertyInt64.LumAugDurationCount, player.LuminanceAugmentSpellDurationCount ?? 0));
-            player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt64(player, PropertyInt64.LumAugSpecializeCount, player.LuminanceAugmentSpecializeCount ?? 0));
-            player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt64(player, PropertyInt64.LumAugSummonCount, player.LuminanceAugmentSummonCount ?? 0));
-            player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt64(player, PropertyInt64.LumAugMeleeCount, player.LuminanceAugmentMeleeCount ?? 0));
-            player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt64(player, PropertyInt64.LumAugMissileCount, player.LuminanceAugmentMissileCount ?? 0));
-
-            // 4. Set Retail Augmentations to max/acquired
-            foreach (var kvp in AugmentationDevice.MaxAugs)
-            {
-                var type = kvp.Key;
-                var maxVal = kvp.Value;
-                var augProp = AugmentationDevice.AugProps[type];
-                player.SetProperty(augProp, maxVal);
-                player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt(player, augProp, maxVal));
-            }
-
-            // 5. Learn All Spells Silently
+        private static void ApplyChAllSpells(Player player)
+        {
             foreach (var spellID in Player.PlayerSpellTable)
             {
                 if (player.AddKnownSpell(spellID))
-                {
                     player.Session.Network.EnqueueSend(new GameEventMagicUpdateSpell(player.Session, (ushort)spellID));
-                }
             }
+        }
 
-            // 6. Enable Aetheria Slots
-            player.UpdateProperty(player, PropertyInt.AetheriaBitfield, (int)AetheriaBitfield.All);
-
-            // 7. Set Enlightenment to 325
-            player.Enlightenment = 325;
-            player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt(player, PropertyInt.Enlightenment, 325));
-
-            // 8. Spawn Eternal Mana Charge (Infinite Mana Stone)
+        private static void SpawnChManaStone(Player player)
+        {
             if (!player.GetAllPossessionsDeep().Any(i => i.WeenieClassId == 30254))
             {
                 var manaCharge = WorldObjectFactory.CreateNewWorldObject(30254);
                 if (manaCharge != null)
-                {
                     player.TryCreateInInventoryWithNetworking(manaCharge);
-                }
             }
         }
 
-        private static void ConfigureStatsAndSpellsT10(Player player)
+        /// <summary>Set all 10 luminance augs at once (plugin order: creature, item, life,
+        /// war, void, duration, specialize, summon, melee, missile).</summary>
+        private static void SetChLumAugs(Player player, uint[] v)
         {
-            // Same as T11 but with lower luminance augs and ENL 300
-            // Reuse T11 to set all attributes, vitals, skills, retail augs, and spells
-            ConfigureStatsAndSpells(player);
-
-            // Override luminance augs for T10
-            player.LuminanceAugmentCreatureCount = 4000;
-            player.LuminanceAugmentItemCount = 2000;
-            player.LuminanceAugmentLifeCount = 2000;
-            player.LuminanceAugmentWarCount = 1750;
-            player.LuminanceAugmentVoidCount = 1750;
-            player.LuminanceAugmentSpellDurationCount = 1750;
-            player.LuminanceAugmentSpecializeCount = 100;
-            player.LuminanceAugmentSummonCount = 1100;
-            player.LuminanceAugmentMeleeCount = 1750;
-            player.LuminanceAugmentMissileCount = 1750;
+            player.LuminanceAugmentCreatureCount = v[0];
+            player.LuminanceAugmentItemCount = v[1];
+            player.LuminanceAugmentLifeCount = v[2];
+            player.LuminanceAugmentWarCount = v[3];
+            player.LuminanceAugmentVoidCount = v[4];
+            player.LuminanceAugmentSpellDurationCount = v[5];
+            player.LuminanceAugmentSpecializeCount = v[6];
+            player.LuminanceAugmentSummonCount = v[7];
+            player.LuminanceAugmentMeleeCount = v[8];
+            player.LuminanceAugmentMissileCount = v[9];
 
             player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt64(player, PropertyInt64.LumAugCreatureCount, player.LuminanceAugmentCreatureCount ?? 0));
             player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt64(player, PropertyInt64.LumAugItemCount, player.LuminanceAugmentItemCount ?? 0));
@@ -580,72 +367,691 @@ namespace ACE.Server.Command.Handlers
             player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt64(player, PropertyInt64.LumAugSummonCount, player.LuminanceAugmentSummonCount ?? 0));
             player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt64(player, PropertyInt64.LumAugMeleeCount, player.LuminanceAugmentMeleeCount ?? 0));
             player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt64(player, PropertyInt64.LumAugMissileCount, player.LuminanceAugmentMissileCount ?? 0));
-
-            // Override Enlightenment to 300
-            player.Enlightenment = 300;
-            player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt(player, PropertyInt.Enlightenment, 300));
         }
 
-        private static void SpawnArmor(Player player)
+        /// <summary>/testchar set|apply|save — the Admin > Character tab's Apply batch
+        /// (CharacterTab_Plan_2026-08-02.md section 3). Setters do NOT save; the batch ends
+        /// with /testchar save.</summary>
+        private static void HandleCharacterSetter(Session session, Player player, string[] parameters)
         {
-            var armorWcids = new List<uint>()
-            {
-                14594, // helmprismatic
-                23777, // coatamulishadowbrilliant
-                23785, // leggingsamulishadowbrilliant
-                23793, // breastplateceldonshadowbrilliant
-                23801, // girthceldonshadowbrilliant
-                23809, // leggingsceldonshadowbrilliant
-                23817, // sleevesceldonshadowbrilliant
-                23825, // breastplatekoujiashadowbrilliant
-                23833, // leggingskoujiashadowbrilliant
-                23841, // sleeveskoujiashadowbrilliant
-            };
+            void Msg(string s) => ChatPacket.SendServerMessage(session, s, ChatMessageType.Broadcast);
+            var sub = parameters[0].ToLowerInvariant();
 
-            foreach (var wcid in armorWcids)
+            if (sub == "save")
             {
-                bool alreadyHas = player.GetAllPossessionsDeep().Any(i => i.WeenieClassId == wcid);
-                if (alreadyHas) continue;
-                var armorItem = WorldObjectFactory.CreateNewWorldObject(wcid);
-                if (armorItem != null)
-                    player.TryCreateInInventoryWithNetworking(armorItem);
+                player.SaveBiotaToDatabase();
+                Msg("testchar: character saved.");
+                return;
+            }
+
+            // /testchar report - read-only. Emits the LIVE character as a [[ZCCHAR]] wire payload
+            // so the plugin's Character tab can show real values beside the preset (owner
+            // 2026-08-20: "add our real aug counts and attribute count, so we can compare
+            // quickly"). The plugin has no other route to this - it never touches Decal's
+            // WorldFilter; every number it draws arrives as chat wire.
+            //
+            // Values are the exact ones the setters target, so preset and live are comparable
+            // without conversion: attr.Base (SetChAttribute writes StartingValue + ranks to hit
+            // it), vital.MaxValue (what SetChVital back-solves for), and the RAW lum aug counts
+            // (NOT the Effective* accessors - charms scale those past the caps by design, and
+            // the preset is raw).
+            if (sub == "report")
+            {
+                var attrOrder = new[] { PropertyAttribute.Strength, PropertyAttribute.Endurance,
+                                        PropertyAttribute.Coordination, PropertyAttribute.Quickness,
+                                        PropertyAttribute.Focus, PropertyAttribute.Self };
+                var attrs = new List<string>();
+                foreach (var a in attrOrder)
+                    attrs.Add(player.Attributes.TryGetValue(a, out var at) ? at.Base.ToString() : "0");
+
+                var vitalOrder = new[] { PropertyAttribute2nd.MaxHealth, PropertyAttribute2nd.MaxStamina,
+                                         PropertyAttribute2nd.MaxMana };
+                var vitals = new List<string>();
+                foreach (var vt in vitalOrder)
+                    vitals.Add(player.Vitals.TryGetValue(vt, out var vi) ? vi.MaxValue.ToString() : "0");
+
+                // Same order as `/testchar set augs`, so the plugin can index one against the other.
+                var augs = new[]
+                {
+                    player.LuminanceAugmentCreatureCount ?? 0,
+                    player.LuminanceAugmentItemCount ?? 0,
+                    player.LuminanceAugmentLifeCount ?? 0,
+                    player.LuminanceAugmentWarCount ?? 0,
+                    player.LuminanceAugmentVoidCount ?? 0,
+                    player.LuminanceAugmentSpellDurationCount ?? 0,
+                    player.LuminanceAugmentSpecializeCount ?? 0,
+                    player.LuminanceAugmentSummonCount ?? 0,
+                    player.LuminanceAugmentMeleeCount ?? 0,
+                    player.LuminanceAugmentMissileCount ?? 0,
+                };
+
+                Msg("[[ZCCHAR]]attr=" + string.Join(",", attrs)
+                    + "|vital=" + string.Join(",", vitals)
+                    + "|level=" + (player.Level ?? 0)
+                    + "|enl=" + player.Enlightenment
+                    + "|augs=" + string.Join(",", augs));
+                return;
+            }
+
+            if (sub == "apply")
+            {
+                if (parameters.Length < 2)
+                {
+                    Msg("usage: /testchar apply skills,spells,aetheria,manastone");
+                    return;
+                }
+                foreach (var key in parameters[1].ToLowerInvariant().Split(','))
+                {
+                    switch (key)
+                    {
+                        case "skills":
+                            ApplyChMaxSkills(player);
+                            Msg("applied: all skills specialized + maxed");
+                            break;
+                        case "spells":
+                            ApplyChAllSpells(player);
+                            Msg("applied: all spells learned");
+                            break;
+                        case "aetheria":
+                            player.UpdateProperty(player, PropertyInt.AetheriaBitfield, (int)AetheriaBitfield.All);
+                            Msg("applied: aetheria slots");
+                            break;
+                        case "manastone":
+                            SpawnChManaStone(player);
+                            Msg("applied: eternal mana charge");
+                            break;
+                        default:
+                            Msg($"testchar apply: unknown '{key}' (skills|spells|aetheria|manastone)");
+                            return;
+                    }
+                }
+                return;
+            }
+
+            // extra <keys csv> — utility-item minting (Admin > Extras tab, 2026-08-03). Same
+            // convention as the gems set: an item already possessed (deep check) is skipped.
+            if (sub == "extra")
+            {
+                if (parameters.Length < 2)
+                {
+                    Msg("usage: /testchar extra healkit,stamkit,manakit,lockpick,ivory,arrow,dispel,enlcoins,mmds,scarabs,aetheria,bags");
+                    return;
+                }
+                var owned = player.GetAllPossessionsDeep();
+                var possessed = new HashSet<uint>(owned.Select(i => i.WeenieClassId));
+                void Mint(uint wcid, string label)
+                {
+                    if (possessed.Contains(wcid)) { Msg($"extra: {label} already in inventory - skipped"); return; }
+                    var wo = WorldObjectFactory.CreateNewWorldObject(wcid);
+                    if (wo == null) { Msg($"extra: {label} (wcid {wcid}) failed to create"); return; }
+                    if (player.TryCreateInInventoryWithNetworking(wo))
+                        Msg($"extra: {label} created");
+                    else
+                        Msg($"extra: {label} could not be added (inventory full?)");
+                }
+                // Stackables top up to the target: possessing 4500 of a 5000 target creates the missing 500.
+                // A pack routes the new stack there (falls back to main pack when full/missing).
+                void MintStack(uint wcid, string label, int target, Container pack = null)
+                {
+                    var have = owned.Where(i => i.WeenieClassId == wcid).Sum(i => i.StackSize ?? 1);
+                    var missing = target - have;
+                    if (missing <= 0) { Msg($"extra: {label} already at {have} - skipped"); return; }
+                    var wo = WorldObjectFactory.CreateNewWorldObject(wcid);
+                    if (wo == null) { Msg($"extra: {label} (wcid {wcid}) failed to create"); return; }
+                    // never past the weenie's own stack cap (an over-stack is an item no player can hold)
+                    missing = Math.Min(missing, wo.MaxStackSize ?? 1);
+                    if (missing > 1)
+                        wo.SetStackSize(missing);
+                    if (TryPlaceInPack(player, wo, pack))
+                        Msg($"extra: {label} +{missing} (now {have + missing}) [{pack.Name}]");
+                    else if (player.TryCreateInInventoryWithNetworking(wo))
+                        Msg($"extra: {label} +{missing} (now {have + missing})");
+                    else
+                        Msg($"extra: {label} could not be added (inventory full?)");
+                }
+                foreach (var key in parameters[1].ToLowerInvariant().Split(','))
+                {
+                    switch (key)
+                    {
+                        case "healkit":  Mint(30247, "Eternal Health Kit"); break;
+                        case "stamkit":  Mint(30249, "Eternal Stamina Kit"); break;
+                        case "manakit":  Mint(30248, "Eternal Mana Kit"); break;
+                        case "lockpick": Mint(30253, "Limitless Lockpick"); break;
+                        case "ivory":    Mint(30092, "Infinite Ivory"); break;
+                        // The never-depleting ammo the /testchar T10/T11 package already
+                        // auto-grants (owner 2026-08-06) — now mintable on its own, so a bow
+                        // test char can get ammo without re-running the whole tier package.
+                        case "arrow":    Mint(4395100, "Infinite Deadly Prismatic Arrow"); break;
+                        case "dispel":   Mint(3110181, "Rune of Dispel"); break;   // ILT variant (sold in VoD), owner 08-03
+                        case "enlcoins": MintStack(300004, "Enlightened Coins", 25000); break;
+                        case "mmds":     MintStack(20630, "Trade Notes (250k)", 5000); break;
+                        case "scarabs":
+                            // 100 of each casting scarab, topped up (owner 08-03). Dark Scarab
+                            // (37117) excluded: its max stack is 1 here. Packed (owner 08-15).
+                            var compsPack = GetOrCreatePack(player, "Spell Comps Pack");
+                            MintStack(691, "Lead Scarabs", 100, compsPack);
+                            MintStack(689, "Iron Scarabs", 100, compsPack);
+                            MintStack(686, "Copper Scarabs", 100, compsPack);
+                            MintStack(688, "Silver Scarabs", 100, compsPack);
+                            MintStack(687, "Gold Scarabs", 100, compsPack);
+                            MintStack(690, "Pyreal Scarabs", 100, compsPack);
+                            MintStack(8897, "Platinum Scarabs", 100, compsPack);
+                            MintStack(37155, "Mana Scarabs", 100, compsPack);
+                            MintStack(7299, "Diamond Scarabs", 100, compsPack);
+                            MintStack(20631, "Prismatic Tapers", 10000, compsPack);   // max stack, owner 08-03
+                            break;
+                        case "aetheria": SpawnAetherias(player); Msg("extra: aetheria set spawned (skips owned pieces)"); break;
+                        case "bags":     MintBoosterPacks(player, Msg); break;
+                        case "growthcharms":
+                            // The five growth charms (aug-caps lane). Items only - the counters
+                            // that actually scale damage are set via /testchar set charms.
+                            Mint(777700030, "Charm of the Triune Weave");
+                            Mint(777700051, "Charm of the Battlemage's Wrath");
+                            Mint(777700056, "Charm of the Nether Veil");
+                            Mint(777700061, "Charm of Crashing Steel");
+                            Mint(777700066, "Charm of the True Shot");
+                            break;
+                        default:
+                            Msg($"testchar extra: unknown '{key}' (healkit|stamkit|manakit|lockpick|ivory|arrow|dispel|enlcoins|mmds|scarabs|aetheria|bags|growthcharms)");
+                            return;
+                    }
+                }
+                player.SaveBiotaToDatabase();
+                return;
+            }
+
+            // set <what> <values>
+            if (parameters.Length < 3)
+            {
+                Msg("usage: /testchar set attrs|vitals|level|enl|augs|charms|raugs <values>");
+                return;
+            }
+            var what = parameters[1].ToLowerInvariant();
+            var arg = parameters[2];
+
+            bool ParseCsv(string csv, int count, out uint[] vals)
+            {
+                vals = new uint[count];
+                var parts = csv.Split(',');
+                if (parts.Length != count) return false;
+                for (int i = 0; i < count; i++)
+                    if (!uint.TryParse(parts[i], out vals[i])) return false;
+                return true;
+            }
+
+            switch (what)
+            {
+                case "attrs":
+                {
+                    if (!ParseCsv(arg, 6, out var v))
+                    {
+                        Msg("set attrs: need 6 csv values (str,end,coord,quick,focus,self)");
+                        return;
+                    }
+                    var order = new[] { PropertyAttribute.Strength, PropertyAttribute.Endurance, PropertyAttribute.Coordination,
+                                        PropertyAttribute.Quickness, PropertyAttribute.Focus, PropertyAttribute.Self };
+                    for (int i = 0; i < 6; i++)
+                        SetChAttribute(player, order[i], v[i]);
+                    Msg("set attrs: " + arg);
+                    return;
+                }
+                case "vitals":
+                {
+                    if (!ParseCsv(arg, 3, out var v))
+                    {
+                        Msg("set vitals: need 3 csv values (health,stamina,mana)");
+                        return;
+                    }
+                    var order = new[] { PropertyAttribute2nd.MaxHealth, PropertyAttribute2nd.MaxStamina, PropertyAttribute2nd.MaxMana };
+                    for (int i = 0; i < 3; i++)
+                        SetChVital(player, order[i], v[i]);
+                    Msg("set vitals: " + arg);
+                    return;
+                }
+                case "level":
+                {
+                    if (!int.TryParse(arg, out var lvl) || lvl < 1)
+                    {
+                        Msg("set level: bad value");
+                        return;
+                    }
+                    player.Level = lvl;
+                    player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt(player, PropertyInt.Level, lvl));
+                    Msg("set level: " + lvl);
+                    return;
+                }
+                case "enl":
+                {
+                    if (!int.TryParse(arg, out var enl) || enl < 0)
+                    {
+                        Msg("set enl: bad value");
+                        return;
+                    }
+                    player.Enlightenment = enl;
+                    player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt(player, PropertyInt.Enlightenment, enl));
+                    Msg("set enl: " + enl);
+                    return;
+                }
+                case "augs":
+                {
+                    if (!ParseCsv(arg, 10, out var v))
+                    {
+                        Msg("set augs: need 10 csv values (creature,item,life,war,void,duration,specialize,summon,melee,missile)");
+                        return;
+                    }
+                    SetChLumAugs(player, v);
+                    Msg("set augs: " + arg);
+                    return;
+                }
+                case "charms":
+                {
+                    // Growth charm counters (PropertyInt64 50000-50004). These are what the
+                    // Effective*AugCount accessors add on top of the raw lum augs - the charm
+                    // ITEMS (extra growthcharms) grant nothing without these.
+                    if (!ParseCsv(arg, 5, out var v))
+                    {
+                        Msg("set charms: need 5 csv values (weave,wrath,nether,steel,trueshot)");
+                        return;
+                    }
+                    var props = new[] { PropertyInt64.TriuneWeaveCount, PropertyInt64.BattlemagesWrathCharmCount,
+                                        PropertyInt64.NetherVeilCharmCount, PropertyInt64.CrashingSteelCharmCount,
+                                        PropertyInt64.TrueShotCharmCount };
+                    for (int i = 0; i < 5; i++)
+                    {
+                        player.SetProperty(props[i], v[i]);
+                        player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt64(player, props[i], v[i]));
+                    }
+                    Msg("set charms: " + arg);
+                    return;
+                }
+                case "raugs":
+                {
+                    if (arg.Equals("max", StringComparison.OrdinalIgnoreCase) || arg.Equals("zero", StringComparison.OrdinalIgnoreCase))
+                    {
+                        var toMax = arg.Equals("max", StringComparison.OrdinalIgnoreCase);
+                        foreach (var kvp in AugmentationDevice.MaxAugs)
+                        {
+                            var prop = AugmentationDevice.AugProps[kvp.Key];
+                            var val = toMax ? kvp.Value : 0;
+                            player.SetProperty(prop, val);
+                            player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt(player, prop, val));
+                        }
+                        Msg("set raugs: " + (toMax ? "all max" : "all zero"));
+                        return;
+                    }
+
+                    var applied = 0;
+                    foreach (var pair in arg.Split(','))
+                    {
+                        var kv = pair.Split('=');
+                        if (kv.Length != 2 || !int.TryParse(kv[1], out var val)
+                            || !Enum.TryParse<AugmentationType>(kv[0], true, out var at)
+                            || !AugmentationDevice.MaxAugs.TryGetValue(at, out var max))
+                        {
+                            Msg($"set raugs: bad entry '{pair}' (key=value, key = augmentation name)");
+                            return;
+                        }
+                        val = Math.Clamp(val, 0, max);
+                        var prop = AugmentationDevice.AugProps[at];
+                        player.SetProperty(prop, val);
+                        player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt(player, prop, val));
+                        applied++;
+                    }
+                    Msg($"set raugs: {applied} set");
+                    return;
+                }
+                default:
+                    Msg("usage: /testchar set attrs|vitals|level|enl|augs|charms|raugs <values>");
+                    return;
             }
         }
 
-        private static void SpawnOlthoiShadowArmor(Player player, string tier = "T11")
+        /// <summary>The 102-slot "Booster Pack" bags (wcid 310025) the /testchar tier package spawns,
+        /// as a standalone extra. Fills the player's pack slots but NEVER past what the client is
+        /// showing: ContainerCapacity is read at login, so a PackSlot aug taken this session gives a
+        /// slot the client won't render until relog and a pack put there looks lost (owner
+        /// 2026-08-11 - hence 7 normally, 8 only for a character that logged in already holding the
+        /// aug). Existing Booster Packs are counted, so re-running tops up instead of duplicating.</summary>
+        private static void MintBoosterPacks(Player player, Action<string> Msg)
         {
-            var armorNames = new Dictionary<uint, string>()
-            {
-                { 3110264, $"{tier} Helm (Test)" },
-                { 3110266, $"{tier} Girth (Test)" },
-                { 3110267, $"{tier} Tassets (Test)" },
-                { 3110268, $"{tier} Greaves (Test)" },
-                { 3110269, $"{tier} Pauldrons (Test)" },
-                { 3110270, $"{tier} Sollerets (Test)" },
-                { 3110271, $"{tier} Gloves (Test)" },
-                { 3110272, $"{tier} Bracers (Test)" },
-                { 3110308, $"{tier} Coat (No Cloak) (Test)" }
-            };
+            const uint PackWcid = 310025;
 
-            foreach (var kvp in armorNames)
+            // Slots the client is showing, minus every container already in the pack bar.
+            var slots = Math.Min(player.ClientPackSlots, player.ContainerCapacity ?? 7);
+            var held = player.Inventory.Values.OfType<Container>().Count();
+            var room = slots - held;
+
+            if (room <= 0)
             {
-                if (HasItemNamed(player, kvp.Value)) continue;
-                var item = WorldObjectFactory.CreateNewWorldObject(kvp.Key);
-                if (item != null)
+                Msg($"extra: bags - all {slots} pack slots already filled ({held} packs) - skipped");
+                if ((player.ContainerCapacity ?? 7) > slots)
+                    Msg("extra: bags - the PackSlot aug added a slot this session; relog and re-run to fill it.");
+                return;
+            }
+
+            var made = 0;
+            for (int i = 1; i <= 8 && made < room; i++)
+            {
+                var packName = $"Booster Pack {i}";
+                if (HasItemNamed(player, packName)) continue;
+                if (!(WorldObjectFactory.CreateNewWorldObject(PackWcid) is Container bag)) continue;
+                bag.Name = packName;
+                bag.SetProperty(PropertyString.Name, packName);
+                if (player.TryCreateInInventoryWithNetworking(bag))
+                    made++;
+                else
                 {
-                    item.Name = kvp.Value;
-                    item.SetProperty(PropertyString.Name, kvp.Value);
-                    item.SetProperty(PropertyInt.MaterialType, 0);
-                    AddItemToInventory(player, item);
+                    bag.Destroy();
+                    break;
                 }
             }
+
+            Msg(made > 0
+                ? $"extra: bags - {made} Booster Pack(s) created ({held + made}/{slots} slots filled, 102 slots each)"
+                : "extra: bags - nothing to create");
+            if ((player.ContainerCapacity ?? 7) > slots)
+                Msg("extra: bags - an 8th slot exists server-side but the client shows it only after a relog; re-run then.");
         }
 
-        private static void SpawnCustomUndergarmentsAndCloak(Player player, string tier = "T11")
+        // The VoD 9-piece Olthoi Shadow set — the ONE armor look for test gear (owner
+        // 2026-08-02). Used by /asforge (any piece at any tier label): piece keys match the
+        // plugin's Armor Forge workbench. The /testchar full-set spawn was deleted 2026-08-23.
+        private static readonly (string Key, uint Wcid, string Label)[] VodArmorPieces =
+        {
+            ("helm",      3110264, "Helm"),
+            ("coat",      3110308, "Coat (No Cloak)"),
+            ("pauldrons", 3110269, "Pauldrons"),
+            ("bracers",   3110272, "Bracers"),
+            ("gloves",    3110271, "Gloves"),
+            ("girth",     3110266, "Girth"),
+            ("tassets",   3110267, "Tassets"),
+            ("greaves",   3110268, "Greaves"),
+            ("sollerets", 3110270, "Sollerets"),
+        };
+
+        // ── Premade suits (owner 2026-08-21, PremadeSuits_Design/Math_2026-08-21.md) ──
+        // /asforge premade <tier> <avg|bis>: the 18-piece `all` roster with the
+        // cantrip lines written EXPLICITLY instead of rolled, so a tester can wear "the average
+        // T-whatever suit" or "the best possible one" without farming. Two presets:
+        //   BiS     = core four at window cap, the tier's MAX line count, every line at band MAX,
+        //             lines in the fixed order below.
+        //   Average = core four at window midpoint, floor(expected) lines per piece dealt
+        //             round-robin from the class-weight mix (trash 10 / mid 6 / chase 1), every
+        //             line at band MIDPOINT.
+        // Line count ladder (max / guaranteed): T11 2/0, T12-14 3/1, T15-17 4/2, T18-20 5/3,
+        // T21-24 6/4, T25 7/5 (owner ruling 08-21 late: T25 = 5 guaranteed, BiS 7th = 34 Item Aug).
+        // ONE BiS list as of 2026-08-22: the class-split aug keys 37-40 are retired, so there is no
+        // longer a melee vs caster suit - the universal damage lines lead. The melee|caster words are
+        // still accepted on the command line and ignored, so old habits don't error.
+        // 2026-08-22 pool: all seven aug keys retired; 47 Pct Max Health + 49 Reinforced (armor) / 48 Life on Hit (jewelry)
+        // added. ArmorOnly / JewelryOnly keys are skipped per piece below, so armor and jewelry each reach the cap.
+        private static readonly int[] PremadeBisLines = { 28, 29, 43, 33, 19, 47, 49, 48 };
+        // Average mix - deal order. 43 All Attributes = the one chase line per suit; 25 Aegis is
+        // armor-only; 33 Crit Rating ladders by COUNT through the per-tier chance, so an average
+        // suit carries none of it (Math file section 2).
+        private static readonly int[] PremadeAvgTrashKeys = { 32 };   // 20/21 left the catalog (2026-08-23: "not a live pool line")
+        private static readonly int[] PremadeAvgMidKeys = { 19, 28, 29, 31, 49 };
+        private const int PremadeAvgChaseKey = 43;
+        private const int PremadeArmorOnlyKey = 25;
+
+        /// <summary>Live slot rule (owner 2026-08-22): the tier's Default-layer override when authored, else the
+        /// catalog's ArmorOnly / JewelryOnly - exactly what a real drop at this tier would obey.</summary>
+        private static bool PremadeKeyAllowed(int key, WorldObject wo, int tier)
+        {
+            if (!ACE.Server.Managers.ZoneControl.ZoneModifiers.TryGet(key, out var def) || def.SlotSpecial)
+                return false;
+            var slotRule = ACE.Server.Managers.ZoneControl.ZoneModifiers.EffectiveSlotMask(def,
+                ACE.Server.Managers.ZoneControl.ZoneControlManager.GetVariationDefault(tier)?.Profile?.CustomModifierSlots);
+            return ACE.Server.Managers.ZoneControl.ZoneModifiers.SlotAllowed(slotRule, ACE.Server.Managers.ZoneControl.ZoneModifiers.PieceMask(wo));
+        }
+
+        /// <summary>
+        /// Test gear is meant to be WORN: SET the minter's wield counters to exactly the tier's gates -
+        /// item augs, Triune Weave, and the four weapon-family charms - BOTH DIRECTIONS, so a premade
+        /// can be re-forged up or down on demand with no extra steps (owner 2026-08-23 "it should go
+        /// lower", reaffirmed 2026-08-31: "t11 to t15 to t20 to t13 to t11 on demand").
+        ///
+        /// 🔴 ITEM AUGS PIN TO THE TIER'S WEAPON DAMAGE CAP, NOT ITS WIELD FLOOR - clamped to the
+        /// 4,000 purchase cap. This is the fix for a two-way conflict, so do not "simplify" it back
+        /// to MinWieldAugs:
+        ///   - MinWieldAugs is the FLOOR and sits exactly 500 BELOW the tier Cap at every tier.
+        ///     Pinning to it left every premade one step under its damage ceiling, because weapon
+        ///     damage uses min(itemAugs, Cap) - that was the 2026-08-20 ruling this method silently
+        ///     defeated for eleven days.
+        ///   - Pinning to the raw Cap would overshoot the purchase cap above T14 (T25 Cap = 9,500 vs
+        ///     a 4,000 buy limit), minting a test character no real player could ever be.
+        /// min(Cap, 4000) satisfies both: T11 lands on 2,500 = its Cap; T15+ freezes at 4,000, and
+        /// TRIUNE carries the tiers above (owner 2026-08-31). Raising the ceiling past T14 is a
+        /// Triune question, never an item-aug one.
+        /// </summary>
+        private static void EnsureWieldCounters(Player player, int tier, Action<string> Msg)
+        {
+            var row = ACE.Server.Managers.WeaponScaling.WeaponScalingManager.GetTier(tier);
+            if (row == null) return;
+            var raised = new List<string>();
+            void Raise(PropertyInt64 prop, long need, string label)
+            {
+                if (need < 0) return;
+                var cur = player.GetProperty(prop) ?? 0;
+                if (cur == need) return;                  // pin: both directions, so re-forging down works
+                player.SetProperty(prop, need);
+                player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt64(player, prop, need));
+                raised.Add($"{label} {cur:N0} -> {need:N0}");
+            }
+            // the tier's damage ceiling, never above what a player could actually buy
+            const long ItemAugPurchaseCap = 4000;          // EmoteManager.AugmentationCaps["Item"]
+            var itemTarget = Math.Min((long)row.Cap, ItemAugPurchaseCap);
+            if (itemTarget > 0 && (player.LuminanceAugmentItemCount ?? 0) != itemTarget)
+            {
+                var cur = player.LuminanceAugmentItemCount ?? 0;
+                player.LuminanceAugmentItemCount = (uint)itemTarget;
+                player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt64(player, PropertyInt64.LumAugItemCount, itemTarget));
+                raised.Add($"Item Augs {cur:N0} -> {itemTarget:N0}");
+            }
+            Raise(PropertyInt64.TriuneWeaveCount, row.MinWieldTriune, "Triune Weave");
+            Raise(PropertyInt64.BattlemagesWrathCharmCount, row.MinWieldSkillCharm, "Battlemage's Wrath");
+            Raise(PropertyInt64.NetherVeilCharmCount, row.MinWieldSkillCharm, "Nether Veil");
+            Raise(PropertyInt64.CrashingSteelCharmCount, row.MinWieldSkillCharm, "Crashing Steel");
+            Raise(PropertyInt64.TrueShotCharmCount, row.MinWieldSkillCharm, "True Shot");
+            if (raised.Count > 0)
+                Msg($"asforge: wield counters set to T{tier} gates - {string.Join(", ", raised)}.");
+        }
+
+        private static int PremadeLineMax(int tier) =>
+            tier <= 11 ? 2 : tier <= 14 ? 3 : tier <= 17 ? 4 : tier <= 20 ? 5 : tier <= 24 ? 6 : 7;
+
+        /// <summary>The effective roll band for a cantrip key at a tier: the live Default-layer band
+        /// authored on variation = tier wins (what real drops there roll from); otherwise the Armor v2
+        /// formula - 1250-class keys max = 1250/18 x f, min = 20 pct; key 25 max 250 x f / min 50 x f;
+        /// keys 32/33 pinned 1-3. Unrounded so the midpoint rounds ONCE (Math file section 1).</summary>
+        private static (double Min, double Max) PremadeBand(int key, int tier)
+        {
+            var vd = ACE.Server.Managers.ZoneControl.ZoneControlManager.GetVariationDefault(tier);
+            if (vd?.Profile?.CustomModifierBands != null
+                && vd.Profile.CustomModifierBands.TryGetValue(key, out var live)
+                && live != null && live.Max >= live.Min && live.Max > 0)
+                return (live.Min, live.Max);
+
+            // no Default authored: the same tier-scaled hardcoded band real drops fall back to (2026-08-23)
+            if (ACE.Server.Managers.ZoneControl.ZoneModifiers.TryGet(key, out var cdef))
+            {
+                var (cmin, cmax) = ACE.Server.Managers.ZoneControl.ZoneModifiers.CatalogBandAt(cdef, tier);
+                return (cmin, cmax);
+            }
+            return (1, 1);
+        }
+
+        /// <summary>Deal the Average suit's lines: per-piece count = guaranteed (max - 2) plus one
+        /// extra on pieces 1,3,5,...,15 (the 8 leftover lines of 18 x 0.44); keys pulled round-robin
+        /// from the class-weight multiset (trash round(L x 10/108) each, Aegis half of that on armor,
+        /// one 43, the rest mid keys ascending), distinct per piece, key 25 only where there is AL.
+        /// Returns one key list per roster index.</summary>
+        private static List<int>[] PremadeDealAverage(int tier, bool[] hasArmorLevel)
+        {
+            var pieces = hasArmorLevel.Length;
+            var guaranteed = Math.Max(0, PremadeLineMax(tier) - 2);
+            var counts = new int[pieces];
+            var total = 0;
+            for (var i = 0; i < pieces; i++)
+            {
+                counts[i] = guaranteed + (i % 2 == 0 && i < 16 ? 1 : 0);
+                total += counts[i];
+            }
+
+            // the multiset, by class weight over the 108-point armor pool
+            var trashEach = (int)Math.Round(total * 10.0 / 108.0);
+            var aegis = trashEach / 2;                                   // armor is half the roster
+            var chase = total >= 18 ? 1 : 0;                             // T11's 8 lines carry no chase
+            var mid = Math.Max(0, total - trashEach * PremadeAvgTrashKeys.Length - aegis - chase);
+
+            var remaining = new Dictionary<int, int>();
+            if (chase > 0) remaining[PremadeAvgChaseKey] = chase;
+            if (aegis > 0) remaining[PremadeArmorOnlyKey] = aegis;
+            foreach (var k in PremadeAvgTrashKeys) remaining[k] = trashEach;
+            for (var i = 0; i < mid; i++)
+            {
+                var k = PremadeAvgMidKeys[i % PremadeAvgMidKeys.Length];
+                remaining[k] = remaining.TryGetValue(k, out var c) ? c + 1 : 1;
+            }
+
+            // deal order: cycle the key list, one of each per pass, so every key spreads across pieces
+            var order = new List<int> { PremadeAvgChaseKey, PremadeArmorOnlyKey };
+            order.AddRange(PremadeAvgTrashKeys);
+            order.AddRange(PremadeAvgMidKeys);
+            var queue = new List<int>();
+            var left = remaining.Values.Sum();
+            while (left > 0)
+                foreach (var k in order)
+                {
+                    if (!remaining.TryGetValue(k, out var c) || c <= 0) continue;
+                    queue.Add(k);
+                    remaining[k] = c - 1;
+                    left--;
+                }
+
+            var dealt = new List<int>[pieces];
+            for (var i = 0; i < pieces; i++) dealt[i] = new List<int>();
+            for (var round = 0; queue.Count > 0 && round < 8; round++)
+                for (var i = 0; i < pieces && queue.Count > 0; i++)
+                {
+                    if (counts[i] <= round) continue;
+                    var idx = queue.FindIndex(k => !dealt[i].Contains(k) && (k != PremadeArmorOnlyKey || hasArmorLevel[i]));
+                    if (idx < 0) continue;                               // nothing this piece can take - it runs short
+                    dealt[i].Add(queue[idx]);
+                    queue.RemoveAt(idx);
+                }
+            return dealt;
+        }
+
+        // The eight per-element armor resistance mods (mirrors LootGenerationFactory's
+        // private list) — the loadout "prot" card overrides all of them uniformly.
+        private static readonly ACE.Entity.Enum.Properties.PropertyFloat[] ForgeArmorModVsProps =
+        {
+            ACE.Entity.Enum.Properties.PropertyFloat.ArmorModVsSlash,
+            ACE.Entity.Enum.Properties.PropertyFloat.ArmorModVsPierce,
+            ACE.Entity.Enum.Properties.PropertyFloat.ArmorModVsBludgeon,
+            ACE.Entity.Enum.Properties.PropertyFloat.ArmorModVsFire,
+            ACE.Entity.Enum.Properties.PropertyFloat.ArmorModVsCold,
+            ACE.Entity.Enum.Properties.PropertyFloat.ArmorModVsAcid,
+            ACE.Entity.Enum.Properties.PropertyFloat.ArmorModVsElectric,
+            ACE.Entity.Enum.Properties.PropertyFloat.ArmorModVsNether,
+        };
+
+        // Loadout spell suites (owner 2026-08-02, DB-verified ids): the 7 Legendary elemental
+        // Wards and the 7 life Protections, both WEARER buffs -> both apply to every minted
+        // piece. Protection tier = "Incantation of X Protection Self" — the tier the /testchar
+        // gear (the set this forge is based on) actually carries (necklace: 4462/4466 + wards
+        // 6079/6085; shirt 4466; pants 4470). Banes/Impen rejected (owner: life protections).
+        private static readonly uint[] LegendaryWardSpells = { 6079, 6080, 6081, 6082, 6083, 6084, 6085 };
+        private static readonly uint[] LifeProtectionSpells = { 4460, 4462, 4464, 4466, 4468, 4470, 4472 };
+        // Owner 2026-08-09, from the live top-30 gear survey: Legendary Impenetrability
+        // (strongest impen; same-family levels don't stack so one id suffices) and the
+        // defensive cantrip cluster worn by virtually every endgame suit.
+        private static readonly uint[] ImpenSpells = { 6095 };
+        private static readonly uint[] DefensiveCantripSpells = { 6055, 6077, 6102, 6103, 6104, 6105 };
+        // Owner 2026-08-16: the necklace is the ONLY test-gear buff carrier — it consolidates
+        // EVERYTHING the old distributed set granted (all 10 builders' spells + the premade's
+        // ward/lifeprot/defcantrip cards + the old trinket default suite), so one piece equals
+        // the whole historical kit. Impen family (4667/6095) deliberately EXCLUDED — armor is
+        // the impen carrier. Shared by BuildTestNecklace (/testchar) and the /asforge default.
+        private static readonly uint[] NecklaceBuffSpells =
+        {
+            // Curated by owner 2026-08-16 (trimmed from the full historical kit: protections,
+            // VI-era self buffs, blessings, banes, and the trade-skill Epics all cut).
+            3731,                                     // Prodigal Regeneration
+            6079, 6080, 6081, 6082, 6083, 6084, 6085, // Legendary elemental Wards x7
+            6055, 6077, 6102, 6103, 6104, 6105,       // Leg. Invuln/Health Gain/Armor/Coord/End/Focus
+            3694, 3730,                               // Prodigal Coordination / Quickness
+            2059,                                     // Honed Control
+            3569, 3570, 3571,                         // Mana / Stamina / Health Boost
+            5137, 5139, 5141, 5187,                   // Augmented Underst./Dmg/DmgReduction + Rare Dmg X
+            5238, 5253,                               // Sigil of Destruction XV / Defense XV
+            5449, 5450,                               // Surging Strength / Towering Defense
+            6170,                                     // Honeyed Life Mead
+        };
+
+        // Owner 2026-08-09: the trinket slot's DEFAULT suite (no card needed) — the 7
+        // Legendary Wards + Legendary Armor, Augmented Understanding III, Augmented
+        // Damage II, Rare Damage Boost X, Sigil of Defense XV, Sigil of Destruction XV,
+        // Honeyed Life Mead, Towering Defense, Health/Stamina/Mana Boost.
+        // UNUSED since 2026-08-16 (trinket mints blank); kept as the historical suite.
+        private static readonly uint[] TrinketDefaultSpells =
+        {
+            6079, 6080, 6081, 6082, 6083, 6084, 6085, 6102,
+            5137, 5139, 5187, 5253, 5238, 6170, 5450,
+            3571, 3570, 3569,
+        };
+
+        /// <summary>Adds spells to a forged piece and stamps the /testchar-norm spell-support
+        /// props (spellcraft/mana) if the piece has none — without them item spells never
+        /// activate. No ItemDifficulty stamp: test gear gets no arcane lore gate.</summary>
+        private static void AddForgeSpells(WorldObject wo, uint[] spells)
+        {
+            foreach (var s in spells)
+                wo.Biota.GetOrAddKnownSpell((int)s, wo.BiotaDatabaseLock, out _);
+            if ((wo.GetProperty(PropertyInt.ItemSpellcraft) ?? 0) == 0)
+                wo.SetProperty(PropertyInt.ItemSpellcraft, 750);
+            if ((wo.GetProperty(PropertyInt.ItemMaxMana) ?? 0) == 0)
+                wo.SetProperty(PropertyInt.ItemMaxMana, 3500);
+            wo.SetProperty(PropertyInt.ItemCurMana, wo.GetProperty(PropertyInt.ItemMaxMana) ?? 3500);
+            wo.UiEffects = UiEffects.Magical;
+        }
+
+        // The full Gear* rating set — /asforge strips these from every mint (owner 2026-08-02:
+        // bare pieces until the per-tier loadout is decided).
+        private static readonly PropertyInt[] ForgeStrippedRatings =
+        {
+            PropertyInt.GearDamage, PropertyInt.GearDamageResist, PropertyInt.GearCrit,
+            PropertyInt.GearCritResist, PropertyInt.GearCritDamage, PropertyInt.GearCritDamageResist,
+            PropertyInt.GearHealingBoost, PropertyInt.GearNetherResist, PropertyInt.GearLifeResist,
+            PropertyInt.GearMaxHealth, PropertyInt.GearPKDamageRating, PropertyInt.GearPKDamageResistRating,
+            PropertyInt.GearOverpower, PropertyInt.GearOverpowerResist,
+        };
+
+
+        private static WorldObject BuildVodArmorPiece(uint wcid, string label, string tier)
+        {
+            var item = WorldObjectFactory.CreateNewWorldObject(wcid);
+            if (item == null) return null;
+            var name = $"{tier} {label} (Test)";
+            item.Name = name;
+            item.SetProperty(PropertyString.Name, name);
+            item.SetProperty(PropertyInt.MaterialType, 0); // Suppress material prefix
+            // Armor is allowed EXACTLY ONE buff: Legendary Impenetrability (owner 2026-08-16;
+            // matches the /asforge T11+ default). All other buffs live on the necklace only.
+            // /asforge re-clears and re-adds this, so both paths agree.
+            item.Biota.ClearSpells(item.BiotaDatabaseLock);
+            AddForgeSpells(item, ImpenSpells);
+            item.ChangesDetected = true;
+            return item;
+        }
+
+        // Clothing + jewelry builders: each configures ONE piece exactly the way the old /testchar
+        // gear was built (name from the tier label, props, spells) and returns it WITHOUT adding
+        // to inventory — /asforge mints them. (The /testchar Spawn wrappers were deleted 2026-08-23.)
+        private static WorldObject BuildTestShirt(string tier)
         {
             var shirtName = $"{tier} Shirt";
-            if (!HasItemNamed(player, shirtName))
-            {
             var shirt = WorldObjectFactory.CreateNewWorldObject(28607);
             if (shirt != null)
             {
@@ -671,21 +1077,17 @@ namespace ACE.Server.Command.Handlers
                 shirt.SetProperty(PropertyInt.GearNetherResist, 9);
                 shirt.SetProperty(PropertyInt.GearMaxHealth, 175);
                 
-                // Spells
+                // BLANK by design (owner 2026-08-16): only the necklace carries buffs.
+                // ClearSpells stays so base-weenie-authored spells are wiped too.
                 shirt.Biota.ClearSpells(shirt.BiotaDatabaseLock);
-                var shirtSpells = new List<uint>() { 2161, 3694, 4466, 4664, 4667, 5238 };
-                foreach (var spellId in shirtSpells)
-                    shirt.Biota.GetOrAddKnownSpell((int)spellId, shirt.BiotaDatabaseLock, out _);
                 shirt.ChangesDetected = true;
-                shirt.UiEffects = UiEffects.Magical;
- 
-                AddItemToInventory(player, shirt);
             }
-            }
- 
+            return shirt;
+        }
+
+        private static WorldObject BuildTestPants(string tier)
+        {
             var pantsName = $"{tier} Pants";
-            if (!HasItemNamed(player, pantsName))
-            {
             var pants = WorldObjectFactory.CreateNewWorldObject(2599);
             if (pants != null)
             {
@@ -711,21 +1113,16 @@ namespace ACE.Server.Command.Handlers
                 pants.SetProperty(PropertyInt.GearNetherResist, 8);
                 pants.SetProperty(PropertyInt.GearMaxHealth, 175);
                 
-                // Spells
+                // BLANK by design (owner 2026-08-16): only the necklace carries buffs.
                 pants.Biota.ClearSpells(pants.BiotaDatabaseLock);
-                var pantsSpells = new List<uint>() { 2157, 3730, 4470, 4667, 4695, 5253 };
-                foreach (var spellId in pantsSpells)
-                    pants.Biota.GetOrAddKnownSpell((int)spellId, pants.BiotaDatabaseLock, out _);
                 pants.ChangesDetected = true;
-                pants.UiEffects = UiEffects.Magical;
- 
-                AddItemToInventory(player, pants);
             }
-            }
- 
+            return pants;
+        }
+
+        private static WorldObject BuildTestCloak(string tier)
+        {
             var cloakName = $"{tier} Cloak";
-            if (!HasItemNamed(player, cloakName))
-            {
             var cloak = WorldObjectFactory.CreateNewWorldObject(227190032);
             if (cloak != null)
             {
@@ -747,22 +1144,16 @@ namespace ACE.Server.Command.Handlers
                 cloak.SetProperty(PropertyInt.GearNetherResist, 5);
                 cloak.SetProperty(PropertyInt.GearMaxHealth, 10);
                 
-                // Spells
+                // BLANK by design (owner 2026-08-16): only the necklace carries buffs.
                 cloak.Biota.ClearSpells(cloak.BiotaDatabaseLock);
-                cloak.Biota.GetOrAddKnownSpell(5450, cloak.BiotaDatabaseLock, out _); // Towering Defense
                 cloak.ChangesDetected = true;
-                cloak.UiEffects = UiEffects.Magical;
- 
-                AddItemToInventory(player, cloak);
             }
-            }
+            return cloak;
         }
- 
-        private static void SpawnCustomJewelry(Player player, string tier = "T11")
+
+        private static WorldObject BuildTestBracelet1(string tier)
         {
             var leftBraceletName = $"{tier} Bracelet 1";
-            if (!HasItemNamed(player, leftBraceletName))
-            {
             var leftBracelet = WorldObjectFactory.CreateNewWorldObject(21392);
             if (leftBracelet != null)
             {
@@ -785,21 +1176,16 @@ namespace ACE.Server.Command.Handlers
                 leftBracelet.SetProperty(PropertyInt.GearMaxHealth, 100);
                 leftBracelet.ValidLocations = EquipMask.WristWearLeft;
  
-                // Spells
+                // BLANK by design (owner 2026-08-16): only the necklace carries buffs.
                 leftBracelet.Biota.ClearSpells(leftBracelet.BiotaDatabaseLock);
-                var spells = new List<uint>() { 4291, 4470, 4693, 4712 };
-                foreach (var spellId in spells)
-                    leftBracelet.Biota.GetOrAddKnownSpell((int)spellId, leftBracelet.BiotaDatabaseLock, out _);
                 leftBracelet.ChangesDetected = true;
-                leftBracelet.UiEffects = UiEffects.Magical;
- 
-                AddItemToInventory(player, leftBracelet);
             }
-            }
- 
+            return leftBracelet;
+        }
+
+        private static WorldObject BuildTestBracelet2(string tier)
+        {
             var rightBraceletName = $"{tier} Bracelet 2";
-            if (!HasItemNamed(player, rightBraceletName))
-            {
             var rightBracelet = WorldObjectFactory.CreateNewWorldObject(21392);
             if (rightBracelet != null)
             {
@@ -822,21 +1208,16 @@ namespace ACE.Server.Command.Handlers
                 rightBracelet.SetProperty(PropertyInt.GearMaxHealth, 100);
                 rightBracelet.ValidLocations = EquipMask.WristWearRight;
  
-                // Spells
+                // BLANK by design (owner 2026-08-16): only the necklace carries buffs.
                 rightBracelet.Biota.ClearSpells(rightBracelet.BiotaDatabaseLock);
-                var spells = new List<uint>() { 2059, 4693, 6067 };
-                foreach (var spellId in spells)
-                    rightBracelet.Biota.GetOrAddKnownSpell((int)spellId, rightBracelet.BiotaDatabaseLock, out _);
                 rightBracelet.ChangesDetected = true;
-                rightBracelet.UiEffects = UiEffects.Magical;
- 
-                AddItemToInventory(player, rightBracelet);
             }
-            }
- 
+            return rightBracelet;
+        }
+
+        private static WorldObject BuildTestRing1(string tier)
+        {
             var leftRingName = $"{tier} Ring 1";
-            if (!HasItemNamed(player, leftRingName))
-            {
             var leftRing = WorldObjectFactory.CreateNewWorldObject(21394);
             if (leftRing != null)
             {
@@ -859,21 +1240,16 @@ namespace ACE.Server.Command.Handlers
                 leftRing.SetProperty(PropertyInt.GearMaxHealth, 100);
                 leftRing.ValidLocations = EquipMask.FingerWearLeft;
  
-                // Spells
+                // BLANK by design (owner 2026-08-16): only the necklace carries buffs.
                 leftRing.Biota.ClearSpells(leftRing.BiotaDatabaseLock);
-                var spells = new List<uint>() { 2197, 2251, 4686, 4708 };
-                foreach (var spellId in spells)
-                    leftRing.Biota.GetOrAddKnownSpell((int)spellId, leftRing.BiotaDatabaseLock, out _);
                 leftRing.ChangesDetected = true;
-                leftRing.UiEffects = UiEffects.Magical;
- 
-                AddItemToInventory(player, leftRing);
             }
-            }
- 
+            return leftRing;
+        }
+
+        private static WorldObject BuildTestRing2(string tier)
+        {
             var rightRingName = $"{tier} Ring 2";
-            if (!HasItemNamed(player, rightRingName))
-            {
             var rightRing = WorldObjectFactory.CreateNewWorldObject(21394);
             if (rightRing != null)
             {
@@ -896,21 +1272,16 @@ namespace ACE.Server.Command.Handlers
                 rightRing.SetProperty(PropertyInt.GearMaxHealth, 100);
                 rightRing.ValidLocations = EquipMask.FingerWearRight;
  
-                // Spells
+                // BLANK by design (owner 2026-08-16): only the necklace carries buffs.
                 rightRing.Biota.ClearSpells(rightRing.BiotaDatabaseLock);
-                var spells = new List<uint>() { 279, 2153, 4701, 6041 };
-                foreach (var spellId in spells)
-                    rightRing.Biota.GetOrAddKnownSpell((int)spellId, rightRing.BiotaDatabaseLock, out _);
                 rightRing.ChangesDetected = true;
-                rightRing.UiEffects = UiEffects.Magical;
- 
-                AddItemToInventory(player, rightRing);
             }
-            }
- 
+            return rightRing;
+        }
+
+        private static WorldObject BuildTestNecklace(string tier)
+        {
             var necklaceName = $"{tier} Necklace";
-            if (!HasItemNamed(player, necklaceName))
-            {
             var necklace = WorldObjectFactory.CreateNewWorldObject(27445);
             if (necklace != null)
             {
@@ -925,29 +1296,31 @@ namespace ACE.Server.Command.Handlers
                 necklace.SetProperty(PropertyInt.WieldDifficulty, 725);
                 necklace.SetProperty(PropertyInt.ItemWorkmanship, 8);
                 necklace.SetProperty(PropertyInt.ItemSpellcraft, 4370);
-                necklace.SetProperty(PropertyInt.ItemCurMana, 2138);
-                necklace.SetProperty(PropertyInt.ItemMaxMana, 2560);
+                // The consolidated ~50-spell suite needs a pool that never runs dry (each item
+                // spell activation draws item mana) — test gear must not fizzle mid-session.
+                necklace.SetProperty(PropertyInt.ItemCurMana, 100000);
+                necklace.SetProperty(PropertyInt.ItemMaxMana, 100000);
                 necklace.SetProperty(PropertyInt.ItemDifficulty, 1935);
                 necklace.SetProperty(PropertyInt.GemCount, 3);
                 necklace.SetProperty(PropertyInt.GemType, 49);
                 necklace.SetProperty(PropertyInt.GearMaxHealth, 100);
                 necklace.ValidLocations = EquipMask.NeckWear;
  
-                // Spells
+                // Spells — THE buff carrier: the necklace is the ONLY test-gear piece that carries
+                // buffs (owner 2026-08-16); armor additionally carries Legendary Impen only.
+                // Suite shared with the /asforge default (NecklaceBuffSpells).
                 necklace.Biota.ClearSpells(necklace.BiotaDatabaseLock);
-                var spells = new List<uint>() { 4462, 4466, 4703, 6079, 6085 };
-                foreach (var spellId in spells)
+                foreach (var spellId in NecklaceBuffSpells)
                     necklace.Biota.GetOrAddKnownSpell((int)spellId, necklace.BiotaDatabaseLock, out _);
                 necklace.ChangesDetected = true;
                 necklace.UiEffects = UiEffects.Magical;
- 
-                AddItemToInventory(player, necklace);
             }
-            }
- 
+            return necklace;
+        }
+
+        private static WorldObject BuildTestTrinket(string tier)
+        {
             var trinketName = $"{tier} Trinket";
-            if (!HasItemNamed(player, trinketName))
-            {
             var trinket = WorldObjectFactory.CreateNewWorldObject(41483);
             if (trinket != null)
             {
@@ -970,30 +1343,571 @@ namespace ACE.Server.Command.Handlers
                 trinket.SetProperty(PropertyInt.GearMaxHealth, 100);
                 trinket.ValidLocations = EquipMask.TrinketOne;
  
-                // Spells
+                // BLANK by design (owner 2026-08-16): only the necklace carries buffs.
                 trinket.Biota.ClearSpells(trinket.BiotaDatabaseLock);
-                var spells = new List<uint>() { 1450, 2281, 4698, 5137, 5139, 5141, 5449, 6081 };
-                foreach (var spellId in spells)
-                    trinket.Biota.GetOrAddKnownSpell((int)spellId, trinket.BiotaDatabaseLock, out _);
                 trinket.ChangesDetected = true;
-                trinket.UiEffects = UiEffects.Magical;
- 
-                AddItemToInventory(player, trinket);
             }
+            return trinket;
+        }
+
+        /// <summary>The Admin > Armor Forge subtab's backend (owner 2026-08-02,
+        /// ArmorForge_Plan_2026-08-02.md): mints the /testchar VoD gear at any tier label.
+        /// Same pipeline contract as /wsforge — normal item creation, never direct DB writes.
+        /// T10 = the basic set (no aug gate); T11+ carry the per-tier item-aug wield gate like
+        /// real drops. Everything forged is Attuned + Bonded (owner 2026-08-02).</summary>
+        [CommandHandler("asforge", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 1,
+            "Forges VoD test armor/clothing/jewelry (the /testchar look) at a chosen tier. All pieces Attuned + Bonded.",
+            "<piece|suit|jewel|all> [tier 10-25, default 11] [cards:key=val,key,...]\n" +
+            "premade <tier 10-25> <avg|bis> [force] = the 18-piece suit with EXPLICIT modifier lines: bis = core at cap + max lines at band max; avg = core at midpoint + expected lines at band midpoint. Minted loose into your main pack (no suit bag since 2026-09-03). Tier 10 = the ENTRY-CASE suit: the measured top T10 set (no lines, no wield gate).\n" +
+            "Pieces: helm coat pauldrons bracers gloves girth tassets greaves sollerets shirt pants cloak neck ring bracelet trinket\n" +
+            "suit = 9 armor + shirt/pants/cloak; jewel = necklace + 2 rings + 2 bracelets + trinket; all = both.\n" +
+            "ring/bracelet mint the left + right pair.\n" +
+            "cards: albonus=N (AL over tier baseline) prot=X (uniform 8-element mod)\n" +
+            "ward (adds the 7 Legendary elemental Wards) lifeprot (adds the 7 life Protections)\n" +
+            "impen (Legendary Impenetrability) defcantrips (Legendary Armor/Invuln/Coord/Endurance/Focus/Health Gain) - all on every minted piece\n" +
+            "Defaults (no card): VoD armor gets Legendary Impen at EVERY tier; the necklace gets the full buff suite. Everything else mints blank.\n" +
+            "force = mint even if you already hold that piece (default is to skip it, so repeat presses cannot stack suits).")]
+        public static void HandleAsForge(Session session, params string[] parameters)
+        {
+            void Msg(string s) => ChatPacket.SendServerMessage(session, s, ChatMessageType.Broadcast);
+
+            var player = session.Player;
+            if (player == null)
+                return;
+
+            var key = parameters[0].ToLowerInvariant();
+
+            if (key == "premade")
+            {
+                HandleAsForgePremade(session, player, parameters);
+                return;
             }
+
+            var tier = 11;
+            if (parameters.Length > 1 && int.TryParse(parameters[1], out var t))
+                tier = Math.Clamp(t, 10, 25);
+            var tierLabel = $"T{tier}";
+
+            // Loadout clause (the plugin's Cards section, owner 2026-08-02): cards:key=val,key,...
+            // Any position after the piece arg. Unknown keys are an error, not a silent skip.
+            var albonus = 0;
+            double? protOverride = null;
+            var ward = false;
+            var lifeprot = false;
+            var impen = false;
+            var defcantrips = false;
+            var loadoutDesc = "";
+
+            // Owner 2026-08-20: pressing Create Premade twice used to hand you a second full
+            // suit, because this command always minted. It now skips a piece the character
+            // already holds, the same deep-possession convention /testchar extra and the
+            // jewelry spawn already use. `force` is the deliberate re-forge (after a card
+            // change, say) - without it a re-press is a no-op and SAYS so.
+            var force = parameters.Skip(1).Any(a => a.Equals("force", StringComparison.OrdinalIgnoreCase));
+
+            foreach (var p in parameters.Skip(1))
+            {
+                if (!p.StartsWith("cards:", StringComparison.OrdinalIgnoreCase))
+                    continue;
+                loadoutDesc = p.Substring(6);
+                foreach (var token in loadoutDesc.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries))
+                {
+                    var parts = token.Split('=');
+                    var ck = parts[0].ToLowerInvariant();
+                    var cv = parts.Length > 1 ? parts[1] : null;
+                    int Iv() => int.TryParse(cv, out var n) ? Math.Max(0, n) : 0;
+                    switch (ck)
+                    {
+                        case "albonus": albonus = Iv(); break;
+                        case "prot":
+                            if (double.TryParse(cv, System.Globalization.NumberStyles.Any,
+                                    System.Globalization.CultureInfo.InvariantCulture, out var pv))
+                                protOverride = pv;
+                            break;
+                        case "ward": ward = true; break;
+                        case "lifeprot": lifeprot = true; break;
+                        case "impen": impen = true; break;
+                        case "defcantrips": defcantrips = true; break;
+                        default:
+                            Msg($"asforge: unknown card '{ck}'. Cards: albonus prot ward lifeprot impen defcantrips.");
+                            return;
+                    }
+                }
+            }
+
+            var items = new List<WorldObject>();
+            bool AddPiece(string piece)
+            {
+                switch (piece)
+                {
+                    case "shirt": items.Add(BuildTestShirt(tierLabel)); return true;
+                    case "pants": items.Add(BuildTestPants(tierLabel)); return true;
+                    case "cloak": items.Add(BuildTestCloak(tierLabel)); return true;
+                    case "neck": items.Add(BuildTestNecklace(tierLabel)); return true;
+                    case "trinket": items.Add(BuildTestTrinket(tierLabel)); return true;
+                    case "ring":
+                        items.Add(BuildTestRing1(tierLabel));
+                        items.Add(BuildTestRing2(tierLabel));
+                        return true;
+                    case "bracelet":
+                        items.Add(BuildTestBracelet1(tierLabel));
+                        items.Add(BuildTestBracelet2(tierLabel));
+                        return true;
+                    default:
+                        foreach (var p in VodArmorPieces)
+                        {
+                            if (p.Key != piece) continue;
+                            items.Add(BuildVodArmorPiece(p.Wcid, p.Label, tierLabel));
+                            return true;
+                        }
+                        return false;
+                }
+            }
+            void AddSuit()
+            {
+                foreach (var p in VodArmorPieces)
+                    items.Add(BuildVodArmorPiece(p.Wcid, p.Label, tierLabel));
+                AddPiece("shirt");
+                AddPiece("pants");
+                AddPiece("cloak");
+            }
+            void AddJewel()
+            {
+                AddPiece("neck");
+                AddPiece("ring");
+                AddPiece("bracelet");
+                AddPiece("trinket");
+            }
+
+            switch (key)
+            {
+                case "suit": AddSuit(); break;
+                case "jewel": AddJewel(); break;
+                case "all": AddSuit(); AddJewel(); break;
+                default:
+                    if (!AddPiece(key))
+                    {
+                        Msg("asforge: unknown piece. Pieces: suit jewel all "
+                            + string.Join(" ", VodArmorPieces.Select(p => p.Key))
+                            + " shirt pants cloak neck ring bracelet trinket");
+                        return;
+                    }
+                    break;
+            }
+
+            var minted = 0;
+            var skipped = 0;
+            foreach (var wo in items)
+            {
+                if (wo == null)
+                {
+                    Msg("asforge: a piece failed to create (missing weenie?)");
+                    continue;
+                }
+
+                // Already held? Skip it. Every forged piece carries a unique tier-prefixed name
+                // ("T12 Ring 1", "T12 Helm (Test)"), so presence is an exact test - and the pair
+                // pieces cannot collide with each other.
+                if (!force && HasItemNamed(player, wo.Name))
+                {
+                    skipped++;
+                    wo.Destroy();
+                    continue;
+                }
+
+                // T11+ carry the per-tier item-aug wield gate like real drops (replacing the
+                // piece's authored skill req, same as the Creature_Death sweep does); the gate
+                // helper appends armor/jewelry's "Wield requires" LongDesc line itself.
+                if (tier >= 11)
+                {
+                    ACE.Server.Factories.LootGenerationFactory.StripWieldRequirements(wo);
+                    ACE.Server.Factories.LootGenerationFactory.ApplyT11WieldRequirement(wo, tier);
+                }
+
+                wo.Attuned = AttunedStatus.Attuned;
+                wo.Bonded = BondedStatus.Bonded;
+
+                // Pieces mint BARE first (owner 2026-08-02): spells, the full Gear* rating set
+                // and equipment-set membership (Dexterous etc.) all stripped — builders' loadout
+                // AND anything base-weenie-authored. The cards clause then layers the requested
+                // loadout back on. /testchar keeps its spells and ratings (it is the regression
+                // yardstick), so none of this lives in the shared builders.
+                wo.Biota.ClearSpells(wo.BiotaDatabaseLock);
+                foreach (var ratingProp in ForgeStrippedRatings)
+                    wo.RemoveProperty(ratingProp);
+                wo.RemoveProperty(PropertyInt.EquipmentSetId);
+
+                // T11+ deterministic per-tier budget - the SAME shared helper the loot path
+                // uses, so premades match drops exactly (owner 2026-08-21). Runs BEFORE the
+                // yardstick/rating cards so cards still win. Also stamps AL (doubling ladder)
+                // and the gear Creature Augs gate base. Tier 10 keeps the legacy path below.
+                if (tier >= 11)
+                    ACE.Server.Factories.LootGenerationFactory.ApplyT11GearStats(wo, tier, forceMax: true);   // forge = core four at window cap
+
+                // Rating cards (dresist/cdresist/maxhp/drating/cdrating) and the yardstick card were DELETED
+                // 2026-08-23: Live Stat Resolution overwrites those props from the record on equip/login.
+
+                // spell-suite cards: wards + life protections are wearer buffs — any piece
+                var isVodArmor = VodArmorPieces.Any(p => p.Wcid == wo.WeenieClassId);
+                if (ward)
+                    AddForgeSpells(wo, LegendaryWardSpells);
+                if (lifeprot)
+                    AddForgeSpells(wo, LifeProtectionSpells);
+                if (impen)
+                    AddForgeSpells(wo, ImpenSpells);
+                if (defcantrips)
+                    AddForgeSpells(wo, DefensiveCantripSpells);
+
+                // Owner defaults (2026-08-16): armor carries Legendary Impenetrability at EVERY
+                // tier (was T11+); the NECKLACE carries the shared buff suite (the only buff
+                // carrier — the trinket's old default suite is gone). Cards stay opt-in.
+                // GetOrAddKnownSpell dedups if the matching cards are also on.
+                if (isVodArmor)
+                    AddForgeSpells(wo, ImpenSpells);
+                if (wo.WeenieClassId == 27445)
+                    AddForgeSpells(wo, NecklaceBuffSpells);
+                wo.ChangesDetected = true;
+
+                // VoD armor pieces: per-tier AL baseline (tier x 100) + albonus card on top;
+                // protection = equalized to the mean (same as real T11+ drops), or the prot
+                // card's uniform override.
+                if (isVodArmor)
+                {
+                    if (tier >= 11)
+                    {
+                        // AL came from the shared budget (1100 doubling); albonus adds on top
+                        if (albonus != 0)
+                            wo.SetProperty(PropertyInt.ArmorLevel, (wo.ArmorLevel ?? 0) + albonus);
+                    }
+                    else
+                    {
+                        wo.SetProperty(PropertyInt.ArmorLevel, tier * 100 + albonus);
+                        ACE.Server.Factories.LootGenerationFactory.EqualizeT11ArmorResists(wo);
+                    }
+                    if (protOverride.HasValue)
+                        foreach (var modProp in ForgeArmorModVsProps)
+                            wo.SetProperty(modProp, protOverride.Value);
+                }
+
+                var provenance = $"Created by: {player.Name}\nTier: {tier}";
+                wo.LongDesc = string.IsNullOrEmpty(wo.LongDesc) ? provenance : wo.LongDesc + "\n" + provenance;
+
+                if (player.TryCreateInInventoryWithNetworking(wo))
+                {
+                    minted++;
+                }
+                else
+                {
+                    Msg($"asforge: could not place {wo.Name} in inventory (full?)");
+                    wo.Destroy();
+                }
+            }
+
+            EnsureWieldCounters(player, tier, Msg);
+            Msg($"asforged: {minted} item(s) at tier {tier} (attuned + bonded"
+                + (tier >= 11 ? ", item-aug wield gate" : ", basic set - no aug gate")
+                + (loadoutDesc.Length > 0 ? $") loadout: {loadoutDesc}" : ") bare"));
+
+            // Said plainly, because a silent no-op reads as a broken command.
+            if (skipped > 0)
+                Msg($"asforge: skipped {skipped} piece(s) you already hold. "
+                    + (minted == 0
+                        ? "Nothing was made. Trash the old set first, or add 'force' to mint anyway."
+                        : "Add 'force' to mint duplicates."));
+        }
+
+        /// <summary>`/asforge premade <tier 11-25> <avg|bis> [force]` (owner 2026-08-21; melee|caster still accepted silently):
+        /// the 18-piece roster with the cantrip lines written from the preset tables above instead of
+        /// rolled. Same bare-strip pipeline as the main verb (no cards), then the shared gear helper
+        /// (bis = core at cap, avg = core at the window midpoint), then explicit ZoneModifiers.Stamp
+        /// per line, FinalizeT11LongDesc (asforge proper never runs it - the stamps would otherwise
+        /// sit under inherited flavor text), then the forge provenance. Minted into a dedicated bag:
+        /// 18 items in one frame through the main-pack path is the silent-loss window.</summary>
+        private static void HandleAsForgePremade(Session session, Player player, string[] parameters)
+        {
+            void Msg(string s) => ChatPacket.SendServerMessage(session, s, ChatMessageType.Broadcast);
+
+            const string usage = "asforge premade <tier 10-25> <avg|bis> [force]";
+            if (parameters.Length < 3 || !int.TryParse(parameters[1], out var tier) || tier < 10 || tier > 25)
+            {
+                Msg($"Usage: {usage}");
+                return;
+            }
+            var modeArg = parameters[2].ToLowerInvariant();
+            bool bis;
+            switch (modeArg)
+            {
+                case "bis": case "best": bis = true; break;
+                case "avg": case "average": bis = false; break;
+                default:
+                    Msg($"asforge premade: mode must be avg or bis. {usage}");
+                    return;
+            }
+            var force = false;
+            foreach (var a in parameters.Skip(3))
+            {
+                switch (a.ToLowerInvariant())
+                {
+                    case "melee": case "caster": break;   // accepted and ignored - one BiS list since 2026-08-22
+                    case "force": force = true; break;
+                    default:
+                        Msg($"asforge premade: unknown option '{a}'. {usage}");
+                        return;
+                }
+            }
+            // T10 (2026-09-02, owner: "T10 premade is missing" for the entry-case test): the T11-25 path below
+            // reads every number off the anchored tier ladder, which clamps 10 up to 11 - so T10 is its own
+            // builder with the MEASURED T10-top values (ref-t10-best-geared-baseline, 2026-08-21).
+            if (tier == 10)
+            {
+                HandleAsForgePremadeT10(session, player, bis, force);
+                return;
+            }
+
+            var tierLabel = $"T{tier}";
+            var modeTag = bis ? "BiS" : "Avg";
+
+            // the `all` roster, in deal order (armor first so the Aegis lines land where AL lives)
+            var roster = new List<(string Piece, WorldObject Wo)>();
+            foreach (var p in VodArmorPieces)
+                roster.Add((p.Label, BuildVodArmorPiece(p.Wcid, p.Label, tierLabel)));
+            roster.Add(("Shirt", BuildTestShirt(tierLabel)));
+            roster.Add(("Pants", BuildTestPants(tierLabel)));
+            roster.Add(("Cloak", BuildTestCloak(tierLabel)));
+            roster.Add(("Necklace", BuildTestNecklace(tierLabel)));
+            roster.Add(("Ring 1", BuildTestRing1(tierLabel)));
+            roster.Add(("Ring 2", BuildTestRing2(tierLabel)));
+            roster.Add(("Bracelet 1", BuildTestBracelet1(tierLabel)));
+            roster.Add(("Bracelet 2", BuildTestBracelet2(tierLabel)));
+            roster.Add(("Trinket", BuildTestTrinket(tierLabel)));
+
+            // names carry the mode so Avg and BiS at one tier never collide on the duplicate guard
+            foreach (var (piece, wo) in roster)
+            {
+                if (wo == null) continue;
+                var name = $"{tierLabel} {piece} ({modeTag})";
+                wo.Name = name;
+                wo.SetProperty(PropertyString.Name, name);
+            }
+
+            // Average deal needs to know which pieces carry AL BEFORE the gear helper runs: only
+            // ItemType.Armor gets the flat ladder (clothing never, jewelry by engine rule).
+            var hasAl = roster.Select(r => r.Wo != null && r.Wo.ItemType == ItemType.Armor).ToArray();
+            var avgDeal = bis ? null : PremadeDealAverage(tier, hasAl);
+            var bisKeys = PremadeBisLines;
+            var bisCount = Math.Min(PremadeLineMax(tier), bisKeys.Length);
+
+            // owner 2026-09-03: premade pieces mint loose into the MAIN pack - no suit bag is ever created
+            var minted = 0;
+            var skipped = 0;
+            var failed = 0;
+            var lines = 0;
+            for (var i = 0; i < roster.Count; i++)
+            {
+                var (piece, wo) = roster[i];
+                if (wo == null)
+                {
+                    Msg($"asforge premade: {piece} failed to create (missing weenie?)");
+                    failed++;
+                    continue;
+                }
+
+                if (!force && HasItemNamed(player, wo.Name))
+                {
+                    skipped++;
+                    wo.Destroy();
+                    continue;
+                }
+
+                // per-tier item-aug wield gate like real drops (the helper appends its own LongDesc line)
+                ACE.Server.Factories.LootGenerationFactory.StripWieldRequirements(wo);
+                ACE.Server.Factories.LootGenerationFactory.ApplyT11WieldRequirement(wo, tier);
+
+                wo.Attuned = AttunedStatus.Attuned;
+                wo.Bonded = BondedStatus.Bonded;
+
+                // bare first, exactly as the main verb: spells, every Gear* rating, set membership
+                wo.Biota.ClearSpells(wo.BiotaDatabaseLock);
+                foreach (var ratingProp in ForgeStrippedRatings)
+                    wo.RemoveProperty(ratingProp);
+                wo.RemoveProperty(PropertyInt.EquipmentSetId);
+
+                // core four: bis = window cap (forceMax), avg = window midpoint (coreFrac 0.5);
+                // also AL ladder + the gear Creature Augs base
+                ACE.Server.Factories.LootGenerationFactory.ApplyT11GearStats(wo, tier,
+                    forceMax: bis, p: null, coreFrac: bis ? null : 0.5);
+
+                // the explicit lines - graded (live stat resolution 2026-08-22): bis = grade 1000, avg = 500,
+                // stamped through the ZcModifiers record; each key at most once per piece
+                // TRUE BiS (owner 2026-08-23): the first PremadeLineMax(tier) keys THIS PIECE CAN CARRY, not the
+                // first N then skip - armor fills its 7th slot with Reinforced, jewelry with Life on Hit.
+                IEnumerable<int> keys = bis ? bisKeys.Where(k => PremadeKeyAllowed(k, wo, tier)).Take(bisCount) : avgDeal[i];
+                var stamped = new HashSet<int>();
+                foreach (var k in keys)
+                {
+                    if (!stamped.Add(k)) continue;
+                    if (!ACE.Server.Managers.ZoneControl.ZoneModifiers.TryGet(k, out var def) || def.SlotSpecial)
+                    {
+                        Msg($"asforge premade: key {k} is not a live pool line - skipped on {piece}");
+                        continue;
+                    }
+                    if (!PremadeKeyAllowed(k, wo, tier))
+                        continue;
+                    var (bMin, bMax) = PremadeBand(k, tier);
+                    var grade = bis ? ACE.Server.Managers.ZoneControl.ZoneStatResolver.GradeMax
+                                    : ACE.Server.Managers.ZoneControl.ZoneStatResolver.GradeMax / 2;
+                    ACE.Server.Managers.ZoneControl.ZoneModifiers.StampGraded(wo, def, grade,
+                        ((int)Math.Round(bMin), (int)Math.Round(bMax)));
+                    lines++;
+                }
+
+                // TRUE BiS (owner 2026-08-23): every enabled slot special on its home piece at grade max, rolled
+                // in the tier's band exactly as a drop would (Default override, else the tier-scaled catalog band)
+                if (bis)
+                {
+                    var dflt = ACE.Server.Managers.ZoneControl.ZoneControlManager.GetVariationDefault(tier)?.Profile;
+                    foreach (var sdef in ACE.Server.Managers.ZoneControl.ZoneModifiers.SlotSpecials())
+                    {
+                        if (dflt?.CustomSpecials != null && dflt.CustomSpecials.TryGetValue(sdef.Key, out var on) && !on)
+                            continue;
+                        var slotId = ACE.Server.Managers.ZoneControl.ZoneModifiers.EffectiveSpecialSlot(sdef, dflt?.CustomModifierSlots);
+                        if (!ACE.Server.Managers.ZoneControl.ZoneModifiers.SpecialPieceMatches(wo, slotId))
+                            continue;
+                        var (sMin, sMax) = dflt?.CustomModifierBands != null && dflt.CustomModifierBands.TryGetValue(sdef.Key, out var sBand)
+                            ? (sBand.Min, sBand.Max) : ACE.Server.Managers.ZoneControl.ZoneModifiers.CatalogBandAt(sdef, tier);
+                        if (sMin > sMax) (sMin, sMax) = (sMax, sMin);
+                        ACE.Server.Managers.ZoneControl.ZoneModifiers.StampGraded(wo, sdef,
+                            ACE.Server.Managers.ZoneControl.ZoneStatResolver.GradeMax, (sMin, sMax));
+                        lines++;
+                    }
+                }
+
+                // owner defaults as the main verb: armor carries Legendary Impen, the necklace the buff suite
+                if (VodArmorPieces.Any(p => p.Wcid == wo.WeenieClassId))
+                    AddForgeSpells(wo, ImpenSpells);
+                if (wo.WeenieClassId == 27445)
+                    AddForgeSpells(wo, NecklaceBuffSpells);
+                wo.ChangesDetected = true;
+
+                // drop-style description: known lines in stamp order, inherited flavor text gone.
+                // Provenance goes AFTER - Finalize's whitelist would discard it.
+                ACE.Server.Factories.LootGenerationFactory.FinalizeT11LongDesc(wo);
+                var provenance = $"Created by: {player.Name}\nTier: {tier}\nPremade: {modeTag}";
+                wo.LongDesc = string.IsNullOrEmpty(wo.LongDesc) ? provenance : wo.LongDesc + "\n\n" + provenance;
+
+                if (player.TryCreateInInventoryWithNetworking(wo))
+                {
+                    minted++;
+                }
+                else
+                {
+                    Msg($"asforge premade: could not place {wo.Name} anywhere (inventory full) - destroyed.");
+                    wo.Destroy();
+                    failed++;
+                }
+            }
+
+            EnsureWieldCounters(player, tier, Msg);
+            Msg($"Premade {tierLabel} {modeTag} suit: {minted} pieces created"
+                + (lines > 0 ? $", {lines} modifier lines" : "")
+                + (failed > 0 ? $", {failed} failed" : "")
+                + (skipped > 0 ? $", {skipped} skipped (already held - add 'force' to re-mint)" : "")
+                + (minted > 0 ? " - in your main pack." : "."));
+        }
+
+        /// <summary>
+        /// `/asforge premade 10 <avg|bis> [force]` (2026-09-02): the T10 ENTRY-CASE suit - what a well-geared
+        /// T10 player brings into T11. Numbers are the MEASURED top T10 sets (Drexel / Nerd Parade, pulled
+        /// from the shard 2026-08-21, ref-t10-best-geared-baseline): gear-set totals Dmg ~205, DR ~88,
+        /// CritDmg ~200, CritDR ~73, Crit 40, CritRes 19, HealBoost 355, AL ~6,200 over 12 armor pieces.
+        /// BiS = those totals spread over the 18 pieces; Avg = about 70 pct of them (GOM-class). Ratings go
+        /// on as plain Gear* props (the worn-sum reads them exactly as retail cantrips' ratings), AL as the
+        /// piece's ArmorLevel. No modifier lines, no wield gate, no slot specials - T10 has none of those.
+        /// The Aetheria surge (the other half of T10 feel) comes from /testchar's T10 aetheria package.
+        /// </summary>
+        private static void HandleAsForgePremadeT10(Session session, Player player, bool bis, bool force)
+        {
+            void Msg(string s) => ChatPacket.SendServerMessage(session, s, ChatMessageType.Broadcast);
+            const string tierLabel = "T10";
+            var modeTag = bis ? "BiS" : "Avg";
+            // per-piece values (18 pieces; AL on the 9 VoD armor pieces + shirt/pants count as 12 AL carriers
+            // in the measured sets, here the 9 armor pieces carry it at 12/9 the per-piece share)
+            int dmg = bis ? 12 : 8, critDmg = bis ? 11 : 8, dr = bis ? 5 : 3, cdr = bis ? 4 : 3,
+                crit = bis ? 2 : 1, critRes = bis ? 1 : 1, heal = bis ? 20 : 14;
+            int al = bis ? 690 : 560;   // 9 pieces x 690 = 6,210 (Nerd Parade 6,482 over 12 pcs); avg = GOM 5,021
+
+            var roster = new List<(string Piece, WorldObject Wo)>();
+            foreach (var p in VodArmorPieces)
+                roster.Add((p.Label, BuildVodArmorPiece(p.Wcid, p.Label, tierLabel)));
+            roster.Add(("Shirt", BuildTestShirt(tierLabel)));
+            roster.Add(("Pants", BuildTestPants(tierLabel)));
+            roster.Add(("Cloak", BuildTestCloak(tierLabel)));
+            roster.Add(("Necklace", BuildTestNecklace(tierLabel)));
+            roster.Add(("Ring 1", BuildTestRing1(tierLabel)));
+            roster.Add(("Ring 2", BuildTestRing2(tierLabel)));
+            roster.Add(("Bracelet 1", BuildTestBracelet1(tierLabel)));
+            roster.Add(("Bracelet 2", BuildTestBracelet2(tierLabel)));
+            roster.Add(("Trinket", BuildTestTrinket(tierLabel)));
+            foreach (var (piece, wo) in roster)
+            {
+                if (wo == null) continue;
+                var name = $"{tierLabel} {piece} ({modeTag})";
+                wo.Name = name;
+                wo.SetProperty(PropertyString.Name, name);
+            }
+
+            // owner 2026-09-03: premade pieces mint loose into the MAIN pack - no suit bag is ever created
+            int minted = 0, skipped = 0, failed = 0;
+            foreach (var (piece, wo) in roster)
+            {
+                if (wo == null) { Msg($"asforge premade: {piece} failed to create (missing weenie?)"); failed++; continue; }
+                if (!force && HasItemNamed(player, wo.Name)) { skipped++; wo.Destroy(); continue; }
+
+                // T10 = the basic set: no item-aug wield gate at all (matches the main verb's tier-10 rule)
+                ACE.Server.Factories.LootGenerationFactory.StripWieldRequirements(wo);
+                wo.Attuned = AttunedStatus.Attuned;
+                wo.Bonded = BondedStatus.Bonded;
+                wo.Biota.ClearSpells(wo.BiotaDatabaseLock);
+                foreach (var ratingProp in ForgeStrippedRatings)
+                    wo.RemoveProperty(ratingProp);
+                wo.RemoveProperty(PropertyInt.EquipmentSetId);
+
+                // the measured ratings, as plain worn-sum props
+                wo.SetProperty(PropertyInt.GearDamage, dmg);
+                wo.SetProperty(PropertyInt.GearCritDamage, critDmg);
+                wo.SetProperty(PropertyInt.GearDamageResist, dr);
+                wo.SetProperty(PropertyInt.GearCritDamageResist, cdr);
+                wo.SetProperty(PropertyInt.GearCrit, crit);
+                wo.SetProperty(PropertyInt.GearCritResist, critRes);
+                wo.SetProperty(PropertyInt.GearHealingBoost, heal);
+                if (wo.ItemType == ItemType.Armor && VodArmorPieces.Any(p => p.Wcid == wo.WeenieClassId))
+                    wo.ArmorLevel = al;
+
+                // owner defaults as the main verb: armor carries Legendary Impen, the necklace the buff suite
+                if (VodArmorPieces.Any(p => p.Wcid == wo.WeenieClassId))
+                    AddForgeSpells(wo, ImpenSpells);
+                if (wo.WeenieClassId == 27445)
+                    AddForgeSpells(wo, NecklaceBuffSpells);
+                wo.ChangesDetected = true;
+                wo.LongDesc = $"T10 entry-case premade ({modeTag}): the measured top T10 set (2026-08-21) spread over 18 pieces.\n"
+                            + $"Dmg +{dmg}  CritDmg +{critDmg}  DR +{dr}  CritDR +{cdr}  Crit +{crit}  CritRes +{critRes}  Heal +{heal}"
+                            + (wo.ItemType == ItemType.Armor ? $"  AL {al}" : "")
+                            + $"\n\nCreated by: {player.Name}\nTier: 10\nPremade: {modeTag}";
+
+                if (player.TryCreateInInventoryWithNetworking(wo)) minted++;
+                else { Msg($"asforge premade: could not place {wo.Name} anywhere (inventory full) - destroyed."); wo.Destroy(); failed++; }
+            }
+            Msg($"Premade {tierLabel} {modeTag} suit: {minted} pieces created"
+                + (failed > 0 ? $", {failed} failed" : "")
+                + (skipped > 0 ? $", {skipped} skipped (already held - add 'force' to re-mint)" : "")
+                + (minted > 0 ? $" - in your main pack. Set totals: Dmg {dmg * 18} CritDmg {critDmg * 18} DR {dr * 18} CritDR {cdr * 18} Crit {crit * 18} CritRes {critRes * 18} Heal {heal * 18}, AL {al} x 9. Pair with /testchar T10 (aetheria surge) and /wsforge <weapon> 10." : "."));
         }
 
         private static void SpawnCharms(Player player)
         {
             if (HasItemNamed(player, "Ability Charms Pack")) return;
 
-            var rucksack = WorldObjectFactory.CreateNewWorldObject(310025) as Container;
-            if (rucksack != null)
-            {
-                rucksack.Name = "Ability Charms Pack";
-                rucksack.SetProperty(PropertyString.Name, "Ability Charms Pack");
-                rucksack.SetProperty(PropertyInt.MaterialType, 0);
-            }
+            var rucksack = GetOrCreatePack(player, "Ability Charms Pack");
 
             var charmWcids = new List<uint>()
             {
@@ -1017,12 +1931,7 @@ namespace ACE.Server.Command.Handlers
             {
                 var charm = WorldObjectFactory.CreateNewWorldObject(wcid);
                 if (charm != null)
-                {
-                    if (rucksack != null)
-                        rucksack.TryAddToInventory(charm);
-                    else
-                        player.TryCreateInInventoryWithNetworking(charm);
-                }
+                    PlaceInPackOrLoose(player, charm, rucksack);
             }
 
             // 1000x Charm Catalyst
@@ -1031,15 +1940,7 @@ namespace ACE.Server.Command.Handlers
             {
                 catalyst.SetProperty(PropertyInt.StackSize, 1000);
                 catalyst.SetProperty(PropertyInt.EncumbranceVal, (catalyst.StackUnitEncumbrance ?? 5) * 1000);
-                if (rucksack != null)
-                    rucksack.TryAddToInventory(catalyst);
-                else
-                    player.TryCreateInInventoryWithNetworking(catalyst);
-            }
-
-            if (rucksack != null)
-            {
-                player.TryCreateInInventoryWithNetworking(rucksack);
+                PlaceInPackOrLoose(player, catalyst, rucksack);
             }
 
             SpawnSpellcastingConsumables(player);
@@ -1048,6 +1949,11 @@ namespace ACE.Server.Command.Handlers
         private static void SpawnSpellcastingConsumables(Player player)
         {
             var possessions = player.GetAllPossessionsDeep().ToList();
+
+            // Comps go into their own pack (owner 08-15)
+            var compsPack = GetOrCreatePack(player, "Spell Comps Pack");
+
+            void AddComp(WorldObject item) => PlaceInPackOrLoose(player, item, compsPack);
 
             // 1. Tapers (1000 Prismatic Tapers)
             var targetTapers = 1000;
@@ -1062,7 +1968,7 @@ namespace ACE.Server.Command.Handlers
                     var maxStack = taper.MaxStackSize ?? 1000;
                     var toSpawn = Math.Min(needed, maxStack);
                     taper.SetStackSize(toSpawn);
-                    player.TryCreateInInventoryWithNetworking(taper);
+                    AddComp(taper);
                     needed -= toSpawn;
                 }
             }
@@ -1084,16 +1990,60 @@ namespace ACE.Server.Command.Handlers
                         var maxStack = scarab.MaxStackSize ?? 100;
                         var toSpawn = Math.Min(needed, maxStack);
                         scarab.SetStackSize(toSpawn);
-                        player.TryCreateInInventoryWithNetworking(scarab);
+                        AddComp(scarab);
                         needed -= toSpawn;
                     }
                 }
             }
+
         }
 
         private static void AddItemToInventory(Player player, WorldObject item)
         {
             player.TryCreateInInventoryWithNetworking(item);
+        }
+
+        /// <summary>Finds an existing 102-slot pack (wcid 310025) by name anywhere in the player's
+        /// possessions, or creates one IN the player's inventory (wsforge GetOrCreateForgePack
+        /// pattern — the pack must be live before TryPlaceInPack's client messages make sense).
+        /// Returns null when no pack slot is free — callers fall back to the main pack.</summary>
+        private static Container GetOrCreatePack(Player player, string name, string legacyName = null)
+        {
+            var pack = player.GetAllPossessionsDeep().OfType<Container>()
+                .FirstOrDefault(c => c.Name == name || (legacyName != null && c.Name == legacyName));
+            if (pack != null) return pack;
+
+            if (!(WorldObjectFactory.CreateNewWorldObject(310025) is Container bag)) return null;
+            bag.Name = name;
+            bag.SetProperty(PropertyString.Name, name);
+            bag.SetProperty(PropertyInt.MaterialType, 0);
+            if (player.TryCreateInInventoryWithNetworking(bag))
+                return bag;
+            bag.Destroy();   // no free pack slot
+            return null;
+        }
+
+        /// <summary>Place a freshly minted item into a pack the player already holds. Same as
+        /// WeaponScalingCommands.TryPlaceInPack: TryCreateInInventoryWithNetworking only targets
+        /// "main pack, else first side pack with room", so the client updates are sent by hand.</summary>
+        private static bool TryPlaceInPack(Player player, WorldObject wo, Container pack)
+        {
+            if (pack == null || !pack.TryAddToInventory(wo))
+                return false;
+
+            player.Session.Network.EnqueueSend(new GameMessageCreateObject(wo));
+            player.Session.Network.EnqueueSend(
+                new GameEventItemServerSaysContainId(player.Session, wo, pack),
+                new GameMessagePrivateUpdatePropertyInt(player, PropertyInt.EncumbranceVal, player.EncumbranceVal ?? 0));
+            wo.SaveBiotaToDatabase();
+            return true;
+        }
+
+        /// <summary>Pack an item, falling back loose to the main pack when the pack is missing/full.</summary>
+        private static void PlaceInPackOrLoose(Player player, WorldObject wo, Container pack)
+        {
+            if (!TryPlaceInPack(player, wo, pack))
+                player.TryCreateInInventoryWithNetworking(wo);
         }
 
         private static bool HasItemNamed(Player player, string name)
@@ -1200,443 +2150,6 @@ namespace ACE.Server.Command.Handlers
             }
         }
 
-        private static void SpawnWeapons(Player player, string targetStyle)
-        {
-            var rucksackName = "Weapons Pack";
-            if (HasItemNamed(player, rucksackName)) return;
-            var rucksack = WorldObjectFactory.CreateNewWorldObject(310025) as Container;
-            if (rucksack != null)
-            {
-                rucksack.Name = rucksackName;
-                rucksack.SetProperty(PropertyString.Name, rucksackName);
-                rucksack.SetProperty(PropertyInt.MaterialType, 0);
-            }
-
-            var weaponBases = new Dictionary<string, (uint wcid, string baseName)>()
-            {
-                { "UA", (29651, "Spiked Knuckles") },
-                { "2H", (46105, "Atlan Two Handed Sword") },
-                { "Bow", (29639, "Bow") },
-                { "Wand", (29661, "Wand") }
-            };
-
-            var elements = new List<DamageType>()
-            {
-                DamageType.Slash,
-                DamageType.Pierce,
-                DamageType.Bludgeon,
-                DamageType.Cold,
-                DamageType.Fire,
-                DamageType.Acid,
-                DamageType.Electric,
-                DamageType.Nether
-            };
-
-            foreach (var baseKvp in weaponBases)
-            {
-                var weaponType = baseKvp.Key;
-                var baseWcid = baseKvp.Value.wcid;
-                var baseName = baseKvp.Value.baseName;
-
-                // If style filter is provided, skip non-matching styles
-                if (targetStyle != null && !weaponType.Equals(targetStyle, StringComparison.OrdinalIgnoreCase))
-                    continue;
-
-                foreach (var element in elements)
-                {
-                    if (weaponType.Equals("Bow", StringComparison.OrdinalIgnoreCase))
-                    {
-                        CreateCustomBow(player, element, true, rucksack);
-                    }
-                    else if (weaponType.Equals("UA", StringComparison.OrdinalIgnoreCase))
-                    {
-                        CreateCustomUA(player, element, rucksack);
-                    }
-                    else if (weaponType.Equals("Wand", StringComparison.OrdinalIgnoreCase))
-                    {
-                        CreateCustomWand(player, element, rucksack);
-                    }
-                    else
-                    {
-                        var weapon = WorldObjectFactory.CreateNewWorldObject(baseWcid);
-                        if (weapon != null)
-                        {
-                            weapon.SetProperty(PropertyInt.DamageType, (int)element);
-                            var elementLabel = GetElementLabel(element);
-                            string label = weaponType.Equals("2H", StringComparison.OrdinalIgnoreCase) ? "2H" : baseName;
-                            weapon.Name = $"{elementLabel} {label} (Test)";
-                            weapon.SetProperty(PropertyString.Name, $"{elementLabel} {label} (Test)");
-                            weapon.SetProperty(PropertyInt.MaterialType, 0); // Suppress material prefix
-                            if (rucksack != null)
-                                rucksack.TryAddToInventory(weapon);
-                            else
-                                player.TryCreateInInventoryWithNetworking(weapon);
-                        }
-                    }
-                }
-            }
-
-            if (targetStyle == null || targetStyle.Equals("UA", StringComparison.OrdinalIgnoreCase))
-            {
-                SpawnHilts(player, rucksack);
-            }
-
-            if (rucksack != null)
-            {
-                player.TryCreateInInventoryWithNetworking(rucksack);
-            }
-        }
-
-        private static void CreateCustomBow(Player player, DamageType element, bool includeRend = true, Container destination = null)
-        {
-            uint baseWcid = 46139;
-            string elementLabel = GetElementLabel(element);
-            var expectedName = $"{elementLabel} Bow (Test)";
-            if (HasItemNamed(player, expectedName)) return;
-
-            var bow = WorldObjectFactory.CreateNewWorldObject(baseWcid);
-            if (bow == null) return;
-            bow.Name = $"{elementLabel} Bow (Test)";
-            bow.SetProperty(PropertyString.Name, $"{elementLabel} Bow (Test)");
-            bow.SetProperty(PropertyInt.MaterialType, 0); // Suppress material prefix
-
-            // Get matching rend background underlay
-            ImbuedEffectType rendType = ImbuedEffectType.Undef;
-
-            if (includeRend)
-            {
-                switch (element)
-                {
-                    case DamageType.Slash:
-                        rendType = ImbuedEffectType.SlashRending;
-                        break;
-                    case DamageType.Pierce:
-                        rendType = ImbuedEffectType.PierceRending;
-                        break;
-                    case DamageType.Bludgeon:
-                        rendType = ImbuedEffectType.BludgeonRending;
-                        break;
-                    case DamageType.Cold:
-                        rendType = ImbuedEffectType.ColdRending;
-                        break;
-                    case DamageType.Fire:
-                        rendType = ImbuedEffectType.FireRending;
-                        break;
-                    case DamageType.Acid:
-                        rendType = ImbuedEffectType.AcidRending;
-                        break;
-                    case DamageType.Electric:
-                        rendType = ImbuedEffectType.ElectricRending;
-                        break;
-                    case DamageType.Nether:
-                        rendType = ImbuedEffectType.NetherRending;
-                        break;
-                }
-            }
-
-            if (includeRend && rendType != ImbuedEffectType.Undef)
-            {
-                if (ACE.Server.Managers.RecipeManager.IconUnderlay.TryGetValue(rendType, out var underlayId))
-                {
-                    bow.IconUnderlayId = underlayId;
-                }
-                else if (rendType == ImbuedEffectType.NetherRending)
-                {
-                    bow.IconUnderlayId = 0x060067A1; // Nether Rending underlay icon
-                }
-            }
-
-            if (includeRend)
-            {
-                bow.SetProperty(PropertyString.LongDesc, $"{elementLabel} Bow (Test) of Swift Killer, set with 1 Emerald");
-            }
-            else
-            {
-                bow.SetProperty(PropertyString.LongDesc, $"{elementLabel} Bow (Test) of Swift Killer");
-            }
-
-            // Int Properties
-            bow.SetProperty(PropertyInt.DamageType, (int)element);
-            bow.SetProperty(PropertyInt.WieldDifficulty, 725);
-            bow.SetProperty(PropertyInt.GearCritDamage, 3);
-            bow.SetProperty(PropertyInt.ElementalDamageBonus, 31);
-            bow.SetProperty(PropertyInt.Cleaving, 3);
-            if (includeRend && rendType != ImbuedEffectType.Undef)
-            {
-                bow.SetProperty(PropertyInt.ImbuedEffect, (int)rendType);
-            }
-            bow.SetProperty(PropertyInt.ImbuedEffect2, (int)ImbuedEffectType.MagicDefense); // 4096 is MagicDefense
-            bow.SetProperty(PropertyInt.NumTimesTinkered, 10);
-
-            // Float Properties
-            bow.SetProperty(PropertyFloat.DamageMod, 3.39f);
-            bow.SetProperty(PropertyFloat.WeaponDefense, 1.29f);
-            bow.SetProperty(PropertyFloat.CriticalFrequency, 0.33f);
-            bow.SetProperty(PropertyFloat.CriticalMultiplier, 2.25f);
-
-            // Split Arrow custom properties
-            bow.SetProperty(PropertyBool.SplitArrows, true);
-            bow.SetProperty(PropertyInt.SplitArrowCount, 3);
-            bow.SetProperty(PropertyFloat.SplitArrowRange, 8.0f);
-            bow.SetProperty(PropertyFloat.SplitArrowDamageMultiplier, 0.95f);
-
-            // Bow Spells
-            bow.Biota.ClearSpells(bow.BiotaDatabaseLock);
-            var bowSpells = new List<uint>()
-            {
-                6089, // Legendary Blood Thirst (CantripBloodThirst4)
-            };
-
-            foreach (var spellId in bowSpells)
-            {
-                bow.Biota.GetOrAddKnownSpell((int)spellId, bow.BiotaDatabaseLock, out _);
-            }
-            bow.ChangesDetected = true;
-            bow.UiEffects = UiEffects.Magical;
-
-            if (destination != null)
-                destination.TryAddToInventory(bow);
-            else
-                player.TryCreateInInventoryWithNetworking(bow);
-        }
-
-        private static void CreateCustomUA(Player player, DamageType element, Container destination = null)
-        {
-            uint baseWcid = 6171;
-            string elementLabel = GetElementLabel(element);
-            string weaponName = $"{elementLabel} UA (Test)";
-            if (HasItemNamed(player, weaponName)) return;
-
-            var claw = WorldObjectFactory.CreateNewWorldObject(baseWcid);
-            if (claw == null) return;
-
-            claw.Name = weaponName;
-            claw.SetProperty(PropertyString.Name, weaponName);
-            claw.SetProperty(PropertyString.LongDesc, $"{weaponName} of Defender, set with 4 Rubies");
-
-            // Get matching rend background underlay
-            ImbuedEffectType rendType = ImbuedEffectType.Undef;
-            switch (element)
-            {
-                case DamageType.Slash:
-                    rendType = ImbuedEffectType.SlashRending;
-                    break;
-                case DamageType.Pierce:
-                    rendType = ImbuedEffectType.PierceRending;
-                    break;
-                case DamageType.Bludgeon:
-                    rendType = ImbuedEffectType.BludgeonRending;
-                    break;
-                case DamageType.Cold:
-                    rendType = ImbuedEffectType.ColdRending;
-                    break;
-                case DamageType.Fire:
-                    rendType = ImbuedEffectType.FireRending;
-                    break;
-                case DamageType.Acid:
-                    rendType = ImbuedEffectType.AcidRending;
-                    break;
-                case DamageType.Electric:
-                    rendType = ImbuedEffectType.ElectricRending;
-                    break;
-                case DamageType.Nether:
-                    rendType = ImbuedEffectType.NetherRending;
-                    break;
-            }
-
-            if (rendType != ImbuedEffectType.Undef)
-            {
-                if (ACE.Server.Managers.RecipeManager.IconUnderlay.TryGetValue(rendType, out var underlayId))
-                {
-                    claw.IconUnderlayId = underlayId;
-                }
-                else if (rendType == ImbuedEffectType.NetherRending)
-                {
-                    claw.IconUnderlayId = 0x060067A1; // Nether Rending underlay icon
-                }
-            }
-
-            // Int Properties
-            claw.SetProperty(PropertyInt.DamageType, (int)element);
-            claw.SetProperty(PropertyInt.Damage, 130);
-            claw.SetProperty(PropertyInt.WieldDifficulty, 800);
-            claw.SetProperty(PropertyInt.WieldRequirements, 2);
-            claw.SetProperty(PropertyInt.WieldSkillType, 46);
-            claw.SetProperty(PropertyInt.GearCritDamage, 3);
-            claw.SetProperty(PropertyInt.GemCount, 4);
-            claw.SetProperty(PropertyInt.GemType, 38);
-            claw.SetProperty(PropertyInt.Cleaving, 3); // Cleaving
-            if (rendType != ImbuedEffectType.Undef)
-            {
-                claw.SetProperty(PropertyInt.ImbuedEffect, (int)rendType);
-            }
-            claw.SetProperty(PropertyInt.ItemCurMana, 1402);
-            claw.SetProperty(PropertyInt.ItemMaxMana, 1814);
-            claw.SetProperty(PropertyInt.ItemSpellcraft, 370);
-            claw.SetProperty(PropertyInt.ItemWorkmanship, 9);
-            claw.SetProperty(PropertyInt.MaterialType, 0); // Suppress material prefix
-            claw.SetProperty(PropertyInt.NumTimesTinkered, 10);
-            claw.SetProperty(PropertyInt.Value, 0); // Sets value to 0
-            claw.SetProperty(PropertyInt.Bonded, 1);
-            claw.SetProperty(PropertyInt.Attuned, 1);
-            claw.SetProperty(PropertyInt.AttackType, 486); // Fine Bandit Hilt multi-strike attack style
-            claw.SetProperty(PropertyInt.WieldRequirements2, 8);
-            claw.SetProperty(PropertyInt.WieldSkillType2, 46);
-            claw.SetProperty(PropertyInt.WieldDifficulty2, 3);
-            claw.SetProperty(PropertyBool.Ivoryable, true);
-
-            // Float Properties
-            claw.SetProperty(PropertyFloat.DamageMod, 1.075f); // Base 1.0f + 0.075f from Recipe 527870096
-            claw.SetProperty(PropertyFloat.DamageVariance, 0.53076923f);
-            claw.SetProperty(PropertyFloat.ManaRate, -0.06666667f);
-            claw.SetProperty(PropertyFloat.WeaponDefense, 1.29f);
-            claw.SetProperty(PropertyFloat.WeaponMagicDefense, 1.04f);
-            claw.SetProperty(PropertyFloat.CriticalFrequency, 0.58f); // Base 0.33f + 0.25f from Recipe 527870096
-            claw.SetProperty(PropertyFloat.CriticalMultiplier, 2.425f); // Base 2.25f + 0.175f from Recipe 527870096
-            claw.SetProperty(PropertyFloat.ManaStoneDestroyChance, 0.01f);
-
-            // Claw Spells
-            claw.Biota.ClearSpells(claw.BiotaDatabaseLock);
-            var clawSpells = new List<uint>()
-            {
-                6089, // Legendary Blood Thirst (CantripBloodThirst4)
-            };
-
-            foreach (var spellId in clawSpells)
-            {
-                claw.Biota.GetOrAddKnownSpell((int)spellId, claw.BiotaDatabaseLock, out _);
-            }
-            claw.ChangesDetected = true;
-            claw.UiEffects = UiEffects.Magical;
-
-            if (destination != null)
-                destination.TryAddToInventory(claw);
-            else
-                player.TryCreateInInventoryWithNetworking(claw);
-        }
-
-        private static void CreateCustomWand(Player player, DamageType element, Container destination = null)
-        {
-            uint baseWcid = 46122;
-            string elementLabel = GetElementLabel(element);
-            string weaponName = $"{elementLabel} Wand (Test)";
-            if (HasItemNamed(player, weaponName)) return;
-
-            var wand = WorldObjectFactory.CreateNewWorldObject(baseWcid);
-            if (wand == null) return;
-
-            wand.Name = weaponName;
-            wand.SetProperty(PropertyString.Name, weaponName);
-            wand.SetProperty(PropertyString.LongDesc, $"{weaponName} of Corrosion, set with 2 Peridots");
-
-            // Underlays
-            ImbuedEffectType rendType = element switch
-            {
-                DamageType.Slash => ImbuedEffectType.SlashRending,
-                DamageType.Pierce => ImbuedEffectType.PierceRending,
-                DamageType.Bludgeon => ImbuedEffectType.BludgeonRending,
-                DamageType.Cold => ImbuedEffectType.ColdRending,
-                DamageType.Fire => ImbuedEffectType.FireRending,
-                DamageType.Acid => ImbuedEffectType.AcidRending,
-                DamageType.Electric => ImbuedEffectType.ElectricRending,
-                DamageType.Nether => ImbuedEffectType.NetherRending,
-                _ => ImbuedEffectType.Undef
-            };
-
-            if (rendType != ImbuedEffectType.Undef)
-            {
-                if (ACE.Server.Managers.RecipeManager.IconUnderlay.TryGetValue(rendType, out var underlayId))
-                {
-                    wand.IconUnderlayId = underlayId;
-                }
-                else if (rendType == ImbuedEffectType.NetherRending)
-                {
-                    wand.IconUnderlayId = 0x060067A1; // Nether Rending underlay icon
-                }
-            }
-
-            // Int Properties
-            wand.SetProperty(PropertyInt.DamageType, (int)element);
-            wand.SetProperty(PropertyInt.WieldDifficulty, 650);
-            wand.SetProperty(PropertyInt.WieldRequirements, 2);
-            wand.SetProperty(PropertyInt.WieldSkillType, element == DamageType.Nether ? (int)43 : (int)34); // Void Magic or Mana Conversion
-            wand.SetProperty(PropertyInt.GearCritDamage, 3);
-            wand.SetProperty(PropertyInt.GemCount, 2);
-            wand.SetProperty(PropertyInt.GemType, 34); // Peridot
-            if (rendType != ImbuedEffectType.Undef)
-            {
-                wand.SetProperty(PropertyInt.ImbuedEffect, (int)rendType);
-            }
-            wand.SetProperty(PropertyInt.ImbuedEffect2, (int)ImbuedEffectType.MagicDefense); // MagicDefense
-            wand.SetProperty(PropertyInt.ItemCurMana, 4084);
-            wand.SetProperty(PropertyInt.ItemMaxMana, 4084);
-            wand.SetProperty(PropertyInt.ItemDifficulty, 400);
-            wand.SetProperty(PropertyInt.ItemSpellcraft, 370);
-            wand.SetProperty(PropertyInt.ItemWorkmanship, 7);
-            wand.SetProperty(PropertyInt.MaterialType, 0); // Suppress material prefix
-            wand.SetProperty(PropertyInt.NumTimesTinkered, 1);
-            wand.Biota.TryRemoveProperty(PropertyInt.SlayerCreatureType, wand.BiotaDatabaseLock);
-            wand.SetProperty(PropertyInt.Value, 31410);
-            wand.SetProperty(PropertyInt.WeaponType, 0);
-            wand.SetProperty(PropertyInt.EncumbranceVal, 50);
-
-            // Float Properties
-            wand.SetProperty(PropertyFloat.CriticalFrequency, 0.33f);
-            wand.SetProperty(PropertyFloat.CriticalMultiplier, 2.25f);
-            wand.SetProperty(PropertyFloat.ElementalDamageMod, 1.375f);
-            wand.SetProperty(PropertyFloat.ManaConversionMod, 0.19f);
-            wand.SetProperty(PropertyFloat.ManaRate, -0.06666667f);
-            wand.SetProperty(PropertyFloat.WeaponDefense, 1.23f);
-
-            // Wand Spells
-            wand.Biota.ClearSpells(wand.BiotaDatabaseLock);
-            var wandSpells = new List<uint>()
-            {
-                6098, // Legendary Spirit Thirst
-            };
-
-            foreach (var spellId in wandSpells)
-            {
-                wand.Biota.GetOrAddKnownSpell((int)spellId, wand.BiotaDatabaseLock, out _);
-            }
-            wand.ChangesDetected = true;
-            wand.UiEffects = UiEffects.Magical;
-
-            if (destination != null)
-                destination.TryAddToInventory(wand);
-            else
-                player.TryCreateInInventoryWithNetworking(wand);
-        }
-
-        private static void SpawnHilts(Player player, Container destination = null)
-        {
-            var existingHiltCount = player.GetAllPossessionsDeep().Count(i => i.WeenieClassId == 719220045);
-            if (existingHiltCount >= 10) return;
-
-            int toSpawn = 10 - existingHiltCount;
-            for (int i = 0; i < toSpawn; i++)
-            {
-                var hilt = WorldObjectFactory.CreateNewWorldObject(719220045);
-                if (hilt != null)
-                {
-                    if (destination != null)
-                        destination.TryAddToInventory(hilt);
-                    else
-                        player.TryCreateInInventoryWithNetworking(hilt);
-                }
-            }
-        }
-
-        private static string GetElementLabel(DamageType element)
-        {
-            return element switch
-            {
-                DamageType.Electric => "Lightning",
-                DamageType.Nether => "Nether",
-                _ => element.ToString()
-            };
-        }
-
         private static void SpawnTeleportGems(Player player, Container destination = null)
         {
             var gemWcids = new List<uint>()
@@ -1664,14 +2177,6 @@ namespace ACE.Server.Command.Handlers
                 694200385,  // Defense of Zaikhal portal gem
                 694200389,  // Elysas Favor portal gem
 
-                // Quest Explorer Portal Gems
-                694200515,  // Quest Explorer Portal Gem Week2
-                694200518,  // Quest Explorer Portal Gem Week3
-                694200521,  // Quest Explorer Portal Gem Week4
-                694200524,  // Quest Explorer Portal Gem Week5
-                694200527,  // Quest Explorer Portal Gem Week6
-                694200530,  // Quest Explorer Portal Gem Week7
-
                 // Self-Teleport / Recall Gems
                 86753075,   // Marketplace Recall Gem
                 86753079,   // Lifestone Recall Gem
@@ -1682,25 +2187,14 @@ namespace ACE.Server.Command.Handlers
                 98760170,   // Zerivax Recall Gem
                 300101193,  // Thaelaryn Lassel Recall Gem
                 867530155,  // Penthouse Penthouse Recall Gem
-                867530100,  // Costco Recall Gem
                 64454319,   // Igmo's Retreat Recall Gem
                 98760065,   // Fraternity of QB Recall Gem
                 19851000,   // Halls of Introduction Gem
                 19860016,   // Prestige Palace Gem
                 500008972,  // Plateau of Agility Gem
                 300101097,  // Admin Bog Gem
+                730003019,  // Testing Area v11 Gem
 
-                // Housing Residence Hall Recalls
-                227190148,  // Alphus Court Recall Gem
-                227190149,  // Gajin Dwellings Recall Gem
-                227190154,  // Hasina Gardens Recall Gem
-                227190150,  // Heartland Yard Recall Gem
-                227190151,  // Ivory Gate Recall Gem
-                227190152,  // Lakespur Gardens Recall Gem
-                227190153,  // Mellas Court Recall Gem
-                227190155,  // Valorya Gate Recall Gem
-                227190156,  // Vesper Gate Recall Gem
-                227190157,  // Winthur Gate Recall Gem
                 777700029   // Tou Tou Prestige Portal Gem
             };
 
@@ -1712,12 +2206,7 @@ namespace ACE.Server.Command.Handlers
 
                 var gem = WorldObjectFactory.CreateNewWorldObject(wcid);
                 if (gem != null)
-                {
-                    if (destination != null)
-                        destination.TryAddToInventory(gem);
-                    else
-                        player.TryCreateInInventoryWithNetworking(gem);
-                }
+                    PlaceInPackOrLoose(player, gem, destination);
             }
         }
     }

--- a/Source/ACE.Server/Command/Handlers/WeaponScalingCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/WeaponScalingCommands.cs
@@ -69,13 +69,11 @@ namespace ACE.Server.Command.Handlers
 
                 var watch = kv.Value;
                 var keepalive = (now - watch.LastSentUtc).TotalSeconds >= SyncKeepaliveSeconds;
-                if (payload == watch.LastPayload && !keepalive)
-                    continue;
-
-                watch.LastSentUtc = now;
-
+                // only the MAIN payload is gated on its own change; the ladder lines below diff on their own, so a
+                // ladder-only edit (script grade / ladder) still goes out this tick instead of at the next keepalive
                 if (payload != watch.LastPayload || keepalive)
                 {
+                    watch.LastSentUtc = now;
                     watch.LastPayload = payload;
                     ChatPacket.SendServerMessage(session, payload, ChatMessageType.Broadcast);
                 }
@@ -738,7 +736,13 @@ namespace ACE.Server.Command.Handlers
                         applied.Add($"proc arc {arcId} @ {c.ProcRate:0.##} dmg {c.ProcDmg:0}");
                     }
 
-                    if (c.ProcRing)
+                    if (c.ProcRing && wo.ProcSpell != null && wo.ProcSpellSelfTargeted == true)
+                    {
+                        // the data model has ONE targeting flag (ProcSpellSelfTargeted) for both slots; a self-targeted
+                        // slot 1 would aim the ring at the wielder, so the combination is refused rather than mis-cast
+                        skipped.Add("proc ring: slot 1 on this item is self-targeted and the ring would share that flag - refused");
+                    }
+                    else if (c.ProcRing)
                     {
                         wo.SetProperty((PropertyDataId)ZoneLootMutator.ProcSpell2PropId, ringId);
                         wo.SetProperty((PropertyFloat)ZoneLootMutator.ProcRate2PropId, c.ProcRate);

--- a/Source/ACE.Server/Command/Handlers/WeaponScalingCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/WeaponScalingCommands.cs
@@ -1,0 +1,1200 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+using ACE.Common.Performance;
+using ACE.Entity.Enum;
+using ACE.Entity.Enum.Properties;
+using ACE.Server.Factories.Tables;
+using ACE.Server.Managers.WeaponScaling;
+using ACE.Server.Managers.ZoneControl;
+using ACE.Server.Managers.ZoneScaling;
+using ACE.Server.Network;
+using ACE.Server.Network.GameEvent.Events;
+using ACE.Server.Network.GameMessages.Messages;
+using ACE.Server.WorldObjects;
+
+namespace ACE.Server.Command.Handlers
+{
+    /// <summary>
+    /// /weaponscale — admin fallback + plugin sync for the weapon aug-scaling config
+    /// (plan: C:\AI\ZoneControl\T11_WeaponRelevance_Plan_2026-07-31.md §9).
+    ///
+    /// The ZoneControl plugin's Weapons section is the intended editing surface; these commands are
+    /// the same operations for when the plugin isn't available. Config edits are pure data — the
+    /// combat wire-in (step 3) reads the config live, gated behind the master Enabled flag.
+    /// </summary>
+    public static class WeaponScalingCommands
+    {
+        private class SyncWatch
+        {
+            public string LastPayload;
+            public DateTime LastSentUtc;
+            /// <summary>Last [[ZCWK]] line sent per family — ladders are diffed individually so a
+            /// one-cell edit re-sends one family, not all eleven.</summary>
+            public readonly Dictionary<string, string> LastLadders = new(StringComparer.OrdinalIgnoreCase);
+        }
+
+        private static readonly ConcurrentDictionary<Session, SyncWatch> _pluginSessions = new();
+        private static readonly RateLimiter _pushTickRateLimiter = new RateLimiter(1, TimeSpan.FromSeconds(2));
+
+        /// <summary>An unchanged [[ZCW]] payload is still re-sent this often as a stale-correction keepalive
+        /// (same shape as the [[ZC]] sync — the config changes rarely, so idle sessions are near-silent).</summary>
+        private const double SyncKeepaliveSeconds = 15.0;
+
+        /// <summary>Called from WorldManager.UpdateGameWorld() every frame; rate-limited to once per 2s.</summary>
+        public static void PushTick()
+        {
+            if (_pluginSessions.IsEmpty)
+                return;
+            if (_pushTickRateLimiter.GetSecondsToWaitBeforeNextEvent() > 0)
+                return;
+            _pushTickRateLimiter.RegisterEvent();
+
+            var payload = BuildPayload();
+            var ladders = BuildLadderPayloads();
+            var now = DateTime.UtcNow;
+
+            foreach (var kv in _pluginSessions)
+            {
+                var session = kv.Key;
+                if (session.IsTerminated)
+                {
+                    _pluginSessions.TryRemove(session, out _);
+                    continue;
+                }
+
+                var watch = kv.Value;
+                var keepalive = (now - watch.LastSentUtc).TotalSeconds >= SyncKeepaliveSeconds;
+                if (payload == watch.LastPayload && !keepalive)
+                    continue;
+
+                watch.LastSentUtc = now;
+
+                if (payload != watch.LastPayload || keepalive)
+                {
+                    watch.LastPayload = payload;
+                    ChatPacket.SendServerMessage(session, payload, ChatMessageType.Broadcast);
+                }
+
+                // Ladders ride their OWN per-family messages rather than the main payload: 11
+                // melee families x 16 rungs would roughly triple a payload that is already ~800
+                // chars, and a single cell edit only has to re-send its own ~150-char line.
+                foreach (var kvL in ladders)
+                {
+                    if (!keepalive && watch.LastLadders.TryGetValue(kvL.Key, out var prev) && prev == kvL.Value)
+                        continue;
+                    watch.LastLadders[kvL.Key] = kvL.Value;
+                    ChatPacket.SendServerMessage(session, kvL.Value, ChatMessageType.Broadcast);
+                }
+
+                // A family whose ladder was cleared stops appearing above; tell the plugin once
+                // so its editor drops back to the lerp view instead of showing a stale ladder.
+                foreach (var goneKey in watch.LastLadders.Keys.Where(k => !ladders.ContainsKey(k)).ToList())
+                {
+                    watch.LastLadders.Remove(goneKey);
+                    ChatPacket.SendServerMessage(session, $"[[ZCWK]]|s={goneKey}|k=", ChatMessageType.Broadcast);
+                }
+            }
+        }
+
+        /// <summary>Pipe/tilde wire format (house style; the plugin has no JSON parser):
+        /// [[ZCW]]|enabled=1|kc=0.6~0.8|tighten=0.7|grades=...|tiers=t~cap~minwield,...
+        /// |scripts=name~kmin~kmax~variance,...   (grade LADDERS ride separate [[ZCWK]] messages)</summary>
+        private static string BuildPayload()
+        {
+            var cfg = WeaponScalingManager.Current;
+            var sb = new StringBuilder("[[ZCW]]");
+            sb.Append("|enabled=").Append(cfg.Enabled ? '1' : '0');
+            sb.Append("|kc=").Append(F(cfg.KcMin)).Append('~').Append(F(cfg.KcMax));
+            sb.Append("|tighten=").Append(F(cfg.TightenStrength));
+            sb.Append("|grades=").Append(string.Join(",",
+                Managers.WeaponScaling.WeaponScalingManager.GradeBands
+                    .Select(b => $"{b.Grade}~{F(cfg.GradeWeights != null && cfg.GradeWeights.TryGetValue(b.Grade, out var gw) ? gw : 0)}")));
+            // 5-field tier rows since 2026-08-15 (charm gates); the plugin parses 3 or 5.
+            sb.Append("|tiers=").Append(string.Join(",",
+                cfg.Tiers.Select(t => $"{t.Tier}~{t.Cap}~{t.MinWieldAugs}~{t.MinWieldTriune}~{t.MinWieldSkillCharm}")));
+            sb.Append("|scripts=").Append(string.Join(",",
+                cfg.Scripts.OrderBy(s => s.Key, StringComparer.OrdinalIgnoreCase)
+                    .Select(s => $"{s.Key}~{F(s.Value.KMin)}~{F(s.Value.KMax)}~{F(s.Value.Variance)}")));
+            return sb.ToString();
+        }
+
+        /// <summary>One message per family that has an authored grade ladder:
+        /// [[ZCWK]]|s=unarmed|k=&lt;16 values, tilde-separated, in SubGradeBands order&gt;
+        /// Sub-grade names are omitted — the order is the contract (plugin indexes by position).</summary>
+        private static Dictionary<string, string> BuildLadderPayloads()
+        {
+            var cfg = WeaponScalingManager.Current;
+            var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var kv in cfg.Scripts)
+            {
+                if (kv.Value == null || !kv.Value.HasLadder)
+                    continue;
+                var vals = WeaponScalingManager.SubGradeBands
+                    .Select(b => F(kv.Value.Grades.TryGetValue(b.Grade, out var k) ? k : 0));
+                result[kv.Key] = $"[[ZCWK]]|s={kv.Key}|k={string.Join("~", vals)}";
+            }
+            return result;
+        }
+
+        private static string F(double v) => v.ToString("0.####", CultureInfo.InvariantCulture);
+
+        [CommandHandler("weaponscale", AccessLevel.Developer, CommandHandlerFlag.None, 0,
+            "Weapon Scaling config (plugin fallback).",
+            "show | enable on|off | tier <t> cap|minwield|minwieldtriune|minwieldskillcharm <n> | tier add <t> [cap] [minwield] | tier remove <t> | "
+            + "script <name> kmin|kmax <v> | script add <name> [kmin] [kmax] | script remove <name> | "
+            + "kc min|max <v> | sync on|off | reset | reload")]
+        public static void HandleWeaponScale(Session session, params string[] parameters)
+        {
+            void Msg(string s) => ChatPacket.SendServerMessage(session, s, ChatMessageType.Broadcast);
+
+            if (parameters.Length == 0 || parameters[0].Equals("help", StringComparison.OrdinalIgnoreCase))
+            {
+                Msg("Weapon Scaling config (items store quality; these knobs give it meaning at swing time):");
+                Msg("  /weaponscale show");
+                Msg("  /weaponscale enable on|off       master switch; off = static-base-only combat (current behavior)");
+                Msg("  /weaponscale tier <t> cap <n>    scaling stops growing at n item augs for tier-t weapons");
+                Msg("  /weaponscale tier <t> minwield <n>   item augs required to WIELD tier-t weapons (economy gate)");
+                Msg("  /weaponscale tier <t> minwieldtriune <n>   Triune Weave count required to wield (T16+ charm gate)");
+                Msg("  /weaponscale tier <t> minwieldskillcharm <n>   weapon-family charm count required to wield (T16+)");
+                Msg("  /weaponscale tier add <t> [cap] [minwield] | tier remove <t>");
+                Msg("  /weaponscale script <name> kmin <v> | kmax <v> | variance <v>   per-loot-script k range + Scheme C family variance");
+                Msg("  /weaponscale script <name> ladder <anchorS> | ladder clear   seed/drop the 16-rung grade ladder (+18 pct per grade)");
+                Msg("  /weaponscale script <name> grade <S|A+|A|A-|..|F-> <k>   author ONE rung");
+                Msg("  /weaponscale ladder <name>       print a family's 16 rungs with step pct");
+                Msg("  /weaponscale script add <name> [kmin] [kmax] | script remove <name>");
+                Msg("  /weaponscale kc min <v> | kc max <v>   crit-channel coefficient range");
+                Msg("  /weaponscale tighten <v>         Scheme C: fraction of family variance a q1000 weapon sheds (0.7 = S keeps 30 pct)");
+                Msg("  /weaponscale grade <S|A|B|C|D|F> <weight>   drop-frequency weight (relative; quality rolls uniform inside the band)");
+                Msg("  /weaponscale reset               restore locked launch defaults (plan section 4)");
+                Msg("  /weaponscale reload              re-read the store from the shard DB");
+                return;
+            }
+
+            var sub = parameters[0].ToLowerInvariant();
+            var args = parameters;
+
+            switch (sub)
+            {
+                case "sync":
+                {
+                    // Machine handshake from the plugin — silent, same contract as /zonecontrol sync.
+                    if (args.Length >= 2 && args[1].Equals("off", StringComparison.OrdinalIgnoreCase))
+                    {
+                        _pluginSessions.TryRemove(session, out _);
+                        return;
+                    }
+                    if (args.Length < 2 || !args[1].Equals("on", StringComparison.OrdinalIgnoreCase))
+                    {
+                        Msg("Usage: /weaponscale sync on | sync off");
+                        return;
+                    }
+                    _pluginSessions[session] = new SyncWatch();
+                    return;
+                }
+
+                case "show":
+                {
+                    var cfg = WeaponScalingManager.Current;
+                    var sb = new StringBuilder();
+                    sb.AppendLine($"Weapon Scaling: {(cfg.Enabled ? "Enabled" : "Disabled")} (kc {cfg.KcMin:0.###}-{cfg.KcMax:0.###}, tighten {cfg.TightenStrength:0.###})");
+                    sb.AppendLine("  tier | cap | minwield | triune | skillcharm");
+                    foreach (var t in cfg.Tiers)
+                        sb.AppendLine($"  T{t.Tier} | {t.Cap:N0} | {t.MinWieldAugs:N0} | {t.MinWieldTriune:N0} | {t.MinWieldSkillCharm:N0}");
+                    sb.AppendLine("  script | kmin | kmax | variance | ladder");
+                    foreach (var s in cfg.Scripts.OrderBy(s => s.Key, StringComparer.OrdinalIgnoreCase))
+                        sb.AppendLine($"  {s.Key} | {s.Value.KMin:0.###} | {s.Value.KMax:0.###} | {s.Value.Variance:0.###} | "
+                            + (s.Value.HasLadder
+                                ? $"S {s.Value.Grades[WeaponScalingManager.SubGradeBands[0].Grade]:0.####} .. "
+                                  + $"F- {s.Value.Grades[WeaponScalingManager.SubGradeBands[WeaponScalingManager.SubGradeBands.Length - 1].Grade]:0.####}"
+                                : "(lerp)"));
+                    var gwTotal = Managers.WeaponScaling.WeaponScalingManager.GradeBands
+                        .Sum(b => cfg.GradeWeights != null && cfg.GradeWeights.TryGetValue(b.Grade, out var w) && w > 0 ? w : 0);
+                    sb.AppendLine("  grade | weight | drop pct");
+                    foreach (var b in Managers.WeaponScaling.WeaponScalingManager.GradeBands)
+                    {
+                        var w = cfg.GradeWeights != null && cfg.GradeWeights.TryGetValue(b.Grade, out var gw) ? gw : 0;
+                        var pct = gwTotal > 0 ? w / gwTotal * 100.0 : 0;
+                        sb.AppendLine($"  {b.Grade} (q{b.QMin}-{b.QMax}) | {w:0.####} | {pct:0.###} pct");
+                    }
+                    if (gwTotal <= 0)
+                        sb.AppendLine("  (no grade weights authored - drops use the legacy uniform 0-1000 roll)");
+                    Msg(sb.ToString().TrimEnd());
+                    return;
+                }
+
+                case "ladder":
+                {
+                    if (args.Length < 2)
+                    {
+                        Msg("Usage: /weaponscale ladder <script>   (prints the 16 authored rungs)");
+                        return;
+                    }
+                    var cfgL = WeaponScalingManager.Current;
+                    if (!cfgL.Scripts.TryGetValue(args[1], out var row))
+                    {
+                        Msg($"No script '{args[1]}'.");
+                        return;
+                    }
+                    if (!row.HasLadder)
+                    {
+                        Msg($"Script {args[1]} has no ladder - k lerps {row.KMin:0.###}..{row.KMax:0.###} across quality. "
+                            + $"Seed one with: /weaponscale script {args[1]} ladder <anchorS>");
+                        return;
+                    }
+                    var sbL = new StringBuilder();
+                    sbL.AppendLine($"{args[1]} grade ladder (variance {row.Variance:0.###}, tighten {cfgL.TightenStrength:0.###}):");
+                    // Two step columns on purpose. Raw k steps UNEVENLY by design — rungs are stored
+                    // with EV normalization divided out, and v_eff rises as grade falls, so k has to
+                    // slope to keep DEALT damage even. The dmg column is the one carrying the
+                    // invariant (+5.7 pct per sub-grade); without it the only number on screen was
+                    // the one nobody is tuning, which is how a three-day-old verify step ended up
+                    // unrunnable (2026-08-06).
+                    sbL.AppendLine("  grade | q band | k | k step | dmg step");
+                    double? prevK = null, prevD = null;
+                    foreach (var b in WeaponScalingManager.SubGradeBands)
+                    {
+                        var k = row.Grades.TryGetValue(b.Grade, out var kv2) ? kv2 : 0;
+                        var dealt = WeaponScalingManager.DealtWeaponTerm(row, cfgL.TightenStrength, b.QMid);
+                        var step = prevK.HasValue && k > 0 ? $"{(prevK.Value / k - 1) * 100:+0.0;-0.0} pct" : "";
+                        var dStep = prevD.HasValue && dealt > 0 ? $"{(prevD.Value / dealt - 1) * 100:+0.0;-0.0} pct" : "";
+                        sbL.AppendLine($"  {b.Grade,-2} | q{b.QMin}-{b.QMax} | {k:0.####} | {step} | {dStep}");
+                        prevK = k;
+                        prevD = dealt;
+                    }
+                    sbL.AppendLine($"  S -> F- spread: {WeaponScalingManager.DealtWeaponTerm(row, cfgL.TightenStrength, 1000) / Math.Max(1e-9, WeaponScalingManager.DealtWeaponTerm(row, cfgL.TightenStrength, 83)):0.###}x dealt damage");
+                    Msg(sbL.ToString().TrimEnd());
+                    return;
+                }
+
+                case "enable":
+                {
+                    if (args.Length < 2 || (!args[1].Equals("on", StringComparison.OrdinalIgnoreCase) && !args[1].Equals("off", StringComparison.OrdinalIgnoreCase)))
+                    {
+                        Msg("Usage: /weaponscale enable on|off");
+                        return;
+                    }
+                    var on = args[1].Equals("on", StringComparison.OrdinalIgnoreCase);
+                    WeaponScalingManager.Mutate(cfg => cfg.Enabled = on);
+                    Msg($"Weapon Scaling: {(on ? "Enabled" : "Disabled")}.");
+                    return;
+                }
+
+                case "tier":
+                {
+                    if (args.Length >= 3 && args[1].Equals("add", StringComparison.OrdinalIgnoreCase))
+                    {
+                        if (!int.TryParse(args[2], out var tAdd)) { Msg("tier add: bad tier number."); return; }
+                        var cap = args.Length >= 4 && int.TryParse(args[3], out var c) ? c : 0;
+                        var minWield = args.Length >= 5 && int.TryParse(args[4], out var m) ? m : 0;
+                        WeaponScalingManager.Mutate(cfg =>
+                        {
+                            var row = cfg.Tiers.FirstOrDefault(x => x.Tier == tAdd);
+                            if (row == null)
+                                cfg.Tiers.Add(new WeaponScalingTier { Tier = tAdd, Cap = cap, MinWieldAugs = minWield });
+                            else { row.Cap = cap; row.MinWieldAugs = minWield; }
+                        });
+                        Msg($"Tier T{tAdd} set: cap {cap:N0}, minwield {minWield:N0}.");
+                        return;
+                    }
+                    if (args.Length >= 3 && args[1].Equals("remove", StringComparison.OrdinalIgnoreCase))
+                    {
+                        if (!int.TryParse(args[2], out var tRem)) { Msg("tier remove: bad tier number."); return; }
+                        WeaponScalingManager.Mutate(cfg => cfg.Tiers.RemoveAll(x => x.Tier == tRem));
+                        Msg($"Tier T{tRem} removed.");
+                        return;
+                    }
+                    if (args.Length < 4 || !int.TryParse(args[1], out var tier) || !int.TryParse(args[3], out var value))
+                    {
+                        Msg("Usage: /weaponscale tier <t> cap|minwield <n>  |  tier add <t> [cap] [minwield]  |  tier remove <t>");
+                        return;
+                    }
+                    var field = args[2].ToLowerInvariant();
+                    if (field != "cap" && field != "minwield" && field != "minwieldtriune" && field != "minwieldskillcharm")
+                    {
+                        Msg("tier: field must be cap, minwield, minwieldtriune, or minwieldskillcharm.");
+                        return;
+                    }
+                    var found = false;
+                    WeaponScalingManager.Mutate(cfg =>
+                    {
+                        var row = cfg.Tiers.FirstOrDefault(x => x.Tier == tier);
+                        if (row == null) return;
+                        found = true;
+                        if (field == "cap") row.Cap = value;
+                        else if (field == "minwield") row.MinWieldAugs = value;
+                        else if (field == "minwieldtriune") row.MinWieldTriune = value;
+                        else row.MinWieldSkillCharm = value;
+                    });
+                    Msg(found ? $"Tier T{tier} {field} = {value:N0}." : $"Tier T{tier} not found (use tier add).");
+                    return;
+                }
+
+                case "script":
+                {
+                    if (args.Length >= 3 && args[1].Equals("add", StringComparison.OrdinalIgnoreCase))
+                    {
+                        var name = args[2];
+                        var kMin = args.Length >= 4 && TryParseDouble(args[3], out var a) ? a : 0.90;
+                        var kMax = args.Length >= 5 && TryParseDouble(args[4], out var b) ? b : 1.15;
+                        WeaponScalingManager.Mutate(cfg => cfg.Scripts[name] = new WeaponScalingScript { KMin = kMin, KMax = kMax });
+                        Msg($"Script {name}: kmin {kMin:0.###}, kmax {kMax:0.###}.");
+                        return;
+                    }
+                    if (args.Length >= 3 && args[1].Equals("remove", StringComparison.OrdinalIgnoreCase))
+                    {
+                        var name = args[2];
+                        WeaponScalingManager.Mutate(cfg => cfg.Scripts.Remove(name));
+                        Msg($"Script {name} removed.");
+                        return;
+                    }
+                    // Grade ladder verbs (owner 2026-08-03). "ladder <anchorS>" seeds all 16 from
+                    // the S anchor at +18 pct per full grade; "ladder clear" drops back to the
+                    // KMin/KMax lerp; "grade <sub> <k>" authors one rung.
+                    if (args.Length >= 3 && args[1].Equals("ladder", StringComparison.OrdinalIgnoreCase))
+                    {
+                        Msg("Usage: /weaponscale script <name> ladder <anchorS> | ladder clear");
+                        return;
+                    }
+                    if (args.Length >= 4 && args[2].Equals("ladder", StringComparison.OrdinalIgnoreCase))
+                    {
+                        var lname = args[1];
+                        var clearing = args[3].Equals("clear", StringComparison.OrdinalIgnoreCase);
+                        if (!clearing && !TryParseDouble(args[3], out _))
+                        {
+                            Msg("Usage: /weaponscale script <name> ladder <anchorS> | ladder clear");
+                            return;
+                        }
+                        TryParseDouble(args[3], out var anchor);
+                        var lfound = false;
+                        WeaponScalingManager.Mutate(cfg =>
+                        {
+                            if (!cfg.Scripts.TryGetValue(lname, out var s)) return;
+                            lfound = true;
+                            // Family-specific by necessity: the rungs divide out EV normalization,
+                            // which depends on this family's variance (see BuildLadder).
+                            s.Grades = clearing
+                                ? null
+                                : WeaponScalingManager.BuildLadder(anchor, s.Variance, cfg.TightenStrength);
+                        });
+                        Msg(!lfound ? $"Script {lname} not found (use script add)."
+                            : clearing ? $"Script {lname} ladder cleared - back to the kmin/kmax lerp."
+                            : $"Script {lname} ladder seeded from S = {anchor:0.####} (+18 pct per grade, 16 rungs).");
+                        return;
+                    }
+                    if (args.Length >= 5 && args[2].Equals("grade", StringComparison.OrdinalIgnoreCase))
+                    {
+                        var gname = args[1];
+                        var subGrade = args[3];
+                        if (!TryParseDouble(args[4], out var gk) || gk < 0)
+                        {
+                            Msg("Usage: /weaponscale script <name> grade <S|A+|A|A-|...|F-> <k>");
+                            return;
+                        }
+                        var band = WeaponScalingManager.SubGradeBands
+                            .FirstOrDefault(b => b.Grade.Equals(subGrade, StringComparison.OrdinalIgnoreCase));
+                        if (band.Grade == null)
+                        {
+                            Msg("script grade: unknown sub-grade. Use " +
+                                string.Join(" ", WeaponScalingManager.SubGradeBands.Select(b => b.Grade)));
+                            return;
+                        }
+                        var gfound = false;
+                        WeaponScalingManager.Mutate(cfg =>
+                        {
+                            if (!cfg.Scripts.TryGetValue(gname, out var s)) return;
+                            gfound = true;
+                            // Authoring one rung on a lerp-only family promotes it to a ladder,
+                            // seeded from the lerp so the other 15 rungs keep their current values
+                            // (Normalize completes partials the same way).
+                            s.Grades ??= new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase);
+                            s.Grades[band.Grade] = gk;
+                        });
+                        Msg(gfound ? $"Script {gname} grade {band.Grade} k = {gk:0.####}."
+                                   : $"Script {gname} not found (use script add).");
+                        return;
+                    }
+
+                    if (args.Length < 4 || !TryParseDouble(args[3], out var v))
+                    {
+                        Msg("Usage: /weaponscale script <name> kmin|kmax|variance <v>  |  script <name> ladder <anchorS>  |  "
+                            + "script <name> grade <sub> <k>  |  script add <name> [kmin] [kmax]  |  script remove <name>");
+                        return;
+                    }
+                    var scriptName = args[1];
+                    var kField = args[2].ToLowerInvariant();
+                    if (kField != "kmin" && kField != "kmax" && kField != "variance")
+                    {
+                        Msg("script: field must be kmin, kmax or variance.");
+                        return;
+                    }
+                    var scriptFound = false;
+                    WeaponScalingManager.Mutate(cfg =>
+                    {
+                        if (!cfg.Scripts.TryGetValue(scriptName, out var s)) return;
+                        scriptFound = true;
+                        if (kField == "kmin") s.KMin = v;
+                        else if (kField == "kmax") s.KMax = v;
+                        else
+                        {
+                            // Keep dealt damage flat across a variance edit — the ladder stores k
+                            // with EV normalization divided out, so it has to be re-priced.
+                            var oldVar = s.Variance;
+                            s.Variance = Math.Max(0.0, Math.Min(0.95, v));
+                            WeaponScalingManager.RebaseLadder(s, oldVar, cfg.TightenStrength,
+                                                              s.Variance, cfg.TightenStrength);
+                        }
+                    });
+                    Msg(scriptFound ? $"Script {scriptName} {kField} = {v:0.###}." : $"Script {scriptName} not found (use script add).");
+                    return;
+                }
+
+                case "kc":
+                {
+                    if (args.Length < 3 || !TryParseDouble(args[2], out var v) || (args[1] != "min" && args[1] != "max"))
+                    {
+                        Msg("Usage: /weaponscale kc min|max <v>");
+                        return;
+                    }
+                    WeaponScalingManager.Mutate(cfg =>
+                    {
+                        if (args[1] == "min") cfg.KcMin = v;
+                        else cfg.KcMax = v;
+                    });
+                    Msg($"kc {args[1]} = {v:0.###}.");
+                    return;
+                }
+
+                case "grade":
+                {
+                    if (args.Length < 3 || !TryParseDouble(args[2], out var gw))
+                    {
+                        Msg("Usage: /weaponscale grade <S|A|B|C|D|F> <weight>  (relative weight, >= 0; 0 = that grade never drops)");
+                        return;
+                    }
+                    var gradeKey = args[1].ToUpperInvariant();
+                    if (!Managers.WeaponScaling.WeaponScalingManager.GradeBands.Any(b => b.Grade == gradeKey))
+                    {
+                        Msg("grade: must be one of S A B C D F.");
+                        return;
+                    }
+                    var gClamped = Math.Max(0.0, gw);
+                    WeaponScalingManager.Mutate(cfg =>
+                    {
+                        cfg.GradeWeights ??= new System.Collections.Generic.Dictionary<string, double>(StringComparer.OrdinalIgnoreCase);
+                        cfg.GradeWeights[gradeKey] = gClamped;
+                    });
+                    Msg($"grade {gradeKey} weight = {gClamped:0.####}.");
+                    return;
+                }
+
+                case "tighten":
+                {
+                    if (args.Length < 2 || !TryParseDouble(args[1], out var v))
+                    {
+                        Msg("Usage: /weaponscale tighten <v>  (0-1; 0.7 = a q1000 weapon sheds 70 pct of its family variance)");
+                        return;
+                    }
+                    var clamped = Math.Max(0.0, Math.Min(1.0, v));
+                    WeaponScalingManager.Mutate(cfg =>
+                    {
+                        // Tighten is global, so EVERY authored ladder needs re-pricing — same
+                        // EV-neutrality rule as a per-family variance edit.
+                        var oldTighten = cfg.TightenStrength;
+                        cfg.TightenStrength = clamped;
+                        foreach (var s in cfg.Scripts.Values)
+                            WeaponScalingManager.RebaseLadder(s, s.Variance, oldTighten, s.Variance, clamped);
+                    });
+                    Msg($"tighten = {clamped:0.###}. (Authored ladders re-priced to hold dealt damage flat.)");
+                    return;
+                }
+
+                case "reset":
+                {
+                    WeaponScalingManager.Mutate(cfg =>
+                    {
+                        var d = WeaponScalingManager.BuildDefaults();
+                        cfg.Enabled = d.Enabled;
+                        cfg.Tiers = d.Tiers;
+                        cfg.Scripts = d.Scripts;
+                        cfg.KcMin = d.KcMin;
+                        cfg.KcMax = d.KcMax;
+                        cfg.TightenStrength = d.TightenStrength;
+                        cfg.GradeWeights = d.GradeWeights;
+                    });
+                    Msg("Weapon Scaling config reset to locked launch defaults (system Disabled).");
+                    return;
+                }
+
+                case "reload":
+                {
+                    WeaponScalingManager.Reload();
+                    Msg("Weapon Scaling config reloaded from store.");
+                    return;
+                }
+
+                default:
+                    Msg("Unknown subcommand. /weaponscale help");
+                    return;
+            }
+        }
+
+        private static bool TryParseDouble(string s, out double v)
+        {
+            return double.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out v);
+        }
+
+        /// <summary>Matched-quality test weapons for cross-family tuning (owner 2026-08-01): one
+        /// UA / bow / sword / wand from the live loot-table weenies, stamped at the SAME chosen
+        /// quality so families compare fairly. Goes through the normal item pipeline — never
+        /// direct DB writes (guid allocation + biota caching make hand-inserted rows unsafe).
+        /// The static damage stays the base weenie's (the scaling term dominates at T11); the
+        /// wield gate + stamps match what the Creature_Death T11 sweep gives real drops.</summary>
+        // ═════════════════ weapon forging (test items via the normal item pipeline) ═════════════════
+        // One representative base weenie per scaling family (all verified in the world DB 08-01:
+        // W_WeaponType + MultiStrike/thrust flags resolve to exactly the intended GetFamilyKey).
+        // TWType = the loot pipeline's weapon type for this class, used by the tier-10 forge
+        // path to run the bench weenie through the SAME mutation scripts a real T10 drop rolls
+        // (owner 2026-08-15: T10 forge output must match the existing T10 loot table range).
+        private static readonly (string Key, uint Wcid, string CleanName, ACE.Server.Factories.Enum.TreasureWeaponType TWType)[] ForgeClasses =
+        {
+            ("sword",     30566, "Sword", ACE.Server.Factories.Enum.TreasureWeaponType.Sword),      // swordsabra — single strike
+            ("sword_ms",   6853, "Rapier", ACE.Server.Factories.Enum.TreasureWeaponType.SwordMS),   // swordrapier — multi-strike
+            ("dagger",    30596, "Poniard", ACE.Server.Factories.Enum.TreasureWeaponType.Dagger),   // daggerponiard — single strike
+            ("dagger_ms",  3779, "Dagger", ACE.Server.Factories.Enum.TreasureWeaponType.DaggerMS),  // daggerelectric — multi-strike
+            ("axe",         301, "Axe", ACE.Server.Factories.Enum.TreasureWeaponType.Axe),          // axebattle
+            ("mace",        331, "Mace", ACE.Server.Factories.Enum.TreasureWeaponType.Mace),        // mace (jitte folds into this family)
+            ("spear",       348, "Spear", ACE.Server.Factories.Enum.TreasureWeaponType.Spear),      // spear
+            ("staff",       338, "Staff", ACE.Server.Factories.Enum.TreasureWeaponType.Staff),      // quarterstaff
+            // FINESSE unarmed (owner 2026-08-11): the old pick (30612 knuckleselectric) was a
+            // LightWeapons weenie, so a finesse-spec test char could not swing it. 31784 is
+            // WeaponSkill 46 with the SAME weapon type / attack type / base damage, so it resolves
+            // to the identical "unarmed" scaling family - a pure skill swap.
+            ("ua",        31784, "Claw", ACE.Server.Factories.Enum.TreasureWeaponType.Unarmed),         // ace31784-claw — W_WeaponType Unarmed, Finesse
+            ("cleaver",   40618, "Spadone", ACE.Server.Factories.Enum.TreasureWeaponType.TwoHandedSword),  // spadone — 2H slash line
+            ("spear2h",   40818, "Corsesca", ACE.Server.Factories.Enum.TreasureWeaponType.TwoHandedSpear), // corsesca — 2H thrust line
+            ("bow",       29243, "Bow", ACE.Server.Factories.Enum.TreasureWeaponType.Bow),              // bowpiercing
+            ("crossbow",  29250, "Crossbow", ACE.Server.Factories.Enum.TreasureWeaponType.Crossbow),    // crossbowpiercing
+            ("atlatl",    29254, "Atlatl", ACE.Server.Factories.Enum.TreasureWeaponType.Atlatl),        // atlatlelectric
+            ("wand",      29265, "Sceptre", ACE.Server.Factories.Enum.TreasureWeaponType.Caster),       // wandslashing (gets EDM 1.5)
+        };
+
+        private static DamageType? ParseElement(string s)
+        {
+            return s?.ToLowerInvariant() switch
+            {
+                "slash" => DamageType.Slash,
+                "pierce" => DamageType.Pierce,
+                "bludge" or "bludgeon" => DamageType.Bludgeon,
+                "acid" => DamageType.Acid,
+                "fire" => DamageType.Fire,
+                "cold" or "frost" => DamageType.Cold,
+                "electric" or "lightning" => DamageType.Electric,
+                "nether" => DamageType.Nether,
+                _ => (DamageType?)null
+            };
+        }
+
+        /// <summary>Mints one stamped test weapon into the player's pack through the normal item
+        /// pipeline (never direct DB writes — guid allocation + biota caching make hand-inserted
+        /// rows unsafe). Wield gate + stamps mirror the Creature_Death T11+ sweep; static damage
+        /// stays the base weenie's (the scaling term/mod dominates). Element override also
+        /// re-colors the icon underlay and renames coherently ("Nether Spadone (Test q800)").</summary>
+        // ─────────────── Weapon loadout cards (/wsforge cards clause, owner 2026-08-11) ───────────────
+        // Deterministic versions of the Zone Control loot special rolls (ZoneLootMutator.TrySpecialRolls):
+        // the SAME properties and clamps, but exact configured values instead of chance rolls. Crafts
+        // (hilt/bowstring) apply LAST, same rule as loot - their bonuses add on top of the other cards.
+
+        private sealed class ForgeCards
+        {
+            // Cast on Strike, rewired 2026-08-27 to the two-slot card. `proc` alone is a shorthand
+            // for both slots, since test gear almost always wants the full thing.
+            public bool ProcArc; public bool ProcRing;
+            public double ProcRate = 0.05; public double ProcDmg = 440;
+            public int ProcSpellcraft = 9999; public double ProcAugCap; public double ProcVariance;
+            public bool Rend;
+            public double? RendPower;
+            public int? Cleave;
+            public int? Split; public double SplitRange = 8.0; public double SplitDmg = 1.0;
+            public double? Bite;
+            public double? Crush;
+            public double? ArmorRend;
+            public double? ShieldCleave;
+            public double? Slayer; public CreatureType SlayerType = CreatureType.Drudge;
+            public bool SlayerAll;          // slayertype=all -> PropertyBool.SlayerAllCreatures, no species
+            // premade (owner 2026-09-01): the drop-equivalent four-card set for the tier; when set, every
+            // other key in the clause is ignored. bis = band top, avg = the drop's own random grade.
+            public bool Premade; public bool PremadeBis = true;
+        }
+
+        private const ImbuedEffectType ForgeAllRends =
+            ImbuedEffectType.SlashRending | ImbuedEffectType.PierceRending | ImbuedEffectType.BludgeonRending |
+            ImbuedEffectType.AcidRending | ImbuedEffectType.ColdRending | ImbuedEffectType.ElectricRending |
+            ImbuedEffectType.FireRending | ImbuedEffectType.NetherRending;
+
+        /// <summary>Parses "key=val,key,..." (the part after "cards:"). Unknown keys are an error,
+        /// not a silent skip - same contract as /asforge.</summary>
+        private static string ParseForgeCards(string clause, ForgeCards cards)
+        {
+            foreach (var token in clause.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries))
+            {
+                var parts = token.Split('=');
+                var key = parts[0].ToLowerInvariant();
+                var val = parts.Length > 1 ? parts[1] : null;
+                double Num(double dflt) => val != null && double.TryParse(val, NumberStyles.Float, CultureInfo.InvariantCulture, out var d) ? d : dflt;
+                switch (key)
+                {
+                    case "proc": cards.ProcArc = true; cards.ProcRing = true; break;
+                    case "procarc": cards.ProcArc = true; break;
+                    case "procring": cards.ProcRing = true; break;
+                    case "procrate": cards.ProcRate = Math.Clamp(Num(0.05), 0.0, 1.0); break;
+                    case "procdmg": cards.ProcDmg = Math.Max(0.0, Num(440)); break;
+                    case "procspellcraft": cards.ProcSpellcraft = (int)Math.Max(0, Num(9999)); break;
+                    case "procaugcap": cards.ProcAugCap = Math.Max(0.0, Num(0)); break;
+                    case "procvariance": cards.ProcVariance = Math.Clamp(Num(0), 0.0, 1.0); break;
+                    case "rend": cards.Rend = true; break;
+                    case "rendpower": cards.RendPower = Math.Clamp(Num(1.5), 1.5, 10.0); break;
+                    case "cleave": cards.Cleave = (int)Math.Clamp(Num(1), 1, 10); break;
+                    case "split": cards.Split = (int)Math.Clamp(Num(1), 1, 10); break;
+                    case "splitrange": cards.SplitRange = Math.Clamp(Num(8), 0.0, 50.0); break;
+                    case "splitdmg": cards.SplitDmg = Math.Clamp(Num(1), 0.0, 1.0); break;
+                    case "bite": cards.Bite = Math.Clamp(Num(0.5), 0.0, 1.0); break;
+                    case "crush": cards.Crush = Math.Clamp(Num(2), 2.0, 10.0); break;
+                    case "armorrend": cards.ArmorRend = Math.Clamp(Num(0.5), 0.0, 1.0); break;
+                    case "shieldcleave": cards.ShieldCleave = Math.Clamp(Num(0.5), 0.0, 1.0); break;
+                    case "slayer": cards.Slayer = Math.Clamp(Num(1.5), 1.5, 10.0); break;
+                    case "slayertype":
+                        if (val != null && val.Equals("all", StringComparison.OrdinalIgnoreCase))
+                        {
+                            cards.SlayerAll = true;
+                            break;
+                        }
+                        if (val == null || !Enum.TryParse<CreatureType>(val, true, out var ct) || ct == CreatureType.Invalid)
+                            return $"cards: unknown slayertype '{val}' (use a CreatureType name, e.g. drudge, olthoi, virindi, or all)";
+                        cards.SlayerType = ct;
+                        break;
+                    case "premade":
+                        cards.Premade = true;
+                        switch ((val ?? "bis").ToLowerInvariant())
+                        {
+                            case "bis": case "best": cards.PremadeBis = true; break;
+                            case "avg": case "average": cards.PremadeBis = false; break;
+                            default: return $"cards: premade must be bis or avg, got '{val}'";
+                        }
+                        break;
+                    default: return $"cards: unknown key '{key}'";
+                }
+            }
+            return null;
+        }
+
+        private static ImbuedEffectType ForgeMatchingRend(DamageType dt)
+        {
+            if (dt.HasFlag(DamageType.Slash)) return ImbuedEffectType.SlashRending;
+            if (dt.HasFlag(DamageType.Pierce)) return ImbuedEffectType.PierceRending;
+            if (dt.HasFlag(DamageType.Bludgeon)) return ImbuedEffectType.BludgeonRending;
+            if (dt.HasFlag(DamageType.Acid)) return ImbuedEffectType.AcidRending;
+            if (dt.HasFlag(DamageType.Cold)) return ImbuedEffectType.ColdRending;
+            if (dt.HasFlag(DamageType.Electric)) return ImbuedEffectType.ElectricRending;
+            if (dt.HasFlag(DamageType.Fire)) return ImbuedEffectType.FireRending;
+            if (dt.HasFlag(DamageType.Nether)) return ImbuedEffectType.NetherRending;
+            return ImbuedEffectType.Undef;
+        }
+
+        /// <summary>Stamps the enabled cards; returns a " | cards: ... | skipped: ..." note for the
+        /// forge message (empty when no cards).</summary>
+        private static string ApplyForgeCards(WorldObject wo, ForgeCards c, int tier)
+        {
+            // premade wins outright - it IS a card set, and mixing hand-set keys into it would make
+            // the weapon something no drop at the tier can be (owner 2026-09-01)
+            if (c.Premade)
+                return ApplyPremadeCards(wo, c.PremadeBis, tier);
+
+            var isMelee = wo is MeleeWeapon;
+            var isMissile = wo is MissileLauncher;
+            var applied = new List<string>();
+            var skipped = new List<string>();
+
+            // Cast on Strike. CASTERS ARE ELIGIBLE - the old "melee/missile only" skip here was stale
+            // even before this rewrite (a wand fires its proc on a spell hit; see ZoneLootMutator).
+            // Spells come from ZoneLootMutator's element table so the forge and the loot path can never
+            // disagree about which spell an element casts.
+            if (c.ProcArc || c.ProcRing)
+            {
+                if (ZoneLootMutator.TryGetProcSpells(wo.W_DamageType, out var arcId, out var ringId))
+                {
+                    if (c.ProcArc)
+                    {
+                        wo.ProcSpell = arcId;
+                        wo.ProcSpellRate = c.ProcRate;
+                        wo.ProcSpellSelfTargeted = false;
+                        wo.SetProperty((PropertyFloat)ZoneLootMutator.ProcArcDamagePropId, c.ProcDmg);
+                        if (c.ProcVariance > 0)
+                            wo.SetProperty((PropertyFloat)ZoneLootMutator.ProcArcVariancePropId, c.ProcVariance);
+                        applied.Add($"proc arc {arcId} @ {c.ProcRate:0.##} dmg {c.ProcDmg:0}");
+                    }
+
+                    if (c.ProcRing)
+                    {
+                        wo.SetProperty((PropertyDataId)ZoneLootMutator.ProcSpell2PropId, ringId);
+                        wo.SetProperty((PropertyFloat)ZoneLootMutator.ProcRate2PropId, c.ProcRate);
+                        wo.SetProperty((PropertyFloat)ZoneLootMutator.ProcRingDamagePropId, c.ProcDmg);
+                        if (c.ProcVariance > 0)
+                            wo.SetProperty((PropertyFloat)ZoneLootMutator.ProcRingVariancePropId, c.ProcVariance);
+                        applied.Add($"proc ring {ringId} @ {c.ProcRate:0.##} dmg {c.ProcDmg:0}");
+                    }
+
+                    // Without this the proc is resisted ~100 pct of the time on a melee character, and
+                    // the forged weapon would look broken for reasons that have nothing to do with it.
+                    if (c.ProcSpellcraft > 0)
+                        wo.ItemSpellcraft = c.ProcSpellcraft;
+
+                    // PER-SLOT caps since 2026-08-29 (prop 9061 = arc, 9064 = ring); the forge's one
+                    // procaugcap key stamps whichever slots it just forged.
+                    if (c.ProcAugCap > 0)
+                    {
+                        if (c.ProcArc)
+                            wo.SetProperty((PropertyFloat)ZoneLootMutator.ProcAugCapPropId, c.ProcAugCap);
+                        if (c.ProcRing)
+                            wo.SetProperty((PropertyFloat)ZoneLootMutator.ProcRingAugCapPropId, c.ProcAugCap);
+                    }
+                }
+                // A plain bow takes its element from the ammo and a generic caster has none, so there is
+                // no element to match a spell to - the same reason they roll no rend.
+                else skipped.Add("proc (weapon has no resolvable damage type)");
+            }
+
+            if (c.Rend)
+            {
+                var rend = ForgeMatchingRend(wo.W_DamageType);
+                // Underlay too, or the forged weapon reads as rended on appraisal but shows a plain
+                // icon in the pack - the same gap the loot path had.
+                if (rend != ImbuedEffectType.Undef)
+                {
+                    wo.ImbuedEffect |= rend;
+                    ZoneLootMutator.ApplyRendUnderlay(wo, rend);
+                    applied.Add(rend.ToString());
+                }
+                else skipped.Add("rend (no resolvable damage type)");
+            }
+
+            if (c.ArmorRend.HasValue)
+            {
+                if (isMelee || isMissile)
+                {
+                    wo.ImbuedEffect |= ImbuedEffectType.ArmorRending;
+                    wo.SetProperty((PropertyFloat)ZoneLootMutator.ArmorRendOverridePropId, c.ArmorRend.Value);
+                    applied.Add($"armorrend {c.ArmorRend.Value:0.##}");
+                }
+                else skipped.Add("armorrend (melee/missile only)");
+            }
+
+            if (c.RendPower.HasValue)
+            {
+                if ((wo.GetImbuedEffects() & ForgeAllRends) != 0)
+                {
+                    wo.SetProperty((PropertyFloat)ZoneLootMutator.RendingModOverridePropId, c.RendPower.Value);
+                    applied.Add($"rendpower {c.RendPower.Value:0.##}");
+                }
+                else skipped.Add("rendpower (weapon carries no rend)");
+            }
+
+            if (c.Cleave.HasValue)
+            {
+                if (isMelee)
+                {
+                    wo.SetProperty(PropertyInt.Cleaving, c.Cleave.Value + 1);   // engine: CleaveTargets = Cleaving - 1
+                    applied.Add($"cleave {c.Cleave.Value}");
+                }
+                else skipped.Add("cleave (melee only)");
+            }
+
+            if (c.Split.HasValue)
+            {
+                if (isMissile)
+                {
+                    wo.SetProperty((PropertyBool)ZoneLootMutator.SplitArrowsBoolId, true);
+                    wo.SetProperty((PropertyInt)ZoneLootMutator.SplitArrowCountIntId, c.Split.Value);
+                    wo.SetProperty((PropertyFloat)ZoneLootMutator.SplitArrowRangeFloatId, c.SplitRange);
+                    wo.SetProperty((PropertyFloat)ZoneLootMutator.SplitArrowDmgFloatId, c.SplitDmg);
+                    applied.Add($"split {c.Split.Value} r{c.SplitRange:0.#} d{c.SplitDmg:0.##}");
+                }
+                else skipped.Add("split (bows only)");
+            }
+
+            if (c.Bite.HasValue) { wo.CriticalFrequency = c.Bite.Value; applied.Add($"bite {c.Bite.Value:0.##}"); }
+
+            // Crushing Blow: card value IS the final crit multiplier; engine computes 1 + CriticalMultiplier.
+            if (c.Crush.HasValue) { wo.SetProperty(PropertyFloat.CriticalMultiplier, c.Crush.Value - 1.0); applied.Add($"crush {c.Crush.Value:0.##}x"); }
+
+            if (c.ShieldCleave.HasValue) { wo.IgnoreShield = c.ShieldCleave.Value; applied.Add($"shieldcleave {c.ShieldCleave.Value:0.##}"); }
+
+            // phantom REMOVED 2026-08-25 with its loot card (owner: "Not gonna be an option").
+
+            if (c.Slayer.HasValue)
+            {
+                if (c.SlayerAll)
+                {
+                    // forge-only all-creatures flag (PropertyBool 50052): no species is stamped
+                    wo.SetProperty(PropertyBool.SlayerAllCreatures, true);
+                    wo.SlayerDamageBonus = c.Slayer.Value;
+                    applied.Add($"slayer all {c.Slayer.Value:0.##}x");
+                }
+                else
+                {
+                    wo.SlayerCreatureType = c.SlayerType;
+                    wo.SlayerDamageBonus = c.Slayer.Value;
+                    applied.Add($"slayer {c.SlayerType} {c.Slayer.Value:0.##}x");
+                }
+            }
+
+            // paragon / hilt / bowstring REMOVED 2026-08-25 with their loot cards (owner).
+            // This verb mints a TEST weapon, so an option mirroring a card that no longer exists
+            // is a knob producing something the loot system never can - the dead-knob case.
+            //
+            // NOTHING RETAIL WAS TOUCHED. The Paragon Weapons recipe, the hilt recipe and the
+            // bowstring recipe all still work and a player can still apply any of them by hand.
+            // What refuses them on T11+ gear now is the craft gate's layer-0 component block,
+            // which is a GATE rather than an edit - the only thing we are allowed to do to
+            // retail content (see the owner's rule, 2026-08-25).
+
+            var note = "";
+            if (applied.Count > 0) note += " | cards: " + string.Join(", ", applied);
+            if (skipped.Count > 0) note += " | skipped: " + string.Join(", ", skipped);
+            return note;
+        }
+
+        // ─────────────── premade (owner 2026-09-01) ───────────────
+        // "A weapon carrying exactly what a monster of that tier can actually DROP." Owner ruling the
+        // same night: EXACTLY FOUR cards at EVERY tier and the modifier cap is NOT consulted -
+        // Rending (+Rend Power), Slayer, Biting Strike, Crushing Blow. No Cast on Strike, no Armor
+        // Rend, no Shield Cleave, no Cleave / Split Arrows. Every value comes from the SAME write
+        // site a drop uses (ZoneLootMutator.StampWeaponCardForForge -> StampWeaponCard): same band
+        // precedence, same grade roll (bis = band top, avg = the tier-weighted random grade), same
+        // EngineValue conversion, same recorded grade line. Slayer is the forge-only ALL-CREATURES
+        // flag, never a species - the drop path attunes to the killed monster's kind, and a test
+        // weapon has no kill behind it.
+
+        /// <summary>The tier Default an ITEM at this tier resolves against, flattened to the shape the
+        /// drop path's write site takes. /asforge premade reads the raw GetVariationDefault(tier) for
+        /// its bands; this reads the ANCHORED accessor instead (v11 anchor board under the tier's own
+        /// Default, stat toggles applied), which is what ZoneStatResolver resolves a weapon card against
+        /// on equip - so a forged card and its later re-resolve agree. The flatten is EvaluateVariant's
+        /// Stats step (StatCurve.Evaluate(1)). EMPTY, never null, when nothing is authored: every Has()
+        /// then misses and WeaponDropBand falls through to the ladder, exactly like a drop in a zone that
+        /// authors no pin.</summary>
+        private static EvaluatedProfile TierDefaultProfile(int tier, out bool authored)
+        {
+            var def = ZoneControlManager.GetAnchoredDefaultProfile(tier);
+            authored = def != null;
+            var values = new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase);
+            if (def?.Stats != null)
+                foreach (var kv in def.Stats)
+                    if (kv.Value != null)
+                        values[kv.Key] = kv.Value.Evaluate(1);
+            return new EvaluatedProfile($"T{tier} Default", 1, ZoneVariant.Minion, values,
+                weaponCardToggles: def?.CustomWeaponCards);
+        }
+
+        /// <summary>Stamps the four premade cards and returns the forge note, e.g.
+        /// " | premade bis T11: Rending Fire 2.13x, Slayer(all) 2.10x, Biting Strike 0.40, Crushing Blow 4.00x".</summary>
+        private static string ApplyPremadeCards(WorldObject wo, bool bis, int tier)
+        {
+            var p = TierDefaultProfile(tier, out var authored);
+            var landed = new List<string>();
+            var skipped = new List<string>();
+
+            // 1. Rending + Rend Power: the rend matching the weapon's own element, the way the drop
+            // path picks it. A plain bow (element from the ammo) or an elementless caster has none.
+            var rend = ForgeMatchingRend(wo.W_DamageType);
+            if (rend != ImbuedEffectType.Undef)
+            {
+                wo.ImbuedEffect |= rend;
+                ZoneLootMutator.ApplyRendUnderlay(wo, rend);
+                var power = ZoneLootMutator.StampWeaponCardForForge(wo, p, ZoneStatResolver.SpecRendPower, tier, bis);
+                landed.Add($"Rending {rend.ToString().Replace("Rending", "")} {power:0.00}x");
+            }
+            else
+                skipped.Add("Rending (no resolvable damage type - forge with an element)");
+
+            // 2. Slayer of all creatures (forge-only flag; the drop path never sets it)
+            wo.SetProperty(PropertyBool.SlayerAllCreatures, true);
+            var slayer = ZoneLootMutator.StampWeaponCardForForge(wo, p, ZoneStatResolver.SpecSlayer, tier, bis);
+            landed.Add($"Slayer(all) {slayer:0.00}x");
+
+            // 3. Biting Strike (crit chance, a 0..1 fraction)
+            var bite = ZoneLootMutator.StampWeaponCardForForge(wo, p, ZoneStatResolver.SpecBite, tier, bis);
+            landed.Add($"Biting Strike {bite:0.00}");
+
+            // 4. Crushing Blow - the wrapper returns the DISPLAY multiplier; what it stored is display - 1
+            var crush = ZoneLootMutator.StampWeaponCardForForge(wo, p, ZoneStatResolver.SpecCrush, tier, bis);
+            landed.Add($"Crushing Blow {crush:0.00}x");
+
+            var note = $" | premade {(bis ? "bis" : "avg")} T{tier}: " + string.Join(", ", landed);
+            if (!authored)
+                note += " [no tier Default authored - ladder bands]";
+            if (skipped.Count > 0)
+                note += " | skipped: " + string.Join(", ", skipped);
+            return note;
+        }
+
+        /// <summary>The 102-slot pack (wcid 310025, the /testchar "Booster Pack" bag) a bagged forge
+        /// run mints into. Found by name so repeat runs keep filling the same pack; created on first
+        /// use, which costs one of the player's 7 visible pack slots.</summary>
+        private const uint ForgePackWcid = 310025;
+        private const string ForgePackName = "Weapon Pack";
+
+        private static Container GetOrCreateForgePack(Player player)
+        {
+            var existing = player.Inventory.Values.OfType<Container>()
+                .FirstOrDefault(c => string.Equals(c.Name, ForgePackName, StringComparison.OrdinalIgnoreCase));
+            if (existing != null)
+                return existing;
+
+            if (!(ACE.Server.Factories.WorldObjectFactory.CreateNewWorldObject(ForgePackWcid) is Container bag))
+                return null;
+            bag.Name = ForgePackName;
+            bag.SetProperty(PropertyString.Name, ForgePackName);
+            if (player.TryCreateInInventoryWithNetworking(bag))
+                return bag;
+
+            bag.Destroy();   // no free pack slot - caller falls back to the main pack
+            return null;
+        }
+
+        /// <summary>Place a freshly minted item into a specific container the player already holds.
+        /// TryCreateInInventoryWithNetworking only targets "main pack, else first side pack with
+        /// room", so the client updates are done by hand here (same messages it sends).</summary>
+        private static bool TryPlaceInPack(Player player, WorldObject wo, Container bag)
+        {
+            if (bag == null || !bag.TryAddToInventory(wo))
+                return false;
+
+            player.Session.Network.EnqueueSend(new GameMessageCreateObject(wo));
+            player.Session.Network.EnqueueSend(
+                new GameEventItemServerSaysContainId(player.Session, wo, bag),
+                new GameMessagePrivateUpdatePropertyInt(player, PropertyInt.EncumbranceVal, player.EncumbranceVal ?? 0));
+            wo.SaveBiotaToDatabase();
+            return true;
+        }
+
+        private static string ForgeWeapon(ACE.Server.WorldObjects.Player player, uint wcid, string cleanName,
+            int quality, int tier, DamageType? element,
+            ACE.Server.Factories.Enum.TreasureWeaponType twType = ACE.Server.Factories.Enum.TreasureWeaponType.Undef,
+            ForgeCards cards = null, Container bag = null, bool force = false)
+        {
+            WorldObject wo;
+            if (tier == 10 && twType != ACE.Server.Factories.Enum.TreasureWeaponType.Undef)
+            {
+                // T10 = the SAME range as the existing tier-10 loot table (owner 2026-08-15). The
+                // bench weenie runs through the real loot pipeline with a synthetic tier-10
+                // profile, so its damage rolls from the same mutation-script ranges as a live T10
+                // drop. It also gets NO quality/tier stamp below - a real T10 drop carries none,
+                // so a forged one gets no aug-scaling term and the quality arg is ignored here.
+                var t10Profile = new ACE.Database.Models.World.TreasureDeath { TreasureType = 0, Tier = 10, LootQualityMod = 0 };
+                var roll = new ACE.Server.Factories.Entity.TreasureRoll(ACE.Server.Factories.Enum.TreasureItemType_Orig.Weapon)
+                {
+                    Wcid = (ACE.Server.Factories.Enum.WeenieClassName)wcid,
+                    WeaponType = twType,
+                };
+                wo = ACE.Server.Factories.LootGenerationFactory.CreateAndMutateWcid(t10Profile, roll, false);
+            }
+            else
+                wo = ACE.Server.Factories.WorldObjectFactory.CreateNewWorldObject(wcid);
+
+            if (wo == null)
+                return $"forge: could not create wcid {wcid}";
+
+            ACE.Server.Factories.LootGenerationFactory.StripWieldRequirements(wo);
+            // Standard T10+ mods: 20 pct attack / 20 pct melee d (wands +20 pct mana c), same as
+            // every loot drop (owner 2026-08-15). The T10 CreateAndMutateWcid path already stamped
+            // them in mutation; this covers the T11+ bench path.
+            ACE.Server.Factories.LootGenerationFactory.ApplyStandardWeaponMods(wo, tier);
+            // T10 = the basic tier, no aug wield gate (same rule as /asforge armor). A minwield-0
+            // tier row would NOT give that: ApplyT11WieldRequirement falls back to the global gate.
+            if (tier >= 11)
+            {
+                ACE.Server.Factories.LootGenerationFactory.ApplyT11WieldRequirement(wo, tier);
+                wo.SetProperty(ACE.Entity.Enum.Properties.PropertyInt.WeaponAugScaleQuality, quality);
+                wo.SetProperty(ACE.Entity.Enum.Properties.PropertyInt.WeaponAugScaleTier, tier);
+            }
+
+            // representative caster: real T11 wands carry an elemental multiplier. At T10 the
+            // loot mutation already authored the wand's real table value - leave it alone.
+            if (wo is ACE.Server.WorldObjects.Caster && tier >= 11)
+                wo.ElementalDamageMod = 1.5;
+
+            // premade weapons carry the mode in the name so a BiS and an Avg at one tier never collide
+            // on the duplicate guard below (the "(BiS)" convention /asforge premade already uses)
+            var tag = (tier == 10 ? "Test T10" : $"Test q{quality}")
+                + (cards != null && cards.Premade ? (cards.PremadeBis ? " BiS" : " Avg") : "");
+
+            if (element != null)
+            {
+                wo.SetProperty(ACE.Entity.Enum.Properties.PropertyInt.DamageType, (int)element.Value);
+
+                // icon underlay matches the element (the base weenie's stays otherwise)
+                var uiEffect = element.Value switch
+                {
+                    DamageType.Slash => UiEffects.Slashing,
+                    DamageType.Pierce => UiEffects.Piercing,
+                    DamageType.Bludgeon => UiEffects.Bludgeoning,
+                    DamageType.Acid => UiEffects.Acid,
+                    DamageType.Fire => UiEffects.Fire,
+                    DamageType.Cold => UiEffects.Frost,
+                    DamageType.Electric => UiEffects.Lightning,
+                    DamageType.Nether => UiEffects.Nether,
+                    _ => UiEffects.Undef
+                };
+                wo.SetProperty(ACE.Entity.Enum.Properties.PropertyInt.UiEffects, (int)uiEffect);
+
+                wo.Name = $"{element.Value} {cleanName} ({tag})";
+            }
+            else
+                wo.Name = $"{wo.Name} ({tag})";
+
+            // Provenance, mirroring real drops' "Dropped by / Location" block (owner 2026-08-01):
+            // who forged it + the tier it was stamped at. AppraiseInfo's per-viewer bonus line
+            // anchors above "Created by" the same way it does "Dropped by".
+            wo.LongDesc = $"Created by: {player.Name}\nTier: {tier}";
+
+            // Everything the forge mints is Attuned + Bonded (owner 2026-08-02) — test gear
+            // can't be traded, vendored, or dropped on death. Same stamps as /asforge.
+            wo.Attuned = ACE.Entity.Enum.AttunedStatus.Attuned;
+            wo.Bonded = ACE.Entity.Enum.BondedStatus.Bonded;
+
+            // Owner 2026-08-20: repeat presses used to stack another full set into the Weapon Pack.
+            // Skip anything already held. Name carries class + element + quality but NOT the tier
+            // (T11+), so a T13 re-forge would otherwise collide with its T12 twin - match the
+            // stamped WeaponAugScaleTier too.
+            if (!force)
+            {
+                // Compare against what THIS forge stamped, not the requested tier: a T10 weapon is minted unscaled
+                // with NO WeaponAugScaleTier, so "== tier" (0 == 10) never matched and every premade press at T10
+                // stacked another full set (owner 2026-09-03: "extra are created when using twice").
+                var stampedTier = wo.GetProperty(ACE.Entity.Enum.Properties.PropertyInt.WeaponAugScaleTier) ?? 0;
+                var heldSame = player.GetAllPossessionsDeep().Any(i =>
+                    i.Name == wo.Name
+                    && (i.GetProperty(ACE.Entity.Enum.Properties.PropertyInt.WeaponAugScaleTier) ?? 0) == stampedTier);
+
+                if (heldSame)
+                {
+                    wo.Destroy();
+                    return $"forge: already holding {wo.Name} at tier {tier} - skipped (add 'force' to mint another)";
+                }
+            }
+
+            var cardNote = cards != null ? ApplyForgeCards(wo, cards, tier) : "";
+
+            // Bagged runs fill the Weapon Pack; if it is full (or could not be made) the weapon still
+            // lands normally rather than being lost.
+            var placed = bag != null && TryPlaceInPack(player, wo, bag);
+            if (!placed && !player.TryCreateInInventoryWithNetworking(wo))
+            {
+                wo.Destroy();
+                return $"forge: could not place {wo.Name} in inventory (full?)";
+            }
+
+            var gradeNote = tier == 10
+                ? "T10 loot table range, no aug scaling"
+                : $"grade {WeaponScalingManager.GetQualityGrade(quality)} ({quality}/1000), tier {tier}";
+            return $"forged: {wo.Name} -> family {WeaponScalingCombat.GetFamilyKey(wo) ?? "none"}, " +
+                   gradeNote + (placed ? " [" + ForgePackName + "]" : "") + cardNote;
+        }
+
+        /// <summary>The Admin > Forge subtab's backend (owner 2026-08-01): any single weapon
+        /// class at any quality/element/tier, minted live.</summary>
+        [CommandHandler("wsforge", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 1,
+            "Forges one Weapon Scaling test weapon of the given class (or a full set with 'all').",
+            "<class|all> [quality 0-1000, default 500] [element] [tier 10-25, default 11; 10 = T10 loot-table range, unscaled + no wield gate, quality ignored] [cards:key=val,key,...]\n" +
+            "Classes: sword sword_ms dagger dagger_ms axe mace spear staff ua cleaver spear2h bow crossbow atlatl wand\n" +
+            "cards: proc (Cast on Strike, BOTH slots) procarc procring (one slot only) procrate=0-1 procdmg=<n> procspellcraft=<n> procaugcap=<n> procvariance=0-1 rend (matching rend imbue)\n" +
+            "rendpower=1.5-10 cleave=1-10 (melee) split=1-10 splitrange=0-50 splitdmg=0-1 (bows) bite=0-1 (crit chance)\n" +
+            "crush=2-10 (crit damage mult) armorrend=0-1 shieldcleave=0-1 slayer=1.5-10 slayertype=<name|all>\n" +
+            "premade[=bis|avg] = the drop-equivalent set for the tier: Rending, Slayer (all creatures), Biting Strike, Crushing Blow; bis = band top, avg = drop roll; other card keys ignored\n" +
+            "bag = mint into a 102-slot \"Weapon Pack\" instead of loose in the main pack (costs one pack slot, reused across runs)\n" +
+            "force = mint even if you already hold that exact weapon at that tier (default is to skip it, so repeat presses cannot stack sets)")]
+        public static void HandleWsForge(Session session, params string[] parameters)
+        {
+            void Msg(string s) => ChatPacket.SendServerMessage(session, s, ChatMessageType.Broadcast);
+
+            var player = session.Player;
+            if (player == null)
+                return;
+
+            // The cards clause may sit at any position - strip it out of the positional args first.
+            ForgeCards cards = null;
+            foreach (var p in parameters)
+            {
+                if (!p.StartsWith("cards:", StringComparison.OrdinalIgnoreCase))
+                    continue;
+                cards = new ForgeCards();
+                var err = ParseForgeCards(p.Substring(6), cards);
+                if (err != null)
+                {
+                    Msg("wsforge " + err);
+                    return;
+                }
+            }
+            // "bag" anywhere = mint into the Weapon Pack (owner 2026-08-11: a premade's weapon set
+            // should not bury the main pack).
+            var useBag = parameters.Any(p => p.Equals("bag", StringComparison.OrdinalIgnoreCase));
+            var force = parameters.Any(p => p.Equals("force", StringComparison.OrdinalIgnoreCase));
+            var positional = parameters
+                .Where(p => !p.StartsWith("cards:", StringComparison.OrdinalIgnoreCase)
+                            && !p.Equals("bag", StringComparison.OrdinalIgnoreCase)
+                            && !p.Equals("force", StringComparison.OrdinalIgnoreCase)).ToArray();
+            if (positional.Length == 0)
+            {
+                Msg("wsforge: missing class. Classes: all " + string.Join(" ", ForgeClasses.Select(c => c.Key)));
+                return;
+            }
+
+            var classKey = positional[0].ToLowerInvariant();
+            var all = classKey == "all";
+            var cls = ForgeClasses.FirstOrDefault(c => c.Key == classKey);
+            if (!all && cls.Wcid == 0)
+            {
+                Msg("wsforge: unknown class. Classes: all " + string.Join(" ", ForgeClasses.Select(c => c.Key)));
+                return;
+            }
+
+            var quality = 500;
+            if (positional.Length > 1 && int.TryParse(positional[1], out var q))
+                quality = Math.Clamp(q, 0, 1000);
+
+            DamageType? element = null;
+            if (positional.Length > 2 && !positional[2].Equals("base", StringComparison.OrdinalIgnoreCase))
+            {
+                element = ParseElement(positional[2]);
+                if (element == null)
+                {
+                    Msg("wsforge: unknown element. Use base|slash|pierce|bludge|acid|fire|cold|electric|nether.");
+                    return;
+                }
+            }
+
+            var tier = 11;
+            if (positional.Length > 3 && int.TryParse(positional[3], out var t))
+                tier = Math.Clamp(t, 10, 25);
+
+            var bag = useBag ? GetOrCreateForgePack(player) : null;
+            if (useBag && bag == null)
+                Msg($"wsforge: no free pack slot for a {ForgePackName} - forging into the main pack instead.");
+
+            if (all)
+            {
+                // one of every class at the same quality/element/tier (owner 2026-08-01)
+                foreach (var c in ForgeClasses)
+                    Msg(ForgeWeapon(player, c.Wcid, c.CleanName, quality, tier, element, c.TWType, cards, bag, force));
+                return;
+            }
+
+            Msg(ForgeWeapon(player, cls.Wcid, cls.CleanName, quality, tier, element, cls.TWType, cards, bag, force));
+        }
+    }
+}

--- a/Source/ACE.Server/Command/Handlers/ZoneControlCommandHelp.cs
+++ b/Source/ACE.Server/Command/Handlers/ZoneControlCommandHelp.cs
@@ -118,12 +118,12 @@ namespace ACE.Server.Command.Handlers
             E("Readiness", "/zonecontrol mobcheckget", "[<zone>] [--wcid <id>]", "Machine twin of mobcheck ([[ZCMC]]) for the Readiness tab."),
 
             // ── Weapon scaling ────────────────────────────────────────────────
-            E("Weapon Scaling", "/weaponscale", "show | enable on|off | tier <t> cap|minwield|minwieldtriune|minwieldskillcharm <n> | tier add|remove <t> | script <name> kmin|kmax <v> | script add|remove <name> | grade ... | kc min|max <v> | sync on|off | reset | reload | tighten", "Weapon aug-scaling config (the plugin's Weapons > Scaling panel)."),
+            E("Weapon Scaling", "/weaponscale", "show | enable on|off | tier <t> cap|minwield|minwieldtriune|minwieldskillcharm <n> | tier add|remove <t> | script <name> kmin|kmax|variance <v> | script <name> ladder <anchorS>|clear | script <name> grade <S..F-> <k> | script add|remove <name> | grade ... | kc min|max <v> | sync on|off | reset | reload | tighten", "Weapon aug-scaling config (the plugin's Weapons > Scaling panel)."),
 
             // ── Character forge ───────────────────────────────────────────────
             E("Character", "/testchar", "T0 | set attrs|vitals|level|enl|augs|charms|raugs <csv> | apply skills,spells,aetheria,manastone | extra <keys> | save | report | gems | charms | print <wcid>", "Test-character builder behind the Character tab."),
             E("Character", "/asforge", "<piece|suit|jewel|all> [tier 10-25] [cards:...] | premade <tier 10-25> <avg|bis> [force]", "Forge test armor / jewelry; premade = the 18-piece suit at a tier's Avg or BiS."),
-            E("Character", "/wsforge", "<class|all> [quality 0-1000] [element] [tier 10-25]", "Forge one Weapon Scaling test weapon (or a full set)."),
+            E("Character", "/wsforge", "<class|all> [quality 0-1000] [element] [tier 10-25] [cards:key=val,...] [bag] [force]", "Forge one Weapon Scaling test weapon (or a full set)."),
 
             // Retail admin / session commands (@cloak, @smite, /createliveops, /clearcache ...) are NOT listed
             // here (owner 2026-09-03: "not zc stuff - just normal admin commands").

--- a/Source/ACE.Server/Command/Handlers/ZoneControlCommandHelp.cs
+++ b/Source/ACE.Server/Command/Handlers/ZoneControlCommandHelp.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ACE.Server.Command.Handlers
+{
+    /// <summary>
+    /// THE registry of every chat command the ZoneControl plugin sends (owner 2026-09-03: a GM Tools >
+    /// Chat Commands tab "that we keep updated"). The plugin renders this list; it never carries its own.
+    /// `/zonecontrol help` prints it as prose, `/zonecontrol help --wire` emits one [[ZCHELP]] row per entry.
+    ///
+    /// KEEP IT UPDATED: when a verb is added, removed or re-shaped in ZoneControlCommands.cs (or any other
+    /// command the plugin sends), edit the matching row here in the same change. A row is
+    /// (Group, Command, Usage, What it does) - one line each, plain ASCII, no '~' (the wire separator).
+    /// </summary>
+    // NOTE for the next audit: `cantrip` is a deliberate silent alias of `modifier` and is not listed.
+    public static class ZoneControlCommandHelp
+    {
+        public readonly struct Entry
+        {
+            public readonly string Group, Command, Usage, Description;
+            public Entry(string group, string command, string usage, string description)
+            { Group = group; Command = command; Usage = usage; Description = description; }
+        }
+
+        private static Entry E(string g, string c, string u, string d) => new Entry(g, c, u, d);
+
+        public static readonly Entry[] All =
+        {
+            // ── Zones ──────────────────────────────────────────────────────────
+            E("Zones", "/zonecontrol create", "<name...> <variation|here> [here|<hex>]", "Create a zone at a variation; multi-word names are fine (create Tou Tou here)."),
+            E("Zones", "/zonecontrol delete", "<name>", "Delete a zone and everything it authors."),
+            E("Zones", "/zonecontrol rename", "<old> <new...>", "Rename a zone."),
+            E("Zones", "/zonecontrol enable", "<name>", "Turn a zone on (its stats, props and effects apply)."),
+            E("Zones", "/zonecontrol disable", "<name>", "Turn a zone off without deleting it."),
+            E("Zones", "/zonecontrol setvar", "<name> <variation>", "Move a zone to another variation (11+ = prestige layers)."),
+            E("Zones", "/zonecontrol clonezone", "<zone> <variation|lo-hi>", "Clone a zone to other variations, e.g. clonezone Tou Tou 12-25."),
+            E("Zones", "/zonecontrol addlb", "<name> <hex|here> [more...]", "Add landblocks to a zone (comma lists ok: F559,F55A)."),
+            E("Zones", "/zonecontrol removelb", "<name> <hex>", "Remove one landblock from a zone."),
+            E("Zones", "/zonecontrol boundary", "<name> <on|off|show>", "Bounded zones keep players inside their landblocks at that variation."),
+            E("Zones", "/zonecontrol arealist", "", "List every zone with its variation and state (the plugin's zone list)."),
+            E("Zones", "/zonecontrol list", "", "Compact one-line-per-zone listing for chat."),
+            E("Zones", "/zonecontrol here", "", "Which zone governs where you stand, and at what variation."),
+            E("Zones", "/zonecontrol show", "<name> [--wcid <id>]", "Print a zone's authored stats (or one monster's merged view)."),
+            E("Zones", "/zonecontrol reload", "", "Re-read the whole Zone Control store from the shard DB."),
+
+            // ── Sync / plugin plumbing ─────────────────────────────────────────
+            E("Plugin Sync", "/zonecontrol get", "[<name>] [--wcid <id>]", "One-shot [[ZC]] sync of a zone (bare get = session state only)."),
+            E("Plugin Sync", "/zonecontrol sync", "on <name> [--wcid <id>] | off", "Start / stop the 2 s live sync stream the plugin window reads."),
+            E("Plugin Sync", "/zonecontrol mobs", "<name>", "The zone's monster list (every creature reachable from placed generators)."),
+            E("Plugin Sync", "/zonecontrol mobinfo", "<wcid>", "A weenie's base stats for the plugin's hints."),
+            E("Plugin Sync", "/zonecontrol propsof", "<wcid> <i|f|b|l>:<id>,...", "A weenie's own values for a list of properties (the Props tab's hints)."),
+            E("Plugin Sync", "/zonecontrol selinfo", "", "What you have selected in game (wcid, name, creature or not)."),
+            E("Plugin Sync", "/zonecontrol findmob", "<text or wcid>", "Search creature weenies by name or id."),
+            E("Plugin Sync", "/zonecontrol help", "[--wire]", "This list. --wire feeds the Chat Commands tab."),
+
+            // ── Stats + ranks ─────────────────────────────────────────────────
+            E("Stats", "/zonecontrol set", "<name> <stat> <value> [--wcid <id>] [--rank regular|leader|boss]", "Author a stat on the zone, one monster's bucket, or a rank row."),
+            E("Stats", "/zonecontrol clearstat", "<name> <stat> [--wcid <id>] [--rank r]", "Unset a stat at that scope (it inherits again)."),
+            E("Stats", "/zonecontrol togglestat", "<name> <stat> <on|off|clear> | list", "Zone-scope only: OFF makes a stat count as unset here even if the tier authors it."),
+            E("Stats", "/zonecontrol default", "<var> <show|set|clearstat|clear|list> ...", "The Tier Default layer every zone at that variation inherits. set/clearstat take --rank."),
+            E("Stats", "/zonecontrol defaultget", "<variation>", "One-shot [[ZCD]] sync of a Tier Default."),
+            E("Stats", "/zonecontrol tier", "<stat> <t11value> <t25value> [--curve augs|linear] | show <stat> | clear <stat> | curves", "Author all 15 Tier Defaults of a stat from a T11..T25 curve."),
+            E("Stats", "/zonecontrol simstats", "<name> --wcid <id>", "Rank-aware effective offense numbers for the Curves simulator."),
+            E("Stats", "/zonecontrol resetmob", "<zone> --wcid <id>", "Remove ALL of one monster's overrides: stats, props, loot, appearance."),
+
+            // ── Master switches ───────────────────────────────────────────────
+            E("Exempt", "/zonecontrol exempt", "<zone> <on|off> --wcid <id>", "Master switch per monster: exempt = the zone leaves it alone entirely."),
+            E("Exempt", "/zonecontrol exempt", "<zone> <on|off> --gen <generator wcid>", "Master switch per generator: everything it spawns here is ungoverned (nested too)."),
+            E("Exempt", "/zonecontrol exempt", "<zone> list", "Print both exempt sets for a zone."),
+
+            // ── Props + body parts ────────────────────────────────────────────
+            E("Props", "/zonecontrol prop", "<name> <int|int64|float|bool> <idOrName> <value> [--wcid <id>]", "Stamp a weenie property onto every governed spawn (or one monster). Applies on respawn."),
+            E("Props", "/zonecontrol clearprop", "<name> <int|int64|float|bool> <idOrName> [--wcid <id>]", "Stop stamping that property."),
+            E("Body Parts", "/zonecontrol part", "<name> <part> <armor|damage|variance|dmgtype> <value> [--wcid <id>]", "Override one body part's armor / damage / variance / damage type."),
+            E("Body Parts", "/zonecontrol clearpart", "<name> <part> [field] [--wcid <id>]", "Clear a body-part override (no field = all four)."),
+            E("Body Parts", "/zonecontrol partsof", "<wcid | sel>", "List a monster's body parts with their weenie values."),
+            E("Body Parts", "/zonecontrol listparts", "<wcid | 0xSetupId>", "List the parts a setup carries."),
+
+            // ── Appearance ────────────────────────────────────────────────────
+            E("Appearance", "/zonecontrol appearance", "<name> <palette|shade|scale|translucency|shiny> <value> [--wcid <id>]", "Cosmetic layer for the zone or one monster; separate from stats."),
+            E("Appearance", "/zonecontrol appearance", "<name> animpart <index> <gfxObjHex> [--wcid <id>]", "Swap one model part."),
+            E("Appearance", "/zonecontrol appearance", "<zone> name <new name> --wcid <id>", "Display name for one monster in this zone."),
+            E("Appearance", "/zonecontrol clearappearance", "<name> [field] [--wcid <id>]", "Clear the cosmetic layer (no field = everything)."),
+            E("Appearance", "/zonecontrol copylook", "<name> <donorWcid> [--wcid <id>]", "Copy a donor weenie's look onto the zone default or one monster."),
+            E("Appearance", "/zonecontrol becomemob", "<donorWcid> --wcid <targetWcid>", "The target becomes a full copy of the donor; keeps its name and scale."),
+            E("Appearance", "/zonecontrol clonemob", "<zone> <newWcid> [new display name] --wcid <srcWcid>", "Mint a new weenie from an existing monster."),
+            E("Appearance", "/zonecontrol bakemob", "<zone> --wcid <id>", "Write the monster's current look into its weenie permanently."),
+            E("Appearance", "/zonecontrol previewmob", "<wcid> [distance]", "Spawn a short-lived preview of a weenie in front of you."),
+            E("Appearance", "/zonecontrol draftslot", "<zone> [release]", "Reserve / release the Look Lab's draft weenie slot."),
+            E("Appearance", "/zonecontrol copydraft", "<zone> <destWcid>", "Save the drafted look onto the destination's zone appearance."),
+            E("Appearance", "/zonecontrol seticon", "<wcid> <iconDid|clear> [icon|overlay|overlay2|underlay]", "Set or clear a weenie's icon layers."),
+
+            // ── Spells + effects ──────────────────────────────────────────────
+            E("Spells", "/zonecontrol spell", "<name> <off|on|add|chance|remove|list> [spellId] [chancePct] [--wcid <id>]", "Zone-added spells and cast chances, per zone or per monster."),
+            E("Effects", "/zonecontrol effect", "<name> [show | dot on|off | dmg <n> | type <t> | interval <s> | suppress on|off | suppress prodigal on|off | suppress regen <pct>]", "Zone-wide DoT and suppression effects."),
+
+            // ── Loot ──────────────────────────────────────────────────────────
+            E("Loot", "/zonecontrol currency", "<name> <add|remove|list> [itemWcid] [amount] [chance] [direct|corpse] [--wcid <id>]", "Bonus currency drops per kill."),
+            E("Loot", "/zonecontrol modifier", "<name> <add|remove|list|catalog|band|slots|special|chance> [args] [--wcid <id>]", "Modifier (cantrip) pool, bands, slots, specials and chances."),
+            E("Loot", "/zonecontrol modifier default", "<variation> <band|slots|special|chance> ...", "The same, on a Tier Default."),
+            E("Loot", "/zonecontrol weaponcard", "<name> <chance_stat> <on|off|clear> | list", "Weapon card on/off per zone (default <var> weaponcard ... for a tier)."),
+            E("Loot", "/zonecontrol craft", "<material> <itemtype> auto|allow|deny | list | get | materials | components ... | enabled true|false | mintier <tier> | test <material> <itemtype>", "Crafting rules for the zone's drops."),
+            E("Loot", "/zonecontrol ladder", "status | apply [tier|all] | migrate [here|<player>] [--dry] | show", "Armor-level ladder: status, re-price, migrate."),
+
+            // ── Generators + territory ────────────────────────────────────────
+            E("Generators", "/zonecontrol genlist", "[<zone>]", "Placed generators in a zone (or where you stand) with counts; feeds the Generators tab."),
+            E("Generators", "/zonecontrol geninfo", "<wcid>", "One generator's knobs: delay, radius, stagger, init, max."),
+            E("Generators", "/zonecontrol genedit", "<wcid> delay|radius|stagger|init|max <value>", "Edit a generator weenie (ace_world) and clear its cache."),
+            E("Generators", "/bossgroup", "status [--wire] | set <group> delay|radius <v> | clear <group> delay|radius | enable|disable <group> | respawn <group>", "Boss groups: generators sharing a BossGroupId. Overrides are runtime (shard store)."),
+            E("Territory", "/zonecontrol survey", "<name> [lbHex]", "Per-landblock survey: generators and creatures reachable."),
+            E("Territory", "/zonecontrol terrain", "<name> <hex> <type|clear>", "Terrain override for a landblock (spawn redirection)."),
+            E("Territory", "/zonecontrol quests", "<name>", "The zone's quest registry rows."),
+
+            // ── Readiness ─────────────────────────────────────────────────────
+            E("Readiness", "/zonecontrol mobcheck", "[<zone>] [<wcid>]", "Is this monster ready in this zone? No wcid = the creature you have selected."),
+            E("Readiness", "/zonecontrol mobcheckget", "[<zone>] [--wcid <id>]", "Machine twin of mobcheck ([[ZCMC]]) for the Readiness tab."),
+
+            // ── Weapon scaling ────────────────────────────────────────────────
+            E("Weapon Scaling", "/weaponscale", "show | enable on|off | tier <t> cap|minwield|minwieldtriune|minwieldskillcharm <n> | tier add|remove <t> | script <name> kmin|kmax <v> | script add|remove <name> | grade ... | kc min|max <v> | sync on|off | reset | reload | tighten", "Weapon aug-scaling config (the plugin's Weapons > Scaling panel)."),
+
+            // ── Character forge ───────────────────────────────────────────────
+            E("Character", "/testchar", "T0 | set attrs|vitals|level|enl|augs|charms|raugs <csv> | apply skills,spells,aetheria,manastone | extra <keys> | save | report | gems | charms | print <wcid>", "Test-character builder behind the Character tab."),
+            E("Character", "/asforge", "<piece|suit|jewel|all> [tier 10-25] [cards:...] | premade <tier 10-25> <avg|bis> [force]", "Forge test armor / jewelry; premade = the 18-piece suit at a tier's Avg or BiS."),
+            E("Character", "/wsforge", "<class|all> [quality 0-1000] [element] [tier 10-25]", "Forge one Weapon Scaling test weapon (or a full set)."),
+
+            // Retail admin / session commands (@cloak, @smite, /createliveops, /clearcache ...) are NOT listed
+            // here (owner 2026-09-03: "not zc stuff - just normal admin commands").
+        };
+
+        /// <summary>Groups in first-seen order, for the prose form.</summary>
+        public static IEnumerable<string> Groups => All.Select(e => e.Group).Distinct();
+
+        private static string Wire(string s) => (s ?? "").Replace('~', '-');
+
+        /// <summary>One [[ZCHELP]] line per entry: "[[ZCHELP]]i~n~group~command~usage~description" - '~' separated
+        /// so usage strings keep their '|' alternatives readable; the plugin splits on '~' at most 6 ways.</summary>
+        public static IEnumerable<string> WireLines()
+        {
+            var n = All.Length;
+            for (var i = 0; i < n; i++)
+            {
+                var e = All[i];
+                yield return new StringBuilder("[[ZCHELP]]").Append(i).Append('~').Append(n).Append('~')
+                    .Append(Wire(e.Group)).Append('~').Append(Wire(e.Command)).Append('~')
+                    .Append(Wire(e.Usage)).Append('~').Append(Wire(e.Description)).ToString();
+            }
+        }
+    }
+}

--- a/Source/ACE.Server/Command/Handlers/ZoneControlCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/ZoneControlCommands.cs
@@ -1,0 +1,5580 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+using ACE.Common.Performance;
+using ACE.DatLoader;
+using ACE.DatLoader.FileTypes;
+using ACE.Database.Models.World;
+using ACE.Entity.Enum;
+using ACE.Entity.Enum.Properties;
+using ACE.Entity.Models;
+using ACE.Server.Managers;
+using ACE.Server.Managers.ZoneControl;
+using ACE.Server.Managers.ZoneScaling;
+using ACE.Server.Network;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace ACE.Server.Command.Handlers
+{
+    /// <summary>
+    /// /zonecontrol â€” author + toggle controlled ZONES (Developer). A zone is a named set of landblocks
+    /// governing one world Variation (0 = normal world, 11+ = variants), with an on/off switch, a DEFAULT
+    /// stat set for all its monsters, and optional per-monster (WCID) overrides. No prestige/tier/boss concepts.
+    /// Disable reverts monsters to baseline (live stats instantly, HP on respawn).
+    /// </summary>
+    public static class ZoneControlCommands
+    {
+        private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
+        /// <summary>What a plugin "sync on" session is watching; rebuilt + pushed each <see cref="PushTick"/>.</summary>
+        private class SyncWatch
+        {
+            public string Name;
+            public uint? Wcid;
+            public string LastPayload;       // change-detection: identical payloads aren't re-sent
+            public DateTime LastSentUtc;     // ... except as a periodic keepalive/correction resend
+        }
+
+        private static readonly ConcurrentDictionary<Session, SyncWatch> _pluginSessions = new();
+        private static readonly RateLimiter _pushTickRateLimiter = new RateLimiter(1, TimeSpan.FromSeconds(2));
+
+        /// <summary>An unchanged [[ZC]] payload is still re-sent this often, so a plugin holding a stale
+        /// optimistic value (e.g. after a failed command) gets corrected without the old every-2s spam.</summary>
+        // 15 -> 120 s (2026-09-03): every full-payload resend costs the client a ~260 ms freeze even chunked
+        // (measured), and the plugin does not track stream liveness - the resend is only a lost-push correction.
+        private const double SyncKeepaliveSeconds = 120.0;
+
+        /// <summary>The last `get` reply per session (2026-09-03): seeds the sync watch's change detector so the
+        /// first push after a target change is not a byte-identical duplicate of the get reply that just went out
+        /// (the plugin Pull()s AND re-handshakes on every pick - two identical 8 KB payloads a second apart).</summary>
+        private static readonly ConcurrentDictionary<Session, (string Name, uint? Wcid, string Payload, DateTime At)> _lastGet = new();
+
+        /// <summary>Called from WorldManager.UpdateGameWorld() every frame; rate-limited to once per 2s.
+        /// Pushes [[ZC]] to registered plugin sessions â€” but only when the payload actually CHANGED since
+        /// that session's last push (movement, live target values, any zone edit), or the keepalive is due.
+        /// An idle GUI session generates ~one line per 15s instead of one per 2s.</summary>
+        public static void PushTick()
+        {
+            if (_pluginSessions.IsEmpty)
+                return;
+            if (_pushTickRateLimiter.GetSecondsToWaitBeforeNextEvent() > 0)
+                return;
+            _pushTickRateLimiter.RegisterEvent();
+
+            foreach (var kv in _pluginSessions)
+            {
+                var session = kv.Key;
+                if (session.IsTerminated)
+                {
+                    _pluginSessions.TryRemove(session, out _);
+                    _lastGet.TryRemove(session, out _);   // never leak a Session through the get cache (review 2026-09-03)
+                    continue;
+                }
+
+                var watch = kv.Value;
+                var payload = BuildZonePayload(watch.Name, watch.Wcid, session);
+                var now = DateTime.UtcNow;
+                if (payload == watch.LastPayload && (now - watch.LastSentUtc).TotalSeconds < SyncKeepaliveSeconds)
+                    continue;
+
+                watch.LastPayload = payload;
+                watch.LastSentUtc = now;
+                SendChunked(session, payload);
+            }
+        }
+
+        /// <summary>Chat lines over this length go out as "[[ZC+]]i/n|piece" chunks (2026-09-03). MEASURED on the
+        /// test client: every 7.7-8.5 KB [[ZC]] line froze the client for ~1.5 s before Decal's chat hook even
+        /// fired (17 of 17), while 2.6 KB lines never did. The plugin (PluginCore) reassembles in order.</summary>
+        private const int ChatChunkChars = 600;   // 1800 -> 600 (2026-09-03 20:40): 5 x 1.8 KB still cost ~480 ms per payload; the cost is superlinear in line length
+
+        private static void SendChunked(Session session, string payload)
+        {
+            if (payload.Length <= ChatChunkChars)
+            {
+                ChatPacket.SendServerMessage(session, payload, ChatMessageType.Broadcast);
+                return;
+            }
+            var n = (payload.Length + ChatChunkChars - 1) / ChatChunkChars;
+            for (var i = 0; i < n; i++)
+            {
+                var piece = payload.Substring(i * ChatChunkChars, Math.Min(ChatChunkChars, payload.Length - i * ChatChunkChars));
+                ChatPacket.SendServerMessage(session, "[[ZC+]]" + i + "/" + n + "|" + piece, ChatMessageType.Broadcast);
+            }
+        }
+
+        /// <summary>One look-preview spawn per player (previewmob) - a new preview replaces the old one.</summary>
+        private static readonly Dictionary<uint, ACE.Server.WorldObjects.WorldObject> ZcPreviews = new Dictionary<uint, ACE.Server.WorldObjects.WorldObject>();
+
+        /// <summary>The five reserved "Drafted Look" weenies (Target Dummy clones, Add_DraftedLook_Dummies_2026-08-10.sql)
+        /// backing the Look Lab's Drafted Look target. Each drafting player gets ONE slot per zone (draftslot);
+        /// the look is crafted in that slot's zone appearance bucket, then copydraft moves it onto a real wcid.</summary>
+        private static readonly uint[] ZcDraftSlotWcids = { 739999995, 739999996, 739999997, 739999998, 739999999 };
+
+        /// <summary>Live draft-slot claims: (zone name lower, player guid) -> slot wcid. Claims of players no
+        /// longer online are evicted (bucket cleared) whenever someone asks for a slot.</summary>
+        private static readonly Dictionary<(string Zone, uint Player), uint> ZcDraftClaims = new();
+
+        /// <summary>Drop a claim and wipe its slot's appearance bucket so the next claimant starts clean.</summary>
+        private static void ReleaseDraftClaim(string zoneKey, uint playerGuid)
+        {
+            if (!ZcDraftClaims.TryGetValue((zoneKey, playerGuid), out var slot))
+                return;
+            ZcDraftClaims.Remove((zoneKey, playerGuid));
+            ZoneControlManager.MutateArea(zoneKey, a => a.AppearanceByWcid?.Remove(slot));
+        }
+
+        [CommandHandler("zonecontrol", AccessLevel.Developer, CommandHandlerFlag.None, 0,
+            "Author/toggle Zone Control zones (any world area).",
+            "help | list | here | create <name> <variation> [here|hex] | rename <old> <new> | delete <name> | "
+            + "default <variation> <show|set|clearstat|copyfrom|clear> | default list | "
+            + "enable <name> | disable <name> | addlb <name> <hex|here> | removelb <name> <hex> | "
+            + "set <name> <stat> <value> [--wcid <id>] | clearstat <name> <stat> [--wcid <id>] | show <name> [--wcid <id>] | "
+            + "part <name> <part> <armor|damage|variance|dmgtype> <value> [--wcid <id>] | clearpart <name> <part> [field] [--wcid <id>] | "
+            + "prop <name> <int|int64|float|bool> <idOrName> <value> [--wcid <id>] | clearprop <name> <type> <idOrName> [--wcid <id>] | "
+            + "appearance <name> <palette|shade|scale|translucency|shiny|setup|clothing|palettebase|motion|sound|icon> <value> [--wcid <id>] | clearappearance <name> [field] [--wcid <id>] | copylook <name> <donorWcid> [--wcid <id>] | draftslot <name> [release] | copydraft <name> <destWcid> | becomemob <donorWcid> --wcid <id> | seticon <wcid> <iconDid|clear> [layer] | "
+            + "modifier <name> <add|remove|list|catalog|band|slots|special|chance> [args] [--wcid <id>] | "
+            + "currency <name> <add|remove|list> [itemWcid] [amount] [chance] [direct|corpse] [--wcid <id>] | "
+            + "boundary <name> <on|off|show> | survey <name> [lbHex] | quests <name> | terrain <name> <hex> <type|clear> | "
+            + "mobinfo <wcid> | geninfo <wcid> | genlist [zone] | genedit <wcid> delay|radius|stagger|init|max <value> | "
+            + "craft <material> <itemtype> auto|allow|deny | craft list|get|test|enabled|mintier|components | "
+            + "effect <name> [dot on|off | dmg <amount> | type <name|percent> | interval <secs>] | reload")]
+        public static void HandleZoneControl(Session session, params string[] parameters)
+        {
+            void Msg(string s) => ChatPacket.SendServerMessage(session, s, ChatMessageType.Broadcast);
+
+            // Bare /zonecontrol = this usage dump. `help` no longer stops here (2026-09-03): it falls through to
+            // case "help" = the registry (prose, or [[ZCHELP]] rows with --wire for the Chat Commands tab).
+            if (parameters.Length == 0)
+            {
+                Msg("Zone Control commands (zones â€” any world area):");
+                Msg("  /zonecontrol list | here | reload");
+                Msg("  /zonecontrol create <name...> <variation|here> [here|<hex>]   variation: 0 = normal world, 11+ = variants");
+                Msg("      multi-word names work unquoted (create Tou Tou here); quote names containing number words (create \"Zone 2\" 11)");
+                Msg("  /zonecontrol rename <old> <new...> | delete <name>");
+                Msg("  /zonecontrol enable <name> | disable <name> | setvar <name> <variation|here>");
+                Msg("  /zonecontrol addlb <name> <hex|here> | removelb <name> <hex>");
+                Msg("  /zonecontrol default <variation> <show|set|clearstat|copyfrom|clear> | default list");
+                Msg("      the per-variation BASELINE every zone at that variation inherits, per stat;");
+                Msg("      a zone (or a --wcid) overrides only the stats it sets. v11-v25 = the progression.");
+                Msg("  /zonecontrol set <name> <stat> <value> [--wcid <id>] [--rank regular|leader|boss]   (--wcid = a specific monster's override; --rank = that rank's ROW on the zone, read over the Default row by monsters of that rank)");
+                Msg("      RANK ROWS (2026-09-02): every stat has Default / Regular / Leader / Boss rows on each layer (tier Default, zone). set / clearstat / togglestat / default ... / tier all take --rank. A monster's rank = its zone bucket's rank bool, else its weenie's. show / mobcheck print which.");
+                Msg("  /zonecontrol clearstat <name> <stat> [--wcid <id>] | show <name> [--wcid <id>]");
+                Msg("  /zonecontrol effect <name> [show | dot on|off | dmg <amount> | type <fire|cold|...|percent> | interval <secs>]   (player DoT)");
+                Msg("  /zonecontrol part <name> <part> <armor|damage|variance|dmgtype> <value> [--wcid <id>]   (per-body-part override; damage 0 = part stops attacking)");
+                Msg("  /zonecontrol clearpart <name> <part> [armor|damage|variance|dmgtype] [--wcid <id>]   (no field = clear the whole part)");
+                Msg("  /zonecontrol prop <name> <int|int64|float|bool> <idOrName> <value> [--wcid <id>]   (stamped on monsters at respawn)");
+                Msg("  /zonecontrol clearprop <name> <int|int64|float|bool> <idOrName> [--wcid <id>]");
+                Msg("  /zonecontrol appearance <name> <palette|shade|scale|translucency|shiny|setup|clothing|palettebase|motion|sound|icon> <value> [--wcid <id>]   (cosmetic; separate from stats; DataId fields take hex 0x.. ; reload landblock to see)");
+                Msg("  /zonecontrol clearappearance <name> [field] [--wcid <id>]   (no field = clear all)");
+                Msg("  /zonecontrol copylook <name> <donorWcid> [--wcid <id>]   (make the target look like another monster - copies its model + palette + parts)");
+                Msg("  /zonecontrol previewmob <wcid> [distance]   (spawn an inert look-preview in front of you for 60s; a new preview replaces the old one; distance 1-120, default 5)");
+                Msg("  /zonecontrol becomemob <donorWcid> --wcid <targetWcid>   (target BECOMES a full copy of the donor - stats/loot/spells/everything; keeps its name, class_Name and scale)");
+                Msg("  /zonecontrol draftslot <name> [release]   (claim your Drafted Look slot in this zone - a scratch wcid to craft a look on; release discards)");
+                Msg("  /zonecontrol copydraft <name> <destWcid>   (save your Drafted Look onto destWcid's zone appearance, then bakemob/clonemob to keep it)");
+                Msg("  /zonecontrol seticon <wcid> <iconDid|clear> [icon|overlay|overlay2|underlay]   (PERMANENT world-db icon change, layer defaults to icon; logged to zc_seticon_<date>.sql. 'appearance icon' is the zone-only version)");
+                Msg("  /zonecontrol listparts <wcid | 0xSetupId>   (dump a mob's body-part layout: index -> model piece; head = index 16)");
+                Msg("  /zonecontrol appearance <name> animpart <index> <gfxObjHex> [--wcid <id>]   (swap ONE body part, e.g. animpart 16 = head; clear with clearappearance <name> animpart <index>)");
+                Msg("  /zonecontrol modifier <name> <add|remove|list|catalog> [key] [--wcid <id>]   (custom Modifier pool for the extra-loot-modifier roll; Retired keys are rejected)");
+                Msg("  /zonecontrol modifier <name> band <key> <min> <max> [procMin procMax]   (override a key's roll band; 'band <key> clear' drops the override; 'modifier default <var> band ...' authors the variation Default)");
+                Msg("  /zonecontrol modifier <name> chance <catalog key> <t11> [t25]   (per-LINE anchored drop chance, 0..1; t25 optional = T25 anchor, absent = flat)");
+                Msg("  /zonecontrol modifier <name> special <key> <on|off|clear>   (per-special on/off for the per-kill slot-special roll; clear = drop the override)");
+                Msg("  /zonecontrol weaponcard <name> <chance_stat> <on|off|clear> | weaponcard <name> list   [--wcid <id>]   (explicit per-card on/off; OFF beats an inherited chance, and the tuned chance value survives an off/on cycle)");
+                Msg("  /zonecontrol togglestat <name> <stat> <on|off|clear> | togglestat <name> list   [--wcid <id>]   (per-STAT on/off for ANY stat; OFF = treated as Not Set at this scope even when a lower layer authors it - the only way to exempt a zone/monster from an inherited Default. Tier form: default <var> togglestat ...)");
+                Msg("  /zonecontrol default <var> weaponcard <chance_stat> <on|off|clear> | list   (the same switch on the tier Default; a zone can override it either way)");
+                Msg("  /zonecontrol currency <name> add <itemWcid> <amount> [chance 0..1] [direct|corpse] | remove <itemWcid> | list   [--wcid <id>]   (per-kill bonus-currency drop table; direct = into the killer's inventory)");
+                Msg("  /zonecontrol boundary <name> <on|off|show>   (bounded: players at the zone's variation may only roam bounded-zone landblocks; variation 11+ only)");
+                Msg("  /zonecontrol survey <name> [lbHex]   (per-landblock content: generator + creature summary; lbHex = full detail for one landblock)");
+                Msg("  /zonecontrol quests <name>   (quest registry for the plugin Quests tab; throttled to one pull per 60s)");
+                Msg("  /zonecontrol terrain <name> <hex> <type|clear>   (override the map terrain color for one landblock; type = " + string.Join("/", ZoneControlManager.TerrainTags) + "; display-only)");
+                Msg("  /zonecontrol mobinfo <wcid>   (weenie base data: body parts, resists, wields)");
+                Msg("  /zonecontrol genlist [zone]   (placed generator wcids + counts for the plugin's Generator Settings table; no zone = where you stand)");
+                Msg("  /zonecontrol ladder status | apply [tier|all] | migrate [here|<player>] [--dry] | show   (live stat resolution: per-tier ladder versions, re-resolve on next equip, dev migration of pre-grade pieces, inspect the appraised item)");
+                Msg("  /zonecontrol craft <material> <itemtype> auto|allow|deny   (T11+ crafting gate matrix; material by NAME, e.g. BlackOpal; itemtype = "
+                    + string.Join("/", ZoneCraftGateStore.Columns) + ")");
+                Msg("      auto = fall through to the downgrade rule (a weaker imbue cannot go on, an un-imbued item can) - every cell starts here");
+                Msg("  /zonecontrol craft list | get | materials   (authored cells / the [[ZCCG]] wire payload / the salvage that carries an imbue recipe)");
+                Msg("  /zonecontrol craft test <material> <itemtype>   (states the decision AND why; appraise a T11+ item first to test against a real piece)");
+                Msg("  /zonecontrol craft enabled true|false | craft mintier <tier>   (master switch; the tier the gate starts applying at, default 11)");
+                Msg("  /zonecontrol craft components [true|false | add <wcid> | remove <wcid> | reset]   (layer 0: salvage barred from T"
+                    + ZoneCraftGateStore.MinTier + "+ items outright, e.g. the Fine Bandit Blade Hilt)");
+                Msg("  parts = " + string.Join(", ", Enum.GetNames(typeof(CombatBodyPart)).Where(n => n != "Undefined")));
+                Msg("  stats = " + string.Join(", ", ZoneStat.All));
+                return;
+            }
+
+            // Re-tokenize honoring double quotes so zone names may contain spaces (ACE's CommandManager
+            // splits purely on spaces): /zonecontrol enable "My Zone". Case is preserved everywhere;
+            // lookups are case-insensitive, and my_zone is accepted for "My Zone" when typed without quotes.
+            var args = RetokenizeParameters(parameters);
+            if (args.Count == 0) { Msg("See /zonecontrol help."); return; }
+            uint? wcid = ExtractWcidFlag(args);
+            // RANK LAYERS (2026-09-02): --rank default|regular|leader|boss picks which ROW of a layer a
+            // stat verb edits (set / clearstat / togglestat / default ... / tier). No flag = the Default
+            // row, exactly the pre-existing behaviour. A per-WCID bucket has no rows (a monster type IS
+            // one rank), so --wcid + --rank is refused at the verbs that take both.
+            var rank = ExtractRankFlag(args, out var rankErr);
+            if (rankErr != null) { Msg(rankErr); return; }
+            var sub = args[0].ToLowerInvariant();
+
+            // Unquoted multi-word zone names: for any subcommand whose <name> is args[1], collapse the
+            // LONGEST token-join that names an EXISTING zone into one arg â€” "enable Tou Tou" and
+            // "set Tou Tou max_health 5000" work without quotes. create scans for its variation token
+            // instead (the zone doesn't exist yet); sync's name sits at args[2].
+            if (sub == "sync")
+                CollapseZoneNameTokens(args, 2);
+            else if (sub != "create" && sub != "default" && sub != "ladder" && sub != "craft")
+                // 'default' takes a VARIATION at args[1], not a zone name â€” collapsing would mangle it.
+                // 'ladder' takes a verb / tier / player name, never a zone.
+                // 'craft' takes a MATERIAL NAME at args[1] (possibly two words, "Black Opal") â€” never a zone.
+                CollapseZoneNameTokens(args, 1);
+
+            try
+            {
+                switch (sub)
+                {
+                    case "list":
+                    {
+                        var zones = ZoneControlManager.ListAreas();
+                        if (zones.Count == 0) { Msg("(no zones)"); return; }
+                        foreach (var z in zones.OrderBy(z => z.Name))
+                            Msg($"  {z.Name,-20} {(z.Enabled ? "ENABLED " : "disabled")}  v{z.Variation}  lbs:{z.Landblocks.Count}  " +
+                                $"stats:{z.Profile.Minion.Stats.Count} overrides:{z.Profile.WcidOverrides.Count}");
+                        return;
+                    }
+
+                    case "here":
+                    {
+                        var loc = session.Player?.Location;
+                        if (loc == null) { Msg("No location."); return; }
+                        var lb = loc.LandblockId.Landblock;
+                        var effVar = ZoneControlManager.GetEffectiveVariation(session.Player);
+                        Msg($"Here: lb:{lb:X4}  variation v{effVar}");
+                        var covering = ZoneControlManager.AreasCovering(lb);
+                        if (covering.Count == 0) { Msg("  (no zone covers this landblock)"); return; }
+                        foreach (var z in covering)
+                            Msg($"  zone '{z.Name}' {(z.Enabled ? "ENABLED" : "disabled")} v{z.Variation}");
+                        return;
+                    }
+
+                    case "reload":
+                        ZoneControlManager.Reload();
+                        Msg("Zone Control store reloaded from shard.");
+                        return;
+
+                    case "arealist":
+                    {
+                        // Machine-parseable zone list for the plugin dropdown: name,enabled,variation,lbCount
+                        var sb = new StringBuilder("[[ZCA]]");
+                        bool first = true;
+                        foreach (var z in ZoneControlManager.ListAreas().OrderBy(z => z.Name))
+                        {
+                            if (!first) sb.Append('|');
+                            first = false;
+                            sb.Append(z.Name).Append(',').Append(z.Enabled ? 1 : 0).Append(',')
+                              .Append(z.Variation).Append(',').Append(z.Landblocks.Count).Append(',')
+                              .Append(z.Bounded ? 1 : 0);
+                        }
+                        Msg(sb.ToString());
+                        return;
+                    }
+
+                    case "get":
+                    {
+                        // Bare get = the GM Tools state alone (session flags + shard-combat rules).
+                        // Those are not zone state, so the plugin asks for them zoneless.
+                        if (args.Count < 2) { Msg(BuildSessionPayload(session)); return; }
+                        var getPayload = BuildZonePayload(args[1], wcid, session, includeLive: true);
+                        SendChunked(session, getPayload);
+                        // seed the change detector (2026-09-03): a live watch on the same target need not re-push this.
+                        // The push-shaped twin is this payload minus its live_ fields - ONE build, not two
+                        // (review 2026-09-04 M4); includeLive changes nothing else in BuildZonePayload.
+                        var getNow = DateTime.UtcNow;
+                        var pushShaped = StripLiveFields(getPayload);   // what the stream would send (no live_)
+                        _lastGet[session] = (args[1], wcid, pushShaped, getNow);
+                        if (_pluginSessions.TryGetValue(session, out var gw) && gw.Name.Equals(args[1], StringComparison.OrdinalIgnoreCase) && gw.Wcid == wcid)
+                        { gw.LastPayload = pushShaped; gw.LastSentUtc = getNow; }
+                        return;
+                    }
+
+                    case "simstats":
+                    {
+                        // One-shot effective offense values for the Curves-tab player simulator: what
+                        // combat actually uses for this wcid (its override bucket if one exists - a
+                        // bucket REPLACES the zone default wholesale - else the zone default).
+                        if (args.Count < 2) { Msg("Usage: simstats <name> --wcid <id>"); return; }
+                        var name = args[1];
+                        var area = ZoneControlManager.GetArea(name);
+                        var hasOverride = wcid.HasValue && area != null && area.Profile.WcidOverrides.ContainsKey(wcid.Value);
+                        // layered (anchor -> Default -> zone -> wcid) AND rank-flattened for the wcid's rank (2026-09-02:
+                        // ResolveProfileForDisplay is the unflattened merge, so a Leader / Boss wcid came back with the
+                        // Default row's numbers). EvaluateForDisplay is what the Bestiary readouts and mobcheck use.
+                        var eval = area != null ? ZoneControlManager.EvaluateForDisplay(name, wcid) : null;
+                        var simRank = wcid.HasValue && area != null ? ZoneControlManager.ResolveRankForWcid(area, wcid.Value) : (ZcRank.None, "none");
+                        var sb = new StringBuilder("[[ZCSIM]]scope=").Append(WireName(name))
+                            .Append("|wcid=").Append(wcid?.ToString() ?? "")
+                            .Append("|found=").Append(area != null ? 1 : 0)
+                            .Append("|override=").Append(hasOverride ? 1 : 0);
+                        foreach (var stat in new[] { ZoneStat.PercentHpBase, ZoneStat.SpellDamage, ZoneStat.SpellVariance, ZoneStat.CritDamageRating })
+                        {
+                            int defined = 0;
+                            double value = 0;
+                            if (eval != null && eval.Values.TryGetValue(stat, out var v)) { defined = 1; value = v; }
+                            sb.Append('|').Append(stat).Append('=').Append(defined).Append(',').Append(value.ToString(CultureInfo.InvariantCulture));
+                        }
+                        // APPEND-ONLY (2026-09-02): the rank the wcid resolves at and its source
+                        sb.Append("|rank=").Append(ZoneRank.Key(simRank.Item1)).Append("|rank_src=").Append(simRank.Item2);
+                        Msg(sb.ToString());
+                        return;
+                    }
+
+                    case "mobs":
+                    {
+                        if (args.Count < 2) { Msg("Usage: mobs <name>"); return; }
+                        var name = args[1];
+                        var mobs = ZoneControlManager.GetAreaMobs(name);
+                        // Override flags ride AFTER the name so an older plugin (which reads exactly three
+                        // fields and takes parts[2] as the name) keeps working against this reply.
+                        var ovFlags = ZoneControlManager.GetAreaMobOverrideFlags(name);
+                        var sb = new StringBuilder("[[ZCM]]scope=").Append(WireName(name));
+                        foreach (var m in mobs)
+                            sb.Append('|').Append(m.Wcid).Append(',').Append(m.IsMonster ? 1 : 0).Append(',')
+                              .Append(m.Name.Replace('|', ' ').Replace(',', ' ')).Append(',')
+                              .Append(ovFlags.TryGetValue(m.Wcid, out var ov) ? ov : 0);
+                        SendChunked(session, sb.ToString());   // [[ZCM]] 1.7 KB: chunked too (2026-09-03)
+                        return;
+                    }
+
+                    case "sync":
+                    {
+                        // Machine handshake from the plugin â€” stay SILENT (no chat confirmation) so the periodic
+                        // live-feed handshake never spams the player's chat window. Only a mistyped manual command
+                        // gets the usage hint below.
+                        if (args.Count >= 2 && args[1].Equals("off", StringComparison.OrdinalIgnoreCase))
+                        {
+                            _pluginSessions.TryRemove(session, out _);
+                            _lastGet.TryRemove(session, out _);
+                            return;
+                        }
+                        if (args.Count < 3 || !args[1].Equals("on", StringComparison.OrdinalIgnoreCase))
+                        {
+                            Msg("Usage: sync on <name> [--wcid <id>]  |  sync off");
+                            return;
+                        }
+                        var newWatch = new SyncWatch { Name = args[2], Wcid = wcid };
+                        // a get reply for this exact target within the last 5 s already delivered the payload (2026-09-03)
+                        if (_lastGet.TryGetValue(session, out var lg) && lg.Name.Equals(args[2], StringComparison.OrdinalIgnoreCase) && lg.Wcid == wcid
+                            && (DateTime.UtcNow - lg.At).TotalSeconds < 5)
+                        { newWatch.LastPayload = lg.Payload; newWatch.LastSentUtc = lg.At; }
+                        _pluginSessions[session] = newWatch;
+                        // Push NOW (2026-09-03 round 4) instead of waiting for the tick: the plugin no longer sends a
+                        // separate `get` on a target change, so this is the only payload a pick costs (~260 ms chunked).
+                        var first = BuildZonePayload(newWatch.Name, newWatch.Wcid, session);
+                        if (first != newWatch.LastPayload)
+                        {
+                            newWatch.LastPayload = first;
+                            newWatch.LastSentUtc = DateTime.UtcNow;
+                            SendChunked(session, first);
+                        }
+                        return;
+                    }
+
+                    case "create":
+                    {
+                        if (args.Count < 3) { Msg("Usage: create <name...> <variation|here> [here|<hex>]   (multi-word names ok: create Tou Tou here)"); return; }
+
+                        // The name may be several unquoted tokens: everything BEFORE the first token that
+                        // reads as a variation (a number or 'here'). A name WORD that is itself a number
+                        // needs quotes: create "Zone 2" 11.
+                        var varIdx = -1;
+                        for (var i = 2; i < args.Count; i++)
+                        {
+                            if (args[i].Equals("here", StringComparison.OrdinalIgnoreCase) ||
+                                int.TryParse(args[i].TrimStart('v', 'V'), out _))
+                            { varIdx = i; break; }
+                        }
+                        if (varIdx < 0)
+                        {
+                            Msg("variation must be a number >= 0 (0 = normal world) or 'here' - none found after the name.");
+                            Msg("  e.g. create Tou Tou here   |   create \"Zone 2\" 11   (quote names containing number words)");
+                            return;
+                        }
+
+                        var name = SanitizeZoneName(string.Join(" ", args.Skip(1).Take(varIdx - 1)));
+                        if (name.Length == 0) { Msg("Zone name required."); return; }
+                        if (ZoneControlManager.GetArea(name) != null) { Msg($"Zone '{name}' already exists."); return; }
+
+                        int variation;
+                        if (args[varIdx].Equals("here", StringComparison.OrdinalIgnoreCase))
+                            variation = ZoneControlManager.GetEffectiveVariation(session.Player);
+                        else
+                            int.TryParse(args[varIdx].TrimStart('v', 'V'), out variation);
+                        if (variation < 0) { Msg($"variation must be >= 0 (you're at v{variation} - zones can't be created on rift design variations)."); return; }
+
+                        ushort lb;
+                        if (args.Count >= varIdx + 2)
+                        {
+                            if (!TryLandblockToken(session, args[varIdx + 1], out lb, out var lbErr)) { Msg(lbErr); return; }
+                        }
+                        else
+                        {
+                            var here = session.Player?.Location?.LandblockId.Landblock;
+                            if (here == null) { Msg("No location â€” pass a hex landblock."); return; }
+                            lb = here.Value;
+                        }
+
+                        ZoneControlManager.UpsertArea(new ControlledArea
+                        {
+                            Name = name, Variation = variation, Enabled = false,
+                            Landblocks = new HashSet<ushort> { lb },
+                        });
+                        Msg($"Created zone '{name}' (v{variation}) with lb {lb:X4} â€” DISABLED. Use 'set' then 'enable'.");
+                        return;
+                    }
+
+                    case "rename":
+                    {
+                        if (args.Count < 3) { Msg("Usage: rename <old> <new...>   (multi-word names ok; the old name matches an existing zone)"); return; }
+                        var oldN = args[1];   // multi-word old names were collapsed above (existing-zone match)
+                        var newN = SanitizeZoneName(string.Join(" ", args.Skip(2)));
+                        if (newN.Length == 0) { Msg("New name required."); return; }
+                        Msg(ZoneControlManager.RenameArea(oldN, newN)
+                            ? $"Renamed '{oldN}' -> '{newN}'."
+                            : $"Rename failed (no '{oldN}', or '{newN}' already exists).");
+                        return;
+                    }
+
+                    case "delete":
+                    {
+                        if (args.Count < 2) { Msg("Usage: delete <name>"); return; }
+                        var name = args[1];
+                        Msg(ZoneControlManager.RemoveArea(name) ? $"Deleted '{name}'." : $"No zone '{name}'.");
+                        return;
+                    }
+
+                    case "enable":
+                    {
+                        if (args.Count < 2) { Msg("Usage: enable <name>"); return; }
+                        var name = args[1];
+                        Msg(ZoneControlManager.SetEnabled(name, true)
+                            ? $"'{name}' ENABLED. Live stats apply now; HP/attributes on respawn."
+                            : $"No zone '{name}' (create it first).");
+                        return;
+                    }
+
+                    case "disable":
+                    {
+                        if (args.Count < 2) { Msg("Usage: disable <name>"); return; }
+                        var name = args[1];
+                        Msg(ZoneControlManager.SetEnabled(name, false)
+                            ? $"'{name}' disabled. Live stats revert now; HP/attributes on respawn."
+                            : $"No zone '{name}'.");
+                        return;
+                    }
+
+                    case "setvar":
+                    {
+                        if (args.Count < 3) { Msg("Usage: setvar <name> <variation>   (0 = normal world, 11+ = variants; use 'here' to read yours)"); return; }
+                        var name = args[1];
+                        int variation;
+                        if (args[2].Equals("here", StringComparison.OrdinalIgnoreCase))
+                            variation = ZoneControlManager.GetEffectiveVariation(session.Player);
+                        else if (!int.TryParse(args[2].TrimStart('v', 'V'), out variation) || variation < 0)
+                        { Msg("variation must be a number >= 0 (or 'here')."); return; }
+                        if (!ZoneControlManager.SetVariation(name, variation)) { Msg($"No zone '{name}'."); return; }
+                        Msg($"'{name}' Variation set to v{variation}. Now governs monsters/effects at that variation.");
+                        // A boundary can't live on a retail variation â€” moving a bounded zone to <= 10 drops it.
+                        var moved = ZoneControlManager.GetArea(name);
+                        if (moved != null && moved.Bounded && variation < ZoneControlManager.MinBoundedVariation)
+                        {
+                            ZoneControlManager.SetBounded(name, false);
+                            Msg($"'{name}' was BOUNDED â€” boundary removed (boundaries need variation 11+).");
+                        }
+                        return;
+                    }
+
+                    case "addlb":
+                    {
+                        if (args.Count < 3) { Msg("Usage: addlb <name> <hex|here> [more...]   (comma lists ok, e.g. F559,F55A)"); return; }
+                        var name = args[1];
+                        if (ZoneControlManager.GetArea(name) == null) { Msg($"No zone '{name}' (create it first - and note zone names are one word)."); return; }
+
+                        // Accept any mix of tokens after the name: 'here', hex ids, comma-separated lists.
+                        var added = new List<string>();
+                        for (var i = 2; i < args.Count; i++)
+                        {
+                            foreach (var tok in args[i].Split(','))
+                            {
+                                if (string.IsNullOrWhiteSpace(tok)) continue;
+                                if (!TryLandblockToken(session, tok.Trim(), out var lb, out var lbErr)) { Msg(lbErr); return; }
+                                ZoneControlManager.AddLandblock(name, lb);
+                                added.Add(lb.ToString("X4"));
+                            }
+                        }
+                        Msg(added.Count > 0 ? $"'{name}' += lb {string.Join(", ", added)}" : "Nothing to add.");
+                        return;
+                    }
+
+                    case "removelb":
+                    {
+                        if (args.Count < 3) { Msg("Usage: removelb <name> <hex>"); return; }
+                        var name = args[1];
+                        if (!TryHex(args[2], out var lb)) { Msg("hex landblock required, e.g. F559"); return; }
+                        Msg(ZoneControlManager.RemoveLandblock(name, (ushort)lb) ? $"'{name}' -= lb {lb:X4}" : $"No zone '{name}' or lb not a member.");
+                        return;
+                    }
+
+                    case "geninfo":
+                    {
+                        // Current generator-weenie knobs for the plugin's Generator Settings boxes.
+                        if (args.Count < 2 || !uint.TryParse(args[1], out var genWcid)) { Msg("Usage: geninfo <wcid>"); return; }
+                        var genWeenie = ACE.Database.DatabaseManager.World.GetCachedWeenie(genWcid);
+                        if (genWeenie == null) { Msg($"[[ZCG]]w={genWcid}~found=0"); return; }
+                        Msg(BuildGenInfoPayload(genWcid, genWeenie));
+                        return;
+                    }
+
+                    case "genlist":
+                    {
+                        // Discovery for the plugin's Generator Settings table (owner 2026-08-08): distinct
+                        // placed generator wcids + counts across a zone's landblocks at the zone's variation.
+                        // No name = the zone covering the player's landblock (their effective variation
+                        // preferred); outside any zone the scan falls back to the single current landblock.
+                        // Emits one [[ZCL]] header then a [[ZCG]] knob line per wcid.
+                        string scopeLabel;
+                        List<ZoneControlManager.SurveyPlacedRow> placedGens;
+                        ControlledArea genArea = null;   // the zone whose per-generator switches ride the header (2026-09-03)
+                        if (args.Count >= 2)
+                        {
+                            placedGens = ZoneControlManager.GetPlacedGenerators(args[1]);
+                            if (placedGens == null) { Msg($"No zone '{args[1]}'."); return; }
+                            scopeLabel = args[1];
+                            genArea = ZoneControlManager.GetArea(args[1]);
+                        }
+                        else
+                        {
+                            var loc = session.Player?.Location;
+                            if (loc == null) { Msg("No location."); return; }
+                            var hereLb = loc.LandblockId.Landblock;
+                            var hereVar = ZoneControlManager.GetEffectiveVariation(session.Player);
+                            var covering = ZoneControlManager.AreasCovering(hereLb);
+                            var hereArea = covering.FirstOrDefault(a => a.Variation == hereVar) ?? covering.FirstOrDefault();
+                            if (hereArea != null)
+                            {
+                                placedGens = ZoneControlManager.GetPlacedGenerators(hereArea.Name) ?? new List<ZoneControlManager.SurveyPlacedRow>();
+                                scopeLabel = hereArea.Name;
+                                genArea = hereArea;
+                            }
+                            else
+                            {
+                                placedGens = ZoneControlManager.GetPlacedGeneratorsForLandblock(hereLb, hereVar);
+                                scopeLabel = $"lb {hereLb:X4}";
+                            }
+                        }
+
+                        const int GenListCap = 200;
+                        var genListTrunc = placedGens.Count > GenListCap;
+                        if (genListTrunc)
+                            placedGens = placedGens.Take(GenListCap).ToList();
+
+                        var zcl = new StringBuilder("[[ZCL]]zone=")
+                            .Append(scopeLabel.Replace('|', ' ').Replace('~', ' ').Replace('=', ' ').Replace(',', ' '));
+                        if (genListTrunc)
+                            zcl.Append("|trunc=1");
+                        zcl.Append("|g=").Append(string.Join(",", placedGens.Select(p => p.Wcid + "~" + p.Count)));
+                        // APPEND-ONLY (2026-09-03): the zone the per-generator master switches belong to, and
+                        // which generator wcids are exempt there. Absent = the scope is not a zone (bare landblock).
+                        if (genArea != null)
+                        {
+                            zcl.Append("|ezone=").Append(genArea.Name.Replace('|', ' ').Replace('~', ' ').Replace('=', ' ').Replace(',', ' '));
+                            if (genArea.Profile.ExemptGenerators is { Count: > 0 })
+                                zcl.Append("|exempt=").Append(string.Join(",", genArea.Profile.ExemptGenerators.OrderBy(x => x)));
+                        }
+                        SendChunked(session, zcl.ToString());   // up to ~2.6 KB at the 200-entry cap (review 2026-09-03)
+
+                        foreach (var p in placedGens)
+                        {
+                            var w = ACE.Database.DatabaseManager.World.GetCachedWeenie(p.Wcid);
+                            Msg(w == null ? $"[[ZCG]]w={p.Wcid}~found=0" : BuildGenInfoPayload(p.Wcid, w));
+                        }
+                        return;
+                    }
+
+                    case "genedit":
+                    {
+                        // WEENIE edit (single source of truth): updates ace_world + clears the weenie
+                        // cache. Live generators keep their old profile until their landblock reloads.
+                        if (args.Count < 4 || !uint.TryParse(args[1], out var genWcid))
+                        { Msg("Usage: genedit <wcid> delay|radius|stagger|init|max <value>"); return; }
+                        var genField = args[2].ToLowerInvariant();
+                        if (!float.TryParse(args[3], NumberStyles.Float, CultureInfo.InvariantCulture, out var genVal) || genVal < 0)
+                        { Msg("Value must be a non-negative number."); return; }
+                        if (ACE.Database.DatabaseManager.World.GetCachedWeenie(genWcid) == null)
+                        { Msg($"No weenie {genWcid}."); return; }
+
+                        // parsed-numeric interpolation only â€” nothing user-typed reaches the SQL as text
+                        var sqls = new List<string>();
+                        var vs = genVal.ToString("0.####", CultureInfo.InvariantCulture);
+                        switch (genField)
+                        {
+                            case "delay":
+                                sqls.Add($"UPDATE `weenie_properties_generator` SET `delay` = {vs} WHERE `object_Id` = {genWcid}");
+                                sqls.Add($"INSERT INTO `weenie_properties_float` (`object_Id`,`type`,`value`) VALUES ({genWcid},41,{vs}) ON DUPLICATE KEY UPDATE `value` = {vs}");
+                                break;
+                            case "radius":
+                                sqls.Add($"INSERT INTO `weenie_properties_float` (`object_Id`,`type`,`value`) VALUES ({genWcid},43,{vs}) ON DUPLICATE KEY UPDATE `value` = {vs}");
+                                break;
+                            case "stagger":
+                                sqls.Add($"INSERT INTO `weenie_properties_float` (`object_Id`,`type`,`value`) VALUES ({genWcid},9034,{vs}) ON DUPLICATE KEY UPDATE `value` = {vs}");
+                                break;
+                            case "init":
+                                sqls.Add($"INSERT INTO `weenie_properties_int` (`object_Id`,`type`,`value`) VALUES ({genWcid},82,{(int)genVal}) ON DUPLICATE KEY UPDATE `value` = {(int)genVal}");
+                                break;
+                            case "max":
+                                sqls.Add($"INSERT INTO `weenie_properties_int` (`object_Id`,`type`,`value`) VALUES ({genWcid},81,{(int)genVal}) ON DUPLICATE KEY UPDATE `value` = {(int)genVal}");
+                                break;
+                            default:
+                                Msg("Field must be delay, radius, stagger, init or max."); return;
+                        }
+
+                        using (var genCtx = new WorldDbContext())
+                            foreach (var s in sqls)
+                                genCtx.Database.ExecuteSqlRaw(s);
+                        ACE.Database.DatabaseManager.World.ClearCachedWeenie(genWcid);
+
+                        Msg($"genedit: wcid {genWcid} {genField} = {vs} (weenie updated + cache cleared). " +
+                            "Live generators keep the OLD value until their landblock next reloads.");
+                        var refreshed = ACE.Database.DatabaseManager.World.GetCachedWeenie(genWcid);
+                        if (refreshed != null)
+                            Msg(BuildGenInfoPayload(genWcid, refreshed));
+                        return;
+                    }
+
+                    case "terrain":
+                    {
+                        if (args.Count < 4) { Msg("Usage: terrain <name> <hex> <type|clear>   (types: " + string.Join(", ", ZoneControlManager.TerrainTags) + ")"); return; }
+                        var name = args[1];
+                        if (ZoneControlManager.GetArea(name) == null) { Msg($"No zone '{name}'."); return; }
+                        if (!TryHex(args[2], out var lb)) { Msg("hex landblock required, e.g. F559"); return; }
+                        var type = args[3].ToLowerInvariant();
+                        var clearing = type == "clear" || type == "none" || type == "auto";
+                        if (!clearing && !ZoneControlManager.TerrainTags.Contains(type))
+                        { Msg("Unknown terrain '" + args[3] + "'. Types: " + string.Join(", ", ZoneControlManager.TerrainTags) + ", or 'clear'."); return; }
+                        ZoneControlManager.SetTerrainOverride(name, (ushort)lb, clearing ? null : type);
+                        Msg(clearing
+                            ? $"'{name}' lb {lb:X4} terrain override cleared (back to auto DAT terrain)."
+                            : $"'{name}' lb {lb:X4} terrain override = {type}.");
+                        return;
+                    }
+
+                    case "set":
+                    {
+                        if (args.Count < 4) { Msg("Usage: set <name> <stat> <value> [--wcid <id>]"); return; }
+                        var name = args[1];
+                        var area = ZoneControlManager.GetArea(name);
+                        if (area == null) { Msg($"No zone '{name}' (create it first)."); return; }
+                        var stat = NormalizeStat(args[2]); if (stat == null) { Msg("Unknown stat. Stats: " + string.Join(", ", ZoneStat.All)); return; }
+                        if (!TryDouble(args[3], out var value)) { Msg("value must be a number."); return; }
+                        if (wcid.HasValue && rank != ZcRank.None)
+                        { StatRowFor(area.Profile, wcid, rank, false, out var refusal); Msg(refusal); return; }
+
+                        ZoneControlManager.MutateArea(name, a =>
+                        {
+                            var vp = StatRowFor(a.Profile, wcid, rank, create: true, out _);
+                            vp.Stats[stat] = new StatCurve { Base = value, Growth = 1.0, Additive = false };
+                        });
+                        Msg($"'{name}'{(wcid.HasValue ? " [wcid " + wcid.Value + "]" : "")}{RankTag(rank)} {stat} = {FmtStatEcho(value)}. " +
+                            $"{(area.Enabled ? "" : "Zone still DISABLED - /zonecontrol enable " + name)}");
+                        return;
+                    }
+
+                    case "clearstat":
+                    {
+                        if (args.Count < 3) { Msg("Usage: clearstat <name> <stat> [--wcid <id>]"); return; }
+                        var name = args[1];
+                        var area = ZoneControlManager.GetArea(name);
+                        if (area == null) { Msg($"No zone '{name}'."); return; }
+                        // same rule as the Default path: a key already in the store can always be
+                        // cleared, even if it is no longer a known stat (see `default clearstat`)
+                        var stat = NormalizeStat(args[2]) ?? args[2].Trim().ToLowerInvariant();
+                        if (wcid.HasValue && rank != ZcRank.None)
+                        { StatRowFor(area.Profile, wcid, rank, false, out var refusal); Msg(refusal); return; }
+                        var removed = false;
+                        ZoneControlManager.MutateArea(name, a =>
+                        {
+                            var vp = StatRowFor(a.Profile, wcid, rank, create: false, out _);
+                            if (vp != null) removed = vp.Stats.Remove(stat);
+                        });
+                        Msg(removed ? $"'{name}'{RankTag(rank)} {stat} cleared." : "That stat wasn't set" + (rank != ZcRank.None ? " on that rank row." : "."));
+                        return;
+                    }
+
+                    case "modifier":
+                    case "cantrip":   // silent alias (renamed 2026-08-28, owner: the lines are flat stat bonuses, not cantrips)
+                    {
+                        // Custom modifier pool + banded rolls for the extra-loot-modifier roll
+                        // (weapon/armor_modifier_chance). Scope is a zone (+ optional --wcid), or
+                        // 'modifier default <var> ...' = the variation Default layer (band/slots/special/lines/weight only â€”
+                        // the pool itself stays zone-scope).
+                        if (args.Count < 3) { Msg("Usage: modifier <name> <add|remove|list|catalog|band|slots|special|chance> [args] [--wcid <id>]"); return; }
+
+                        var isDefaultScope = args[1].Equals("default", StringComparison.OrdinalIgnoreCase);
+                        var defaultVar = -1;
+                        var opIdx = 2;
+                        string name = null;
+                        if (isDefaultScope)
+                        {
+                            if (args.Count < 4 || !int.TryParse(args[2].TrimStart('v', 'V'), out defaultVar) || defaultVar < 0)
+                            { Msg("Usage: modifier default <variation> <band|slots|special|chance> ..."); return; }
+                            opIdx = 3;
+                        }
+                        else
+                        {
+                            name = args[1];
+                            if (ZoneControlManager.GetArea(name) == null) { Msg($"No zone '{name}' (create it first)."); return; }
+                        }
+
+                        var op = args[opIdx].ToLowerInvariant();
+                        var scopeTag = isDefaultScope
+                            ? $"Default v{defaultVar}"
+                            : $"'{name}'{(wcid.HasValue ? " [wcid " + wcid.Value + "]" : "")}";
+
+                        // One writer for both scopes: variation Default / zone default / --wcid bucket.
+                        void MutateScope(Action<ZoneVariantProfile> edit)
+                        {
+                            if (isDefaultScope)
+                                ZoneControlManager.MutateVariationDefault(defaultVar, d => edit(d.Profile));
+                            else
+                                ZoneControlManager.MutateArea(name, a =>
+                                    edit(wcid.HasValue ? a.Profile.VariantForWcid(wcid.Value, create: true) : a.Profile.Minion));
+                        }
+
+                        if (op == "catalog")
+                        {
+                            foreach (var d in ZoneModifiers.Catalog.Values)
+                                Msg($"  {d.Key,3}  {d.Name} - {d.Effect}  [rolls {d.Min}-{d.Max}]");
+                            return;
+                        }
+
+                        if (op == "band")
+                        {
+                            // modifier <scope> band <key> clear â€” drop the override, back to the catalog band.
+                            if (args.Count >= opIdx + 3 && int.TryParse(args[opIdx + 1], out var clearKey)
+                                && args[opIdx + 2].Equals("clear", StringComparison.OrdinalIgnoreCase))
+                            {
+                                if (!ZoneModifiers.TryGet(clearKey, out var clearDef))
+                                { Msg($"No Modifier with key {clearKey}. See 'modifier <name> catalog'."); return; }
+                                MutateScope(vp => vp.CustomModifierBands.Remove(clearKey));
+                                // do not claim the catalog band applies - a lower layer (variation
+                                // Default) may still author this key; the merge decides per key
+                                Msg($"{scopeTag} modifier band: {clearDef.Name} override cleared at this scope - drops roll the next authored layer, or the catalog band {clearDef.Min}-{clearDef.Max}.");
+                                AutoApplyForDefault(session, isDefaultScope, defaultVar, Msg);
+                                return;
+                            }
+
+                            // modifier <scope> band <key> <min> <max> â€” override the roll band.
+                            if (args.Count < opIdx + 4
+                                || !int.TryParse(args[opIdx + 1], out var bandKey)
+                                || !int.TryParse(args[opIdx + 2], out var bandMin)
+                                || !int.TryParse(args[opIdx + 3], out var bandMax))
+                            { Msg("Usage: modifier <name> band <key> <min> <max>"); return; }
+                            if (!ZoneModifiers.TryGet(bandKey, out var bandDef))
+                            { Msg($"No Modifier with key {bandKey}. See 'modifier <name> catalog'."); return; }
+                            if (bandMin < 0) { Msg("min must be >= 0."); return; }
+                            if (bandMin > bandMax) { Msg("min must be <= max."); return; }
+
+                            MutateScope(vp => vp.CustomModifierBands[bandKey] =
+                                new ModifierBand { Min = bandMin, Max = bandMax });
+                            Msg($"{scopeTag} modifier band: {bandDef.Name} rolls {bandMin}-{bandMax}.");
+                            AutoApplyForDefault(session, isDefaultScope, defaultVar, Msg);
+                            return;
+                        }
+
+                        if (op == "special")
+                        {
+                            // modifier <scope> special <key> <on|off|clear> (owner 2026-08-23): per-special on/off for the
+                            // per-kill special roll. clear = drop the override (back to the next layer / on).
+                            if (args.Count < opIdx + 3 || !int.TryParse(args[opIdx + 1], out var spKey))
+                            { Msg("Usage: modifier <name> special <key> <on|off|clear>"); return; }
+                            if (!ZoneModifiers.TryGet(spKey, out var spDef) || !spDef.SlotSpecial)
+                            { Msg($"Key {spKey} is not a slot special."); return; }
+                            var spTok = args[opIdx + 2].ToLowerInvariant();
+                            if (spTok == "clear")
+                            {
+                                MutateScope(vp => vp.CustomSpecials.Remove(spKey));
+                                Msg($"{scopeTag} special: {spDef.Name} override cleared (rolls unless a lower layer turns it off).");
+                                return;
+                            }
+                            if (spTok != "on" && spTok != "off") { Msg("Usage: modifier <name> special <key> <on|off|clear>"); return; }
+                            var spOn = spTok == "on";
+                            MutateScope(vp => vp.CustomSpecials[spKey] = spOn);
+                            Msg($"{scopeTag} special: {spDef.Name} {(spOn ? "ON" : "OFF")} - {(spOn ? "rolls" : "never rolls")} on kills here.");
+                            return;
+                        }
+
+                        if (op == "slots")
+                        {
+                            // modifier <scope> slots <key> <any|armor|shield|jewelry|clothing|cloak[,...] | mask | clear>
+                            // (owner 2026-08-22): which piece kinds this line may roll on, live. clear = back to the catalog default.
+                            if (args.Count < opIdx + 3 || !int.TryParse(args[opIdx + 1], out var slotKey))
+                            { Msg("Usage: modifier <name> slots <key> <any|armor|shield|jewelry|clothing|cloak[,...]|clear>"); return; }
+                            if (!ZoneModifiers.TryGet(slotKey, out var slotDef))
+                            { Msg($"No Modifier with key {slotKey}. See 'modifier <name> catalog'."); return; }
+                            var spec = string.Join(" ", args.Skip(opIdx + 2));
+                            if (slotDef.SlotSpecial)
+                            {
+                                // a SPECIAL has ONE home slot: helm|chest|shoulders|bracers|gauntlets|girth|tassets|greaves|boots|shield|neck|trinket|ring|bracelet|cloak
+                                if (!ZoneModifiers.TryParseSpecialSlot(spec, out var specialSlot))
+                                { Msg("Special slots: helm, chest, shoulders, bracers, gauntlets, girth, tassets, greaves, boots, shield, neck, trinket, ring, bracelet, cloak - or clear."); return; }
+                                if (specialSlot < 0)
+                                {
+                                    MutateScope(vp => vp.CustomModifierSlots.Remove(slotKey));
+                                    Msg($"{scopeTag} modifier slots: {slotDef.Name} override cleared at this scope - next authored layer, else the catalog slot ({ZoneModifiers.DefaultSpecialSlot(slotDef)}).");
+                                }
+                                else
+                                {
+                                    MutateScope(vp => vp.CustomModifierSlots[slotKey] = specialSlot);
+                                    Msg($"{scopeTag} modifier slots: {slotDef.Name} special now lands on {ZoneModifiers.SpecialSlotName(specialSlot)}.");
+                                }
+                                return;
+                            }
+                            if (!ZoneModifiers.TryParseSlotSpec(spec, out var slotMask))
+                            { Msg("Slot names: any, armor, shield, jewelry, clothing, cloak (comma-separated), or clear."); return; }
+                            if (slotMask < 0)
+                            {
+                                MutateScope(vp => vp.CustomModifierSlots.Remove(slotKey));
+                                Msg($"{scopeTag} modifier slots: {slotDef.Name} override cleared at this scope - the next authored layer applies, else the catalog default ({ZoneModifiers.SlotMaskName((int)ZoneModifiers.DefaultSlotMask(slotDef))}).");
+                            }
+                            else
+                            {
+                                MutateScope(vp => vp.CustomModifierSlots[slotKey] = slotMask);
+                                Msg($"{scopeTag} modifier slots: {slotDef.Name} rolls on {ZoneModifiers.SlotMaskName(slotMask)}.");
+                            }
+                            return;
+                        }
+
+                        // Plain StatCurve write on the scope - same shape as 'default <var> set'.
+                        void SetStat(string stat, double value)
+                            => MutateScope(vp => vp.Stats[stat] = new StatCurve { Base = value, Growth = 1.0, Additive = false });
+
+                        // `lines` and `weight` REMOVED 2026-08-29 (owner, one-row-per-Modifier design):
+                        // the line-count ladder and class weights are retired - every line rolls its own
+                        // anchored chance now. Author those with `chance` below or the generic stat set.
+                        if (op == "chance")
+                        {
+                            // modifier <scope> chance <key> <t11> [t25]   (0..1; t25 = the T25 anchor)
+                            if (args.Count < opIdx + 3
+                                || !int.TryParse(args[opIdx + 1], out var lineKey)
+                                || !ZoneModifiers.TryGet(lineKey, out var lineDef) || lineDef.SlotSpecial
+                                || !double.TryParse(args[opIdx + 2], NumberStyles.Float, CultureInfo.InvariantCulture, out var c11) || c11 < 0 || c11 > 1)
+                            { Msg("Usage: modifier <name> chance <catalog key> <t11 chance 0..1> [t25 chance 0..1]"); return; }
+                            SetStat(ZoneModifiers.LineChanceStat(lineKey), c11);
+                            if (args.Count > opIdx + 3
+                                && double.TryParse(args[opIdx + 3], NumberStyles.Float, CultureInfo.InvariantCulture, out var c25)
+                                && c25 >= 0 && c25 <= 1)
+                            {
+                                SetStat(ZoneModifiers.LineChanceStat(lineKey) + "_t25", c25);
+                                Msg($"{scopeTag} {lineDef.Name} chance: {c11:0.###} at T11 -> {c25:0.###} at T25.");
+                            }
+                            else
+                                Msg($"{scopeTag} {lineDef.Name} chance: {c11:0.###} (flat, every tier).");
+                            return;
+                        }
+
+                        if (isDefaultScope)
+                        { Msg("Default scope supports band | slots | chance | special only (the pool add | remove | list are zone-scope)."); return; }
+
+                        if (op == "list")
+                        {
+                            // effective pool: variation Default + zone + this wcid (union across layers)
+                            var vp = ZoneControlManager.ResolveProfileForDisplay(name, wcid);
+                            var ids = vp?.CustomModifiers;
+                            if (ids == null || ids.Count == 0) { Msg("(no modifiers in the pool)"); return; }
+                            foreach (var id in ids)
+                                Msg(ZoneModifiers.TryGet(id, out var d) ? $"  {id}  {d.Name} - {d.Effect}" : $"  {id}  (unknown key)");
+                            return;
+                        }
+
+                        if (args.Count < 4 || !int.TryParse(args[3], out var modifierKey) || modifierKey <= 0)
+                        { Msg("Usage: modifier <name> add|remove <key>  (see 'modifier <name> catalog')"); return; }
+
+                        if (op == "add")
+                        {
+                            if (!ZoneModifiers.TryGet(modifierKey, out var def))
+                            { Msg($"No modifier with key {modifierKey}. See 'modifier <name> catalog'."); return; }
+                            ZoneControlManager.MutateArea(name, a =>
+                            {
+                                var vp = wcid.HasValue ? a.Profile.VariantForWcid(wcid.Value, create: true) : a.Profile.Minion;
+                                if (!vp.CustomModifiers.Contains(modifierKey)) vp.CustomModifiers.Add(modifierKey);
+                            });
+                            Msg($"'{name}'{(wcid.HasValue ? " [wcid " + wcid.Value + "]" : "")} modifier added: {def.Name} ({def.Effect}).");
+                        }
+                        else if (op == "remove")
+                        {
+                            var removed = false;
+                            ZoneControlManager.MutateArea(name, a =>
+                            {
+                                var vp = wcid.HasValue ? a.Profile.VariantForWcid(wcid.Value) : a.Profile.Minion;
+                                if (vp != null) removed = vp.CustomModifiers.Remove(modifierKey);
+                            });
+                            Msg(removed ? $"'{name}' modifier removed: {(ZoneModifiers.TryGet(modifierKey, out var rdef) ? rdef.Name : "key " + modifierKey)}." : "That line wasn't in the pool.");
+                        }
+                        else
+                            Msg("op must be add | remove | list | catalog | band | slots | special | chance");
+                        return;
+                    }
+
+                    case "spell":
+                    {
+                        // Spell-book rules: disable/re-enable a governed mob's spells, override cast
+                        // chances (percent per cast opportunity), or ADD spells the weenie doesn't know.
+                        // Read-time (Monster_Magic.TryRollSpell) - changes apply LIVE, no respawn needed.
+                        if (args.Count < 3) { Msg("Usage: spell <name> <off|on|add|chance|remove|list> [spellId] [chancePct] [--wcid <id>]"); return; }
+                        var name = args[1];
+                        var area = ZoneControlManager.GetArea(name);
+                        if (area == null) { Msg($"No zone '{name}' (create it first)."); return; }
+                        var op = args[2].ToLowerInvariant();
+                        var wcidTag = wcid.HasValue ? " [wcid " + wcid.Value + "]" : "";
+
+                        if (op == "list")
+                        {
+                            // effective rules: variation Default + zone + this wcid (union, most specific wins)
+                            var vpl = ZoneControlManager.ResolveProfileForDisplay(name, wcid);
+                            var rules = vpl?.SpellRules;
+                            if (rules == null || rules.Count == 0) { Msg("(no spell rules)"); return; }
+                            foreach (var r in rules)
+                            {
+                                var spl = new ACE.Server.Entity.Spell(r.SpellId);
+                                Msg($"  {r.SpellId}  {(spl.NotFound ? "(unknown)" : spl.Name)}  {(r.Disabled ? "OFF" : "on")}{(r.Chance.HasValue ? "  chance " + r.Chance.Value.ToString(CultureInfo.InvariantCulture) + " pct" : "")}");
+                            }
+                            return;
+                        }
+
+                        if (args.Count < 4 || !int.TryParse(args[3], out var ruleSpellId) || ruleSpellId <= 0)
+                        { Msg("Usage: spell <name> off|on|add|chance|remove <spellId> [chancePct]"); return; }
+
+                        var spellCheck = new ACE.Server.Entity.Spell(ruleSpellId);
+                        if (spellCheck.NotFound && op != "remove" && op != "on")
+                        { Msg($"No spell with id {ruleSpellId}."); return; }
+                        var spellLabel = spellCheck.NotFound ? "#" + ruleSpellId : spellCheck.Name;
+
+                        double? chanceArg = null;
+                        if (args.Count >= 5 && double.TryParse(args[4], System.Globalization.NumberStyles.Any, CultureInfo.InvariantCulture, out var chanceVal))
+                            chanceArg = Math.Clamp(chanceVal, 0.0, 100.0);
+
+                        switch (op)
+                        {
+                            case "off":
+                                ZoneControlManager.MutateArea(name, a =>
+                                {
+                                    var vp2 = wcid.HasValue ? a.Profile.VariantForWcid(wcid.Value, create: true) : a.Profile.Minion;
+                                    var rule = vp2.SpellRules.Find(r => r.SpellId == ruleSpellId);
+                                    if (rule == null) vp2.SpellRules.Add(new ZoneSpellRule { SpellId = ruleSpellId, Disabled = true });
+                                    else rule.Disabled = true;
+                                });
+                                Msg($"'{name}'{wcidTag} spell OFF: {spellLabel}. Applies live.");
+                                return;
+
+                            case "on":
+                                ZoneControlManager.MutateArea(name, a =>
+                                {
+                                    var vp2 = wcid.HasValue ? a.Profile.VariantForWcid(wcid.Value) : a.Profile.Minion;
+                                    var rule = vp2?.SpellRules.Find(r => r.SpellId == ruleSpellId);
+                                    if (rule != null)
+                                    {
+                                        rule.Disabled = false;
+                                        if (!rule.Chance.HasValue) vp2.SpellRules.Remove(rule);   // empty rule = no rule
+                                    }
+                                });
+                                Msg($"'{name}'{wcidTag} spell ON: {spellLabel}.");
+                                return;
+
+                            case "add":
+                            case "chance":
+                                ZoneControlManager.MutateArea(name, a =>
+                                {
+                                    var vp2 = wcid.HasValue ? a.Profile.VariantForWcid(wcid.Value, create: true) : a.Profile.Minion;
+                                    var rule = vp2.SpellRules.Find(r => r.SpellId == ruleSpellId);
+                                    if (rule == null) vp2.SpellRules.Add(new ZoneSpellRule { SpellId = ruleSpellId, Chance = chanceArg ?? 2.0 });
+                                    else { rule.Disabled = false; rule.Chance = chanceArg ?? rule.Chance ?? 2.0; }
+                                });
+                                Msg($"'{name}'{wcidTag} spell {(op == "add" ? "added" : "chance set")}: {spellLabel} at {(chanceArg ?? 2.0).ToString(CultureInfo.InvariantCulture)} pct per cast roll.");
+                                return;
+
+                            case "remove":
+                                var removedRule = false;
+                                ZoneControlManager.MutateArea(name, a =>
+                                {
+                                    var vp2 = wcid.HasValue ? a.Profile.VariantForWcid(wcid.Value) : a.Profile.Minion;
+                                    if (vp2 != null) removedRule = vp2.SpellRules.RemoveAll(r => r.SpellId == ruleSpellId) > 0;
+                                });
+                                Msg(removedRule ? $"'{name}'{wcidTag} spell rule removed for {spellLabel} (back to book default)." : "No rule for that spell.");
+                                return;
+
+                            default:
+                                Msg("op must be off | on | add | chance | remove | list");
+                                return;
+                        }
+                    }
+
+                    case "help":
+                    {
+                        // The command registry (ZoneControlCommandHelp.cs, owner 2026-09-03): prose here, one
+                        // [[ZCHELP]] row per entry with --wire for the plugin's GM Tools > Chat Commands tab.
+                        var helpWire = args.Any(a => a.Equals("--wire", StringComparison.OrdinalIgnoreCase));
+                        if (helpWire)
+                        {
+                            foreach (var line in ZoneControlCommandHelp.WireLines()) Msg(line);
+                            return;
+                        }
+                        var helpFilter = args.Count >= 2 && !args[1].StartsWith("--") ? args[1] : null;
+                        foreach (var g in ZoneControlCommandHelp.Groups)
+                        {
+                            var rows = ZoneControlCommandHelp.All.Where(e => e.Group == g
+                                && (helpFilter == null || e.Command.Contains(helpFilter, StringComparison.OrdinalIgnoreCase)
+                                    || e.Description.Contains(helpFilter, StringComparison.OrdinalIgnoreCase))).ToList();
+                            if (rows.Count == 0) continue;
+                            Msg("== " + g);
+                            foreach (var e in rows)
+                                Msg("  " + e.Command + (e.Usage.Length > 0 ? " " + e.Usage : "") + "  - " + e.Description);
+                        }
+                        return;
+                    }
+
+                    case "exempt":
+                    {
+                        // MASTER SWITCH per monster (owner 2026-09-03: "master switch only, retire the per-stat
+                        // off"): `exempt <zone> on|off --wcid <id>` puts the WCID on / takes it off the zone's
+                        // ExemptWcids set; `exempt <zone> list` prints the set. An exempt monster is ungoverned
+                        // in this zone (FindZoneRef returns null): weenie stats, no props, no effects, no hit gate.
+                        // --gen <wcid> (2026-09-03): the same switch per GENERATOR - everything it spawns, nested
+                        // generators included, is ungoverned here. Exempt wins from either side (owner).
+                        var exGen = ExtractGenFlag(args);
+                        if (args.Count < 3)
+                        { Msg("Usage: exempt <name> <on|off> --wcid <id> | exempt <name> <on|off> --gen <generator wcid> | exempt <name> list"); return; }
+                        var exName = args[1];
+                        var exArea = ZoneControlManager.GetArea(exName);
+                        if (exArea == null) { Msg($"No zone '{exName}' (create it first)."); return; }
+                        var exVerb = args[2].ToLowerInvariant();
+                        if (exVerb == "list")
+                        {
+                            var set = exArea.Profile.ExemptWcids;
+                            var gset = exArea.Profile.ExemptGenerators;
+                            Msg(set == null || set.Count == 0
+                                ? $"'{exName}': no exempt monsters - every WCID here is zone-governed."
+                                : $"'{exName}' exempt monsters (master switch OFF): {string.Join(", ", set.OrderBy(x => x))}");
+                            Msg(gset == null || gset.Count == 0
+                                ? $"'{exName}': no exempt generators."
+                                : $"'{exName}' exempt generators (everything they spawn is ungoverned): {string.Join(", ", gset.OrderBy(x => x))}");
+                            return;
+                        }
+                        if (!wcid.HasValue && !exGen.HasValue) { Msg("exempt needs --wcid <id> or --gen <generator wcid>: the master switch is per monster or per generator."); return; }
+                        if (wcid.HasValue && exGen.HasValue) { Msg("exempt takes --wcid OR --gen, not both."); return; }
+                        if (exVerb != "on" && exVerb != "off") { Msg("Usage: exempt <name> <on|off> --wcid <id> | --gen <generator wcid>"); return; }
+                        var exOn = exVerb == "on";
+                        var exChanged = false;
+                        if (exGen.HasValue)
+                        {
+                            ZoneControlManager.MutateArea(exName, a =>
+                            {
+                                a.Profile.ExemptGenerators ??= new HashSet<uint>();
+                                exChanged = exOn ? a.Profile.ExemptGenerators.Add(exGen.Value) : a.Profile.ExemptGenerators.Remove(exGen.Value);
+                            });
+                            Msg(exOn
+                                ? $"'{exName}' [generator {exGen.Value}] EXEMPT{(exChanged ? "" : " (already was)")} - everything it spawns here plays as its weenie says (nested generators included). Standing spawns change on their next respawn."
+                                : $"'{exName}' [generator {exGen.Value}] zone scaling ON{(exChanged ? "" : " (already was)")}.");
+                            return;
+                        }
+                        ZoneControlManager.MutateArea(exName, a =>
+                        {
+                            a.Profile.ExemptWcids ??= new HashSet<uint>();
+                            exChanged = exOn ? a.Profile.ExemptWcids.Add(wcid.Value) : a.Profile.ExemptWcids.Remove(wcid.Value);
+                        });
+                        Msg(exOn
+                            ? $"'{exName}' [wcid {wcid.Value}] EXEMPT from zone scaling{(exChanged ? "" : " (already was)")} - it plays as its weenie says; its override bucket is kept for when you switch it back on."
+                            : $"'{exName}' [wcid {wcid.Value}] zone scaling ON{(exChanged ? "" : " (already was)")}.");
+                        return;
+                    }
+
+                    case "togglestat":
+                    {
+                        // ZONE-scope stat on/off (2026-08-29, release audit blocker 3): the weaponcard
+                        // three-state generalized to EVERY stat. off = the stat evaluates as ABSENT at
+                        // this scope even when a lower layer authors it (never/unset semantics); on =
+                        // cancel an inherited off; clear = this scope stops deciding. The authored value
+                        // underneath is never touched. Tier-Default form: `default <var> togglestat ...`.
+                        if (args.Count < 3)
+                        { Msg("Usage: togglestat <name> <stat> <on|off|clear> | togglestat <name> list   [--rank r]"); return; }
+                        var tsName = args[1];
+                        var tsArea = ZoneControlManager.GetArea(tsName);
+                        if (tsArea == null) { Msg($"No zone '{tsName}' (create it first)."); return; }
+                        // PER-MONSTER form RETIRED 2026-09-03 (owner: "master switch only, retire the per-stat
+                        // off"): a monster either takes the zone (override values in its bucket) or is exempt.
+                        if (wcid.HasValue)
+                        { Msg("Per-monster stat toggles were retired 2026-09-03. Use `exempt <name> on --wcid <id>` (master switch) or set an override value."); return; }
+                        var tsScopeTag = $"'{tsName}'{RankTag(rank)}";
+
+                        HandleStatToggle(args, 2, tsScopeTag,
+                            "Usage: togglestat <name> <stat> <on|off|clear> | togglestat <name> list   [--rank r]",
+                            StatRowFor(tsArea.Profile, wcid, rank, create: false, out _),
+                            ZoneControlManager.ResolveProfileForDisplay(tsName, wcid),
+                            edit => ZoneControlManager.MutateArea(tsName, a =>
+                                edit(StatRowFor(a.Profile, wcid, rank, create: true, out _))),
+                            Msg);
+                        return;
+                    }
+
+                    case "weaponcard":
+                    {
+                        // ZONE-scope weapon-card on/off (owner 2026-08-25). The tier-Default form lives under
+                        // `default <var> weaponcard ...` instead - see case "default" below. Two forms rather
+                        // than one `weaponcard default <var>` because the plugin's Weapons > Specials tab is
+                        // zone-capable with a Target dropdown, unlike the armour Specials tab, and these are
+                        // the two literal strings it emits.
+                        //
+                        // A DISTINCT VERB FROM ARMOUR'S `cantrip <scope> special <key> on|off` on purpose:
+                        // armour specials are numeric catalog keys, weapon cards are named chance stats.
+                        // Overloading one verb across two id spaces would make "special 28" and
+                        // "special weapon_bite_chance" the same command and guarantee a class of typo that
+                        // silently hits the wrong system.
+                        if (args.Count < 3)
+                        { Msg("Usage: weaponcard <name> <chance_stat> <on|off|clear> | weaponcard <name> list   [--wcid <id>]"); return; }
+                        var wcName = args[1];
+                        var wcArea = ZoneControlManager.GetArea(wcName);
+                        if (wcArea == null) { Msg($"No zone '{wcName}' (create it first)."); return; }
+                        var wcScopeTag = $"'{wcName}'{(wcid.HasValue ? " [wcid " + wcid.Value + "]" : "")}";
+
+                        HandleWeaponCard(args, 2, wcScopeTag,
+                            "Usage: weaponcard <name> <chance_stat> <on|off|clear> | weaponcard <name> list",
+                            wcid.HasValue ? wcArea.Profile.VariantForWcid(wcid.Value) : wcArea.Profile.Minion,
+                            ZoneControlManager.ResolveProfileForDisplay(wcName, wcid),
+                            edit => ZoneControlManager.MutateArea(wcName, a =>
+                                edit(wcid.HasValue ? a.Profile.VariantForWcid(wcid.Value, create: true) : a.Profile.Minion)),
+                            Msg);
+                        return;
+                    }
+
+                    case "currency":
+                    {
+                        // Per-zone bonus-currency drop table: each entry = item wcid + stack amount + independent
+                        // per-kill chance, injected onto every governed corpse. Loot-table independent; stacks
+                        // with the legacy bonus_currency stat (which uses the server-wide token wcid).
+                        if (args.Count < 3) { Msg("Usage: currency <name> <add|remove|list> [itemWcid] [amount] [chance] [--wcid <id>]"); return; }
+                        var name = args[1];
+                        var area = ZoneControlManager.GetArea(name);
+                        if (area == null) { Msg($"No zone '{name}' (create it first)."); return; }
+                        var op = args[2].ToLowerInvariant();
+
+                        if (op == "list")
+                        {
+                            // effective table: variation Default + zone + this wcid (union, most specific wins)
+                            var vp = ZoneControlManager.ResolveProfileForDisplay(name, wcid);
+                            var drops = vp?.CurrencyDrops;
+                            if (drops == null || drops.Count == 0) { Msg("(no currency drops defined)"); return; }
+                            foreach (var d in drops)
+                            {
+                                var w = ACE.Database.DatabaseManager.World.GetCachedWeenie(d.Wcid);
+                                Msg($"  {d.Wcid}  {w?.GetName() ?? "(unknown weenie)"}  x{d.Amount}  chance {d.Chance.ToString(CultureInfo.InvariantCulture)}  -> {(d.Direct ? "killer inventory" : "corpse")}");
+                            }
+                            return;
+                        }
+
+                        if (args.Count < 4 || !uint.TryParse(args[3], out var itemWcid) || itemWcid == 0)
+                        { Msg("Usage: currency <name> add <itemWcid> <amount> [chance 0..1] [direct|corpse] | remove <itemWcid>"); return; }
+
+                        if (op == "add")
+                        {
+                            var weenie = ACE.Database.DatabaseManager.World.GetCachedWeenie(itemWcid);
+                            if (weenie == null) { Msg($"No weenie {itemWcid} in the world db."); return; }
+
+                            var amount = 1;
+                            if (args.Count >= 5 && (!int.TryParse(args[4], out amount) || amount < 1))
+                            { Msg("amount must be a positive integer."); return; }
+
+                            // Safeguard: the spawn path delivers ONE stack, so cap the count at the item's own
+                            // max stack size (1 for non-stackables) â€” a typo like 5000000 can't be stored.
+                            var maxStack = 1;
+                            if (weenie.PropertiesInt != null && weenie.PropertiesInt.TryGetValue(PropertyInt.MaxStackSize, out var ms) && ms > 1)
+                                maxStack = ms;
+                            if (amount > maxStack)
+                            {
+                                amount = maxStack;
+                                Msg($"amount capped at {weenie.GetName() ?? "this item"}'s max stack size: {maxStack}.");
+                            }
+
+                            // optional trailing args in any order: chance (0..1] and/or direct|corpse
+                            var chance = 1.0;
+                            var direct = false;
+                            for (var i = 5; i < args.Count; i++)
+                            {
+                                var tok = args[i].ToLowerInvariant();
+                                if (tok == "direct" || tok == "inventory") direct = true;
+                                else if (tok == "corpse") direct = false;
+                                else if (double.TryParse(tok, NumberStyles.Any, CultureInfo.InvariantCulture, out var c) && c > 0 && c <= 1) chance = c;
+                                else { Msg($"'{args[i]}' - optional args are a chance in (0..1] and/or direct|corpse."); return; }
+                            }
+
+                            ZoneControlManager.MutateArea(name, a =>
+                            {
+                                var vp = wcid.HasValue ? a.Profile.VariantForWcid(wcid.Value, create: true) : a.Profile.Minion;
+                                var existing = vp.CurrencyDrops.FirstOrDefault(d => d.Wcid == itemWcid);
+                                if (existing != null) { existing.Amount = amount; existing.Chance = chance; existing.Direct = direct; }
+                                else vp.CurrencyDrops.Add(new ZoneCurrencyDrop { Wcid = itemWcid, Amount = amount, Chance = chance, Direct = direct });
+                            });
+                            Msg($"'{name}'{(wcid.HasValue ? " [wcid " + wcid.Value + "]" : "")} currency drop set: {weenie.GetName() ?? "?"} ({itemWcid}) x{amount}, chance {chance.ToString(CultureInfo.InvariantCulture)}, to {(direct ? "killer inventory" : "corpse")}.");
+                        }
+                        else if (op == "remove")
+                        {
+                            var removed = false;
+                            ZoneControlManager.MutateArea(name, a =>
+                            {
+                                var vp = wcid.HasValue ? a.Profile.VariantForWcid(wcid.Value) : a.Profile.Minion;
+                                if (vp != null) removed = vp.CurrencyDrops.RemoveAll(d => d.Wcid == itemWcid) > 0;
+                            });
+                            Msg(removed ? $"'{name}' currency drop {itemWcid} removed." : "That item wasn't in the drop table.");
+                        }
+                        else
+                            Msg("op must be add | remove | list");
+                        return;
+                    }
+
+                    case "part":
+                    {
+                        if (args.Count < 5) { Msg("Usage: part <name> <part> <armor|damage|variance|dmgtype> <value> [--wcid <id>]"); return; }
+                        var name = args[1];
+                        if (ZoneControlManager.GetArea(name) == null) { Msg($"No zone '{name}' (create it first)."); return; }
+                        if (!TryParseBodyPart(args[2], out var partKey)) { Msg("Unknown body part. Parts: " + string.Join(", ", Enum.GetNames(typeof(CombatBodyPart)).Where(n => n != "Undefined"))); return; }
+                        var field = args[3].ToLowerInvariant();
+                        if (field != "armor" && field != "damage" && field != "variance" && field != "dmgtype")
+                        { Msg("field must be armor | damage | variance | dmgtype"); return; }
+
+                        double value;
+                        if (field == "dmgtype")
+                        {
+                            if (!TryParseDamageMask(args[4], out var mask)) { Msg("dmgtype must be a DamageType flag int or name (multi-flag ok, e.g. 24 = Cold+Fire)."); return; }
+                            value = mask;
+                        }
+                        else if (!TryDouble(args[4], out value) || value < 0) { Msg("value must be a number >= 0."); return; }
+
+                        ZoneControlManager.MutateArea(name, a =>
+                        {
+                            var vp = wcid.HasValue ? a.Profile.VariantForWcid(wcid.Value, create: true) : a.Profile.Minion;
+                            if (!vp.BodyParts.TryGetValue((int)partKey, out var bp))
+                                vp.BodyParts[(int)partKey] = bp = new ZoneBodyPart();
+                            switch (field)
+                            {
+                                case "armor": bp.Armor = value; break;
+                                case "damage": bp.Damage = value; break;
+                                case "variance": bp.Variance = value; break;
+                                case "dmgtype": bp.DamageType = (int)value; break;
+                            }
+                        });
+                        Msg($"'{name}'{(wcid.HasValue ? " [wcid " + wcid.Value + "]" : "")} part {partKey} {field} = " +
+                            (field == "dmgtype" ? ((DamageType)(int)value).ToString() : value.ToString("0.####", CultureInfo.InvariantCulture)) + ".");
+                        return;
+                    }
+
+                    case "clearpart":
+                    {
+                        if (args.Count < 3) { Msg("Usage: clearpart <name> <part> [armor|damage|variance|dmgtype] [--wcid <id>]"); return; }
+                        var name = args[1];
+                        if (ZoneControlManager.GetArea(name) == null) { Msg($"No zone '{name}'."); return; }
+                        if (!TryParseBodyPart(args[2], out var partKey)) { Msg("Unknown body part."); return; }
+                        var field = args.Count >= 4 ? args[3].ToLowerInvariant() : null;
+                        var removed = false;
+                        ZoneControlManager.MutateArea(name, a =>
+                        {
+                            var vp = wcid.HasValue ? a.Profile.VariantForWcid(wcid.Value) : a.Profile.Minion;
+                            if (vp == null || !vp.BodyParts.TryGetValue((int)partKey, out var bp))
+                                return;
+                            switch (field)
+                            {
+                                case null: removed = vp.BodyParts.Remove((int)partKey); return;
+                                case "armor": removed = bp.Armor != null; bp.Armor = null; break;
+                                case "damage": removed = bp.Damage != null; bp.Damage = null; break;
+                                case "variance": removed = bp.Variance != null; bp.Variance = null; break;
+                                case "dmgtype": removed = bp.DamageType != null; bp.DamageType = null; break;
+                            }
+                            if (bp.IsEmpty)
+                                vp.BodyParts.Remove((int)partKey);
+                        });
+                        Msg(removed ? $"'{name}' part {partKey} {(field ?? "override")} cleared." : "Nothing to clear for that part.");
+                        return;
+                    }
+
+                    case "prop":
+                    {
+                        if (args.Count < 5) { Msg("Usage: prop <name> <int|int64|float|bool> <idOrName> <value> [--wcid <id>]"); return; }
+                        var name = args[1];
+                        if (ZoneControlManager.GetArea(name) == null) { Msg($"No zone '{name}' (create it first)."); return; }
+                        var type = args[2].ToLowerInvariant();
+                        if (!TryParsePropId(type, args[3], out var propId, out var propLabel)) { Msg($"Unknown {type} property '{args[3]}' (use a raw id or the enum name)."); return; }
+                        if (IsPropBlocked(type, propId)) { Msg($"Property {propLabel} is protected and cannot be stamped by a zone."); return; }
+
+                        Action<ZoneVariantProfile> applyProp;
+                        string valueEcho;
+                        switch (type)
+                        {
+                            case "int":
+                            case "int64":
+                                if (!long.TryParse(args[4], NumberStyles.Integer, CultureInfo.InvariantCulture, out var lv)) { Msg("value must be an integer."); return; }
+                                applyProp = type == "int" ? vp => vp.PropInts[propId] = lv : vp => vp.PropInt64s[propId] = lv;
+                                valueEcho = lv.ToString(CultureInfo.InvariantCulture);
+                                break;
+                            case "float":
+                                if (!TryDouble(args[4], out var dv)) { Msg("value must be a number."); return; }
+                                applyProp = vp => vp.PropFloats[propId] = dv;
+                                valueEcho = dv.ToString("0.####", CultureInfo.InvariantCulture);
+                                break;
+                            case "bool":
+                                var bv = args[4].Equals("true", StringComparison.OrdinalIgnoreCase) || args[4] == "1" || args[4].Equals("on", StringComparison.OrdinalIgnoreCase);
+                                applyProp = vp => vp.PropBools[propId] = bv;
+                                valueEcho = bv ? "true" : "false";
+                                break;
+                            default:
+                                Msg("type must be int | int64 | float | bool"); return;
+                        }
+
+                        ZoneControlManager.MutateArea(name, a => applyProp(
+                            wcid.HasValue ? a.Profile.VariantForWcid(wcid.Value, create: true) : a.Profile.Minion));
+                        Msg($"'{name}'{(wcid.HasValue ? " [wcid " + wcid.Value + "]" : "")} prop {propLabel} = {valueEcho}. Applies on (re)spawn.");
+                        return;
+                    }
+
+                    case "clearprop":
+                    {
+                        if (args.Count < 4) { Msg("Usage: clearprop <name> <int|int64|float|bool> <idOrName> [--wcid <id>]"); return; }
+                        var name = args[1];
+                        if (ZoneControlManager.GetArea(name) == null) { Msg($"No zone '{name}'."); return; }
+                        var type = args[2].ToLowerInvariant();
+                        if (!TryParsePropId(type, args[3], out var propId, out var propLabel)) { Msg($"Unknown {type} property '{args[3]}'."); return; }
+                        var removed = false;
+                        ZoneControlManager.MutateArea(name, a =>
+                        {
+                            var vp = wcid.HasValue ? a.Profile.VariantForWcid(wcid.Value) : a.Profile.Minion;
+                            if (vp == null) return;
+                            removed = type switch
+                            {
+                                "int" => vp.PropInts.Remove(propId),
+                                "int64" => vp.PropInt64s.Remove(propId),
+                                "float" => vp.PropFloats.Remove(propId),
+                                "bool" => vp.PropBools.Remove(propId),
+                                _ => false,
+                            };
+                        });
+                        Msg(removed ? $"'{name}' prop {propLabel} cleared (reverts on respawn)." : "That prop wasn't set.");
+                        return;
+                    }
+
+                    case "appearance":
+                    {
+                        // Cosmetic appearance layer, kept SEPARATE from stats. Field-based; the default set and
+                        // per-WCID (--wcid) overlays layer (per-WCID non-null wins). Never creates a stat bucket.
+                        if (args.Count < 4) { Msg("Usage: appearance <name> <palette|shade|scale|translucency|shiny> <value> [--wcid <id>]"); return; }
+                        var name = args[1];
+                        if (ZoneControlManager.GetArea(name) == null) { Msg($"No zone '{name}' (create it first)."); return; }
+                        var field = args[2].ToLowerInvariant();
+
+                        // Per-part model override: "appearance <name> animpart <index> <gfxObjHex> [--wcid]" -
+                        // layers ONE body-part swap over the base model (e.g. index 16 = head on humanoid setups).
+                        // Different arg shape (index + id) than the single-value levers, so handled up here. Each
+                        // index is stored once (re-setting the same index replaces it); it accumulates with copylook'd
+                        // parts. Clear with "clearappearance <name> animpart <index>".
+                        if (field == "animpart" || field == "part")
+                        {
+                            if (args.Count < 5) { Msg("Usage: appearance <name> animpart <index 0-255> <gfxObjHex 0x01......> [--wcid <id>]"); return; }
+                            if (!byte.TryParse(args[3], NumberStyles.Integer, CultureInfo.InvariantCulture, out var pIdx)) { Msg("index must be 0-255."); return; }
+                            if (!TryParseDid(args[4], out var gfx) || (gfx >> 24) != 0x01) { Msg("gfxObj must be a 0x01...... DataId (a model piece, e.g. from listparts)."); return; }
+                            ZoneControlManager.MutateArea(name, a =>
+                            {
+                                var ap = a.AppearanceFor(wcid, create: true);
+                                ap.AnimParts ??= new List<AnimPartEntry>();
+                                ap.AnimParts.RemoveAll(p => p.Index == pIdx);
+                                ap.AnimParts.Add(new AnimPartEntry { Index = pIdx, GfxObj = gfx });
+                            });
+                            Msg($"'{name}'{(wcid.HasValue ? " [wcid " + wcid.Value + "]" : "")} body part [{pIdx}] = 0x{gfx:X8}. Reload the landblock to see it.");
+                            return;
+                        }
+
+                        string valueEcho;
+                        Action<ZoneAppearance> applyAp;
+                        switch (field)
+                        {
+                            case "name":
+                                // Display-name override (owner 2026-08-09). Per-WCID ONLY: a zone-wide
+                                // default would rename every mob in the zone identically. Value = the rest
+                                // of the args (--wcid was already extracted), so spaces need no quotes.
+                                if (!wcid.HasValue) { Msg("name is per-monster only - target a specific monster (--wcid)."); return; }
+                                var newName = string.Join(" ", args.Skip(3)).Trim().Trim('"').Trim();
+                                newName = new string(newName.Where(c => c >= 32 && c < 127 && c != '|' && c != '~' && c != '=').ToArray()).Trim();
+                                if (newName.Length == 0) { Msg("Usage: appearance <zone> name <new name> --wcid <id>"); return; }
+                                if (newName.Length > 64) newName = newName.Substring(0, 64);
+                                var nmFinal = newName;
+                                applyAp = ap => ap.Name = nmFinal;
+                                valueEcho = nmFinal;
+                                break;
+                            case "palette":
+                            case "palettetemplate":
+                                if (!int.TryParse(args[3], NumberStyles.Integer, CultureInfo.InvariantCulture, out var pal)) { Msg("palette must be an integer id."); return; }
+                                applyAp = ap => ap.PaletteTemplate = pal;
+                                valueEcho = pal.ToString(CultureInfo.InvariantCulture);
+                                break;
+                            case "shade":
+                                if (!TryDouble(args[3], out var sh)) { Msg("shade must be a number 0..1."); return; }
+                                applyAp = ap => ap.Shade = sh;
+                                valueEcho = sh.ToString("0.####", CultureInfo.InvariantCulture);
+                                break;
+                            case "scale":
+                                if (!TryDouble(args[3], out var sc)) { Msg("scale must be a number."); return; }
+                                applyAp = ap => ap.Scale = sc;
+                                valueEcho = sc.ToString("0.####", CultureInfo.InvariantCulture);
+                                break;
+                            case "translucency":
+                            case "trans":
+                                if (!TryDouble(args[3], out var tr)) { Msg("translucency must be a number 0..1."); return; }
+                                applyAp = ap => ap.Translucency = tr;
+                                valueEcho = tr.ToString("0.####", CultureInfo.InvariantCulture);
+                                break;
+                            case "shiny":
+                                var on = args[3].Equals("true", StringComparison.OrdinalIgnoreCase) || args[3] == "1" || args[3].Equals("on", StringComparison.OrdinalIgnoreCase);
+                                applyAp = ap => ap.Shiny = on;
+                                valueEcho = on ? "on" : "off";
+                                break;
+                            case "setup":
+                            case "setuptableid":
+                                if (!TryParseDid(args[3], out var didSetup)) { Msg("setup must be a DataId (hex like 0x02001234 or decimal)."); return; }
+                                applyAp = ap => ap.SetupTableId = didSetup;
+                                valueEcho = "0x" + didSetup.ToString("X8");
+                                break;
+                            case "clothing":
+                            case "clothingbase":
+                                if (!TryParseDid(args[3], out var didClo)) { Msg("clothing must be a DataId (0x10......)."); return; }
+                                applyAp = ap => ap.ClothingBase = didClo;
+                                valueEcho = "0x" + didClo.ToString("X8");
+                                break;
+                            case "palettebase":
+                            case "palbase":
+                                if (!TryParseDid(args[3], out var didPb)) { Msg("palettebase must be a DataId (0x04......)."); return; }
+                                applyAp = ap => ap.PaletteBase = didPb;
+                                valueEcho = "0x" + didPb.ToString("X8");
+                                break;
+                            case "motion":
+                            case "motiontable":
+                                if (!TryParseDid(args[3], out var didMt)) { Msg("motion must be a DataId (0x09......)."); return; }
+                                applyAp = ap => ap.MotionTable = didMt;
+                                valueEcho = "0x" + didMt.ToString("X8");
+                                break;
+                            case "sound":
+                            case "soundtable":
+                                if (!TryParseDid(args[3], out var didSt)) { Msg("sound must be a DataId (0x20......)."); return; }
+                                applyAp = ap => ap.SoundTable = didSt;
+                                valueEcho = "0x" + didSt.ToString("X8");
+                                break;
+                            case "icon":
+                                if (!TryParseDid(args[3], out var didIcon)) { Msg("icon must be a DataId (0x06......)."); return; }
+                                applyAp = ap => ap.Icon = didIcon;
+                                valueEcho = "0x" + didIcon.ToString("X8");
+                                break;
+                            default:
+                                Msg("field must be name | palette | shade | scale | translucency | shiny | setup | clothing | palettebase | motion | sound | icon"); return;
+                        }
+
+                        ZoneControlManager.MutateArea(name, a => applyAp(a.AppearanceFor(wcid, create: true)));
+                        Msg($"'{name}'{(wcid.HasValue ? " [wcid " + wcid.Value + "]" : "")} appearance {field} = {valueEcho}. Applies on (re)spawn (reload the landblock).");
+                        return;
+                    }
+
+                    case "clearappearance":
+                    {
+                        if (args.Count < 2) { Msg("Usage: clearappearance <name> [field] [--wcid <id>]  (no field = clear ALL, incl. model/clothing/palette)"); return; }
+                        var name = args[1];
+                        if (ZoneControlManager.GetArea(name) == null) { Msg($"No zone '{name}'."); return; }
+                        var field = args.Count >= 3 ? args[2].ToLowerInvariant() : null;
+                        var cleared = false;
+                        ZoneControlManager.MutateArea(name, a =>
+                        {
+                            var ap = a.AppearanceFor(wcid, create: false);
+                            if (ap == null) return;
+                            if (field == null)
+                            {
+                                cleared = !ap.IsEmpty;
+                                ap.Clear();   // ALL fields incl. the DataId swaps (Setup/Clothing/PaletteBase/Motion/Sound/Icon)
+                            }
+                            else
+                            {
+                                switch (field)
+                                {
+                                    case "name": cleared = !string.IsNullOrEmpty(ap.Name); ap.Name = null; break;
+                                    case "palette": case "palettetemplate": cleared = ap.PaletteTemplate.HasValue; ap.PaletteTemplate = null; break;
+                                    case "shade": cleared = ap.Shade.HasValue; ap.Shade = null; break;
+                                    case "scale": cleared = ap.Scale.HasValue; ap.Scale = null; break;
+                                    case "translucency": case "trans": cleared = ap.Translucency.HasValue; ap.Translucency = null; break;
+                                    case "shiny": cleared = ap.Shiny.HasValue; ap.Shiny = null; break;
+                                    case "setup": case "setuptableid": cleared = ap.SetupTableId.HasValue; ap.SetupTableId = null; break;
+                                    case "clothing": case "clothingbase": cleared = ap.ClothingBase.HasValue; ap.ClothingBase = null; break;
+                                    case "palettebase": case "palbase": cleared = ap.PaletteBase.HasValue; ap.PaletteBase = null; break;
+                                    case "motion": case "motiontable": cleared = ap.MotionTable.HasValue; ap.MotionTable = null; break;
+                                    case "sound": case "soundtable": cleared = ap.SoundTable.HasValue; ap.SoundTable = null; break;
+                                    case "icon": cleared = ap.Icon.HasValue; ap.Icon = null; break;
+                                    case "parts": case "bodyparts": cleared = ap.PartCount > 0; ap.AnimParts = null; ap.TextureMaps = null; break;
+                                    case "animpart":
+                                        // "clearappearance <name> animpart <index>" removes ONE part override;
+                                        // "clearappearance <name> animpart" (no index) removes all part overrides.
+                                        if (args.Count >= 4 && byte.TryParse(args[3], NumberStyles.Integer, CultureInfo.InvariantCulture, out var ci))
+                                        {
+                                            int before = ap.AnimParts?.Count ?? 0;
+                                            ap.AnimParts?.RemoveAll(p => p.Index == ci);
+                                            if (ap.AnimParts != null && ap.AnimParts.Count == 0) ap.AnimParts = null;
+                                            cleared = (ap.AnimParts?.Count ?? 0) != before;
+                                        }
+                                        else { cleared = (ap.AnimParts?.Count ?? 0) > 0; ap.AnimParts = null; }
+                                        break;
+                                    default: Msg("field must be name | palette | shade | scale | translucency | shiny | setup | clothing | palettebase | motion | sound | icon | parts | animpart <index>"); return;
+                                }
+                            }
+                            if (wcid.HasValue && ap.IsEmpty) a.AppearanceByWcid.Remove(wcid.Value);
+                        });
+                        Msg(cleared ? $"'{name}' appearance {(field ?? "all")} cleared (reverts on respawn)." : "That appearance wasn't set.");
+                        return;
+                    }
+
+                    case "resetmob":
+                    {
+                        // One-shot "back to zone defaults" for ONE monster (owner 2026-08-09): drops the
+                        // wcid's whole stat/prop/loot override bucket AND its appearance bucket (incl.
+                        // parts + name). The zone layer and the variation Default are untouched.
+                        if (args.Count < 2 || !wcid.HasValue) { Msg("Usage: resetmob <zone> --wcid <id>  (removes ALL of that monster's overrides - stats, props, loot, appearance)"); return; }
+                        var name = args[1];
+                        if (ZoneControlManager.GetArea(name) == null) { Msg($"No zone '{name}'."); return; }
+                        bool hadStats = false, hadAp = false;
+                        ZoneControlManager.MutateArea(name, a =>
+                        {
+                            hadStats = a.Profile.WcidOverrides != null && a.Profile.WcidOverrides.Remove(wcid.Value);
+                            hadAp = a.AppearanceByWcid != null && a.AppearanceByWcid.Remove(wcid.Value);
+                        });
+                        Msg(hadStats || hadAp
+                            ? $"'{name}' wcid {wcid.Value} reset to zone defaults ({(hadStats ? "stats/props/loot" : "")}{(hadStats && hadAp ? " + " : "")}{(hadAp ? "appearance" : "")} removed). Reload the landblock to see it."
+                            : "That monster had no overrides - it already runs on zone defaults.");
+                        return;
+                    }
+
+                    case "bakemob":
+                    {
+                        // The OPPOSITE of resetmob (owner 2026-08-09): write the monster's current
+                        // effective LOOK (zone default overlaid by its per-WCID entry) into its weenie
+                        // in ace_world - permanent, global (every zone and variation), survives zone
+                        // deletion. APPEARANCE ONLY by design: stats stay ZC-tuned (weak-baseline
+                        // philosophy). After a successful bake the wcid's appearance bucket is removed
+                        // (redundant); the zone-wide appearance default is left alone.
+                        if (args.Count < 2 || !wcid.HasValue) { Msg("Usage: bakemob <zone> --wcid <id>  (writes the monster's current look into its base template permanently)"); return; }
+                        var name = args[1];
+                        var area = ZoneControlManager.GetArea(name);
+                        if (area == null) { Msg($"No zone '{name}'."); return; }
+                        var w = wcid.Value;
+                        if (ACE.Database.DatabaseManager.World.GetCachedWeenie(w) == null) { Msg($"No weenie {w} in the world db."); return; }
+
+                        var apOverlay = area.AppearanceByWcid != null && area.AppearanceByWcid.TryGetValue(w, out var apw3) ? apw3 : null;
+                        var merged = ZoneAppearance.Merge(area.AppearanceDefault, apOverlay);
+                        if (merged == null || merged.IsEmpty) { Msg("Nothing to bake - this monster has no appearance overrides here."); return; }
+
+                        var bake = BuildAppearanceBakeSql(w, merged);
+
+                        using (var bakeCtx = new WorldDbContext())
+                            foreach (var s in bake)
+                                bakeCtx.Database.ExecuteSqlRaw(s);
+                        ACE.Database.DatabaseManager.World.ClearCachedWeenie(w);
+
+                        ZoneControlManager.MutateArea(name, a => a.AppearanceByWcid?.Remove(w));
+
+                        Msg($"bakemob: wcid {w} - {bake.Count} change(s) written to the WORLD DB (permanent; applies in every zone and variation). " +
+                            "This monster's appearance overrides here were removed (now baked in). Reload the landblock to see it.");
+                        return;
+                    }
+
+                    case "clonemob":
+                    {
+                        // Mint a BRAND-NEW monster (owner 2026-08-09): full weenie clone of the source
+                        // wcid + the source's current effective ZC look baked in + optional new display
+                        // name, under a NEW wcid. The SOURCE weenie and its zone overrides are UNTOUCHED
+                        // (other devs keep iterating on it). Ends by exporting the finished weenie to the
+                        // Content sql folder - the shippable per-wcid file (import-discord compatible).
+                        // Usage: clonemob <zone> <newWcid> [new display name...] --wcid <srcWcid>
+                        if (args.Count < 3 || !wcid.HasValue)
+                        { Msg("Usage: clonemob <zone> <newWcid> [new display name] --wcid <srcWcid>"); return; }
+                        var name = args[1];
+                        var area = ZoneControlManager.GetArea(name);
+                        if (area == null) { Msg($"No zone '{name}'."); return; }
+                        if (!uint.TryParse(args[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out var newWcid) || newWcid == 0)
+                        { Msg("newWcid must be a number."); return; }
+                        var srcWcid = wcid.Value;
+                        if (newWcid == srcWcid) { Msg("newWcid must differ from the source wcid."); return; }
+                        var srcWeenie = ACE.Database.DatabaseManager.World.GetWeenie(srcWcid);
+                        if (srcWeenie == null) { Msg($"No weenie {srcWcid} in the world db."); return; }
+                        if (ACE.Database.DatabaseManager.World.GetCachedWeenie(newWcid) != null)
+                        { Msg($"Weenie {newWcid} already exists - pick an unused wcid."); return; }
+
+                        // optional new display name = the remaining tokens (same sanitize as the name lever)
+                        var cloneName = string.Join(" ", args.Skip(3)).Trim().Trim('"').Trim();
+                        cloneName = new string(cloneName.Where(c => c >= 32 && c < 127 && c != '|' && c != '~' && c != '=').ToArray()).Trim();
+                        if (cloneName.Length > 64) cloneName = cloneName.Substring(0, 64);
+
+                        // 1) Full-fidelity clone: the Adapter's SQL writer emits the source weenie's
+                        //    complete per-wcid SQL (every table incl. emotes). The wcid is re-pointed on
+                        //    the loaded MODEL (ClassId + self-references) before the writer runs.
+                        RemapWeenieModel(srcWeenie, srcWcid, newWcid);
+                        // weenie.class_Name is UNIQUE (className_UNIQUE): the clone needs its own before
+                        // the INSERT, not a fix-up UPDATE after it (which never ran - the INSERT threw).
+                        srcWeenie.ClassName = $"{srcWeenie.ClassName}_{newWcid}";
+                        if (Processors.DeveloperContentCommands.WeenieSQLWriter == null)
+                        {
+                            Processors.DeveloperContentCommands.WeenieSQLWriter = new ACE.Database.SQLFormatters.World.WeenieSQLWriter
+                            {
+                                WeenieNames = ACE.Database.DatabaseManager.World.GetAllWeenieNames(),
+                                SpellNames = ACE.Database.DatabaseManager.World.GetAllSpellNames(),
+                                TreasureDeath = ACE.Database.DatabaseManager.World.GetAllTreasureDeath(),
+                                TreasureWielded = ACE.Database.DatabaseManager.World.GetAllTreasureWielded(),
+                                PacketOpCodes = ACE.Entity.PacketOpCodeNames.Values,
+                            };
+                        }
+                        string cloneSql;
+                        using (var ms = new System.IO.MemoryStream())
+                        {
+                            using (var sw = new System.IO.StreamWriter(ms, System.Text.Encoding.UTF8, 4096, leaveOpen: true))
+                            {
+                                Processors.DeveloperContentCommands.WeenieSQLWriter.CreateSQLDELETEStatement(srcWeenie, sw);
+                                sw.WriteLine();
+                                Processors.DeveloperContentCommands.WeenieSQLWriter.CreateSQLINSERTStatement(srcWeenie, sw);
+                                sw.Flush();
+                            }
+                            cloneSql = System.Text.Encoding.UTF8.GetString(ms.ToArray());
+                        }
+
+                        using (var cloneCtx = new WorldDbContext())
+                        {
+                            cloneCtx.Database.SetCommandTimeout(0);
+                            cloneCtx.Database.ExecuteSqlRaw(cloneSql.Replace("\r\n", "\n"));
+                        }
+
+                        // 1b) Copy the source's per-monster ZONE buckets too (stats/props/loot/cantrips/
+                        //     currency/spell rules) so the clone behaves identically IN THIS ZONE (owner
+                        //     2026-08-09: "loot table, stats etc - would need it"). Deep copy via the same
+                        //     JSON round-trip the store itself persists with; source bucket untouched.
+                        ZoneControlManager.MutateArea(name, a =>
+                        {
+                            if (a.Profile.WcidOverrides != null && a.Profile.WcidOverrides.TryGetValue(srcWcid, out var srcVp) && srcVp != null)
+                                a.Profile.WcidOverrides[newWcid] = Newtonsoft.Json.JsonConvert.DeserializeObject<ZoneVariantProfile>(
+                                    Newtonsoft.Json.JsonConvert.SerializeObject(srcVp));
+                        });
+
+                        // 2) Bake the source's effective ZC look (+ the new display name) onto the CLONE.
+                        //    Source buckets stay exactly as they are.
+                        var apOv = area.AppearanceByWcid != null && area.AppearanceByWcid.TryGetValue(srcWcid, out var apw4) ? apw4 : null;
+                        var look = ZoneAppearance.Merge(area.AppearanceDefault, apOv) ?? new ZoneAppearance();
+                        if (cloneName.Length > 0)
+                            look.Name = cloneName;
+                        if (!look.IsEmpty)
+                        {
+                            var bakeSql = BuildAppearanceBakeSql(newWcid, look);
+                            using var lookCtx = new WorldDbContext();
+                            foreach (var s in bakeSql)
+                                lookCtx.Database.ExecuteSqlRaw(s);
+                        }
+                        ACE.Database.DatabaseManager.World.ClearCachedWeenie(newWcid);
+
+                        // 3) Export the FINISHED weenie to the Content sql folder - the permanent,
+                        //    shippable per-wcid file.
+                        Processors.DeveloperContentCommands.ExportSQLWeenie(session, newWcid.ToString(CultureInfo.InvariantCulture));
+
+                        Msg($"clonemob: {srcWcid} cloned to NEW wcid {newWcid}" +
+                            (cloneName.Length > 0 ? $" named '{cloneName}'" : "") +
+                            " with the current look baked in. The source monster is untouched. " +
+                            "SQL exported to the Content sql folder (see above). Summon it anywhere (e.g. /ci " + newWcid + ").");
+                        return;
+                    }
+
+                    case "becomemob":
+                    {
+                        // Convert an EXISTING monster into a full copy of another (owner 2026-08-10,
+                        // after the 36-PH-mobs-to-drudge hand-SQL): everything the donor is - stats,
+                        // skills, body parts, spell book, loot, emotes - lands on the target wcid.
+                        // The target keeps exactly four things: class_Id, class_Name, display Name,
+                        // and its current DefaultScale. Zone buckets are untouched (stats stay
+                        // zone-tuned). Zone-less on purpose: this edits the WORLD DB, not a zone.
+                        // Usage: becomemob <donorWcid> --wcid <targetWcid>
+                        if (args.Count < 2 || !wcid.HasValue ||
+                            !uint.TryParse(args[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var bmDonor))
+                        { Msg("Usage: becomemob <donorWcid> --wcid <targetWcid>   (target becomes a full copy of the donor; keeps name + scale)"); return; }
+                        var bmTarget = wcid.Value;
+                        if (bmDonor == bmTarget) { Msg("Donor and target must differ."); return; }
+                        if (ZcDraftSlotWcids.Contains(bmTarget)) { Msg("The target cannot be a Drafted Look slot."); return; }
+                        var bmDonorWeenie = ACE.Database.DatabaseManager.World.GetWeenie(bmDonor);
+                        if (bmDonorWeenie == null) { Msg($"No weenie {bmDonor} in the world db."); return; }
+                        var bmTargetWeenie = ACE.Database.DatabaseManager.World.GetCachedWeenie(bmTarget);
+                        if (bmTargetWeenie == null) { Msg($"No weenie {bmTarget} in the world db."); return; }
+
+                        // What the target KEEPS.
+                        var bmKeepName = bmTargetWeenie.GetProperty(PropertyString.Name);
+                        var bmKeepScale = bmTargetWeenie.GetProperty(PropertyFloat.DefaultScale);
+                        string bmKeepClassName;
+                        using (var bmCtx = new WorldDbContext())
+                            bmKeepClassName = bmCtx.Weenie.Where(x => x.ClassId == bmTarget).Select(x => x.ClassName).FirstOrDefault();
+
+                        // Same engine as clonemob: full-fidelity donor SQL, the donor wcid re-pointed at
+                        // the target on the loaded model (ClassId + emote/create/generator self-references).
+                        RemapWeenieModel(bmDonorWeenie, bmDonor, bmTarget);
+                        // weenie.class_Name is UNIQUE: the copy carries the TARGET's class_Name (kept identity)
+                        // into the INSERT itself - the donor's would clash with the donor's own row.
+                        bmDonorWeenie.ClassName = !string.IsNullOrEmpty(bmKeepClassName) ? bmKeepClassName : $"{bmDonorWeenie.ClassName}_{bmTarget}";
+                        if (Processors.DeveloperContentCommands.WeenieSQLWriter == null)
+                        {
+                            Processors.DeveloperContentCommands.WeenieSQLWriter = new ACE.Database.SQLFormatters.World.WeenieSQLWriter
+                            {
+                                WeenieNames = ACE.Database.DatabaseManager.World.GetAllWeenieNames(),
+                                SpellNames = ACE.Database.DatabaseManager.World.GetAllSpellNames(),
+                                TreasureDeath = ACE.Database.DatabaseManager.World.GetAllTreasureDeath(),
+                                TreasureWielded = ACE.Database.DatabaseManager.World.GetAllTreasureWielded(),
+                                PacketOpCodes = ACE.Entity.PacketOpCodeNames.Values,
+                            };
+                        }
+                        string bmSql;
+                        using (var ms = new System.IO.MemoryStream())
+                        {
+                            using (var sw = new System.IO.StreamWriter(ms, System.Text.Encoding.UTF8, 4096, leaveOpen: true))
+                            {
+                                Processors.DeveloperContentCommands.WeenieSQLWriter.CreateSQLDELETEStatement(bmDonorWeenie, sw);
+                                sw.WriteLine();
+                                Processors.DeveloperContentCommands.WeenieSQLWriter.CreateSQLINSERTStatement(bmDonorWeenie, sw);
+                                sw.Flush();
+                            }
+                            bmSql = System.Text.Encoding.UTF8.GetString(ms.ToArray());
+                        }
+
+                        using (var bmCtx = new WorldDbContext())
+                        {
+                            bmCtx.Database.SetCommandTimeout(0);
+                            // ONE transaction (review 2026-09-04): the target's old self is wiped before the
+                            // donor copy lands, so a failure half-way (a key clash, a bad row) must roll the
+                            // wipe back rather than leave the target gone from the world DB.
+                            using var bmTx = bmCtx.Database.BeginTransaction();
+                            // Wipe the target's OLD self first (the remapped DELETE also targets it,
+                            // but be explicit), then import the donor copy.
+                            bmCtx.Database.ExecuteSqlRaw($"DELETE FROM `weenie` WHERE `class_Id` = {bmTarget}");
+                            bmCtx.Database.ExecuteSqlRaw(bmSql.Replace("\r\n", "\n"));
+                            // Restore the kept identity (class_Name rode in on the model above).
+                            if (!string.IsNullOrEmpty(bmKeepName))
+                            {
+                                bmCtx.Database.ExecuteSqlRaw($"DELETE FROM `weenie_properties_string` WHERE `object_Id` = {bmTarget} AND `type` = 1");
+                                bmCtx.Database.ExecuteSqlRaw($"INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`) VALUES ({bmTarget}, 1, {SqlStr(bmKeepName)})");
+                            }
+                            if (bmKeepScale.HasValue)
+                            {
+                                bmCtx.Database.ExecuteSqlRaw($"DELETE FROM `weenie_properties_float` WHERE `object_Id` = {bmTarget} AND `type` = 39");
+                                bmCtx.Database.ExecuteSqlRaw($"INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`) VALUES ({bmTarget}, 39, {bmKeepScale.Value.ToString(CultureInfo.InvariantCulture)})");
+                            }
+                            bmTx.Commit();
+                        }
+                        ACE.Database.DatabaseManager.World.ClearCachedWeenie(bmTarget);
+
+                        // Fresh shippable per-wcid SQL so the pack file matches the new reality.
+                        Processors.DeveloperContentCommands.ExportSQLWeenie(session, bmTarget.ToString(CultureInfo.InvariantCulture));
+
+                        var bmDonorName = bmDonorWeenie.GetProperty(PropertyString.Name) ?? bmDonor.ToString();
+                        Msg($"becomemob: {bmKeepName ?? bmTarget.ToString()} ({bmTarget}) is now a full copy of {bmDonorName} ({bmDonor}) - " +
+                            "stats, loot, spells, everything. Kept: name, class_Name" + (bmKeepScale.HasValue ? $", scale {bmKeepScale.Value:0.##}" : "") + ". " +
+                            "Zone tuning unaffected. SQL exported. Reload the landblock to see it.");
+                        return;
+                    }
+
+                    case "copylook":
+                    {
+                        // "Make the target look like <donorWcid>": read the donor weenie's model + palette data and
+                        // stamp it into this zone's appearance layer (default set, or a single --wcid overlay).
+                        if (args.Count < 3) { Msg("Usage: copylook <name> <donorWcid> [--wcid <id>]"); return; }
+                        var name = args[1];
+                        if (ZoneControlManager.GetArea(name) == null) { Msg($"No zone '{name}' (create it first)."); return; }
+                        if (!uint.TryParse(args[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out var donorWcid)) { Msg("donorWcid must be a number."); return; }
+                        var donor = ACE.Database.DatabaseManager.World.GetCachedWeenie(donorWcid);
+                        if (donor == null) { Msg($"No weenie {donorWcid} in the world db."); return; }
+
+                        var setup = donor.GetProperty(PropertyDataId.Setup);
+                        var motion = donor.GetProperty(PropertyDataId.MotionTable);
+                        var sound = donor.GetProperty(PropertyDataId.SoundTable);
+                        var palBase = donor.GetProperty(PropertyDataId.PaletteBase);
+                        var clothing = donor.GetProperty(PropertyDataId.ClothingBase);
+                        var icon = donor.GetProperty(PropertyDataId.Icon);
+                        var palTemplate = donor.GetProperty(PropertyInt.PaletteTemplate);
+                        var shade = donor.GetProperty(PropertyFloat.Shade);
+                        var scale = donor.GetProperty(PropertyFloat.DefaultScale);
+                        // Per-part body swaps (e.g. Tusgian's 21 anim + 27 texture rows): copy the whole set so the
+                        // target reproduces the donor's custom body. Only set when the donor actually has parts, so
+                        // copying a plain mob never blanks the target's own parts.
+                        var donorAnim = donor.PropertiesAnimPart;
+                        var donorTex = donor.PropertiesTextureMap;
+
+                        ZoneControlManager.MutateArea(name, a =>
+                        {
+                            var ap = a.AppearanceFor(wcid, create: true);
+                            if (setup.HasValue) ap.SetupTableId = setup;
+                            if (motion.HasValue) ap.MotionTable = motion;
+                            if (sound.HasValue) ap.SoundTable = sound;
+                            if (palBase.HasValue) ap.PaletteBase = palBase;
+                            if (clothing.HasValue) ap.ClothingBase = clothing;
+                            if (icon.HasValue) ap.Icon = icon;
+                            if (palTemplate.HasValue) ap.PaletteTemplate = palTemplate;
+                            if (shade.HasValue) ap.Shade = shade;
+                            if (scale.HasValue) ap.Scale = scale;
+                            ap.AnimParts = (donorAnim != null && donorAnim.Count > 0)
+                                ? donorAnim.Select(p => new AnimPartEntry { Index = p.Index, GfxObj = p.AnimationId }).ToList() : null;
+                            ap.TextureMaps = (donorTex != null && donorTex.Count > 0)
+                                ? donorTex.Select(t => new TextureMapEntry { Index = t.PartIndex, OldTex = t.OldTexture, NewTex = t.NewTexture }).ToList() : null;
+                        });
+                        var donorName = donor.GetProperty(PropertyString.Name) ?? donorWcid.ToString();
+                        var partN = (donorAnim?.Count ?? 0) + (donorTex?.Count ?? 0);
+                        Msg($"'{name}'{(wcid.HasValue ? " [wcid " + wcid.Value + "]" : "")} appearance copied from {donorName} ({donorWcid}){(partN > 0 ? $", incl. {partN} body-part swaps" : "")}. Reload the landblock to see it.");
+                        return;
+                    }
+
+                    case "previewmob":
+                    {
+                        // Look-preview (owner 2026-08-09): spawn an INERT copy of a weenie in front of the
+                        // player - not attackable, never aggros, 60s lifespan (heartbeat-driven, ~5s grain).
+                        // One preview slot per player: a new preview replaces the previous one. Spawned inside
+                        // a governed zone it picks up that zone's appearance overrides like any spawn, so it
+                        // can also preview an override set, not just stock looks.
+                        if (session?.Player == null) { Msg("previewmob needs an in-world player."); return; }
+                        if (args.Count < 2 || !uint.TryParse(args[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var pvWcid))
+                        { Msg("Usage: previewmob <wcid> [distance]"); return; }
+                        // Optional spawn distance (owner 2026-08-10). Explicit distance wins over the
+                        // automatic scale push-out below.
+                        float pvDist = 5f;
+                        var pvDistExplicit = args.Count >= 3 &&
+                            float.TryParse(args[2], NumberStyles.Float, CultureInfo.InvariantCulture, out pvDist);
+                        if (pvDistExplicit) pvDist = Math.Clamp(pvDist, 1f, 120f); else pvDist = 5f;
+                        var pvWeenie = ACE.Database.DatabaseManager.World.GetCachedWeenie(pvWcid);
+                        if (pvWeenie == null) { Msg($"No weenie {pvWcid} in the world db."); return; }
+
+                        if (ZcPreviews.TryGetValue(session.Player.Guid.Full, out var prevPv)
+                            && prevPv != null && !prevPv.IsDestroyed)
+                            prevPv.DeleteObject();
+
+                        var pv = ACE.Server.Factories.WorldObjectFactory.CreateNewWorldObject(pvWcid);
+                        if (pv == null) { Msg($"Weenie {pvWcid} could not be instantiated."); return; }
+                        if (!(pv is ACE.Server.WorldObjects.Creature pvCreature))
+                        { pv.Destroy(); Msg($"{pv.Name ?? pvWcid.ToString()} is not a creature - nothing to preview."); return; }
+
+                        pv.Location = session.Player.Location.InFrontOf(pvDist, true);
+                        pv.Location.LandblockId = new ACE.Entity.LandblockId(ACE.Server.Entity.PositionExtensions.GetCell(pv.Location));
+                        // The single-object factory path skips the zone spawn snapshot (only landblock/
+                        // generator spawns get it), so previews never wore zone appearance overrides
+                        // (found 2026-08-10: zone-default scale did not show on a preview). Location is
+                        // set, so the scaler's ordering guard is satisfied; stats on an inert preview
+                        // are harmless.
+                        ZoneSpawnScaler.ApplyToSpawn(pvCreature);
+                        // Scale-aware spawn distance (found 2026-08-10): a zone scale like 5x placed the
+                        // preview's huge model ON the player - from inside a mesh you see nothing, which
+                        // reads as "it despawned and never came back". Push big previews out proportionally
+                        // UNLESS the caller chose a distance - their number is respected as-is.
+                        var pvScale = (float)(pv.ObjScale ?? 1.0);
+                        if (!pvDistExplicit && pvScale > 1.5f)
+                        {
+                            pv.Location = session.Player.Location.InFrontOf(pvDist * pvScale, true);
+                            pv.Location.LandblockId = new ACE.Entity.LandblockId(ACE.Server.Entity.PositionExtensions.GetCell(pv.Location));
+                        }
+                        pv.Lifespan = 60;
+                        pv.Attackable = false;
+                        pvCreature.Tolerance = Tolerance.NoAttack;
+                        pv.Name = (pv.Name ?? "Preview") + " (Preview)";
+
+                        if (!pv.EnterWorld()) { pv.Destroy(); Msg("Preview failed to spawn (physics placement)."); return; }
+                        ZcPreviews[session.Player.Guid.Full] = pv;
+                        Msg($"Previewing {pvWeenie.GetProperty(PropertyString.Name) ?? pvWcid.ToString()} ({pvWcid}) for 60s.");
+                        return;
+                    }
+
+                    case "draftslot":
+                    {
+                        // Look Lab "Drafted Look" target (owner 2026-08-10): hand the asking player ONE of the
+                        // five reserved Drafted Look wcids for this zone, so up to five admins can craft looks
+                        // in the same zone without clobbering each other. Re-asking returns the same slot.
+                        // "draftslot <zone> release" frees the slot and wipes its scratch bucket.
+                        // Machine reply line for the plugin: [[ZCDRAFT]]<wcid>  (0 = all slots busy / released).
+                        if (session?.Player == null) { Msg("draftslot needs an in-world player."); return; }
+                        if (args.Count < 2) { Msg("Usage: draftslot <zone> [release]"); return; }
+                        var dsArea = ZoneControlManager.GetArea(args[1]);
+                        if (dsArea == null) { Msg($"No zone '{args[1]}'."); return; }
+                        var dsZone = dsArea.Name;
+                        var dsMe = session.Player.Guid.Full;
+
+                        if (args.Count > 2 && args[2].Equals("release", StringComparison.OrdinalIgnoreCase))
+                        {
+                            ReleaseDraftClaim(dsZone, dsMe);
+                            Msg("Draft slot released (scratch look discarded).");
+                            Msg("[[ZCDRAFT]]0");
+                            return;
+                        }
+
+                        // Evict claims of players no longer online (their scratch buckets are wiped too).
+                        foreach (var dead in ZcDraftClaims.Keys.Where(k => PlayerManager.GetOnlinePlayer(k.Player) == null).ToList())
+                            ReleaseDraftClaim(dead.Zone, dead.Player);
+
+                        if (ZcDraftClaims.TryGetValue((dsZone, dsMe), out var mine))
+                        { Msg("[[ZCDRAFT]]" + mine); return; }
+
+                        var free = ZcDraftSlotWcids.FirstOrDefault(s =>
+                            !ZcDraftClaims.Any(kv => kv.Key.Zone.Equals(dsZone, StringComparison.OrdinalIgnoreCase) && kv.Value == s));
+                        if (free == 0)
+                        { Msg("All 5 draft slots in this zone are in use."); Msg("[[ZCDRAFT]]0"); return; }
+
+                        ZcDraftClaims[(dsZone, dsMe)] = free;
+                        // Start clean even if something left junk in the bucket.
+                        ZoneControlManager.MutateArea(dsZone, a => a.AppearanceByWcid?.Remove(free));
+                        Msg("[[ZCDRAFT]]" + free);
+                        return;
+                    }
+
+                    case "copydraft":
+                    {
+                        // Save the crafted Drafted Look: copy YOUR slot's zone appearance bucket onto the
+                        // destination wcid's bucket in the same zone (REPLACES the destination's bucket),
+                        // then clear + release the slot. bakemob / clonemob take it from there.
+                        if (session?.Player == null) { Msg("copydraft needs an in-world player."); return; }
+                        if (args.Count < 3) { Msg("Usage: copydraft <zone> <destWcid>   (saves your Drafted Look onto the destination's zone appearance)"); return; }
+                        var cdArea = ZoneControlManager.GetArea(args[1]);
+                        if (cdArea == null) { Msg($"No zone '{args[1]}'."); return; }
+                        var cdZone = cdArea.Name;
+                        if (!uint.TryParse(args[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out var cdDest) || cdDest == 0)
+                        { Msg("destWcid must be a number."); return; }
+                        if (ZcDraftSlotWcids.Contains(cdDest))
+                        { Msg("The destination cannot be a Drafted Look slot."); return; }
+                        if (ACE.Database.DatabaseManager.World.GetCachedWeenie(cdDest) == null)
+                        { Msg($"No weenie {cdDest} in the world db."); return; }
+
+                        if (!ZcDraftClaims.TryGetValue((cdZone, session.Player.Guid.Full), out var cdSlot))
+                        { Msg($"You have no draft slot in '{cdZone}' - nothing to save."); return; }
+
+                        var cdBucket = cdArea.AppearanceByWcid != null && cdArea.AppearanceByWcid.TryGetValue(cdSlot, out var cdb) ? cdb : null;
+                        if (cdBucket == null || cdBucket.IsEmpty)
+                        { Msg("Your Drafted Look is empty - apply a look or set a lever first."); return; }
+
+                        // Deep copy via the same JSON round-trip the store persists with; REPLACES dest's bucket.
+                        ZoneControlManager.MutateArea(cdZone, a =>
+                        {
+                            a.AppearanceByWcid ??= new Dictionary<uint, ZoneAppearance>();
+                            a.AppearanceByWcid[cdDest] = Newtonsoft.Json.JsonConvert.DeserializeObject<ZoneAppearance>(
+                                Newtonsoft.Json.JsonConvert.SerializeObject(cdBucket));
+                        });
+                        ReleaseDraftClaim(cdZone, session.Player.Guid.Full);
+
+                        var cdName = ACE.Database.DatabaseManager.World.GetCachedWeenie(cdDest)?.GetProperty(PropertyString.Name) ?? cdDest.ToString();
+                        Msg($"copydraft: your Drafted Look now overrides {cdName} ({cdDest}) in '{cdZone}' (its previous appearance overrides here were replaced). " +
+                            "Slot released. Make it permanent with bakemob, or mint a new monster with clonemob.");
+                        return;
+                    }
+
+                    case "seticon":
+                    {
+                        // PERMANENT world-db edit: sets PropertyDataId.Icon (type 8) on a weenie.
+                        // Unlike `appearance icon`, which is a per-zone override living in the ZC
+                        // store, this rewrites the weenie itself and affects every server.
+                        //
+                        // Every edit is mirrored to zc_seticon_<date>.sql next to the server dll so
+                        // the standing "no orphan MariaDB edits" rule still holds - that file is the
+                        // migration artifact for ILT.
+                        // LAYERS (owner 2026-08-12): the client composites an icon from four
+                        // PropertyDataIds - Icon 8 (base), IconOverlay 50 (corner badge),
+                        // IconOverlaySecondary 51, IconUnderlay 52. Overlay art is a FULL 32x32
+                        // texture that is mostly transparent, not a small image.
+                        if (args.Count < 3)
+                        {
+                            Msg("Usage: seticon <wcid> <iconDid|clear> [icon|overlay|overlay2|underlay]   "
+                                + "(layer defaults to icon; 'clear' removes an overlay/underlay. "
+                                + "Permanent world-db edit - use 'appearance icon' for a zone-only override)");
+                            return;
+                        }
+                        if (!uint.TryParse(args[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var siWcid) || siWcid == 0)
+                        { Msg("wcid must be a number."); return; }
+
+                        var siLayerArg = args.Count > 3 ? args[3].ToLowerInvariant() : "icon";
+                        PropertyDataId siProp;
+                        switch (siLayerArg)
+                        {
+                            case "icon": siProp = PropertyDataId.Icon; break;
+                            case "overlay": siProp = PropertyDataId.IconOverlay; break;
+                            case "overlay2":
+                            case "secondary": siProp = PropertyDataId.IconOverlaySecondary; break;
+                            case "underlay": siProp = PropertyDataId.IconUnderlay; break;
+                            default:
+                                Msg($"Unknown layer '{siLayerArg}'. Use icon | overlay | overlay2 | underlay.");
+                                return;
+                        }
+                        var siType = (int)siProp;
+
+                        var siClear = args[2].Equals("clear", StringComparison.OrdinalIgnoreCase)
+                                   || args[2].Equals("none", StringComparison.OrdinalIgnoreCase)
+                                   || args[2] == "0";
+
+                        uint siIcon = 0;
+                        if (!siClear)
+                        {
+                            if (!uint.TryParse(args[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out siIcon) || siIcon == 0)
+                            { Msg("iconDid must be a number (decimal, eg 100668365), or 'clear'."); return; }
+
+                            // Icons live in the 0x06 texture band. Anything else is a typo - most likely
+                            // a hex DID pasted without conversion - and would render as a missing icon.
+                            if (siIcon < 0x06000000 || siIcon > 0x06FFFFFF)
+                            { Msg($"{siIcon} is not in the icon range 0x06000000-0x06FFFFFF ({0x06000000}-{0x06FFFFFF}). Paste the DECIMAL DID."); return; }
+                        }
+                        else if (siProp == PropertyDataId.Icon)
+                        {
+                            // An item with no base icon draws nothing at all. Overlays and underlays
+                            // are the layers you legitimately want to remove; to change the base,
+                            // set a different DID rather than clearing it.
+                            Msg("Refusing to clear the BASE icon - the item would render blank. Set a different iconDid instead, or clear an overlay/underlay layer.");
+                            return;
+                        }
+
+                        var siWeenie = ACE.Database.DatabaseManager.World.GetCachedWeenie(siWcid);
+                        if (siWeenie == null) { Msg($"No weenie {siWcid} in the world db."); return; }
+                        var siName = siWeenie.GetProperty(PropertyString.Name) ?? siWcid.ToString();
+                        var siOld = siWeenie.GetProperty(siProp);
+
+                        try
+                        {
+                            // Upsert: plenty of weenies have no row for a given layer at all, so a
+                            // bare UPDATE would silently affect 0 rows and report success.
+                            var sql = siClear
+                                ? $"DELETE FROM weenie_properties_d_i_d WHERE object_Id = {siWcid} AND type = {siType};"
+                                : $"INSERT INTO weenie_properties_d_i_d (object_Id, type, value) VALUES ({siWcid}, {siType}, {siIcon}) "
+                                  + $"ON DUPLICATE KEY UPDATE value = {siIcon};";
+
+                            using (var ctx = new ACE.Database.Models.World.WorldDbContext())
+                            {
+                                ctx.Database.SetCommandTimeout(0);
+                                ctx.Database.ExecuteSqlRaw(sql);
+                            }
+
+                            var siWhat = siClear ? "cleared" : siIcon.ToString(CultureInfo.InvariantCulture);
+                            var siLog = System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory,
+                                $"zc_seticon_{DateTime.Now:yyyy-MM-dd}.sql");
+                            System.IO.File.AppendAllText(siLog,
+                                $"-- {DateTime.Now:HH:mm:ss} {siName} ({siWcid}) {siLayerArg}({siType}) {(siOld?.ToString() ?? "none")} -> {siWhat}{System.Environment.NewLine}{sql}{System.Environment.NewLine}");
+
+                            ACE.Database.DatabaseManager.World.ClearCachedWeenie(siWcid);
+
+                            Msg($"seticon: {siName} ({siWcid}) {siLayerArg} layer (type {siType}) {(siOld?.ToString() ?? "none")} -> {siWhat}. " +
+                                "Weenie cache cleared; items ALREADY in a pack keep their old biota snapshot - trash and /ci a fresh one to see it. " +
+                                $"Logged to zc_seticon_{DateTime.Now:yyyy-MM-dd}.sql");
+                        }
+                        catch (Exception ex)
+                        {
+                            Msg($"seticon failed: {ex.Message}");
+                        }
+                        return;
+                    }
+
+                    case "listparts":
+                    {
+                        // Inspect a mob's (or a raw Setup's) body-part layout: part index -> GfxObj model piece,
+                        // plus any anim_part overrides baked on the weenie. Writes a full dump to zc_partsdump.txt
+                        // (next to the server dll) + a chat summary. Step 1 of the per-part editor: reveals which
+                        // index is the head (humanoid setups use index 16) and whether parts are isolable.
+                        if (args.Count < 2) { Msg("Usage: listparts <wcid | 0xSetupId>"); return; }
+                        uint setupId;
+                        string label;
+                        IList<PropertiesAnimPart> ovrList = null;
+                        if (args[1].StartsWith("0x", StringComparison.OrdinalIgnoreCase) &&
+                            uint.TryParse(args[1].Substring(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var sid) && (sid >> 24) == 0x02)
+                        {
+                            setupId = sid; label = $"setup 0x{sid:X8}";
+                        }
+                        else if (uint.TryParse(args[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var w))
+                        {
+                            var wpn = ACE.Database.DatabaseManager.World.GetCachedWeenie(w);
+                            if (wpn == null) { Msg($"No weenie {w}."); return; }
+                            setupId = wpn.GetProperty(PropertyDataId.Setup) ?? 0;
+                            ovrList = wpn.PropertiesAnimPart;
+                            label = $"{wpn.GetProperty(PropertyString.Name) ?? w.ToString()} (wcid {w})";
+                        }
+                        else { Msg("Give a wcid (number) or a 0x02...... Setup id."); return; }
+                        if ((setupId >> 24) != 0x02) { Msg("That target has no valid Setup (0x02......)."); return; }
+
+                        SetupModel setup;
+                        try { setup = DatManager.PortalDat.ReadFromDat<SetupModel>(setupId); }
+                        catch (Exception ex) { Msg($"Could not read Setup 0x{setupId:X8}: {ex.Message}"); return; }
+
+                        var ovr = new Dictionary<int, uint>();
+                        if (ovrList != null) foreach (var o in ovrList) ovr[o.Index] = o.AnimationId;
+
+                        // Per-part placement positions (first usable placement frame) so we can spot the head =
+                        // the highest (max-Z) real part, instead of assuming index 16 (which varies per setup).
+                        var pos = (setup.PlacementFrames.Count > 0)
+                            ? setup.PlacementFrames.Values
+                                .FirstOrDefault(p => p.AnimFrame?.Frames != null && p.AnimFrame.Frames.Count >= setup.Parts.Count)
+                                ?.AnimFrame.Frames.Select(f => f.Origin).ToList()
+                            : null;
+                        int headIdx = -1; float maxZ = float.NegativeInfinity;
+                        if (pos != null)
+                            for (int i = 0; i < setup.Parts.Count; i++)
+                                if (setup.Parts[i] != 0x010001EC && pos[i].Z > maxZ) { maxZ = pos[i].Z; headIdx = i; }
+
+                        var sbp = new StringBuilder();
+                        sbp.Append("=== listparts ").Append(label).Append(" | setup 0x").Append(setupId.ToString("X8"))
+                           .Append(" | ").Append(setup.Parts.Count).Append(" parts | ").Append(ovr.Count).Append(" overrides")
+                           .Append(" | highest/likely-head = idx ").Append(headIdx).Append(" ===\n");
+                        for (int i = 0; i < setup.Parts.Count; i++)
+                        {
+                            sbp.Append("  [").Append(i.ToString().PadLeft(2)).Append("] 0x").Append(setup.Parts[i].ToString("X8"));
+                            if (ovr.TryGetValue(i, out var g)) sbp.Append("  OVR->0x").Append(g.ToString("X8"));
+                            if (pos != null) sbp.Append("  pos(x").Append(pos[i].X.ToString("0.00")).Append(" y").Append(pos[i].Y.ToString("0.00")).Append(" z").Append(pos[i].Z.ToString("0.00")).Append(")");
+                            if (setup.Parts[i] == 0x010001EC) sbp.Append("  [null]");
+                            if (i == headIdx) sbp.Append("   <== HIGHEST (likely HEAD)");
+                            sbp.Append('\n');
+                        }
+                        foreach (var kv in ovr)
+                            if (kv.Key >= setup.Parts.Count)
+                                sbp.Append("  [").Append(kv.Key.ToString().PadLeft(2)).Append("] (added by override) -> 0x").Append(kv.Value.ToString("X8")).Append('\n');
+
+                        try
+                        {
+                            var path = System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "zc_partsdump.txt");
+                            System.IO.File.AppendAllText(path, sbp.ToString() + "\n");
+                        }
+                        catch { }
+
+                        Msg($"{label}: setup 0x{setupId:X8}, {setup.Parts.Count} parts, {ovr.Count} overrides. " +
+                            (headIdx >= 0 ? $"Highest/likely-head = idx {headIdx} (0x{setup.Parts[headIdx]:X8})." : "(no placement data - can't locate head.)") +
+                            " Full dump -> zc_partsdump.txt");
+                        return;
+                    }
+
+                    case "partsof":
+                    {
+                        // Plugin-facing: reply a mob's body-part layout for the per-part editor's slot list +
+                        // "copy from mob" picker. [[ZCPARTS]]w=<wcid>|n=<name>|s=<setupHex>|h=<headIdx>|<i>=<gfxHex>|...
+                        // "partsof <wcid>" (typed) = left/editing side; "partsof sel" = the in-game SELECTED mob,
+                        // tagged role=src for the right/steal-from side.
+                        if (args.Count < 2) { Msg("Usage: partsof <wcid | sel>"); return; }
+                        uint pw; uint pSetup; string pName; string roleTag = "";
+                        if (args[1].Equals("sel", StringComparison.OrdinalIgnoreCase))
+                        {
+                            var selp = session.Player?.SelectedTarget;
+                            if (selp == null) { Msg("Nothing selected in-game (left-click a mob first)."); return; }
+                            pw = selp.WeenieClassId;
+                            pSetup = selp.GetProperty(PropertyDataId.Setup) ?? 0;
+                            pName = selp.Name ?? pw.ToString();
+                            // "partsof sel tgt" = the mob we're EDITING (left, zone-checked plugin-side); else = source (right).
+                            roleTag = (args.Count >= 3 && args[2].Equals("tgt", StringComparison.OrdinalIgnoreCase)) ? "role=tgt|" : "role=src|";
+                        }
+                        else
+                        {
+                            if (!uint.TryParse(args[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out pw)) { Msg("wcid must be a number or 'sel'."); return; }
+                            var pwn = ACE.Database.DatabaseManager.World.GetCachedWeenie(pw);
+                            if (pwn == null) { Msg($"No weenie {pw}."); return; }
+                            pSetup = pwn.GetProperty(PropertyDataId.Setup) ?? 0;
+                            pName = pwn.GetProperty(PropertyString.Name) ?? pw.ToString();
+                        }
+                        if ((pSetup >> 24) != 0x02) { Msg("That mob has no Setup (0x02......)."); return; }
+                        SetupModel pModel;
+                        try { pModel = DatManager.PortalDat.ReadFromDat<SetupModel>(pSetup); }
+                        catch (Exception ex) { Msg($"Could not read Setup 0x{pSetup:X8}: {ex.Message}"); return; }
+                        var pHead = SetupHeadIndex(pModel);
+                        var pLabels = SetupPartLabels(pModel, pHead);
+                        var psb = new StringBuilder("[[ZCPARTS]]").Append(roleTag).Append("w=").Append(pw)
+                            .Append("|n=").Append(CleanWire(pName))
+                            .Append("|s=").Append(pSetup.ToString("X8"))
+                            .Append("|h=").Append(pHead);
+                        for (int i = 0; i < pModel.Parts.Count; i++)
+                            psb.Append('|').Append(i).Append('=').Append(pModel.Parts[i].ToString("X8")).Append('~').Append(pLabels[i]);
+                        Msg(psb.ToString());
+                        return;
+                    }
+
+                    case "findmob":
+                    {
+                        // Name/wcid search over creature weenies for the plugin's Copy-look mob picker.
+                        // Replies [[ZCFIND]]q=<query>|<wcid>~<name>|... (creatures only, capped).
+                        if (args.Count < 2) { Msg("Usage: findmob <text or wcid>"); return; }
+                        var q = string.Join(" ", args.Skip(1)).Trim();
+                        var sb = new StringBuilder("[[ZCFIND]]q=").Append(CleanWire(q));
+                        var seen = new HashSet<uint>();
+
+                        if (uint.TryParse(q, NumberStyles.Integer, CultureInfo.InvariantCulture, out var qWcid))
+                        {
+                            var byId = ACE.Database.DatabaseManager.World.GetCachedWeenie(qWcid);
+                            if (byId != null && byId.WeenieType == WeenieType.Creature && seen.Add(qWcid))
+                                sb.Append('|').Append(qWcid).Append('~').Append(CleanWire(byId.GetProperty(PropertyString.Name)));
+                        }
+
+                        if (q.Length > 0)
+                        {
+                            try
+                            {
+                                using var context = new WorldDbContext();
+                                var rows = context.Weenie
+                                    .Where(w => w.Type == (int)WeenieType.Creature)
+                                    .Join(context.WeeniePropertiesString.Where(s => s.Type == (ushort)PropertyString.Name && s.Value.Contains(q)),
+                                          w => w.ClassId, s => s.ObjectId, (w, s) => new { w.ClassId, s.Value })
+                                    .Take(30).AsNoTracking().ToList();
+                                foreach (var row in rows)
+                                {
+                                    if (!seen.Add(row.ClassId)) continue;
+                                    sb.Append('|').Append(row.ClassId).Append('~').Append(CleanWire(row.Value));
+                                }
+                            }
+                            catch (Exception) { /* search failed - reply with whatever already matched */ }
+                        }
+                        Msg(sb.ToString());
+                        return;
+                    }
+
+                    case "selinfo":
+                    {
+                        // Report the admin's in-game SELECTED object for the plugin's "Copy selected" confirm popup:
+                        // [[ZCSEL]]found=<0|1>|wcid=<n>|creature=<0|1>|name=<name>. Lets the plugin verify it's a real
+                        // creature (not an item) before copying its look.
+                        var sel = session.Player?.SelectedTarget;
+                        var sbSel = new StringBuilder("[[ZCSEL]]found=").Append(sel != null ? 1 : 0);
+                        if (sel != null)
+                            sbSel.Append("|wcid=").Append(sel.WeenieClassId)
+                                 .Append("|creature=").Append(sel is ACE.Server.WorldObjects.Creature ? 1 : 0)
+                                 .Append("|name=").Append(CleanWire(sel.Name));
+                        Msg(sbSel.ToString());
+                        return;
+                    }
+
+                    case "boundary":
+                    {
+                        if (args.Count < 3) { Msg("Usage: boundary <name> <on|off|show>"); return; }
+                        var name = args[1];
+                        var area = ZoneControlManager.GetArea(name);
+                        if (area == null) { Msg($"No zone '{name}' (create it first)."); return; }
+                        var op = args[2].ToLowerInvariant();
+
+                        if (op == "show")
+                        {
+                            Msg($"'{name}' v{area.Variation}: {(area.Bounded ? "BOUNDED" : "free roam")} " +
+                                $"({area.Landblocks.Count} landblock(s), {(area.Enabled ? "ENABLED" : "disabled â€” stats off; the boundary enforces regardless")}).");
+                            if (area.Bounded)
+                            {
+                                var sharing = ZoneControlManager.BoundedZoneNamesAt(area.Variation).Where(n => !n.Equals(name, StringComparison.OrdinalIgnoreCase)).ToList();
+                                Msg(sharing.Count > 0
+                                    ? $"  Travel space at v{area.Variation} is shared with: {string.Join(", ", sharing)}."
+                                    : $"  This is the only bounded zone at v{area.Variation}.");
+                            }
+                            return;
+                        }
+
+                        if (op != "on" && op != "off") { Msg("op must be on | off | show"); return; }
+                        var bounded = op == "on";
+
+                        if (bounded && area.Variation < ZoneControlManager.MinBoundedVariation)
+                        {
+                            Msg($"Boundaries need variation 11+ â€” '{name}' is on v{area.Variation}. " +
+                                "A bounded zone on a retail variation would confine every player there.");
+                            return;
+                        }
+
+                        ZoneControlManager.SetBounded(name, bounded);
+                        Msg(bounded
+                            ? $"'{name}' is now BOUNDED: players at v{area.Variation} may only roam bounded-zone landblocks there. " +
+                              "Active now - the boundary enforces whether the zone is enabled or not."
+                            : $"'{name}' boundary removed (free roam unless another bounded zone covers v{area.Variation}).");
+                        return;
+                    }
+
+                    case "survey":
+                    {
+                        if (args.Count < 2) { Msg("Usage: survey <name> [lbHex]"); return; }
+                        var name = args[1];
+                        var rows = ZoneControlManager.SurveyArea(name);
+                        if (rows == null) { Msg($"No zone '{name}'."); return; }
+                        // Echo the STORED name so the plugin's zone= match works whatever form was typed.
+                        name = ZoneControlManager.GetArea(name)?.Name ?? name;
+
+                        ushort? detailLb = null;
+                        if (args.Count >= 3)
+                        {
+                            if (!TryHex(args[2], out var lbHex)) { Msg("hex landblock required, e.g. F559"); return; }
+                            detailLb = (ushort)lbHex;
+                        }
+
+                        if (detailLb.HasValue)
+                        {
+                            var row = rows.FirstOrDefault(r => r.Landblock == detailLb.Value);
+                            if (row == null) { Msg($"lb {detailLb.Value:X4} is not a member of '{name}'."); return; }
+                            Msg(BuildSurveyDetailPayload(name, row));
+                            return;
+                        }
+
+                        // Summary: one [[ZCS]] line per landblock so the plugin can render rows as they arrive.
+                        foreach (var row in rows)
+                            Msg(BuildSurveySummaryPayload(name, row));
+                        Msg($"[[ZCS]]zone={name}|done={rows.Count}");
+                        return;
+                    }
+
+                    case "quests":
+                    {
+                        if (args.Count < 2) { Msg("Usage: quests <name>"); return; }
+                        var name = args[1];
+                        var area = ZoneControlManager.GetArea(name);
+                        if (area == null) { Msg($"No zone '{name}'."); return; }
+                        name = area.Name;   // echo the STORED name so the plugin's zone= match works
+
+                        // Owner rule: quest data may be pulled at most once per 60s per player. A throttled
+                        // pull gets a short notice line so the plugin can show a countdown on its Refresh.
+                        var nowUtc = DateTime.UtcNow;
+                        if (_questPulls.TryGetValue(session, out var lastPull) &&
+                            (nowUtc - lastPull).TotalSeconds < QuestPullCooldownSeconds)
+                        {
+                            var wait = (int)Math.Ceiling(QuestPullCooldownSeconds - (nowUtc - lastPull).TotalSeconds);
+                            Msg($"[[ZCQ]]zone={name}|throttle={wait}");
+                            return;
+                        }
+                        _questPulls[session] = nowUtc;
+                        if (_questPulls.Count > 128)
+                            foreach (var dead in _questPulls.Keys.Where(s => s.IsTerminated).ToList())
+                                _questPulls.TryRemove(dead, out _);
+
+                        var quests = ZoneControlManager.GetZoneQuests(name);
+
+                        // BUILD EVERY LINE FIRST, THEN SEND (2026-07-30). BuildQuestPayload reads the
+                        // player's QuestManager (GetQuest / GetNextSolveTime) for `st=live` rows only, so
+                        // the old build-and-send loop interleaved player-state lookups BETWEEN EnqueueSends.
+                        // Exactly the live rows then escaped the plugin's chat interception and rendered in
+                        // the player's chat box - deterministically, the same 9 of 24 every pull, while the
+                        // survey payload (90 messages, no per-line lookups) and the single-message mob
+                        // roster were always clean. Wire format is unchanged; the plugin needs no update.
+                        var qi = 0;
+                        var questLines = new List<string>(quests.Count);
+                        foreach (var q in quests)
+                            questLines.Add(BuildQuestPayload(name, q, ++qi, session));
+                        foreach (var line in questLines)
+                            Msg(line);
+                        Msg($"[[ZCQ]]zone={name}|done={quests.Count}");
+                        return;
+                    }
+
+                    case "mobinfo":
+                    {
+                        if (args.Count < 2 || !uint.TryParse(args[1], out var infoWcid)) { Msg("Usage: mobinfo <wcid>"); return; }
+                        Msg(BuildMobInfoPayload(infoWcid));
+                        return;
+                    }
+
+                    case "propsof":
+                    {
+                        // The WEENIE's own values for a list of properties (2026-09-03, Props tab: "none of these are
+                        // auto populating"). `propsof <wcid> i:31,f:41,b:6,l:9` -> "[[ZCPV]]w=<wcid>|i:31=<v>|f:41=<v>|..."
+                        // (absent = the weenie does not carry it). Read from the weenie cache, never a live creature.
+                        if (args.Count < 3 || !uint.TryParse(args[1], out var pvWcid)) { Msg("Usage: propsof <wcid> <i|f|b|l>:<id>,..."); return; }
+                        var pvWeenie = ACE.Database.DatabaseManager.World.GetCachedWeenie(pvWcid);
+                        var pv = new StringBuilder("[[ZCPV]]w=").Append(pvWcid).Append("|found=").Append(pvWeenie != null ? 1 : 0);
+                        if (pvWeenie != null)
+                            foreach (var tok in args[2].Split(','))
+                            {
+                                var c = tok.IndexOf(':');
+                                if (c <= 0 || !int.TryParse(tok.Substring(c + 1), out var pid)) continue;
+                                var kind = tok.Substring(0, c);
+                                string val = null;
+                                switch (kind)
+                                {
+                                    case "i": if (pvWeenie.PropertiesInt != null && pvWeenie.PropertiesInt.TryGetValue((PropertyInt)pid, out var iv)) val = iv.ToString(CultureInfo.InvariantCulture); break;
+                                    case "l": if (pvWeenie.PropertiesInt64 != null && pvWeenie.PropertiesInt64.TryGetValue((PropertyInt64)pid, out var lv)) val = lv.ToString(CultureInfo.InvariantCulture); break;
+                                    case "f": if (pvWeenie.PropertiesFloat != null && pvWeenie.PropertiesFloat.TryGetValue((PropertyFloat)pid, out var fv)) val = fv.ToString("0.####", CultureInfo.InvariantCulture); break;
+                                    case "b": if (pvWeenie.PropertiesBool != null && pvWeenie.PropertiesBool.TryGetValue((PropertyBool)pid, out var bv)) val = bv ? "true" : "false"; break;
+                                }
+                                if (val != null) pv.Append('|').Append(kind).Append(':').Append(pid).Append('=').Append(val);
+                            }
+                        Msg(pv.ToString());
+                        return;
+                    }
+
+                    case "clonezone":
+                    {
+                        // clonezone <src> <variation|lo-hi>
+                        //
+                        // The new name is DERIVED as "<src> <variation>" rather than taken as an
+                        // argument, and that is deliberate: `create` has to hunt for the first token
+                        // that parses as a variation, so a name ending in a number ("Tou Tou 12") is
+                        // ambiguous and needs quoting. Deriving it removes the ambiguity entirely and
+                        // matches the convention anyway.
+                        if (args.Count < 3) { Msg("Usage: clonezone <zone> <variation|lo-hi>   e.g. clonezone Tou Tou 12-25"); return; }
+
+                        var czSrc = ZoneControlManager.GetArea(args[1]);
+                        if (czSrc == null) { Msg($"No zone '{args[1]}'."); return; }
+
+                        var czSpec = args[2];
+                        int czLo, czHi;
+                        var czDash = czSpec.IndexOf('-');
+                        if (czDash > 0)
+                        {
+                            if (!int.TryParse(czSpec.Substring(0, czDash).TrimStart('v', 'V'), out czLo)
+                                || !int.TryParse(czSpec.Substring(czDash + 1).TrimStart('v', 'V'), out czHi))
+                            { Msg("Usage: clonezone <zone> <variation|lo-hi>"); return; }
+                        }
+                        else
+                        {
+                            if (!int.TryParse(czSpec.TrimStart('v', 'V'), out czLo)) { Msg("Usage: clonezone <zone> <variation|lo-hi>"); return; }
+                            czHi = czLo;
+                        }
+
+                        if (czLo < 0 || czHi < czLo || czHi - czLo > 50) { Msg("Bad variation range."); return; }
+
+                        var czMade = new List<string>();
+                        var czSkipped = new List<string>();
+
+                        for (var v = czLo; v <= czHi; v++)
+                        {
+                            if (v == czSrc.Variation) { czSkipped.Add($"v{v} (the source)"); continue; }
+
+                            var czName = SanitizeZoneName(czSrc.Name + " " + v);
+                            if (ZoneControlManager.GetArea(czName) != null) { czSkipped.Add($"'{czName}' exists"); continue; }
+
+                            var clone = new ControlledArea
+                            {
+                                Name = czName,
+                                Variation = v,
+                                // DISABLED on purpose. Creature stats do NOT interpolate across tiers -
+                                // AnchoredDefaultProfileFor only underlays FLAT v11 values - so a zone
+                                // enabled before its own VariationDefault is authored would run
+                                // T11-strength monsters wearing a higher-tier label, silently.
+                                Enabled = false,
+                                Bounded = czSrc.Bounded,
+                                Notes = $"cloned from '{czSrc.Name}' (v{czSrc.Variation})",
+                                Landblocks = new HashSet<ushort>(czSrc.Landblocks),
+                                TerrainOverrides = new Dictionary<ushort, string>(czSrc.TerrainOverrides ?? new Dictionary<ushort, string>()),
+                            };
+
+                            ZoneControlManager.UpsertArea(clone);
+                            czMade.Add(czName);
+                        }
+
+                        if (czMade.Count == 0) { Msg("Nothing created. " + string.Join("; ", czSkipped)); return; }
+
+                        Msg($"Created {czMade.Count} zone(s) from '{czSrc.Name}', {czSrc.Landblocks.Count} landblock(s) each:");
+                        Msg("  " + string.Join(", ", czMade));
+                        if (czSkipped.Count > 0) Msg("  skipped: " + string.Join("; ", czSkipped));
+                        Msg("All DISABLED - author each tier's Default first, then enable.");
+                        Msg("  Seed a tier from the one below it:  default <var> copyfrom <var>");
+                        Msg("  Stats do NOT interpolate: an unauthored tier runs T11-strength monsters.");
+                        PlayerManager.BroadcastToAuditChannel(session?.Player,
+                            $"clonezone {czSrc.Name} -> {czMade.Count} zone(s) v{czLo}-v{czHi}");
+                        return;
+                    }
+
+                    case "tier":
+                    {
+                        HandleTierTune(args, rank, Msg);
+                        return;
+                    }
+
+                    case "mobcheck":
+                    case "mobcheckget":
+                    {
+                        // mobcheckget is the MACHINE twin - same parsing, same evaluation, [[ZCMC]] out
+                        // instead of chat lines. Same split as mobinfo/defaultget: the plugin panel reads
+                        // the payload, a dev with no plugin still types `mobcheck` and gets prose.
+                        var mcWire = sub == "mobcheckget";
+                        // Every reasonable shape works. The wcid may arrive as --wcid (house flag), or
+                        // as a bare number in either position; the zone may be named or left out, in
+                        // which case the zone you are STANDING IN is used. Requiring one exact form
+                        // here bought nothing but a usage message.
+                        var mcWcid = wcid;
+                        string mcZone = null;
+
+                        for (var i = 1; i < args.Count; i++)
+                        {
+                            if (!mcWcid.HasValue && uint.TryParse(args[i], out var parsedWcid)) { mcWcid = parsedWcid; continue; }
+                            if (mcZone == null) mcZone = args[i];
+                        }
+
+                        // On the wire path EVERY exit must be a payload - a panel waiting on [[ZCMC]] must
+                        // not be left hanging by a prose usage line it will never parse.
+                        void McFail()
+                        {
+                            if (mcWire) Msg("[[ZCMC]]wcid=" + (mcWcid ?? 0) + "|found=0");
+                        }
+
+                        // No wcid = the creature the admin has SELECTED in game (owner 2026-09-03: assess a
+                        // monster, click Check, read its readiness) - the same selection the live_ hints use.
+                        if (!mcWcid.HasValue && session.Player?.SelectedTarget is ACE.Server.WorldObjects.Creature mcSel && !(mcSel is ACE.Server.WorldObjects.Player))
+                            mcWcid = mcSel.WeenieClassId;
+
+                        if (!mcWcid.HasValue)
+                        {
+                            McFail();
+                            if (!mcWire)
+                            {
+                                Msg("Usage: mobcheck <wcid>            - checks the zone you are standing in");
+                                Msg("       mobcheck <zone> <wcid>     - checks a named zone");
+                                Msg("       mobcheck [<zone>]          - checks the creature you have selected");
+                            }
+                            return;
+                        }
+
+                        if (string.IsNullOrWhiteSpace(mcZone))
+                        {
+                            var mcLoc = session.Player?.Location;
+                            if (mcLoc == null)
+                            {
+                                McFail();
+                                if (!mcWire) Msg("No location - name the zone: mobcheck <zone> <wcid>");
+                                return;
+                            }
+                            var here = ZoneControlManager.ResolveWinnerForLocation(
+                                mcLoc.LandblockId.Landblock, ZoneControlManager.GetEffectiveVariation(session.Player));
+                            if (here == null)
+                            {
+                                McFail();
+                                if (!mcWire)
+                                {
+                                    Msg($"You are not standing in an authored zone (landblock {mcLoc.LandblockId.Landblock:X4}).");
+                                    Msg("Name one instead: mobcheck <zone> <wcid>");
+                                }
+                                return;
+                            }
+                            mcZone = here.Name;
+                        }
+
+                        if (mcWire) Msg(BuildMobCheckPayload(mcZone, mcWcid.Value));
+                        else HandleMobCheck(mcZone, mcWcid.Value, Msg);
+                        return;
+                    }
+
+                    case "show":
+                    {
+                        if (args.Count < 2) { Msg("Usage: show <name> [--wcid <id>]"); return; }
+                        var name = args[1];
+                        var area = ZoneControlManager.GetArea(name);
+                        if (area == null) { Msg($"No zone '{name}'."); return; }
+                        var eval = ZoneControlManager.EvaluateForDisplay(name, wcid);
+                        var showRank = wcid.HasValue ? ZoneControlManager.ResolveRankForWcid(area, wcid.Value) : (ZcRank.None, "none");
+                        Msg($"'{name}' v{area.Variation} {(area.Enabled ? "ENABLED" : "disabled")}" +
+                            $"{(wcid.HasValue ? " [wcid " + wcid.Value + "]" : " [zone]")}" +
+                            (wcid.HasValue ? $" rank {ZoneRank.Label(showRank.Item1)} (from {showRank.Item2})" : " [Default row]") + ":");
+                        if (eval == null || eval.Values.Count == 0) { Msg("  (no stats set)"); return; }
+                        // Layered values with PROVENANCE, so it is obvious which layer each number came from.
+                        foreach (var kv in eval.Values.OrderBy(k => k.Key))
+                        {
+                            var src = ZoneControlManager.ResolveStatSource(name, wcid, kv.Key);
+                            Msg($"    {kv.Key,-22} = {kv.Value,-12:0.####} ({src ?? "?"})");
+                        }
+                        return;
+                    }
+
+                    case "defaultget":
+                    {
+                        // Machine payload for the plugin's Defaults editor (owner 2026-08-11). READ ONLY -
+                        // every write still goes through the 'default set|clearstat|copyfrom|clear'
+                        // verbs below. Wire shape matches [[ZC]] ("<stat>=<defined>,<value>") so the plugin
+                        // reuses its zone-grid parser.
+                        if (args.Count < 2 || !int.TryParse(args[1].TrimStart('v', 'V'), out var getVar) || getVar < 0)
+                        { Msg("Usage: defaultget <variation>"); return; }
+                        SendChunked(session, BuildVariationDefaultPayload(getVar));   // [[ZCD]] 2.6 KB: chunked too (2026-09-03)
+                        return;
+                    }
+
+                    case "default":
+                    {
+                        // Per-variation Default layer (2026-07-30). Every zone at <var> inherits these, per
+                        // stat; a zone or per-WCID value overrides just that stat. Progression across v11-v25
+                        // is 15 of these, all explicitly authored â€” the server never derives one.
+                        if (args.Count < 2)
+                        {
+                            Msg("Usage: default <variation> <show|set|clearstat|copyfrom|clear|list>");
+                            Msg("  default list                              variations that have a Default");
+                            Msg("  default <var> show                        the Default's stats");
+                            Msg("  default <var> set <stat> <value>");
+                            Msg("  default <var> clearstat <stat>");
+                            Msg("  default <var> copyfrom <var>              seed from another variation");
+                            Msg("  default <var> clear                       drop the whole Default");
+                            Msg("  default <var> weaponcard <chance_stat> <on|off|clear> | weaponcard list");
+                            return;
+                        }
+
+                        if (args[1].Equals("list", StringComparison.OrdinalIgnoreCase))
+                        {
+                            var vars = ZoneControlManager.ListVariationDefaults();
+                            if (vars.Count == 0) { Msg("(no variation Defaults authored)"); return; }
+                            foreach (var v in vars)
+                            {
+                                var d = ZoneControlManager.GetVariationDefault(v);
+                                Msg($"  v{v,-4} stats:{d?.Profile?.Stats?.Count ?? 0}  " +
+                                    $"effects:{(d?.Effects != null && !d.Effects.IsEmpty ? "yes" : "no")}  " +
+                                    $"appearance:{(d?.Appearance != null && !d.Appearance.IsEmpty ? "yes" : "no")}");
+                            }
+                            return;
+                        }
+
+                        if (!int.TryParse(args[1].TrimStart('v', 'V'), out var dvar))
+                        { Msg("variation must be a number, e.g. 'default 11 show'."); return; }
+                        if (dvar < 0)
+                        { Msg("variation must be >= 0 (negative variations are rift instances and never inherit a Default)."); return; }
+
+                        var dop = args.Count >= 3 ? args[2].ToLowerInvariant() : "show";
+
+                        if (dop == "show")
+                        {
+                            var d = ZoneControlManager.GetVariationDefault(dvar);
+                            if (d == null) { Msg($"v{dvar} has no Default."); return; }
+                            var stats = d.Profile?.Stats;
+                            Msg($"Default v{dvar}:");
+                            if (stats == null || stats.Count == 0) Msg("  (no stats set)");
+                            else
+                                foreach (var kv in stats.OrderBy(k => k.Key))
+                                    Msg($"    {kv.Key,-22} = {kv.Value.Base:0.####}");
+                            // rank rows (2026-09-02): only what the row AUTHORS; everything else inherits the Default row
+                            foreach (var rr in ZoneRank.Ranked)
+                            {
+                                var row = d.Profile?.RankLayer(rr, create: false);
+                                if (row?.Stats == null || row.Stats.Count == 0) continue;
+                                Msg($"  {ZoneRank.Label(rr)} row:");
+                                foreach (var kv in row.Stats.OrderBy(k => k.Key))
+                                    Msg($"    {kv.Key,-22} = {kv.Value.Base:0.####}");
+                            }
+                            if (d.Effects != null && !d.Effects.IsEmpty) Msg($"  effects: {DescribeDot(d.Effects)}");
+                            return;
+                        }
+
+                        if (dop == "clear")
+                        {
+                            Msg(ZoneControlManager.ClearVariationDefault(dvar)
+                                ? $"Default v{dvar} cleared. Zones at v{dvar} fall back to their own stats only."
+                                : $"v{dvar} had no Default.");
+                            return;
+                        }
+
+                        if (dop == "copyfrom")
+                        {
+                            if (args.Count < 4 || !int.TryParse(args[3].TrimStart('v', 'V'), out var srcVar))
+                            { Msg("Usage: default <var> copyfrom <var>"); return; }
+                            Msg(ZoneControlManager.CopyVariationDefault(srcVar, dvar)
+                                ? $"Default v{dvar} seeded from v{srcVar} (deep copy - edit either independently)."
+                                : $"v{srcVar} has no Default to copy.");
+                            return;
+                        }
+
+                        if (dop == "set")
+                        {
+                            if (args.Count < 5) { Msg("Usage: default <var> set <stat> <value>"); return; }
+                            var dstat = NormalizeStat(args[3]);
+                            if (dstat == null) { Msg("Unknown stat. Stats: " + string.Join(", ", ZoneStat.All)); return; }
+                            if (!TryDouble(args[4], out var dval)) { Msg("value must be a number."); return; }
+
+                            ZoneControlManager.MutateVariationDefault(dvar, d =>
+                                d.Profile.RankLayer(rank, create: true).Stats[dstat] = new StatCurve { Base = dval, Growth = 1.0, Additive = false });
+                            Msg($"Default v{dvar}{RankTag(rank)} {dstat} = {FmtStatEcho(dval)}. " + (rank == ZcRank.None
+                                ? $"Every zone at v{dvar} that doesn't set it inherits this."
+                                : $"Every {ZoneRank.Label(rank)} at v{dvar} reads this instead of the Default row."));
+                            if (dstat == ZoneStat.CoreAnchorDr || dstat == ZoneStat.CoreAnchorCdr)
+                                AutoApplyForDefault(session, true, dvar, Msg);
+                            return;
+                        }
+
+                        if (dop == "clearstat")
+                        {
+                            if (args.Count < 4) { Msg("Usage: default <var> clearstat <stat>"); return; }
+                            // CLEARING accepts any key PRESENT IN THE STORE, not only a currently-known
+                            // stat. Renaming a stat otherwise strands its old key forever: NormalizeStat
+                            // only matches ZoneStat.All, so `clearstat loot_max_drops` answered "Unknown
+                            // stat" while the dead key sat in the Default being read by nothing.
+                            // Found 2026-08-24 after loot_max_drops -> loot_drops_min. Setting still
+                            // validates - you may only clear rubbish, never author it.
+                            var dstat = NormalizeStat(args[3]) ?? args[3].Trim().ToLowerInvariant();
+                            var dremoved = false;
+                            ZoneControlManager.MutateVariationDefault(dvar, d =>
+                            {
+                                var row = d.Profile.RankLayer(rank, create: false);
+                                if (row != null) dremoved = row.Stats.Remove(dstat);
+                            });
+                            Msg(dremoved ? $"Default v{dvar}{RankTag(rank)} {dstat} cleared." : $"That stat wasn't set on the Default{RankTag(rank)}.");
+                            if (dremoved && (dstat == ZoneStat.CoreAnchorDr || dstat == ZoneStat.CoreAnchorCdr))
+                                AutoApplyForDefault(session, true, dvar, Msg);
+                            return;
+                        }
+
+                        if (dop == "weaponcard")
+                        {
+                            // TIER-DEFAULT weapon-card on/off (owner 2026-08-25). Same op set as the zone
+                            // form; the zone form layers over whatever is set here. Note the argument order
+                            // is `default <var> weaponcard <stat>` while the zone form is
+                            // `weaponcard <name> <stat>` - that asymmetry is inherited from this verb's
+                            // existing shape (`default <var> set <stat> <value>`), not a choice, and the
+                            // plugin sends both literal strings.
+                            var dprof = ZoneControlManager.GetVariationDefault(dvar)?.Profile;
+                            HandleWeaponCard(args, 3, $"Default v{dvar}",
+                                "Usage: default <var> weaponcard <chance_stat> <on|off|clear> | default <var> weaponcard list",
+                                dprof, dprof,
+                                edit => ZoneControlManager.MutateVariationDefault(dvar, d => edit(d.Profile)),
+                                Msg);
+                            return;
+                        }
+
+                        if (dop == "togglestat")
+                        {
+                            // TIER-DEFAULT stat on/off (2026-08-29) - same shape as weaponcard above.
+                            // --rank (2026-09-02) toggles inside that rank row.
+                            var dprof = ZoneControlManager.GetVariationDefault(dvar)?.Profile?.RankLayer(rank, create: false);
+                            HandleStatToggle(args, 3, $"Default v{dvar}{RankTag(rank)}",
+                                "Usage: default <var> togglestat <stat> <on|off|clear> | default <var> togglestat list   [--rank r]",
+                                dprof, dprof,
+                                edit => ZoneControlManager.MutateVariationDefault(dvar, d => edit(d.Profile.RankLayer(rank, create: true))),
+                                Msg);
+                            return;
+                        }
+
+                        Msg("op must be show | set | clearstat | copyfrom | clear | list | weaponcard | togglestat");
+                        return;
+                    }
+
+                    case "effect":
+                    {
+                        if (args.Count < 2) { Msg("Usage: effect <name> [show | dot on|off | dmg <amount> | type <fire|cold|acid|electric|nether|stamina|mana|health|percent> | interval <seconds> | suppress on|off | suppress prodigal on|off | suppress regen <pct 0-100>]"); return; }
+                        var name = args[1];
+                        var area = ZoneControlManager.GetArea(name);
+                        if (area == null) { Msg($"No zone '{name}'."); return; }
+
+                        if (args.Count < 3 || args[2].Equals("show", StringComparison.OrdinalIgnoreCase))
+                        {
+                            Msg($"'{name}' effects: {DescribeDot(area.Effects ?? new ZoneEffects())}");
+                            return;
+                        }
+
+                        // Validate the field/value FIRST (outside the lock), building the mutation to apply atomically.
+                        Action<ZoneEffects> apply;
+                        var field = args[2].ToLowerInvariant();
+                        switch (field)
+                        {
+                            case "dot":
+                                if (args.Count < 4) { Msg("Usage: effect <name> dot on|off"); return; }
+                                var on = args[3].Equals("on", StringComparison.OrdinalIgnoreCase) || args[3] == "1"
+                                         || args[3].Equals("true", StringComparison.OrdinalIgnoreCase);
+                                apply = e => e.DotEnabled = on;
+                                break;
+                            case "dmg":
+                            case "dotdmg":
+                                if (args.Count < 4 || !TryDouble(args[3], out var d) || d < 0) { Msg("dmg must be a number >= 0 (flat points, or percent when type=percent)."); return; }
+                                apply = e => e.DotDamage = d;
+                                break;
+                            case "interval":
+                                if (args.Count < 4 || !TryDouble(args[3], out var iv)) { Msg("interval must be a number of seconds (min 1)."); return; }
+                                var interval = Math.Max(1.0, iv);
+                                apply = e => e.DotIntervalSeconds = interval;
+                                break;
+                            case "type":
+                            case "dottype":
+                                if (args.Count < 4) { Msg("type must be 'percent' or one of: " + string.Join(", ", DamageTypeNames)); return; }
+                                if (args[3].Equals("percent", StringComparison.OrdinalIgnoreCase) || args[3].Equals("%", StringComparison.Ordinal))
+                                    apply = e => { e.DotPercent = true; e.DotDamageType = (int)DamageType.Health; }; // percent drains health
+                                else if (TryParseDamageType(args[3], out var dt))
+                                    apply = e => { e.DotPercent = false; e.DotDamageType = (int)dt; };
+                                else { Msg("type must be 'percent' or one of: " + string.Join(", ", DamageTypeNames)); return; }
+                                break;
+                            case "suppress":
+                            {
+                                if (args.Count < 4) { Msg("Usage: effect <name> suppress on|off | suppress prodigal on|off | suppress regen <pct 0-100>"); return; }
+                                var supField = args[3].ToLowerInvariant();
+                                if (supField == "on" || supField == "off" || supField == "1" || supField == "0" || supField == "true" || supField == "false")
+                                {
+                                    var supOn = supField == "on" || supField == "1" || supField == "true";
+                                    apply = e => e.SuppressEnabled = supOn;
+                                }
+                                else if (supField == "prodigal")
+                                {
+                                    if (args.Count < 5) { Msg("Usage: effect <name> suppress prodigal on|off"); return; }
+                                    var prodOn = args[4].Equals("on", StringComparison.OrdinalIgnoreCase) || args[4] == "1"
+                                                 || args[4].Equals("true", StringComparison.OrdinalIgnoreCase);
+                                    apply = e => e.SuppressProdigal = prodOn;
+                                }
+                                else if (supField == "regen")
+                                {
+                                    if (args.Count < 5 || !TryDouble(args[4], out var pct) || pct < 0 || pct > 100)
+                                    { Msg("regen must be a percent 0-100 (100 = normal regen, 0 = no regen)."); return; }
+                                    var mult = pct / 100.0;
+                                    apply = e => e.SuppressRegenMult = mult;
+                                }
+                                else { Msg("Usage: effect <name> suppress on|off | suppress prodigal on|off | suppress regen <pct 0-100>"); return; }
+                                break;
+                            }
+                            default:
+                                Msg("Unknown effect field. Use: dot on|off | dmg <amount> | type <name|percent> | interval <seconds> | suppress ... | show");
+                                return;
+                        }
+
+                        ZoneControlManager.MutateArea(name, a => { a.Effects ??= new ZoneEffects(); apply(a.Effects); });
+                        var updated = ZoneControlManager.GetArea(name);
+                        Msg($"'{name}' effects: {DescribeDot(updated?.Effects ?? new ZoneEffects())}." +
+                            $"{(area.Enabled ? "" : " Zone still DISABLED - /zonecontrol enable " + name)}");
+                        return;
+                    }
+
+                    case "ladder":
+                    {
+                        // Live stat resolution (2026-08-22): status | apply [tier|all] | migrate [here|<player>] [--dry] | show
+                        HandleLadder(session, args, Msg);
+                        return;
+                    }
+
+                    case "craft":
+                    {
+                        // T11+ crafting gate, LAYER 1 (2026-08-24): the authorable (item type x material)
+                        // matrix. list | get | enabled | mintier | test | <material> <itemtype> <mode>
+                        HandleCraft(session, args, Msg);
+                        return;
+                    }
+
+                    default:
+                        Msg($"Unknown subcommand '{sub}'. See /zonecontrol help.");
+                        return;
+                }
+            }
+            catch (Exception ex)
+            {
+                // the chat line keeps only the message; the stack goes to the server log (review 2026-09-04 C4)
+                log.Warn($"[ZC] /zonecontrol {string.Join(" ", parameters ?? Array.Empty<string>())} threw: {ex}");
+                Msg("Error: " + ex.Message);
+            }
+        }
+
+        /// <summary>Builds the "[[ZC]]scope=..|found=..|enabled=..|variation=..|&lt;stat&gt;=defined,value|..|
+        /// live_&lt;stat&gt;=..|here_lb=..|here_var=..|here_zone=.." payload the plugin's grid parses. Shared by
+        /// "get" and the sync push tick. Values are flat.</summary>
+        // Reference "Test Dummy" weenie used to fill the effective-look table when no specific mob is targeted
+        // (so the plugin shows a real reference look instead of a column of N/A). 99999099 = "Target Dummy".
+        private const uint ZoneControlDummyWcid = 99999099;
+
+        /// <summary>"[[ZCD]]var=..|found=..|&lt;stat&gt;=defined,value|.." - one variation Default's stats,
+        /// in the same wire shape as [[ZC]] so the plugin's grid parser is shared. Stats only: a Default
+        /// also carries Effects/Appearance, which the editor does not author (owner 2026-08-11).</summary>
+        /// <summary>"|sess=..." â€” session-state flags for the GM Tools On/Off highlight, server truth.
+        /// Fixed order: adminvision, attackable, unkillable, cloak (any cloaked state), portal bypass.
+        /// Shared by the zone payload and the session-only payload so the two can never drift.</summary>
+        private static void AppendSessionState(StringBuilder sb, Session session)
+        {
+            var sp = session?.Player;
+            if (sp != null)
+                sb.Append("|sess=").Append(sp.Adminvision ? 1 : 0).Append(',')
+                  .Append(sp.Attackable ? 1 : 0).Append(',')
+                  .Append(sp.IsUnkillable ? 1 : 0).Append(',')
+                  .Append(sp.CloakStatus != CloakStatus.Off ? 1 : 0).Append(',')
+                  .Append(sp.IgnorePortalRestrictions ? 1 : 0);
+        }
+
+        /// <summary>"|combatdefs=..." â€” live combat-rule bool states so the plugin's GM Tools toggles
+        /// show truth. Fixed order: missile_power_bar, zonecontrol_enabled, zc_weapon_zone_lock,
+        /// zc_pertier_authoring, zc_armor_zone_lock. APPEND-ONLY: the plugin indexes positionally.</summary>
+        private static void AppendCombatDefs(StringBuilder sb)
+        {
+            sb.Append("|combatdefs=")
+              .Append(ServerConfig.missile_power_bar.Value ? '1' : '0').Append(',')
+              .Append(ServerConfig.zonecontrol_enabled.Value ? '1' : '0').Append(',')
+              .Append(ServerConfig.zc_weapon_zone_lock.Value ? '1' : '0').Append(',')
+              .Append(ServerConfig.zc_pertier_authoring.Value ? '1' : '0').Append(',')
+              .Append(ServerConfig.zc_armor_zone_lock.Value ? '1' : '0');
+        }
+
+        /// <summary>"[[ZCSESS]]|sess=..|combatdefs=.." â€” the GM Tools state alone, for a bare
+        /// "/zonecontrol get" with no zone name. Session flags and shard-combat rules are not zone
+        /// state, so the plugin must be able to fetch them with no Zone loaded (owner 2026-08-17:
+        /// the GM Tools toggles sat on "--" until a zone sync happened to run).</summary>
+        private static string BuildSessionPayload(Session session)
+        {
+            var sb = new StringBuilder("[[ZCSESS]]");
+            AppendSessionState(sb, session);
+            AppendCombatDefs(sb);
+            AppendLadder(sb);   // APPEND-ONLY (2026-08-22): ladder apply versions, last so older plugins ignore it
+            return sb.ToString();
+        }
+
+        /// <summary>"|ladder=tier:version:allowNerf:yyyy-MM-dd;..." - the per-tier ladder apply state
+        /// (live stat resolution, 2026-08-22). Sparse: only tiers with version > 0; the plugin shows tiers
+        /// 11-25 and treats a missing tier as v0 / never applied. Rebuilt on every sync. APPEND-ONLY tag,
+        /// emitted LAST in both [[ZC]] and [[ZCSESS]] so it works zoneless and old plugins ignore it.</summary>
+        /// <summary>
+        /// `ladder apply` proper: bump the per-tier version (null = 11..25), then re-stamp every ONLINE
+        /// player's worn pieces now (bounded 18 per player, on each player's own action chain so it never
+        /// races combat). Packed items, mules and offline characters stay lazy (equip / login). Also called
+        /// by the Default-layer band / core-anchor editors (owner 2026-08-23: "just ladder apply on save").
+        /// Always follows the ladder BOTH ways - the raise-only guard was dropped the same day.
+        /// </summary>
+        private static void LadderApplyNow(Session session, int? tier, Action<string> Msg)
+        {
+            var by = session?.Player?.Name ?? "console";
+            var bumped = ZoneControlManager.BumpLadder(tier, true, by);
+            if (bumped.Count == 0) { Msg("Nothing bumped."); return; }
+
+            var parts = bumped.Select(t => $"T{t}->v{ZoneControlManager.GetLadderVersion(t).Version}");
+            Msg($"Ladder applied by {by}: {string.Join(", ", parts)}");
+
+            var online = PlayerManager.GetAllOnline();
+            foreach (var op in online)
+            {
+                var target = op;
+                var chain = new ACE.Server.Entity.Actions.ActionChain();
+                chain.AddAction(target, ACE.Server.Entity.Actions.ActionType.ZoneControl_LadderReresolve, () =>
+                {
+                    var n = target.ReresolveWornZoneGear();
+                    if (n > 0)
+                        target.Session?.Network?.EnqueueSend(new ACE.Server.Network.GameMessages.Messages.GameMessageSystemChat(
+                            $"Zone Control: {n} worn piece(s) re-resolved against the live ladder.", ChatMessageType.Broadcast));
+                });
+                chain.EnqueueChain();
+            }
+            Msg($"Online players re-resolving worn gear: {online.Count}; everyone else catches up at login / equip.");
+        }
+
+        /// <summary>Default-layer edits auto-apply for their tier (owner 2026-08-23). Zone-scoped band edits do
+        /// NOT: the resolver reads the tier Default, so a zone band only shapes NEW drops in that zone.</summary>
+        private static void AutoApplyForDefault(Session session, bool isDefaultScope, int defaultVar, Action<string> Msg)
+        {
+            if (!isDefaultScope) { Msg("  (zone band: new drops in this zone only - existing gear follows the tier Default)"); return; }
+            if (defaultVar < 11 || defaultVar > 25) return;
+            LadderApplyNow(session, defaultVar, Msg);
+        }
+
+        /// <summary>
+        /// `ladder bench [n]` (owner 2026-08-23: "nothing has ever been tested at scale"): in-process timing of
+        /// the hot paths. Mints ONE T11 armor piece and ONE T11 melee weapon through the real producers (so they
+        /// carry a record / a quality stamp), then times n iterations of: armor Compute (the appraisal cost),
+        /// armor Compute+Apply (the equip / ladder-apply cost, no DB), weapon TryResolve x3 (one swing's worth of
+        /// WeaponScalingCombat lookups). Single thread, so it measures CPU per op - not lock contention.
+        /// Both objects are destroyed afterwards; nothing is saved.
+        /// </summary>
+        private static void LadderBench(Session session, List<string> args, Action<string> Msg)
+        {
+            var n = 10000;
+            if (args.Count >= 3 && int.TryParse(args[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out var nn) && nn > 0)
+                n = Math.Min(nn, 1_000_000);
+
+            var player = session?.Player;
+            var p = player != null ? ZoneControlManager.ResolveZoneDefaultForPlayer(player) : null;
+
+            // armor: Iron Celdon Breastplate; weapon: Iron Spada (same wcids the plugin Preview uses)
+            var armor = ACE.Server.Factories.WorldObjectFactory.CreateNewWorldObject("breastplatecelodoniron")
+                     ?? ACE.Server.Factories.WorldObjectFactory.CreateNewWorldObject(37);
+            var weapon = ACE.Server.Factories.WorldObjectFactory.CreateNewWorldObject("swordspada")
+                      ?? ACE.Server.Factories.WorldObjectFactory.CreateNewWorldObject(30571);
+            if (armor == null || weapon == null) { Msg("bench: could not create the sample items."); return; }
+            if (!(weapon is ACE.Server.WorldObjects.MeleeWeapon)) { Msg($"bench: '{weapon.Name}' is not a melee weapon - weapon timings would be the bail-out path."); armor.Destroy(); weapon.Destroy(); return; }
+
+            try
+            {
+                ACE.Server.Factories.LootGenerationFactory.ApplyT11GearStats(armor, 11, forceMax: false, p: p);
+                if (p != null) ZoneLootMutator.MutateLootItem(armor, p, null, 11);
+                // guarantee at least one graded line on the piece regardless of the zone's roll
+                if (ZoneModifiers.TryGet(28, out var dr))
+                    ZoneModifiers.StampGraded(armor, dr, 500, ZoneStatResolver.EffectiveBand(28, 11));
+                ACE.Server.Factories.LootGenerationFactory.ApplyWeaponAugScaleStamp(weapon, 11);
+
+                var rec = ZoneStatResolver.Read(armor).Count;
+                Msg($"bench: armor '{armor.Name}' record {rec} entries (\"{armor.GetProperty(PropertyString.ZcModifiers)}\"), weapon '{weapon.Name}' quality {weapon.GetProperty(PropertyInt.WeaponAugScaleQuality)}; n = {n:N0}");
+
+                var sw = System.Diagnostics.Stopwatch.StartNew();
+                for (var i = 0; i < n; i++) ZoneStatResolver.Compute(armor);
+                sw.Stop();
+                Msg($"  armor Compute (appraisal):        {sw.Elapsed.TotalMilliseconds * 1000.0 / n,8:0.00} us/op  ({sw.ElapsedMilliseconds} ms total)");
+
+                sw.Restart();
+                for (var i = 0; i < n; i++) ZoneStatResolver.Apply(armor, ZoneStatResolver.Compute(armor));
+                sw.Stop();
+                var equipUs = sw.Elapsed.TotalMilliseconds * 1000.0 / n;
+                Msg($"  armor Compute+Apply (equip):      {equipUs,8:0.00} us/op  ({sw.ElapsedMilliseconds} ms total, no DB)");
+
+                sw.Restart();
+                for (var i = 0; i < n; i++) ZoneStatResolver.ApplyIfStale(armor);
+                sw.Stop();
+                Msg($"  armor ApplyIfStale (login, current): {sw.Elapsed.TotalMilliseconds * 1000.0 / n,5:0.00} us/op  (the no-op path every login takes)");
+
+                var sink = 0f;
+                sw.Restart();
+                for (var i = 0; i < n; i++)
+                {
+                    sink += ACE.Server.Managers.WeaponScaling.WeaponScalingCombat.GetFlatBonus(weapon, player);
+                    sink += ACE.Server.Managers.WeaponScaling.WeaponScalingCombat.GetCritDamageBonus(weapon, player);
+                    ACE.Server.Managers.WeaponScaling.WeaponScalingCombat.TryGetEffectiveVariance(weapon, out var v); sink += (float)v;
+                }
+                sw.Stop();
+                Msg($"  weapon swing (3 resolves):        {sw.Elapsed.TotalMilliseconds * 1000.0 / n,8:0.00} us/swing  ({sw.ElapsedMilliseconds} ms total, sink {sink:0})");
+
+                var hits = 400 * 2;
+                Msg($"  at 400 players x 2 hits/s: weapons ~{sw.Elapsed.TotalMilliseconds / n * hits:0.0} ms CPU per second; one ladder apply = {400 * 18:N0} armor resolves ~{equipUs * 400 * 18 / 1000.0:0.0} ms CPU total.");
+            }
+            finally
+            {
+                armor.Destroy();
+                weapon.Destroy();
+            }
+        }
+
+        /// <summary>
+        /// Resolve a weapon-card identifier typed in chat or sent by the plugin.
+        ///
+        /// The canonical form is the card's CHANCE STAT NAME (weapon_bite_chance) - that is what the
+        /// plugin sends and what the store holds. The bare card name ("bite", "rend_power", "rend power")
+        /// is also accepted as a chat convenience and normalised to the same key; the store never sees
+        /// the short form, so there is exactly one spelling on disk and on the wire.
+        ///
+        /// Returns null for anything that is not a weapon card, INCLUDING armor_cantrip_chance and any
+        /// other chance stat - this is the gate that keeps ZoneVariantProfile.CustomWeaponCards free of
+        /// keys EvaluatedProfile.WeaponCardEnabled would then wrongly answer for.
+        /// </summary>
+        private static string NormalizeWeaponCard(string s)
+        {
+            if (string.IsNullOrWhiteSpace(s)) return null;
+            var t = s.Trim().ToLowerInvariant().Replace(' ', '_');
+            if (ZoneStat.IsWeaponCardChance(t)) return NormalizeStat(t);
+            var expanded = "weapon_" + t + "_chance";
+            return ZoneStat.IsWeaponCardChance(expanded) ? NormalizeStat(expanded) : null;
+        }
+
+        /// <summary>
+        /// The ONE implementation of `weaponcard <stat> on|off|clear` / `weaponcard list`, shared by the
+        /// zone form (`weaponcard &lt;name&gt; ...`) and the tier-Default form (`default &lt;var&gt; weaponcard ...`).
+        /// Both scopes must behave identically or the plugin's checkbox means two different things
+        /// depending on the Target dropdown, so there is deliberately no second copy of this logic.
+        ///
+        /// <paramref name="authored"/> is the bucket being EDITED (may be null when it does not exist yet -
+        /// `list` then shows nothing authored, and a write creates it). <paramref name="effective"/> is the
+        /// merged view after inheritance, which is what actually gates drops; for a tier Default the two are
+        /// the same object because nothing sits under it.
+        ///
+        /// ðŸ”´ `clear` and `off` are NOT the same thing and the messages say so out loud, because assuming
+        /// they were is the bug this whole feature exists to fix: at zone scope `clear` means INHERIT (the
+        /// tier Default's answer wins, which may well be ON) while `off` means OFF regardless.
+        /// </summary>
+        private static void HandleWeaponCard(List<string> args, int idIdx, string scopeTag, string usage,
+            ZoneVariantProfile authored, ZoneVariantProfile effective,
+            Action<Action<ZoneVariantProfile>> mutate, Action<string> Msg)
+        {
+            if (args.Count <= idIdx) { Msg(usage); return; }
+
+            if (args[idIdx].Equals("list", StringComparison.OrdinalIgnoreCase))
+            {
+                Msg($"{scopeTag} weapon cards (absent = ON):");
+                foreach (var stat in ZoneStat.WeaponCardChances)
+                {
+                    var own = authored?.CustomWeaponCards != null && authored.CustomWeaponCards.TryGetValue(stat, out var o)
+                        ? (bool?)o : null;
+                    var eff = effective?.CustomWeaponCards != null && effective.CustomWeaponCards.TryGetValue(stat, out var e)
+                        ? (bool?)e : null;
+                    // only the interesting rows: authored here, or turned off by a layer underneath
+                    if (own == null && eff != false) continue;
+                    var where = own.HasValue ? "here" : "inherited";
+                    Msg($"    {stat,-30} {((eff ?? true) ? "ON" : "OFF")}  ({where})");
+                }
+                Msg("    (every card not listed is ON)");
+                return;
+            }
+
+            if (args.Count <= idIdx + 1) { Msg(usage); return; }
+            var card = NormalizeWeaponCard(args[idIdx]);
+            if (card == null)
+            {
+                Msg($"'{args[idIdx]}' is not a weapon card. Name it by its chance stat, e.g. weapon_bite_chance.");
+                Msg("  cards = " + string.Join(", ", ZoneStat.WeaponCardChances));
+                return;
+            }
+
+            var tok = args[idIdx + 1].ToLowerInvariant();
+            if (tok == "clear")
+            {
+                var had = false;
+                mutate(vp => had = vp.CustomWeaponCards.Remove(card));
+                Msg(had
+                    ? $"{scopeTag} weapon card: {card} override cleared - this scope no longer decides; the layer underneath does (which may be ON)."
+                    : $"{scopeTag} weapon card: {card} had no override here.");
+                return;
+            }
+            if (tok != "on" && tok != "off") { Msg(usage); return; }
+
+            var on = tok == "on";
+            mutate(vp => vp.CustomWeaponCards[card] = on);
+            // The tuned chance value is NEVER touched by this verb - that is the point of the flag. Say so,
+            // because the old way of switching a card off was to delete the chance and lose the number.
+            Msg(on
+                ? $"{scopeTag} weapon card: {card} ON - rolls at its authored chance here (chance value untouched)."
+                : $"{scopeTag} weapon card: {card} OFF - never rolls here, even if a lower layer sets a chance (chance value kept).");
+        }
+
+        /// <summary>The togglestat handler (2026-08-29) - HandleWeaponCard's shape over the full
+        /// stat registry. on/off/clear semantics identical; identifier space = ZoneStat.All.</summary>
+        private static void HandleStatToggle(List<string> args, int idIdx, string scopeTag, string usage,
+            ZoneVariantProfile authored, ZoneVariantProfile effective,
+            Action<Action<ZoneVariantProfile>> mutate, Action<string> Msg)
+        {
+            if (args.Count <= idIdx) { Msg(usage); return; }
+
+            if (args[idIdx].Equals("list", StringComparison.OrdinalIgnoreCase))
+            {
+                Msg($"{scopeTag} stat toggles (absent = ON):");
+                var any = false;
+                foreach (var stat in ZoneStat.All)
+                {
+                    var own = authored?.StatToggles != null && authored.StatToggles.TryGetValue(stat, out var o)
+                        ? (bool?)o : null;
+                    var eff = effective?.StatToggles != null && effective.StatToggles.TryGetValue(stat, out var e)
+                        ? (bool?)e : null;
+                    if (own == null && eff != false) continue;
+                    any = true;
+                    var where = own.HasValue ? "here" : "inherited";
+                    Msg($"    {stat,-34} {((eff ?? true) ? "ON" : "OFF")}  ({where})");
+                }
+                Msg(any ? "    (every stat not listed is ON)" : "    (none - every stat is ON)");
+                return;
+            }
+
+            if (args.Count <= idIdx + 1) { Msg(usage); return; }
+            var tsKey = args[idIdx].ToLowerInvariant();
+            if (!ZoneStat.IsKnownStat(tsKey))
+            { Msg($"'{args[idIdx]}' is not a registered stat key."); return; }
+
+            var tok = args[idIdx + 1].ToLowerInvariant();
+            if (tok == "clear")
+            {
+                var had = false;
+                mutate(vp => had = vp.StatToggles.Remove(tsKey));
+                Msg(had
+                    ? $"{scopeTag} stat toggle: {tsKey} override cleared - this scope no longer decides; the layer underneath does."
+                    : $"{scopeTag} stat toggle: {tsKey} had no override here.");
+                return;
+            }
+            if (tok != "on" && tok != "off") { Msg(usage); return; }
+
+            var on = tok == "on";
+            mutate(vp => vp.StatToggles[tsKey] = on);
+            Msg(on
+                ? $"{scopeTag} stat toggle: {tsKey} ON - the authored/inherited value applies here again."
+                : $"{scopeTag} stat toggle: {tsKey} OFF - treated as NOT SET here, even if a lower layer authors it (the value underneath is kept).");
+        }
+
+        /// <summary>statoff=stat,stat,... - the stats toggled OFF at this (evaluated) scope. Sparse;
+        /// absent = every stat on. APPEND-ONLY tag (2026-08-29), same reduction as wpnoff.</summary>
+        private static void AppendStatOffs(StringBuilder sb, Dictionary<string, bool> toggles)
+        {
+            if (toggles == null || toggles.Count == 0) return;
+            var off = toggles.Where(kv => !kv.Value).Select(kv => kv.Key).OrderBy(k => k, StringComparer.Ordinal).ToList();
+            if (off.Count == 0) return;
+            sb.Append("|statoff=").Append(string.Join(",", off));
+        }
+
+        /// <summary>ctspoff=key,key,... - the specials turned OFF at this (evaluated) scope. Sparse; absent = all on.
+        /// APPEND-ONLY tag (2026-08-23).</summary>
+        private static void AppendSpecialsOff(StringBuilder sb, Dictionary<int, bool> toggles)
+        {
+            if (toggles == null || toggles.Count == 0) return;
+            var off = toggles.Where(kv => !kv.Value).Select(kv => kv.Key).OrderBy(k => k).ToList();
+            if (off.Count == 0) return;
+            sb.Append("|ctspoff=").Append(string.Join(",", off));
+        }
+
+        /// <summary>
+        /// wpnoff=weapon_bite_chance,weapon_slayer_chance - the weapon CARDS turned OFF at this scope, by
+        /// chance stat name. Sparse; the tag being absent means every card is on, exactly like ctspoff.
+        /// APPEND-ONLY tag (2026-08-25): it is appended LAST in both payloads so an older plugin, which
+        /// splits on '|' and matches by key, ignores it harmlessly.
+        ///
+        /// Only the FALSE entries ride the wire. The store holds explicit true/false per card (a zone must
+        /// be able to re-enable what its tier Default turned off), but "on" is the default the plugin
+        /// already assumes, so an explicit true carries no information and would only make the tag bigger.
+        /// Same reduction AppendSpecialsOff does, for the same reason.
+        /// </summary>
+        private static void AppendWeaponCardsOff(StringBuilder sb, Dictionary<string, bool> toggles)
+        {
+            if (toggles == null || toggles.Count == 0) return;
+            var off = toggles.Where(kv => !kv.Value).Select(kv => kv.Key).OrderBy(k => k, StringComparer.Ordinal).ToList();
+            if (off.Count == 0) return;
+            sb.Append("|wpnoff=").Append(string.Join(",", off));
+        }
+
+        private static void AppendLadder(StringBuilder sb)
+        {
+            sb.Append("|ladder=");
+            bool first = true;
+            foreach (var kv in ZoneControlManager.ListLadderVersions())
+            {
+                var la = kv.Value;
+                if (la == null || la.Version <= 0) continue;
+                if (!first) sb.Append(';');
+                first = false;
+                sb.Append(kv.Key).Append(':').Append(la.Version).Append(':').Append(la.AllowNerf ? 1 : 0)
+                  .Append(':').Append(la.AppliedUtc.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+            }
+        }
+
+        private static string BuildVariationDefaultPayload(int variation)
+        {
+            var d = ZoneControlManager.GetVariationDefault(variation);
+            var stats = d?.Profile?.Stats;
+
+            var sb = new StringBuilder();
+            sb.Append("[[ZCD]]var=").Append(variation)
+              .Append("|found=").Append(d != null ? 1 : 0);
+
+            // SPARSE since 2026-08-23: only DEFINED stats ride the wire. The full 192-row form was ~4 KB per
+            // reply and each such chat line stalls the client ~0.5 s (tier stepper lock-up). The plugin
+            // marks every row of the variation undefined before applying, so an absent key = cleared.
+            if (stats != null)
+                foreach (var stat in ZoneStat.All)
+                    if (stats.TryGetValue(stat, out var curve) && curve != null)
+                        // NEVER let a small value go out in scientific notation (2026-08-30). Double.ToString()
+                        // emits "2.28E-05" for the armor CHASE chances (0.0000228), and anything downstream
+                        // that is not exponent-aware reads that as 0 - which is indistinguishable from
+                        // "never rolls" in the GUI. A plain decimal round-trips through every parser.
+                        sb.Append('|').Append(stat).Append("=1,")
+                          .Append(curve.Base.ToString("0.##########", CultureInfo.InvariantCulture));
+
+            // APPEND-ONLY (2026-08-23): this Default's OWN authored bands + slot rules, same shapes as the
+            // [[ZC]] sync, so the plugin Catalog at "Default v[N]" scope shows N's bands instead of the last
+            // zone's. Sparse: absent keys fall back to the tier-scaled hardcoded band.
+            var vp = d?.Profile;
+            // rank rows (2026-09-02), sparse, append-only - see AppendRankRows
+            AppendRankRows(sb, vp);
+            if (vp?.CustomModifierBands is { Count: > 0 })
+            {
+                sb.Append("|cantrips=");
+                bool firstCb = true;
+                foreach (var b in vp.CustomModifierBands)
+                {
+                    if (b.Value == null) continue;
+                    if (!firstCb) sb.Append(';');
+                    firstCb = false;
+                    sb.Append(b.Key).Append(':').Append(b.Value.Min).Append(':').Append(b.Value.Max)
+                      .Append(':').Append(b.Value.ProcMin).Append(':').Append(b.Value.ProcMax);
+                }
+            }
+            if (vp?.CustomModifierSlots is { Count: > 0 })
+            {
+                sb.Append("|ctslots=");
+                bool firstSl = true;
+                foreach (var kv in vp.CustomModifierSlots)
+                {
+                    if (!firstSl) sb.Append(';');
+                    firstSl = false;
+                    sb.Append(kv.Key).Append(':').Append(kv.Value);
+                }
+            }
+            AppendSpecialsOff(sb, vp?.CustomSpecials);
+            // vp here is this Default's OWN authored profile, so the off-sets are "authored on this
+            // tier Default" - there is no layer under a Default for them to have inherited from.
+            AppendWeaponCardsOff(sb, vp?.CustomWeaponCards);
+            // LAST tag in the [[ZCD]] payload - APPEND-ONLY (2026-08-29).
+            AppendStatOffs(sb, vp?.StatToggles);
+            return sb.ToString();
+        }
+
+        /// <summary>The sparse "<stat>@<rank>=1,<value>" rows for every rank row a profile authors
+        /// (2026-09-02). Shared by the [[ZC]] and [[ZCD]] builders. Plain decimal, never exponent (see
+        /// the 2026-08-30 note in BuildVariationDefaultPayload).</summary>
+        private static void AppendRankRows(StringBuilder sb, ZoneVariantProfile vp)
+        {
+            if (vp?.Ranks == null || vp.Ranks.Count == 0) return;
+            foreach (var rank in ZoneRank.Ranked)
+            {
+                var row = vp.RankLayer(rank, create: false);
+                if (row?.Stats == null || row.Stats.Count == 0) continue;
+                var key = ZoneRank.Key(rank);
+                foreach (var stat in ZoneStat.All)
+                    if (row.Stats.TryGetValue(stat, out var curve) && curve != null)
+                        sb.Append('|').Append(stat).Append('@').Append(key).Append("=1,")
+                          .Append(curve.Base.ToString("0.##########", CultureInfo.InvariantCulture));
+            }
+        }
+
+        /// <summary>Stat echo in SHORT form (owner 2026-08-23): big numbers read as 100M / 5B, everything
+        /// else as the plain value. Display only - the store keeps the exact double.</summary>
+        private static string FmtStatEcho(double v)
+        {
+            var a = Math.Abs(v);
+            if (a >= 1_000_000_000 && v % 1_000_000 == 0) return (v / 1_000_000_000).ToString("0.###", CultureInfo.InvariantCulture) + "B";
+            if (a >= 1_000_000 && v % 1_000 == 0) return (v / 1_000_000).ToString("0.###", CultureInfo.InvariantCulture) + "M";
+            if (a >= 10_000 && v % 1_000 == 0) return (v / 1_000).ToString("0.###", CultureInfo.InvariantCulture) + "K";
+            return v.ToString("0.####", CultureInfo.InvariantCulture);
+        }
+
+        /// <param name="includeLive">live_&lt;stat&gt; hints from the admin's in-game selection. ONLY the one-shot `get`
+        /// sends them (2026-09-03 round 5): in the push stream they made the payload flip with the selection, which
+        /// cost a second ~260 ms chunked push on every pick and one on every matching selection change.</param>
+        private static string BuildZonePayload(string name, uint? wcid, Session session, bool includeLive = false)
+        {
+            var area = ZoneControlManager.GetArea(name);
+            // LAYERED view (2026-07-30): VariationDefault -> zone -> wcid, so the plugin shows the value combat
+            // actually uses rather than only what this bucket authors. Wire shape is unchanged (still
+            // "<stat>=<defined>,<value>") â€” provenance is a Phase 3 change made together with the plugin.
+            var vp = ZoneControlManager.ResolveProfileForDisplay(name, wcid);
+
+            var sb = new StringBuilder();
+            sb.Append("[[ZC]]scope=").Append(WireName(name))
+              .Append("|found=").Append(area != null ? 1 : 0)
+              .Append("|enabled=").Append(area?.Enabled == true ? 1 : 0)
+              .Append("|wcid=").Append(wcid?.ToString() ?? "")
+              .Append("|variation=").Append(area?.Variation ?? 0)
+              .Append("|bounded=").Append(area?.Bounded == true ? 1 : 0);
+
+            // Other bounded zones sharing this zone's variation (for the Territory tab's union line).
+            if (area?.Bounded == true)
+            {
+                var sharing = ZoneControlManager.BoundedZoneNamesAt(area.Variation)
+                    .Where(n => !n.Equals(area.Name, StringComparison.OrdinalIgnoreCase));
+                sb.Append("|bshared=").Append(string.Join(",", sharing.Select(n => n.Replace('|', ' ').Replace(',', ' ').Replace('=', ' '))));
+            }
+
+            // Member landblocks (hex), so the plugin can show a selectable list with per-row removal.
+            if (area?.Landblocks is { Count: > 0 })
+            {
+                sb.Append("|lbs=");
+                bool firstLb = true;
+                foreach (var lb in area.Landblocks.OrderBy(x => x))
+                {
+                    if (!firstLb) sb.Append(',');
+                    firstLb = false;
+                    sb.Append(lb.ToString("X4"));
+                }
+            }
+
+            foreach (var stat in ZoneStat.All)
+            {
+                int defined = 0;
+                double value = 0;
+                if (vp != null && vp.TryGet(stat, out var curve)) { defined = 1; value = curve.Base; }
+                sb.Append('|').Append(stat).Append('=').Append(defined).Append(',').Append(value.ToString(CultureInfo.InvariantCulture));
+            }
+            // RANK ROWS (2026-09-02), APPEND-ONLY and SPARSE: "<stat>@<rank>=1,<value>" for every stat a
+            // Regular / Leader / Boss row AUTHORS anywhere in the merged tier+zone stack (ResolveProfileForDisplay
+            // merges Ranks recursively). Absent = that rank inherits the Default row. Older plugins ignore
+            // unknown row keys (ParseZoneSync's default branch checks _rows first). A --wcid target also
+            // reports which rank it resolves at and where that came from.
+            AppendRankRows(sb, vp);
+            if (wcid.HasValue && area != null)
+            {
+                var (wr, wsrc) = ZoneControlManager.ResolveRankForWcid(area, wcid.Value);
+                sb.Append("|rank=").Append(ZoneRank.Key(wr)).Append("|rank_src=").Append(wsrc);
+                // own= (2026-09-03, APPEND-ONLY, SPARSE): the stats THIS monster's bucket authors. The stat
+                // rows above are the merged chain (defined=1 for anything ANY layer authors), so without
+                // this the single-monster grid cannot tell an override from an inherited value.
+                if (area.Profile.WcidOverrides.TryGetValue(wcid.Value, out var ownBucket) && ownBucket?.Stats is { Count: > 0 })
+                    sb.Append("|own=").Append(string.Join(",", ZoneStat.All.Where(st => ownBucket.Stats.ContainsKey(st))));
+                // exempt=1 (2026-09-03, APPEND-ONLY, SPARSE): the master switch is OFF for this monster here.
+                if (area.Profile.ExemptWcids != null && area.Profile.ExemptWcids.Contains(wcid.Value))
+                    sb.Append("|exempt=1");
+            }
+
+            // Live server-wide relief-curve defaults (v11_relief_* config, /modify-tunable) so the
+            // plugin's Curves tab hints/graphs/simulator never drift from what combat actually uses
+            // when a zone doesn't author its own anchors. Fixed order: aug s,m,c,b | dr | critdr.
+            sb.Append("|reliefdefs=")
+              .Append(ServerConfig.v11_relief_aug_start.Value.ToString(CultureInfo.InvariantCulture)).Append(',')
+              .Append(ServerConfig.v11_relief_aug_max.Value.ToString(CultureInfo.InvariantCulture)).Append(',')
+              .Append(ServerConfig.v11_relief_aug_cap.Value.ToString(CultureInfo.InvariantCulture)).Append(',')
+              .Append(ServerConfig.v11_relief_aug_bend.Value.ToString(CultureInfo.InvariantCulture)).Append(',')
+              .Append(ServerConfig.v11_relief_dr_start.Value.ToString(CultureInfo.InvariantCulture)).Append(',')
+              .Append(ServerConfig.v11_relief_dr_max.Value.ToString(CultureInfo.InvariantCulture)).Append(',')
+              .Append(ServerConfig.v11_relief_dr_cap.Value.ToString(CultureInfo.InvariantCulture)).Append(',')
+              .Append(ServerConfig.v11_relief_dr_bend.Value.ToString(CultureInfo.InvariantCulture)).Append(',')
+              .Append(ServerConfig.v11_relief_critdr_start.Value.ToString(CultureInfo.InvariantCulture)).Append(',')
+              .Append(ServerConfig.v11_relief_critdr_max.Value.ToString(CultureInfo.InvariantCulture)).Append(',')
+              .Append(ServerConfig.v11_relief_critdr_cap.Value.ToString(CultureInfo.InvariantCulture)).Append(',')
+              .Append(ServerConfig.v11_relief_critdr_bend.Value.ToString(CultureInfo.InvariantCulture));
+
+            // Live shard-wide tuning defaults for the plugin's Curves Server-defaults view
+            // (owner-approved 2026-07-28). Fixed order: pcthp variance, pcthp crit mult,
+            // vuln effectiveness, vuln cap, vuln enabled (1/0).
+            sb.Append("|tunedefs=")
+              .Append(ServerConfig.v11_pcthp_variance.Value.ToString(CultureInfo.InvariantCulture)).Append(',')
+              .Append(ServerConfig.v11_pcthp_crit_mult.Value.ToString(CultureInfo.InvariantCulture)).Append(',')
+              .Append(ServerConfig.v11_vuln_effectiveness.Value.ToString(CultureInfo.InvariantCulture)).Append(',')
+              .Append(ServerConfig.v11_vuln_cap.Value.ToString(CultureInfo.InvariantCulture)).Append(',')
+              .Append(ServerConfig.v11_vuln_enabled.Value ? '1' : '0');
+
+            // Live diagnostics-bool states so the plugin's Log-section toggles show truth.
+            // Fixed order: damage_event_debug_server_log, damage_event_debug_only_nonplayer_attackers,
+            // spawn_diag_verbose, generator_diag_verbose, visibility_create_object_diag_verbose,
+            // regen_diag_verbose. APPEND-ONLY: the plugin indexes this list positionally.
+            sb.Append("|diagdefs=")
+              .Append(ServerConfig.damage_event_debug_server_log.Value ? '1' : '0').Append(',')
+              .Append(ServerConfig.damage_event_debug_only_nonplayer_attackers.Value ? '1' : '0').Append(',')
+              .Append(ServerConfig.spawn_diag_verbose.Value ? '1' : '0').Append(',')
+              .Append(ServerConfig.generator_diag_verbose.Value ? '1' : '0').Append(',')
+              .Append(ServerConfig.visibility_create_object_diag_verbose.Value ? '1' : '0').Append(',')
+              .Append(ServerConfig.regen_diag_verbose.Value ? '1' : '0');
+
+            AppendCombatDefs(sb);
+
+            // Body-part overrides: bp_<key>=<armor|->,<damage|->,<variance|->,<dmgtype|-> ('-' = not overridden)
+            if (vp?.BodyParts is { Count: > 0 })
+            {
+                foreach (var kv in vp.BodyParts.OrderBy(k => k.Key))
+                {
+                    var bp = kv.Value;
+                    if (bp == null || bp.IsEmpty) continue;
+                    sb.Append("|bp_").Append(kv.Key).Append('=')
+                      .Append(bp.Armor?.ToString(CultureInfo.InvariantCulture) ?? "-").Append(',')
+                      .Append(bp.Damage?.ToString(CultureInfo.InvariantCulture) ?? "-").Append(',')
+                      .Append(bp.Variance?.ToString(CultureInfo.InvariantCulture) ?? "-").Append(',')
+                      .Append(bp.DamageType?.ToString(CultureInfo.InvariantCulture) ?? "-");
+                }
+            }
+
+            // Prop stamps: prop_<i|l|f|b>_<id>=<value>
+            if (vp != null)
+            {
+                foreach (var kv in vp.PropInts.OrderBy(k => k.Key))
+                    sb.Append("|prop_i_").Append(kv.Key).Append('=').Append(kv.Value.ToString(CultureInfo.InvariantCulture));
+                foreach (var kv in vp.PropInt64s.OrderBy(k => k.Key))
+                    sb.Append("|prop_l_").Append(kv.Key).Append('=').Append(kv.Value.ToString(CultureInfo.InvariantCulture));
+                foreach (var kv in vp.PropFloats.OrderBy(k => k.Key))
+                    sb.Append("|prop_f_").Append(kv.Key).Append('=').Append(kv.Value.ToString(CultureInfo.InvariantCulture));
+                foreach (var kv in vp.PropBools.OrderBy(k => k.Key))
+                    sb.Append("|prop_b_").Append(kv.Key).Append('=').Append(kv.Value ? 1 : 0);
+            }
+
+            // Appearance overrides (cosmetic layer, separate from props/stats): ap_<field>=<value>. Sparse â€” the
+            // selected bucket's OWN fields (the zone default with no --wcid, else that WCID's overlay), so the
+            // plugin's Set/Clear act on exactly what it shows.
+            var apVp = area == null ? null : (wcid.HasValue
+                ? (area.AppearanceByWcid != null && area.AppearanceByWcid.TryGetValue(wcid.Value, out var apw) ? apw : null)
+                : area.AppearanceDefault);
+            if (apVp != null)
+            {
+                if (!string.IsNullOrEmpty(apVp.Name)) sb.Append("|ap_name=").Append(CleanWire(apVp.Name));
+                if (apVp.PaletteTemplate.HasValue) sb.Append("|ap_palette=").Append(apVp.PaletteTemplate.Value.ToString(CultureInfo.InvariantCulture));
+                if (apVp.Shade.HasValue) sb.Append("|ap_shade=").Append(apVp.Shade.Value.ToString(CultureInfo.InvariantCulture));
+                if (apVp.Scale.HasValue) sb.Append("|ap_scale=").Append(apVp.Scale.Value.ToString(CultureInfo.InvariantCulture));
+                if (apVp.Translucency.HasValue) sb.Append("|ap_trans=").Append(apVp.Translucency.Value.ToString(CultureInfo.InvariantCulture));
+                if (apVp.Shiny.HasValue) sb.Append("|ap_shiny=").Append(apVp.Shiny.Value ? 1 : 0);
+                if (apVp.SetupTableId.HasValue) sb.Append("|ap_setup=").Append(apVp.SetupTableId.Value.ToString("X8"));
+                if (apVp.MotionTable.HasValue) sb.Append("|ap_motion=").Append(apVp.MotionTable.Value.ToString("X8"));
+                if (apVp.SoundTable.HasValue) sb.Append("|ap_sound=").Append(apVp.SoundTable.Value.ToString("X8"));
+                if (apVp.PaletteBase.HasValue) sb.Append("|ap_palbase=").Append(apVp.PaletteBase.Value.ToString("X8"));
+                if (apVp.ClothingBase.HasValue) sb.Append("|ap_clothing=").Append(apVp.ClothingBase.Value.ToString("X8"));
+                if (apVp.Icon.HasValue) sb.Append("|ap_icon=").Append(apVp.Icon.Value.ToString("X8"));
+                if (apVp.PartCount > 0) sb.Append("|ap_parts=").Append(apVp.PartCount.ToString(CultureInfo.InvariantCulture));
+                if (apVp.AnimParts != null && apVp.AnimParts.Count > 0)
+                {
+                    sb.Append("|ap_partlist=");
+                    for (int i = 0; i < apVp.AnimParts.Count; i++)
+                    {
+                        if (i > 0) sb.Append(',');
+                        sb.Append(apVp.AnimParts[i].Index).Append(':').Append(apVp.AnimParts[i].GfxObj.ToString("X8"));
+                    }
+                }
+            }
+
+            // Effective look: the target's ACTUAL resolved value + source for every lever, so the plugin shows what
+            // it looks like even with nothing overridden. WITH a specific mob: self = this WCID's override, zone =
+            // the zone default, stock = the mob's own weenie. With NO target: self = the zone default (the bucket
+            // being edited) and a reference "Test Dummy" weenie stands in for stock (tagged 'dummy'), so the table
+            // is never a wall of N/A. eff_<field>=<value>~<self|zone|stock|dummy>.
+            if (area != null)
+            {
+                bool hasMob = wcid.HasValue;
+                uint refWcid = wcid ?? ZoneControlDummyWcid;
+                var apDef = area.AppearanceDefault;
+                var apW = (hasMob && area.AppearanceByWcid != null && area.AppearanceByWcid.TryGetValue(wcid.Value, out var apw2)) ? apw2 : null;
+                var selfAp = hasMob ? apW : apDef;
+                var zoneAp = hasMob ? apDef : null;
+                var wpn = ACE.Database.DatabaseManager.World.GetCachedWeenie(refWcid);
+                string stockSrc = hasMob ? "stock" : "dummy";
+
+                void Eff(string key, string self, string zone, string stock)
+                {
+                    string val, src;
+                    if (self != null) { val = self; src = "self"; }
+                    else if (zone != null) { val = zone; src = "zone"; }
+                    else if (stock != null) { val = stock; src = stockSrc; }
+                    else return;
+                    sb.Append("|eff_").Append(key).Append('=').Append(val).Append('~').Append(src);
+                }
+                string I(int? v) => v?.ToString(CultureInfo.InvariantCulture);
+                string F(double? v) => v?.ToString(CultureInfo.InvariantCulture);
+                string D(uint? v) => v?.ToString("X8");
+                string B(bool? v) => v.HasValue ? (v.Value ? "1" : "0") : null;
+                string Bi(int? v) => v.HasValue ? (v.Value != 0 ? "1" : "0") : null;
+
+                string N(string v) => string.IsNullOrEmpty(v) ? null : CleanWire(v);
+                Eff("name",     N(selfAp?.Name),            N(zoneAp?.Name),            N(wpn?.GetProperty(PropertyString.Name)));
+                Eff("palette",  I(selfAp?.PaletteTemplate), I(zoneAp?.PaletteTemplate), I(wpn?.GetProperty(PropertyInt.PaletteTemplate)));
+                Eff("shade",    F(selfAp?.Shade),           F(zoneAp?.Shade),           F(wpn?.GetProperty(PropertyFloat.Shade)));
+                Eff("scale",    F(selfAp?.Scale),           F(zoneAp?.Scale),           F(wpn?.GetProperty(PropertyFloat.DefaultScale)) ?? "1");
+                Eff("trans",    F(selfAp?.Translucency),    F(zoneAp?.Translucency),    F(wpn?.GetProperty(PropertyFloat.Translucency)) ?? "0");
+                Eff("shiny",    B(selfAp?.Shiny),           B(zoneAp?.Shiny),           Bi(wpn?.GetProperty(PropertyInt.CreatureVariant)) ?? "0");
+                Eff("setup",    D(selfAp?.SetupTableId),    D(zoneAp?.SetupTableId),    D(wpn?.GetProperty(PropertyDataId.Setup)));
+                Eff("clothing", D(selfAp?.ClothingBase),    D(zoneAp?.ClothingBase),    D(wpn?.GetProperty(PropertyDataId.ClothingBase)));
+                Eff("palbase",  D(selfAp?.PaletteBase),     D(zoneAp?.PaletteBase),     D(wpn?.GetProperty(PropertyDataId.PaletteBase)));
+                Eff("motion",   D(selfAp?.MotionTable),     D(zoneAp?.MotionTable),     D(wpn?.GetProperty(PropertyDataId.MotionTable)));
+                Eff("sound",    D(selfAp?.SoundTable),      D(zoneAp?.SoundTable),      D(wpn?.GetProperty(PropertyDataId.SoundTable)));
+                Eff("icon",     D(selfAp?.Icon),            D(zoneAp?.Icon),            D(wpn?.GetProperty(PropertyDataId.Icon)));
+
+                // Body parts: count of per-part overrides (anim + texture). self/zone come from the appearance
+                // layer; stock = the reference weenie's own baked parts (Tusgian-style mobs). Always emit a stock
+                // count (even 0) so the row always shows.
+                string PC(ZoneAppearance a) => a != null && a.PartCount > 0 ? a.PartCount.ToString(CultureInfo.InvariantCulture) : null;
+                int stockParts = (wpn?.PropertiesAnimPart?.Count ?? 0) + (wpn?.PropertiesTextureMap?.Count ?? 0);
+                Eff("parts", PC(selfAp), PC(zoneAp), stockParts.ToString(CultureInfo.InvariantCulture));
+            }
+
+            // Capability hint: does the TARGET mob have a usable ClothingBase (so PaletteTemplate/Shade can recolor
+            // it)? Only meaningful for a specific --wcid; omitted for "all monsters" (capability varies per mob).
+            if (wcid.HasValue)
+            {
+                bool hasClothing;
+                if (apVp?.ClothingBase.HasValue == true)
+                    hasClothing = true;                                   // an override supplies one
+                else if (apVp?.SetupTableId.HasValue == true)
+                    hasClothing = false;                                  // model swapped -> base clothing won't match
+                else
+                    hasClothing = ACE.Database.DatabaseManager.World.GetCachedWeenie(wcid.Value)?.GetProperty(PropertyDataId.ClothingBase) != null;
+                sb.Append("|cap_clothing=").Append(hasClothing ? 1 : 0);
+            }
+
+            // Custom cantrip pool (for the plugin's Loot cards).
+            if (vp?.CustomModifiers is { Count: > 0 })
+                sb.Append("|cantrips=").Append(string.Join(",", vp.CustomModifiers));
+
+            // Banded cantrips (sparse, rebuilt each sync like the pool): the EVALUATED/merged view â€”
+            // vp is ResolveProfileForDisplay, so Default-layer bands sync too; a key absent here
+            // rolls the catalog band. cantrips=<key>:<min>:<max>:<procMin>:<procMax>;...
+            // Entries carry ':' / ';' so the parser can tell them from the legacy comma pool list above.
+            if (vp?.CustomModifierBands is { Count: > 0 })
+            {
+                sb.Append("|cantrips=");
+                bool firstCb = true;
+                foreach (var b in vp.CustomModifierBands)
+                {
+                    if (b.Value == null) continue;
+                    if (!firstCb) sb.Append(';');
+                    firstCb = false;
+                    sb.Append(b.Key).Append(':').Append(b.Value.Min).Append(':').Append(b.Value.Max)
+                      .Append(':').Append(b.Value.ProcMin).Append(':').Append(b.Value.ProcMax);
+                }
+            }
+
+            // Slot rules (sparse, EVALUATED view like the bands): ctslots=<key>:<mask>;... - only authored keys.
+            // APPEND-ONLY tag (2026-08-22); old plugins ignore it.
+            if (vp?.CustomModifierSlots is { Count: > 0 })
+            {
+                sb.Append("|ctslots=");
+                bool firstSl = true;
+                foreach (var kv in vp.CustomModifierSlots)
+                {
+                    if (!firstSl) sb.Append(';');
+                    firstSl = false;
+                    sb.Append(kv.Key).Append(':').Append(kv.Value);
+                }
+            }
+
+            AppendSpecialsOff(sb, vp?.CustomSpecials);
+
+            // Spell-book rules (sparse, rebuilt each sync): sprules=id~disabled~chancePct,...
+            // chance blank = book default (or 2 for added spells).
+            if (vp?.SpellRules is { Count: > 0 })
+            {
+                sb.Append("|sprules=");
+                bool firstSr = true;
+                foreach (var r in vp.SpellRules)
+                {
+                    if (r == null || r.SpellId == 0) continue;
+                    if (!firstSr) sb.Append(',');
+                    firstSr = false;
+                    sb.Append(r.SpellId).Append('~').Append(r.Disabled ? 1 : 0).Append('~')
+                      .Append(r.Chance.HasValue ? r.Chance.Value.ToString(CultureInfo.InvariantCulture) : "");
+                }
+            }
+
+            // Currency drop table: curr=wcid~amount~chance~direct~name~own,... (sparse; rebuilt each sync
+            // like cantrips=). Name is display-only for the plugin; sanitized of the wire's separator chars.
+            // OWN (field 6, added 2026-08-24) = 1 when this drop is authored in the CURRENTLY TARGETED
+            // bucket, 0 when it is inherited from a broader layer. vp is the MERGED view, so without this
+            // the plugin cannot tell an inherited row from one this monster owns - and `currency remove`
+            // only ever touches the targeted bucket, so deleting an inherited row is a silent no-op.
+            // Deliberately the same bucket the remove verb resolves, so the badge cannot disagree with it.
+            // Append-only field: an older plugin ignores it, an older server omits it and the plugin
+            // falls back to treating the row as owned (the pre-2026-08-24 behaviour).
+            if (vp?.CurrencyDrops is { Count: > 0 })
+            {
+                var ownScope = wcid.HasValue
+                    ? area?.Profile?.VariantForWcid(wcid.Value)
+                    : area?.Profile?.Minion;
+                sb.Append("|curr=");
+                bool firstCd = true;
+                foreach (var d in vp.CurrencyDrops)
+                {
+                    if (d == null || d.Wcid == 0) continue;
+                    if (!firstCd) sb.Append(',');
+                    firstCd = false;
+                    var cdName = (ACE.Database.DatabaseManager.World.GetCachedWeenie(d.Wcid)?.GetName() ?? "")
+                        .Replace('|', ' ').Replace(',', ' ').Replace('~', ' ').Replace('=', ' ');
+                    var own = ownScope?.CurrencyDrops?.Any(x => x != null && x.Wcid == d.Wcid) == true;
+                    sb.Append(d.Wcid).Append('~').Append(d.Amount).Append('~').Append(d.Chance.ToString(CultureInfo.InvariantCulture))
+                      .Append('~').Append(d.Direct ? 1 : 0).Append('~').Append(cdName).Append('~').Append(own ? 1 : 0);
+                }
+            }
+
+            // Zone player-effects (for the plugin's Effects tab).
+            var effects = area?.Effects ?? new ZoneEffects();
+            sb.Append("|fx_dot=").Append(effects.EffectiveDotEnabled ? 1 : 0)
+              .Append("|fx_dotdmg=").Append(effects.EffectiveDotDamage.ToString(CultureInfo.InvariantCulture))
+              .Append("|fx_dottype=").Append(effects.EffectiveDotDamageType)
+              .Append("|fx_dotpercent=").Append(effects.EffectiveDotPercent ? 1 : 0)
+              .Append("|fx_dotinterval=").Append(effects.EffectiveDotIntervalSeconds.ToString(CultureInfo.InvariantCulture))
+              .Append("|fx_sup=").Append(effects.EffectiveSuppressEnabled ? 1 : 0)
+              .Append("|fx_supprod=").Append(effects.EffectiveSuppressProdigal ? 1 : 0)
+              .Append("|fx_supregen=").Append(effects.EffectiveSuppressRegenMult.ToString(CultureInfo.InvariantCulture));
+
+            AppendSessionState(sb, session);
+
+            // Live hints from the admin's in-game target. When the plugin is watching a SPECIFIC monster
+            // (--wcid), only send them if the in-game target IS that monster â€” otherwise targeting some other
+            // mob would overwrite the watched monster's weenie base values in the GUI. With no wcid watch
+            // ("All monsters"), any target's live stats are useful context and flow through as before.
+            var target = includeLive ? session.Player?.SelectedTarget as ACE.Server.WorldObjects.Creature : null;
+            if (target != null && (!wcid.HasValue || target.WeenieClassId == wcid.Value))
+            {
+                foreach (var stat in ZoneStat.All)
+                {
+                    var liveVal = GetLiveStatValue(target, stat);
+                    if (liveVal.HasValue)
+                        sb.Append("|live_").Append(stat).Append('=').Append(liveVal.Value.ToString(CultureInfo.InvariantCulture));
+                }
+            }
+
+            var loc = session.Player?.Location;
+            if (loc != null)
+            {
+                var hereLb = loc.LandblockId.Landblock;
+                var hereVar = ZoneControlManager.GetEffectiveVariation(session.Player);
+                // The zone that actually governs here (enabled + variation-match + most-specific), not just any cover.
+                var winner = ZoneControlManager.ResolveWinnerForLocation(hereLb, hereVar);
+                sb.Append("|here_lb=").Append(hereLb.ToString("X4"))
+                  .Append("|here_var=").Append(hereVar)
+                  .Append("|here_zone=").Append(winner?.Name ?? "");
+
+                // Every zone whose landblocks cover this spot (any variation) as name~enabled~varMatch, so the GUI
+                // can show overlaps and which are shadowed. ',' separates entries, '~' separates sub-fields.
+                var covering = ZoneControlManager.AreasCovering(hereLb);
+                if (covering.Count > 0)
+                {
+                    sb.Append("|here_covers=");
+                    bool first = true;
+                    foreach (var z in covering.OrderBy(z => z.Landblocks.Count))
+                    {
+                        if (!first) sb.Append(',');
+                        first = false;
+                        var safeName = z.Name.Replace('~', '-').Replace(',', ' ').Replace('|', ' ');
+                        sb.Append(safeName).Append('~').Append(z.Enabled ? 1 : 0).Append('~').Append(z.Variation == hereVar ? 1 : 0);
+                    }
+                }
+            }
+
+            AppendLadder(sb);   // APPEND-ONLY (2026-08-22): ladder apply versions, last so older plugins ignore it
+            // APPEND-ONLY (2026-08-25), and genuinely last in the [[ZC]] payload. ðŸ”´ vp here is
+            // ResolveProfileForDisplay - the EVALUATED view after the Default -> zone -> wcid merge, which is
+            // the convention every other layered tag in this payload already uses (the stat rows, cantrips=,
+            // ctslots=, ctspoff=). So wpnoff at zone scope answers "which cards are OFF FOR THIS ZONE",
+            // inherited ones included - not "which did this zone author". That is exactly what gates the
+            // drop, so it is what a checkbox should show. If the plugin ever needs the authored-vs-inherited
+            // split it wants a second field, the way curr= carries its own OWN flag; do not quietly change
+            // what this one means, because the two readings disagree only in the inherited case, which is
+            // the case nobody tests.
+            AppendWeaponCardsOff(sb, vp?.CustomWeaponCards);
+            // LAST tag in the [[ZC]] payload - APPEND-ONLY (2026-08-29). Same evaluated-view rule as
+            // wpnoff above: this answers "which stats are OFF FOR THIS SCOPE", inherited included.
+            AppendStatOffs(sb, vp?.StatToggles);
+            return sb.ToString();
+        }
+
+        private static double? GetLiveStatValue(ACE.Server.WorldObjects.Creature creature, string stat)
+        {
+            switch (stat)
+            {
+                case ZoneStat.Strength: return creature.Attributes[PropertyAttribute.Strength].Base;
+                case ZoneStat.Endurance: return creature.Attributes[PropertyAttribute.Endurance].Base;
+                case ZoneStat.Coordination: return creature.Attributes[PropertyAttribute.Coordination].Base;
+                case ZoneStat.Quickness: return creature.Attributes[PropertyAttribute.Quickness].Base;
+                case ZoneStat.Focus: return creature.Attributes[PropertyAttribute.Focus].Base;
+                case ZoneStat.Self: return creature.Attributes[PropertyAttribute.Self].Base;
+                case ZoneStat.MaxHealth: return creature.Health.MaxValue;
+                case ZoneStat.MaxStamina: return creature.Stamina.MaxValue;
+                case ZoneStat.MaxMana: return creature.Mana.MaxValue;
+                case ZoneStat.DamageRating: return creature.GetProperty(PropertyInt.DamageRating) ?? 0;
+                case ZoneStat.DamageResistRating: return creature.GetProperty(PropertyInt.DamageResistRating) ?? 0;
+                case ZoneStat.AttackSkill: return creature.GetCreatureSkill(creature.GetCurrentAttackSkill()).Base;
+                case ZoneStat.MeleeDefense: return creature.GetCreatureSkill(Skill.MeleeDefense).Base;
+                case ZoneStat.MissileDefense: return creature.GetCreatureSkill(Skill.MissileDefense).Base;
+                case ZoneStat.MagicDefense: return creature.GetCreatureSkill(Skill.MagicDefense).Base;
+
+                case ZoneStat.ResistSlash: return creature.GetProperty(PropertyFloat.ResistSlash) ?? 1.0;
+                case ZoneStat.ResistPierce: return creature.GetProperty(PropertyFloat.ResistPierce) ?? 1.0;
+                case ZoneStat.ResistBludgeon: return creature.GetProperty(PropertyFloat.ResistBludgeon) ?? 1.0;
+                case ZoneStat.ResistFire: return creature.GetProperty(PropertyFloat.ResistFire) ?? 1.0;
+                case ZoneStat.ResistCold: return creature.GetProperty(PropertyFloat.ResistCold) ?? 1.0;
+                case ZoneStat.ResistAcid: return creature.GetProperty(PropertyFloat.ResistAcid) ?? 1.0;
+                case ZoneStat.ResistElectric: return creature.GetProperty(PropertyFloat.ResistElectric) ?? 1.0;
+                case ZoneStat.ResistNether: return creature.GetProperty(PropertyFloat.ResistNether) ?? 1.0;
+
+                case ZoneStat.ArmorVsSlash: return creature.GetProperty(PropertyFloat.ArmorModVsSlash) ?? 1.0;
+                case ZoneStat.ArmorVsPierce: return creature.GetProperty(PropertyFloat.ArmorModVsPierce) ?? 1.0;
+                case ZoneStat.ArmorVsBludgeon: return creature.GetProperty(PropertyFloat.ArmorModVsBludgeon) ?? 1.0;
+                case ZoneStat.ArmorVsFire: return creature.GetProperty(PropertyFloat.ArmorModVsFire) ?? 1.0;
+                case ZoneStat.ArmorVsCold: return creature.GetProperty(PropertyFloat.ArmorModVsCold) ?? 1.0;
+                case ZoneStat.ArmorVsAcid: return creature.GetProperty(PropertyFloat.ArmorModVsAcid) ?? 1.0;
+                case ZoneStat.ArmorVsElectric: return creature.GetProperty(PropertyFloat.ArmorModVsElectric) ?? 1.0;
+                case ZoneStat.ArmorVsNether: return creature.GetProperty(PropertyFloat.ArmorModVsNether) ?? 1.0;
+
+                case ZoneStat.ArmorLevel:
+                {
+                    // weenie/biota base body armor (max across parts â€” parts are uniform on nearly all mobs)
+                    var parts = creature.Biota.PropertiesBodyPart;
+                    if (parts == null || parts.Count == 0) return null;
+                    return parts.Values.Max(p => p.BaseArmor);
+                }
+                case ZoneStat.AttackDamage:
+                {
+                    // what the mob hits for today: weapon damage if wielding, else best attacking part's DVal
+                    var weapon = creature.GetEquippedMeleeWeapon();
+                    if (weapon != null) return weapon.GetProperty(PropertyInt.Damage) ?? 0;
+                    var parts = creature.Biota.PropertiesBodyPart;
+                    if (parts == null || parts.Count == 0) return null;
+                    return parts.Values.Max(p => p.DVal);
+                }
+                case ZoneStat.AttackVariance:
+                {
+                    var weapon = creature.GetEquippedMeleeWeapon();
+                    if (weapon != null) return weapon.GetProperty(PropertyFloat.DamageVariance) ?? 0.0;
+                    var parts = creature.Biota.PropertiesBodyPart;
+                    if (parts == null || parts.Count == 0) return null;
+                    var best = parts.Values.OrderByDescending(p => p.DVal).First();
+                    return best.DVar;
+                }
+
+                default: return null;
+            }
+        }
+
+        /// <summary>Re-tokenize the space-split parameters honoring double quotes, so zone names may contain
+        /// spaces: /zonecontrol enable "My Zone". (ACE's CommandManager splits purely on spaces, so runs of
+        /// spaces inside quotes collapse to one â€” cosmetic only.)</summary>
+        private static List<string> RetokenizeParameters(string[] parameters)
+        {
+            var joined = string.Join(" ", parameters ?? Array.Empty<string>());
+            var list = new List<string>();
+            var sb = new StringBuilder();
+            var inQuotes = false;
+            foreach (var ch in joined)
+            {
+                if (ch == '"') { inQuotes = !inQuotes; continue; }
+                if (ch == ' ' && !inQuotes)
+                {
+                    if (sb.Length > 0) { list.Add(sb.ToString()); sb.Clear(); }
+                    continue;
+                }
+                sb.Append(ch);
+            }
+            if (sb.Length > 0) list.Add(sb.ToString());
+            return list;
+        }
+
+        /// <summary>Finds the LONGEST join of consecutive args (from <paramref name="startIndex"/>) that
+        /// names an EXISTING zone and collapses those tokens into a single arg, so multi-word zone names
+        /// work without quotes in every name-taking subcommand. No-op when nothing matches.</summary>
+        private static void CollapseZoneNameTokens(List<string> args, int startIndex)
+        {
+            var available = args.Count - startIndex;
+            if (available < 2)
+                return;
+            for (var take = available; take >= 2; take--)
+            {
+                var candidate = string.Join(" ", args.Skip(startIndex).Take(take));
+                if (ZoneControlManager.GetArea(candidate) != null)
+                {
+                    args.RemoveRange(startIndex, take);
+                    args.Insert(startIndex, candidate);
+                    return;
+                }
+            }
+        }
+
+        /// <summary>Display-name cleanup for create/rename: strip the wire separator chars (| , ~ =),
+        /// collapse whitespace runs, trim. CASE IS PRESERVED (lookups are case-insensitive).</summary>
+        private static string SanitizeZoneName(string raw)
+        {
+            var s = (raw ?? "").Replace('|', ' ').Replace(',', ' ').Replace('~', ' ').Replace('=', ' ');
+            return System.Text.RegularExpressions.Regex.Replace(s, @"\s+", " ").Trim();
+        }
+
+        private static bool TryLandblockToken(Session session, string token, out ushort landblock, out string error)
+        {
+            error = null; landblock = 0;
+            if (token.Equals("here", StringComparison.OrdinalIgnoreCase))
+            {
+                var lb = session.Player?.Location?.LandblockId.Landblock;
+                if (lb == null) { error = "No location for 'here'."; return false; }
+                landblock = lb.Value;
+                return true;
+            }
+            if (!TryHex(token, out var hex)) { error = "hex landblock required, e.g. F559 (or 'here')"; return false; }
+            landblock = (ushort)hex;
+            return true;
+        }
+
+        /// <summary>A caller-supplied name echoed into a wire field: never let '|' '=' '~' ',' forge a field (review 2026-09-03 L8).</summary>
+        private static string WireName(string s) => (s ?? "").Replace('|', ' ').Replace('=', ' ').Replace('~', ' ').Replace(',', ' ');
+
+        /// <summary>--gen <generator wcid> (2026-09-03): the per-generator master switch's key. Removed from args.</summary>
+        private static uint? ExtractGenFlag(List<string> args)
+        {
+            var idx = args.FindIndex(a => a.Equals("--gen", StringComparison.OrdinalIgnoreCase));
+            if (idx < 0 || idx + 1 >= args.Count) return null;
+            var valStr = args[idx + 1];
+            args.RemoveRange(idx, 2);
+            return uint.TryParse(valStr, out var id) ? id : null;
+        }
+
+        private static uint? ExtractWcidFlag(List<string> args)
+        {
+            var idx = args.FindIndex(a => a.Equals("--wcid", StringComparison.OrdinalIgnoreCase));
+            if (idx < 0 || idx + 1 >= args.Count) return null;
+            var valStr = args[idx + 1];
+            args.RemoveRange(idx, 2);
+            return uint.TryParse(valStr, out var id) ? id : null;
+        }
+
+        /// <summary>--rank default|regular|leader|boss (2026-09-02). Absent = None (the Default row).
+        /// A present-but-unknown value is an ERROR, not None - silently editing the Default row when the
+        /// operator typed "--rank lead" is exactly the invisible mistake the rank view exists to prevent.</summary>
+        private static ZcRank ExtractRankFlag(List<string> args, out string error)
+        {
+            error = null;
+            var idx = args.FindIndex(a => a.Equals("--rank", StringComparison.OrdinalIgnoreCase));
+            if (idx < 0) return ZcRank.None;
+            if (idx + 1 >= args.Count) { error = "--rank needs a value: default | regular | leader | boss"; return ZcRank.None; }
+            var valStr = args[idx + 1];
+            args.RemoveRange(idx, 2);
+            if (ZoneRank.TryParse(valStr, out var r)) return r;
+            error = $"Unknown rank '{valStr}'. Use default | regular | leader | boss.";
+            return ZcRank.None;
+        }
+
+        /// <summary>The row a stat verb edits: the zone layer or the per-WCID bucket, then the rank row
+        /// inside it. Returns null with <paramref name="refusal"/> set for --wcid + --rank (a bucket has
+        /// no rows). <paramref name="create"/> = author (set) vs inspect/clear.</summary>
+        private static ZoneVariantProfile StatRowFor(ZoneScalingProfile profile, uint? wcid, ZcRank rank, bool create, out string refusal)
+        {
+            refusal = null;
+            if (wcid.HasValue && rank != ZcRank.None)
+            {
+                refusal = "A monster override has no rank rows - it IS one rank. Drop --rank, or set the rank row on the zone / tier without --wcid.";
+                return null;
+            }
+            var layer = wcid.HasValue ? profile.VariantForWcid(wcid.Value, create) : profile.Minion;
+            return layer?.RankLayer(rank, create);
+        }
+
+        private static string RankTag(ZcRank rank) => rank == ZcRank.None ? "" : " [" + ZoneRank.Label(rank) + " row]";
+
+        private static bool TryHex(string s, out int value)
+        {
+            s = s.Trim();
+            if (s.StartsWith("0x", StringComparison.OrdinalIgnoreCase)) s = s.Substring(2);
+            return int.TryParse(s, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out value);
+        }
+
+        private static bool TryDouble(string s, out double value)
+            => double.TryParse(s, NumberStyles.Any, CultureInfo.InvariantCulture, out value);
+
+        /// <summary>Strip the wire's separator chars from a value so it can't break payload parsing.</summary>
+        // â”€â”€ live stat resolution: /zonecontrol ladder ... (2026-08-22) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+
+        private const int LadderTierMin = 11, LadderTierMax = 25;
+
+        /// <summary>`/zonecontrol ladder status | apply [tier|all] | migrate [here|&lt;player&gt;] [--dry] | show`.
+        /// Contract: LiveStat_Contract_2026-08-22.md (Commands). Replies use modifier NAMES, never keys.</summary>
+        private static void HandleLadder(Session session, List<string> args, Action<string> Msg)
+        {
+            if (args.Count < 2)
+            {
+                Msg("Usage: ladder status | apply [tier|all] | migrate [here|<player>] [--dry] | show");
+                Msg("  status  = per-tier ladder apply version (v0 = never applied)");
+                Msg("  apply   = bump a tier's ladder version so its gear re-resolves on next equip (online players now, others at login)");
+                Msg("  migrate = dev: grade a player's pre-grade Modifier pieces (equipped + packs); writes a dated SQL file; --dry = preview");
+                Msg("  show    = the item you last appraised: tier, version, each graded line");
+                return;
+            }
+
+            var verb = args[1].ToLowerInvariant();
+            switch (verb)
+            {
+                case "status":
+                {
+                    Msg("Ladder apply state (live stat resolution):");
+                    for (var t = LadderTierMin; t <= LadderTierMax; t++)
+                    {
+                        var la = ZoneControlManager.GetLadderVersion(t);
+                        if (la == null || la.Version <= 0)
+                            Msg($"  Tier {t,2}: v0 (never applied)");
+                        else
+                            Msg($"  Tier {t,2}: v{la.Version} by {la.AppliedBy ?? "?"} on {la.AppliedUtc:yyyy-MM-dd HH:mm} UTC");
+                    }
+                    return;
+                }
+
+                case "apply":
+                {
+                    int? tier = null;
+                    for (var i = 2; i < args.Count; i++)
+                    {
+                        var a = args[i];
+                        if (a.Equals("--nerf", StringComparison.OrdinalIgnoreCase)) continue;   // accepted and ignored: apply always follows the ladder both ways (owner 2026-08-23)
+                        if (a.Equals("all", StringComparison.OrdinalIgnoreCase)) { tier = null; continue; }
+                        if (int.TryParse(a.TrimStart('t', 'T', 'v', 'V'), NumberStyles.Integer, CultureInfo.InvariantCulture, out var tv))
+                        {
+                            if (tv < LadderTierMin || tv > LadderTierMax) { Msg($"Tier must be {LadderTierMin}-{LadderTierMax} (or 'all')."); return; }
+                            tier = tv;
+                            continue;
+                        }
+                        Msg($"Unknown apply argument '{a}'. Usage: ladder apply [tier|all]");
+                        return;
+                    }
+
+                    LadderApplyNow(session, tier, Msg);
+                    return;
+                }
+
+                case "migrate":
+                    LadderMigrate(session, args, Msg);
+                    return;
+
+                case "bench":
+                    LadderBench(session, args, Msg);
+                    return;
+
+                case "show":
+                case "inspect":
+                    LadderShow(session, Msg);
+                    return;
+
+                default:
+                    Msg($"Unknown ladder verb '{args[1]}'. Usage: ladder status | apply [tier|all] | migrate [here|<player>] [--dry] | show");
+                    return;
+            }
+        }
+
+        /// <summary>`ladder show`: read-only view of the last APPRAISED item's record, resolved through
+        /// ZoneStatResolver.Compute (never writes).</summary>
+        private static void LadderShow(Session session, Action<string> Msg)
+        {
+            var player = session?.Player;
+            if (player == null) { Msg("In-game only."); return; }
+            ACE.Server.WorldObjects.WorldObject wo = null;
+            if (player.CurrentAppraisalTarget.HasValue)
+                wo = player.FindObject(player.CurrentAppraisalTarget.Value, ACE.Server.WorldObjects.Player.SearchLocations.Everywhere, out _, out _, out _);
+            if (wo == null) { Msg("No item selected - appraise (examine) the piece first, then run ladder show."); return; }
+
+            Msg($"{wo.Name} (0x{wo.Guid.Full:X8}, wcid {wo.WeenieClassId}):");
+            if (!ZoneStatResolver.HasRecord(wo))
+            {
+                var hasLines = (wo.LongDesc ?? "").Contains("Zone Cantrip:", StringComparison.Ordinal);
+                Msg(hasLines
+                    ? "  no grade record (pre-grade piece: Zone Cantrip lines but no ZcModifiers) - 'ladder migrate' grades it"
+                    : "  no grade record (not a Zone Control piece)");
+                return;
+            }
+
+            var r = ZoneStatResolver.Compute(wo);
+            if (r == null) { Msg("  record present but nothing resolved."); return; }
+            var ladder = ZoneControlManager.GetLadderVersion(r.Tier);
+            var seen = wo.GetProperty(PropertyInt.ZcResolvedVersion) ?? 0;
+            var want = ZoneStatResolver.ResolveStamp(r.Tier);
+            Msg($"  Tier {r.Tier}  stamp {seen} / current {want} (ladder v{ladder.Version}, Zone Control "
+                + (ACE.Server.Managers.ServerConfig.zonecontrol_enabled.Value ? "on" : "OFF")
+                + $"){(seen != want ? "  STALE - re-resolves on next equip" : "  current")}");
+            foreach (var line in r.Lines)
+                Msg($"  {line.Name} {line.Record.Grade}/{ZoneStatResolver.GradeMax} -> {line.Value} [{line.Min}-{line.Max}]");
+            if (r.ArmorLevel.HasValue)
+                Msg($"  Armor Level resolves to {r.ArmorLevel.Value} (base {ZoneStatResolver.BaseArmorLevel(r.Tier)}; stamped {wo.ArmorLevel ?? 0})");
+        }
+
+        // â”€â”€ T11+ crafting gate, LAYER 1 ([[ZCCG]]) â”€â”€
+
+        private const string CraftUsage =
+            "Usage: craft <material> <itemtype> auto|allow|deny | craft list | craft get | craft materials | "
+          + "craft test <material> <itemtype> | craft enabled true|false | craft mintier <tier> | "
+          + "craft components [true|false | add <wcid> | remove <wcid> | reset]";
+
+        /// <summary>true/false, and the on/off and 1/0 spellings a GM is as likely to type.</summary>
+        private static bool TryParseBoolWord(string s, out bool value)
+        {
+            value = false;
+            if (string.IsNullOrWhiteSpace(s)) return false;
+            switch (s.Trim().ToLowerInvariant())
+            {
+                case "true": case "on": case "1": case "yes": value = true; return true;
+                case "false": case "off": case "0": case "no": value = false; return true;
+                default: return false;
+            }
+        }
+
+        /// <summary>A material may be given by NAME ("BlackOpal", or "Black Opal" across two tokens) or by
+        /// numeric MaterialType id. Names are what the owner uses in conversation; ids are what the store
+        /// and the wire carry.</summary>
+        private static bool TryTakeMaterial(List<string> args, int idx, out int material, out int next)
+        {
+            material = 0; next = idx;
+            if (idx >= args.Count)
+                return false;
+            if (ZoneCraftGateStore.TryParseMaterial(args[idx], out material)) { next = idx + 1; return true; }
+            if (idx + 1 < args.Count && ZoneCraftGateStore.TryParseMaterial(args[idx] + args[idx + 1], out material))
+            { next = idx + 2; return true; }
+            return false;
+        }
+
+        /// <summary>`craft ...`: author + inspect the T11+ crafting gate's layer-1 matrix. Every cell
+        /// starts Auto, which means "no opinion, fall through to the downgrade rule", so an install that
+        /// has authored nothing behaves exactly as the layer-2-only gate did.</summary>
+        private static void HandleCraft(Session session, List<string> args, Action<string> Msg)
+        {
+            var verb = args.Count > 1 ? args[1].ToLowerInvariant() : "list";
+
+            switch (verb)
+            {
+                case "help":
+                    Msg(CraftUsage);
+                    Msg("  itemtype = " + string.Join(" / ", ZoneCraftGateStore.Columns));
+                    Msg("  auto = fall through to the downgrade rule | allow = always, skipping it | deny = never");
+                    Msg("  " + CraftComponentsUsage + "   (layer 0: salvage WCIDs barred from Tier "
+                        + ZoneCraftGateStore.MinTier + "+ items outright)");
+                    return;
+
+                case "get":
+                    Msg(BuildCraftGatePayload());
+                    return;
+
+                case "reload":
+                    ZoneCraftGateStore.Reload();
+                    Msg("Crafting gate matrix reloaded from shard.");
+                    return;
+
+                case "list":
+                {
+                    Msg($"T11+ crafting gate: {(ZoneCraftGateStore.Enabled ? "ENABLED" : "DISABLED (whole gate bypassed)")}"
+                        + $", MinTier {ZoneCraftGateStore.MinTier}, {ZoneCraftGateStore.RuleCount} authored cell(s).");
+                    Msg($"  layer 0: blocked components {(ZoneCraftGateStore.BlockComponents ? "ENFORCED" : "not enforced")}"
+                        + $", {ZoneCraftGateStore.BlockedComponents().Count} entr(ies)  (craft components)");
+                    var rules = ZoneCraftGateStore.ListRules();
+                    if (rules.Count == 0)
+                    {
+                        Msg("  (every cell is Auto - decisions fall through to the downgrade rule)");
+                        return;
+                    }
+                    foreach (var r in rules)
+                        Msg($"  {ZoneCraftGateStore.MaterialName(r.Material),-16} {r.Class,-8} {r.Mode.ToString().ToUpperInvariant()}");
+                    return;
+                }
+
+                case "materials":
+                {
+                    var cat = ZoneCraftGateStore.ImbueMaterials();
+                    if (cat.Count == 0) { Msg("(no imbue materials found - world DB read failed; the matrix is unaffected)"); return; }
+                    Msg($"{cat.Count} salvage material(s) carry an imbue recipe:");
+                    foreach (var m in cat)
+                        Msg($"  {m.Material,3}  {m.Name,-16} {(m.Effect == ImbuedEffectType.Undef ? "" : m.Effect.ToString())}");
+                    return;
+                }
+
+                case "enabled":
+                {
+                    if (args.Count < 3) { Msg("Usage: craft enabled true|false"); return; }
+                    if (!TryParseBoolWord(args[2], out var on)) { Msg("Usage: craft enabled true|false"); return; }
+                    ZoneCraftGateStore.SetEnabled(on);
+                    Msg(on
+                        ? "Crafting gate ENABLED."
+                        : "Crafting gate DISABLED - the whole gate is bypassed, matrix and downgrade rule alike.");
+                    return;
+                }
+
+                case "mintier":
+                {
+                    if (args.Count < 3 || !int.TryParse(args[2], out var t) || t < 1 || t > 100)
+                    { Msg("Usage: craft mintier <tier>   (1-100; 11 is the default)"); return; }
+                    ZoneCraftGateStore.SetMinTier(t);
+                    Msg($"Crafting gate now applies at Tier {t} and above.");
+                    return;
+                }
+
+                case "components":
+                case "component":
+                    HandleCraftComponents(args, Msg);
+                    return;
+
+                case "test":
+                {
+                    if (!TryTakeMaterial(args, 2, out var tMat, out var tNext))
+                    { Msg("Usage: craft test <material> <itemtype>   (material by name, e.g. BlackOpal, or by MaterialType id)"); return; }
+                    if (tNext >= args.Count || !Enum.TryParse<CraftItemClass>(args[tNext], true, out var tCls))
+                    { Msg("Usage: craft test <material> <itemtype>   itemtype = " + string.Join(" / ", ZoneCraftGateStore.Columns)); return; }
+                    CraftTest(session, tMat, tCls, Msg);
+                    return;
+                }
+
+                default:
+                {
+                    // craft <material> <itemtype> auto|allow|deny
+                    if (!TryTakeMaterial(args, 1, out var mat, out var next))
+                    { Msg($"Unknown material '{args[1]}'. " + CraftUsage); return; }
+                    if (next >= args.Count || !Enum.TryParse<CraftItemClass>(args[next], true, out var cls))
+                    { Msg("itemtype = " + string.Join(" / ", ZoneCraftGateStore.Columns) + ". " + CraftUsage); return; }
+                    if (next + 1 >= args.Count || !Enum.TryParse<CraftRuleMode>(args[next + 1], true, out var mode))
+                    { Msg("mode = auto | allow | deny. " + CraftUsage); return; }
+
+                    var changed = ZoneCraftGateStore.SetMode(mat, cls, mode);
+                    var name = ZoneCraftGateStore.MaterialName(mat);
+                    if (!changed) { Msg($"{name} x {cls} was already {mode.ToString().ToUpperInvariant()}."); return; }
+                    Msg(mode switch
+                    {
+                        CraftRuleMode.Allow => $"{name} on a {cls}: ALLOW - always permitted, the downgrade rule is skipped.",
+                        CraftRuleMode.Deny => $"{name} on a {cls}: DENY - never permitted at Tier {ZoneCraftGateStore.MinTier}+.",
+                        _ => $"{name} on a {cls}: AUTO - the cell is cleared; decisions fall through to the downgrade rule.",
+                    });
+                    return;
+                }
+            }
+        }
+
+        private const string CraftComponentsUsage =
+            "Usage: craft components   |   craft components true|false   |   craft components add <wcid>   |   "
+          + "craft components remove <wcid>   |   craft components reset";
+
+        /// <summary>`craft components ...`: LAYER 0, the flat list of SALVAGE WCIDs that may never be
+        /// applied to a MinTier+ item, plus the toggle that turns the layer off without clearing it.
+        ///
+        /// The list is authorable precisely so this is not a hardcode: `add` closes a newly-found offender
+        /// without a rebuild, and `reset` goes back to tracking the built-in pair. Any edit takes ownership
+        /// of the list - from then on it no longer follows the default, which is what `reset` undoes.</summary>
+        private static void HandleCraftComponents(List<string> args, Action<string> Msg)
+        {
+            var op = args.Count > 2 ? args[2].ToLowerInvariant() : "list";
+
+            // `craft components true|false` - the toggle, spelled the same way `craft enabled` is.
+            if (TryParseBoolWord(op, out var on))
+            {
+                ZoneCraftGateStore.SetBlockComponents(on);
+                Msg(on
+                    ? $"Blocked crafting components ENFORCED at Tier {ZoneCraftGateStore.MinTier}+ "
+                      + $"({ZoneCraftGateStore.BlockedComponents().Count} on the list)."
+                    : "Blocked crafting components NOT enforced - the list is kept, just not consulted.");
+                return;
+            }
+
+            switch (op)
+            {
+                case "list":
+                {
+                    var list = ZoneCraftGateStore.BlockedComponents();
+                    Msg($"Blocked crafting components: {(ZoneCraftGateStore.BlockComponents ? "ENFORCED" : "NOT ENFORCED (list kept)")}"
+                        + $" at Tier {ZoneCraftGateStore.MinTier}+, {list.Count} entr(ies)"
+                        + (ZoneCraftGateStore.ComponentsAreDefault ? ", still the built-in default." : ", authored."));
+                    if (list.Count == 0)
+                    {
+                        Msg("  (nothing is blocked)");
+                        return;
+                    }
+                    foreach (var w in list)
+                        Msg($"  {w}  {ACE.Database.DatabaseManager.World.GetCachedWeenie(w)?.GetName() ?? "(no such weenie)"}");
+                    return;
+                }
+
+                case "reset":
+                    ZoneCraftGateStore.ResetComponents();
+                    Msg($"Blocked component list reset to the built-in default ({ZoneCraftGateStore.BlockedComponents().Count} entr(ies)).");
+                    return;
+
+                case "add":
+                case "remove":
+                {
+                    if (args.Count < 4 || !uint.TryParse(args[3], out var wcid) || wcid == 0)
+                    { Msg(CraftComponentsUsage); return; }
+
+                    // A missing weenie is a WARNING, not a refusal: the list is matched by number and a
+                    // wcid that does not exist yet simply never matches. Refusing would make it impossible
+                    // to pre-block something before its weenie lands.
+                    var name = ACE.Database.DatabaseManager.World.GetCachedWeenie(wcid)?.GetName();
+                    if (name == null)
+                        Msg($"Warning: no weenie {wcid} in the world db - blocking it anyway; it will simply never match.");
+
+                    if (op == "add")
+                    {
+                        Msg(ZoneCraftGateStore.AddComponent(wcid)
+                            ? $"{wcid} {name ?? ""} may no longer be applied to a Tier {ZoneCraftGateStore.MinTier}+ item."
+                            : $"{wcid} {name ?? ""} was already blocked.");
+                    }
+                    else
+                    {
+                        Msg(ZoneCraftGateStore.RemoveComponent(wcid)
+                            ? $"{wcid} {name ?? ""} may be applied again."
+                            : $"{wcid} {name ?? ""} was not on the blocked list.");
+                    }
+                    return;
+                }
+
+                default:
+                    Msg(CraftComponentsUsage);
+                    return;
+            }
+        }
+
+        /// <summary>`craft test`: state the decision AND why. Layer 1 answers on its own; when the cell is
+        /// Auto the answer belongs to layer 2, which depends on the TARGET's current values - so if a
+        /// Tier-MinTier+ item has been appraised, the real comparison is run against it and reported.</summary>
+        private static void CraftTest(Session session, int material, CraftItemClass cls, Action<string> Msg)
+        {
+            var name = ZoneCraftGateStore.MaterialName(material);
+            Msg($"{name} on a {cls}:");
+
+            if (!ZoneCraftGateStore.Enabled)
+            { Msg("  ALLOW - the crafting gate is disabled shard-wide (craft enabled true to turn it back on)."); return; }
+
+            var mode = ZoneCraftGateStore.GetMode(material, cls);
+            if (mode == CraftRuleMode.Allow)
+            { Msg("  ALLOW - layer 1: the matrix cell is set to Allow, so the downgrade rule is skipped."); return; }
+            if (mode == CraftRuleMode.Deny)
+            { Msg($"  DENY - layer 1: the matrix cell is set to Deny for Tier {ZoneCraftGateStore.MinTier}+ items."); return; }
+
+            Msg("  layer 1: the matrix cell is Auto - no opinion. Falling through to the downgrade rule.");
+
+            // What layer 2 would compare, for a STOCK imbue salvage.
+            var effect = ImbuedEffectType.Undef;
+            foreach (var m in ZoneCraftGateStore.ImbueMaterials())
+                if (m.Material == material) { effect = m.Effect; break; }
+
+            if (effect == ImbuedEffectType.Undef)
+            {
+                Msg("  layer 2: this material carries no stock imbue this gate models. The decision then rests on the");
+                Msg("    recipe's own SetValue rows - it is refused only if one would replace an authored property with");
+                Msg("    a value no better than the item's. Apply it to a real piece to see the exact verdict.");
+                return;
+            }
+
+            if (!ZoneCraftGate.TryDescribeImbue(effect, out var propId, out var label, out var capped, out var shown))
+            {
+                Msg($"  ALLOW - layer 2: {effect} competes with nothing this system authors.");
+                return;
+            }
+
+            Msg($"  layer 2: {effect} competes over {label}, and is worth {shown} at capped skill.");
+            Msg($"    Refused only when the item already has {label} of {shown} or better; an item carrying none gets it.");
+
+            var player = session?.Player;
+            ACE.Server.WorldObjects.WorldObject wo = null;
+            if (player != null && player.CurrentAppraisalTarget.HasValue)
+                wo = player.FindObject(player.CurrentAppraisalTarget.Value, ACE.Server.WorldObjects.Player.SearchLocations.Everywhere, out _, out _, out _);
+            if (wo == null)
+            { Msg("    (appraise a Tier " + ZoneCraftGateStore.MinTier + "+ item to test this against a real piece)"); return; }
+
+            var tier = ZoneCraftGate.TierOf(wo);
+            var woCls = ZoneCraftGateStore.Classify(wo);
+            Msg($"  against {wo.Name}: Tier {tier}, reads as {(woCls?.ToString() ?? "no matrix column")}.");
+            if (tier < ZoneCraftGateStore.MinTier)
+            { Msg($"    ALLOW - below Tier {ZoneCraftGateStore.MinTier}, the gate does not apply at all."); return; }
+
+            var cur = wo.GetProperty((PropertyFloat)propId);
+            if (!cur.HasValue)
+            { Msg($"    ALLOW - it carries no {label} at all, so this is a real upgrade."); return; }
+            Msg(cur.Value >= capped
+                ? $"    DENY - it already has {label} {ZoneCraftGate.ShowStored(propId, cur.Value)}, which is not worse than {shown}."
+                : $"    ALLOW - its {label} is {ZoneCraftGate.ShowStored(propId, cur.Value)}, weaker than {shown}.");
+        }
+
+        /// <summary>"[[ZCCG]]enabled=..|mintier=..|types=..|mats=..|rules=.." - the layer-1 matrix, for the
+        /// plugin's Crafting tab. Fields are matched by NAME and the tag is APPEND-ONLY: a plugin that does
+        /// not know a field ignores it, and an older server simply sends fewer.
+        ///
+        /// SPARSE by construction. `rules=` carries ONLY authored (non-Auto) cells - an untouched install
+        /// sends `rules=` empty, and the plugin renders every cell Auto. `types=` is the column order and
+        /// `mats=` the row catalog (the 33 salvage materials that carry an imbue recipe, each with the
+        /// imbue it applies where one is known), so the plugin can draw the matrix with no DB access.</summary>
+        private static string BuildCraftGatePayload()
+        {
+            var sb = new StringBuilder("[[ZCCG]]enabled=").Append(ZoneCraftGateStore.Enabled ? 1 : 0)
+                .Append("|mintier=").Append(ZoneCraftGateStore.MinTier)
+                .Append("|types=").Append(string.Join(",", ZoneCraftGateStore.Columns));
+
+            sb.Append("|mats=");
+            var firstMat = true;
+            foreach (var m in ZoneCraftGateStore.ImbueMaterials())
+            {
+                if (!firstMat) sb.Append(';');
+                firstMat = false;
+                sb.Append(m.Material).Append('~').Append(CleanWire(m.Name)).Append('~')
+                  .Append(m.Effect == ImbuedEffectType.Undef ? "" : m.Effect.ToString());
+            }
+
+            sb.Append("|rules=");
+            var firstRule = true;
+            foreach (var r in ZoneCraftGateStore.ListRules())
+            {
+                if (!firstRule) sb.Append(';');
+                firstRule = false;
+                sb.Append(r.Material).Append('~').Append(r.Class).Append('~').Append(r.Mode);
+            }
+
+            // â”€â”€ APPENDED 2026-08-25: layer 0, the blocked-component list â”€â”€
+            // `blockcomponents` is the toggle, 0/1, exactly like `enabled`.
+            // `components` is wcid~name pairs, ';' between records and '~' inside one - the same shape as
+            // `mats=` and `rules=`. The name is a display convenience read from the world weenie cache and
+            // may be EMPTY (a wcid can be pre-blocked before its weenie exists), so the plugin must fall
+            // back to showing the number rather than dropping the row.
+            sb.Append("|blockcomponents=").Append(ZoneCraftGateStore.BlockComponents ? 1 : 0)
+              .Append("|components=");
+            var firstComp = true;
+            foreach (var w in ZoneCraftGateStore.BlockedComponents())
+            {
+                if (!firstComp) sb.Append(';');
+                firstComp = false;
+                sb.Append(w).Append('~')
+                  .Append(CleanWire(ACE.Database.DatabaseManager.World.GetCachedWeenie(w)?.GetName() ?? ""));
+            }
+
+            // â”€â”€ APPENDED 2026-08-26: the layer-0 CANDIDATE catalog, for the per-component toggles â”€â”€
+            // `components=` above is what IS blocked. This is what COULD be, so the plugin can draw an
+            // UNTICKED row - the store records only the blocked set, so without this there is nothing to
+            // draw an allowed component from.
+            //
+            // wcid~group ONLY, deliberately. This whole payload is ONE unchunked chat line (Msg at the
+            // `craft get` verb), the 49 blocked names already measure 907 characters, and adding a prose
+            // description per row would put ~4.7 KB more on that same line. The plugin owns the display
+            // name and the explanation, compiled in. It has to anyway: TWELVE of these weenies are named
+            // exactly "Foolproof" in the world DB and three more are named "Salvage", so wire names could
+            // never have driven a legible list.
+            sb.Append("|compcat=");
+            var firstCat = true;
+            foreach (var e in ZoneCraftGateStore.ComponentCatalogRows())
+            {
+                if (!firstCat) sb.Append(';');
+                firstCat = false;
+                sb.Append(e.Wcid).Append('~').Append(CleanWire(e.Group));
+            }
+
+            return sb.ToString();
+        }
+
+        private static readonly System.Text.RegularExpressions.Regex ZcTierLine =
+            new(@"^\s*Tier:\s*(\d+)", System.Text.RegularExpressions.RegexOptions.Multiline | System.Text.RegularExpressions.RegexOptions.Compiled);
+        private static readonly System.Text.RegularExpressions.Regex ZcBand =
+            new(@"\[\s*(-?\d+)\s*-\s*(-?\d+)\s*\]", System.Text.RegularExpressions.RegexOptions.Compiled);
+        private static readonly System.Text.RegularExpressions.Regex ZcInt =
+            new(@"[+-]?\d+", System.Text.RegularExpressions.RegexOptions.Compiled);
+
+        /// <summary>Parse one "Zone Cantrip: ..." LongDesc line: catalog def by Name (longest match,
+        /// case-insensitive), the integer right after the name (any ValFmt shape: "+41", "x3", "+5% vitals",
+        /// "50", "2 pct HP per hit"), and the [min-max] band when present. Proc-shaped lines ("N% to ...")
+        /// return false with proc=true.</summary>
+        private static bool TryParseZcLine(string line, out ZoneModifiers.Def def, out int? value, out (int Min, int Max)? band, out bool proc)
+        {
+            def = null; value = null; band = null; proc = false;
+            var idx = line.IndexOf("Zone Cantrip:", StringComparison.OrdinalIgnoreCase);
+            if (idx < 0) return false;
+            var rest = line.Substring(idx + "Zone Cantrip:".Length).Trim();
+            if (rest.Length == 0) return false;
+
+            foreach (var d in ZoneModifiers.Catalog.Values.OrderByDescending(d => d.Name?.Length ?? 0))
+            {
+                if (string.IsNullOrEmpty(d.Name)) continue;
+                if (!rest.StartsWith(d.Name, StringComparison.OrdinalIgnoreCase)) continue;
+                if (rest.Length > d.Name.Length && !char.IsWhiteSpace(rest[d.Name.Length])) continue;
+                def = d;
+                break;
+            }
+            if (def == null) return false;
+
+            var tail = rest.Substring(def.Name.Length).Trim();
+            if (tail.Contains("% to", StringComparison.OrdinalIgnoreCase) || tail.Contains(" to +", StringComparison.OrdinalIgnoreCase))
+            { proc = true; return false; }
+
+            var bm = ZcBand.Match(tail);
+            if (bm.Success)
+            {
+                band = (int.Parse(bm.Groups[1].Value, CultureInfo.InvariantCulture), int.Parse(bm.Groups[2].Value, CultureInfo.InvariantCulture));
+                tail = tail.Substring(0, bm.Index);
+            }
+            var vm = ZcInt.Match(tail);
+            if (vm.Success && int.TryParse(vm.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var v))
+                value = v;
+            return true;
+        }
+
+        /// <summary>Equipped + inventory, packs walked recursively, no duplicates.</summary>
+        private static List<ACE.Server.WorldObjects.WorldObject> WalkPossessions(ACE.Server.WorldObjects.Player player)
+        {
+            var seen = new HashSet<uint>();
+            var list = new List<ACE.Server.WorldObjects.WorldObject>();
+            void Visit(ACE.Server.WorldObjects.WorldObject wo)
+            {
+                if (wo == null || !seen.Add(wo.Guid.Full)) return;
+                list.Add(wo);
+                if (wo is ACE.Server.WorldObjects.Container c)
+                    foreach (var inner in c.Inventory.Values.ToList())
+                        Visit(inner);
+            }
+            foreach (var e in player.EquippedObjects.Values.ToList()) Visit(e);
+            foreach (var i in player.Inventory.Values.ToList()) Visit(i);
+            return list;
+        }
+
+        private static string SqlStr(string s) => "'" + (s ?? "").Replace("\\", "\\\\").Replace("'", "''") + "'";
+
+        /// <summary>A [[ZC]] payload with its `|live_&lt;stat&gt;=value` fields removed - the push-shaped twin of a
+        /// `get` reply (the live block is the only thing includeLive adds).</summary>
+        private static string StripLiveFields(string payload)
+            => System.Text.RegularExpressions.Regex.Replace(payload, @"\|live_[^|=]+=[^|]*", "");
+
+        /// <summary>Re-point a loaded world-DB weenie MODEL at a new wcid before the SQL writer runs: ClassId
+        /// (the writer emits input.ClassId for every child row) plus the self-references that name the source
+        /// wcid (emote actions, create list, generator rows). Replaces the whole-word text replace over the
+        /// exported SQL, which for a low wcid also rewrote property types, values, spell ids and emote amounts
+        /// (review 2026-09-04 C1). GetWeenie(uint) hands back a fresh NoTracking model - the entity cache holds
+        /// a converted copy - so mutating it touches nothing live.</summary>
+        private static void RemapWeenieModel(ACE.Database.Models.World.Weenie w, uint from, uint to)
+        {
+            w.ClassId = to;
+            if (w.WeeniePropertiesEmote != null)
+                foreach (var e in w.WeeniePropertiesEmote)
+                    if (e.WeeniePropertiesEmoteAction != null)
+                        foreach (var a in e.WeeniePropertiesEmoteAction)
+                            if (a.WeenieClassId == from) a.WeenieClassId = to;
+            if (w.WeeniePropertiesCreateList != null)
+                foreach (var c in w.WeeniePropertiesCreateList)
+                    if (c.WeenieClassId == from) c.WeenieClassId = to;
+            if (w.WeeniePropertiesGenerator != null)
+                foreach (var g in w.WeeniePropertiesGenerator)
+                    if (g.WeenieClassId == from) g.WeenieClassId = to;
+        }
+
+        /// <summary>`ladder migrate [here|&lt;player&gt;] [--dry]` - grade a player's pre-grade Zone Cantrip pieces
+        /// (plan Â§5): the stamped numbers become grades against the tier's live bands, the record is written,
+        /// identity stamped, biota saved, and the same rows land in a dated SQL file.</summary>
+        private static void LadderMigrate(Session session, List<string> args, Action<string> Msg)
+        {
+            var dry = false;
+            var nameTokens = new List<string>();
+            for (var i = 2; i < args.Count; i++)
+            {
+                if (args[i].Equals("--dry", StringComparison.OrdinalIgnoreCase) || args[i].Equals("dry", StringComparison.OrdinalIgnoreCase)) dry = true;
+                else nameTokens.Add(args[i]);
+            }
+            var who = string.Join(" ", nameTokens);
+
+            ACE.Server.WorldObjects.Player target;
+            if (who.Length == 0 || who.Equals("here", StringComparison.OrdinalIgnoreCase))
+                target = session?.Player;
+            else
+                target = PlayerManager.GetOnlinePlayer(who);
+            if (target == null) { Msg(who.Length == 0 ? "In-game only (or name an ONLINE player)." : $"Player '{who}' is not online - migrate walks live objects only."); return; }
+
+            var items = WalkPossessions(target);
+            int migrated = 0, skippedHasRecord = 0, skippedNoLines = 0, skippedTier = 0;
+            var unparsable = new List<string>();
+            var sql = new StringBuilder();
+
+            foreach (var wo in items)
+            {
+                var desc = wo.LongDesc ?? "";
+                if (!desc.Contains("Zone Cantrip:", StringComparison.Ordinal)) { skippedNoLines++; continue; }
+                if (ZoneStatResolver.HasRecord(wo)) { skippedHasRecord++; continue; }
+
+                // tier: "Tier: N" provenance line, else WeaponAugScaleTier, else 11
+                var tier = 0;
+                var tm = ZcTierLine.Match(desc);
+                if (tm.Success) int.TryParse(tm.Groups[1].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out tier);
+                if (tier <= 0) tier = wo.GetProperty(PropertyInt.WeaponAugScaleTier) ?? 0;
+                if (tier <= 0) tier = LadderTierMin;
+                if (tier < LadderTierMin || tier > LadderTierMax)
+                {
+                    skippedTier++;
+                    unparsable.Add($"{wo.Name} (0x{wo.Guid.Full:X8}): tier {tier} outside {LadderTierMin}-{LadderTierMax}");
+                    continue;
+                }
+
+                var records = new List<ZoneStatResolver.LineRecord>();
+                void Put(int key, int grade)
+                {
+                    records.RemoveAll(r => r.Key == key);
+                    records.Add(new ZoneStatResolver.LineRecord { Key = key, Grade = Math.Clamp(grade, 0, ZoneStatResolver.GradeMax) });
+                }
+                var hasArmorLevelLine = false;
+                var detail = new List<string>();
+
+                foreach (var raw in desc.Split('\n'))
+                {
+                    var line = raw.Trim();
+                    if (!line.Contains("Zone Cantrip:", StringComparison.OrdinalIgnoreCase)) continue;
+                    if (!TryParseZcLine(line, out var def, out var lineValue, out var lineBand, out var proc))
+                    {
+                        if (proc) { detail.Add($"skip proc line: {line}"); continue; }
+                        unparsable.Add($"{wo.Name} (0x{wo.Guid.Full:X8}): {line}");
+                        continue;
+                    }
+                    if (def.SetsProtection) { detail.Add($"skip {def.Name} (earned, frozen)"); continue; }
+                    if (def.ArmorOnly && def.Ints == null) { hasArmorLevelLine = true; continue; }   // key 25: graded from AL below
+
+                    var band = lineBand ?? ZoneStatResolver.EffectiveBand(def.Key, tier);
+                    int? v = lineValue;
+                    if (def.SlotSpecial)
+                    {
+                        // specials: the prop value is the truth (the line may carry no number at all)
+                        band = ZoneStatResolver.EffectiveBand(def.Key, tier);
+                        if (def.Ints != null && def.Ints.Length > 0)
+                        {
+                            var pv = wo.GetProperty((PropertyInt)def.Ints[0].PropId);
+                            if (pv.HasValue) v = pv.Value;
+                        }
+                    }
+                    else if (!v.HasValue && def.Ints != null && def.Ints.Length > 0)
+                        v = wo.GetProperty((PropertyInt)def.Ints[0].PropId);
+                    if (!v.HasValue)
+                    {
+                        unparsable.Add($"{wo.Name} (0x{wo.Guid.Full:X8}): {def.Name} has no value on the line or the item");
+                        continue;
+                    }
+                    var grade = ZoneStatResolver.GradeFor(band.Min, band.Max, v.Value);
+                    Put(def.Key, grade);
+                    detail.Add($"{def.Name} {v.Value} in [{band.Min}-{band.Max}] -> {grade}");
+                }
+
+                // core four from the stamped Gear* props against the tier's window
+                foreach (var coreKey in ZoneStatResolver.CoreKeys)
+                {
+                    var pv = wo.GetProperty(ZoneStatResolver.CoreProp(coreKey));
+                    if (!pv.HasValue) continue;
+                    var (cmin, cmax) = ZoneStatResolver.CoreWindow(coreKey, tier);
+                    var grade = ZoneStatResolver.GradeFor(cmin, cmax, pv.Value);
+                    Put(coreKey, grade);
+                    detail.Add($"{ZoneStatResolver.CoreName(coreKey)} {pv.Value} in [{cmin}-{cmax}] -> {grade}");
+                }
+
+                // key 25 Armor Level: only an Armor piece above the tier base, and only when the line exists
+                if (hasArmorLevelLine && wo.ItemType == ItemType.Armor && wo.ArmorLevel.HasValue
+                    && wo.ArmorLevel.Value > ZoneStatResolver.BaseArmorLevel(tier))
+                {
+                    var (amin, amax) = ZoneStatResolver.EffectiveBand(25, tier);
+                    var bonus = wo.ArmorLevel.Value - ZoneStatResolver.BaseArmorLevel(tier);
+                    var grade = ZoneStatResolver.GradeFor(amin, amax, bonus);
+                    Put(25, grade);
+                    detail.Add($"Armor Level +{bonus} in [{amin}-{amax}] -> {grade}");
+                }
+
+                if (records.Count == 0)
+                {
+                    unparsable.Add($"{wo.Name} (0x{wo.Guid.Full:X8}): no gradable line");
+                    continue;
+                }
+
+                var version = ZoneStatResolver.ResolveStamp(tier);   // must match what StampIdentity just wrote
+                var recordText = ZoneStatResolver.Format(records);
+                Msg($"{(dry ? "[dry] " : "")}{wo.Name} (0x{wo.Guid.Full:X8}) T{tier}: {string.Join("; ", detail)}");
+                if (dry) { migrated++; continue; }
+
+                ZoneStatResolver.Write(wo, records);
+                ZoneStatResolver.StampIdentity(wo, tier);
+                wo.ChangesDetected = true;
+                wo.SaveBiotaToDatabase();
+                migrated++;
+
+                var oid = wo.Guid.Full;
+                sql.AppendLine($"-- {wo.Name.Replace('\n', ' ')} T{tier}")
+                   .AppendLine($"INSERT INTO biota_properties_string (object_Id, type, value) VALUES ({oid}, {(int)PropertyString.ZcModifiers}, {SqlStr(recordText)}) ON DUPLICATE KEY UPDATE value=VALUES(value);")
+                   .AppendLine($"INSERT INTO biota_properties_int (object_Id, type, value) VALUES ({oid}, {(int)PropertyInt.ZcTier}, {tier}) ON DUPLICATE KEY UPDATE value=VALUES(value);")
+                   .AppendLine($"INSERT INTO biota_properties_int (object_Id, type, value) VALUES ({oid}, {(int)PropertyInt.ZcResolvedVersion}, {version}) ON DUPLICATE KEY UPDATE value=VALUES(value);");
+            }
+
+            string sqlNote = "";
+            if (!dry && sql.Length > 0)
+            {
+                try
+                {
+                    // next to the server binary (the seticon log's convention) - never a workstation path
+                    var path = System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory,
+                        $"T11_LiveStat_Migration_{DateTime.UtcNow:yyyy-MM-dd}.sql");
+                    var isNew = !System.IO.File.Exists(path);
+                    var block = new StringBuilder();
+                    if (isNew)
+                        block.AppendLine("-- T11 Live Stat Resolution migration (pre-grade pieces -> ZcModifiers grade records)")
+                             .AppendLine("-- Written by /zonecontrol ladder migrate; rows mirror what SaveBiotaToDatabase already wrote live.")
+                             .AppendLine("-- biota_properties_string type 50100 = ZcModifiers; biota_properties_int 50109 = ZcTier, 50110 = ZcResolvedVersion.")
+                             .AppendLine();
+                    block.AppendLine($"-- run {DateTime.UtcNow:yyyy-MM-dd HH:mm:ss} UTC by {session?.Player?.Name ?? "console"} on player {target.Name} ({migrated} pieces)");
+                    block.Append(sql).AppendLine();
+                    System.IO.File.AppendAllText(path, block.ToString());
+                    sqlNote = $" SQL appended to {path}.";
+                }
+                catch (Exception ex)
+                {
+                    sqlNote = $" SQL file NOT written: {ex.Message}";
+                }
+            }
+
+            Msg($"{(dry ? "[dry] " : "")}Migrate {target.Name}: {migrated} pieces {(dry ? "would be " : "")}migrated, {skippedHasRecord} skipped (already graded), " +
+                $"{skippedTier} skipped (tier out of range), {items.Count - skippedNoLines} Zone Control pieces of {items.Count} objects walked.{sqlNote}");
+            if (unparsable.Count > 0)
+            {
+                Msg($"Unparsable ({unparsable.Count}):");
+                foreach (var u in unparsable.Take(40)) Msg("  " + u);
+                if (unparsable.Count > 40) Msg($"  ... and {unparsable.Count - 40} more");
+            }
+        }
+
+        private static string CleanWire(string s) => (s ?? "").Replace('|', ' ').Replace(',', ' ').Replace('~', ' ').Replace('=', ' ');
+
+        /// <summary>The raw-SQL statements that write an appearance set into a weenie â€” shared by
+        /// bakemob (bake onto the SAME wcid) and clonemob (bake onto a fresh clone). Numeric-only
+        /// interpolation, except Name which is ASCII-sanitized at set time and quote-escaped here.
+        /// A Setup swap clears the weenie's own overlay first (parity with the runtime applier).</summary>
+        private static List<string> BuildAppearanceBakeSql(uint w, ZoneAppearance merged)
+        {
+            var bake = new List<string>();
+            void Did(int type, uint? v) { if (v.HasValue) bake.Add($"INSERT INTO `weenie_properties_d_i_d` (`object_Id`,`type`,`value`) VALUES ({w},{type},{v.Value}) ON DUPLICATE KEY UPDATE `value` = {v.Value}"); }
+            void Flt(int type, double? v) { if (v.HasValue) { var s = v.Value.ToString("0.####", CultureInfo.InvariantCulture); bake.Add($"INSERT INTO `weenie_properties_float` (`object_Id`,`type`,`value`) VALUES ({w},{type},{s}) ON DUPLICATE KEY UPDATE `value` = {s}"); } }
+
+            if (merged.SetupTableId.HasValue)
+            {
+                bake.Add($"DELETE FROM `weenie_properties_d_i_d` WHERE `object_Id` = {w} AND `type` IN (6,7)");
+                bake.Add($"DELETE FROM `weenie_properties_int` WHERE `object_Id` = {w} AND `type` = 3");
+                bake.Add($"DELETE FROM `weenie_properties_float` WHERE `object_Id` = {w} AND `type` = 12");
+                bake.Add($"DELETE FROM `weenie_properties_anim_part` WHERE `object_Id` = {w}");
+                bake.Add($"DELETE FROM `weenie_properties_palette` WHERE `object_Id` = {w}");
+                bake.Add($"DELETE FROM `weenie_properties_texture_map` WHERE `object_Id` = {w}");
+            }
+            Did(1, merged.SetupTableId); Did(2, merged.MotionTable); Did(3, merged.SoundTable);
+            Did(6, merged.PaletteBase); Did(7, merged.ClothingBase); Did(8, merged.Icon);
+            if (merged.PaletteTemplate.HasValue) bake.Add($"INSERT INTO `weenie_properties_int` (`object_Id`,`type`,`value`) VALUES ({w},3,{merged.PaletteTemplate.Value}) ON DUPLICATE KEY UPDATE `value` = {merged.PaletteTemplate.Value}");
+            if (merged.Shiny.HasValue) bake.Add(merged.Shiny.Value
+                ? $"INSERT INTO `weenie_properties_int` (`object_Id`,`type`,`value`) VALUES ({w},9038,1) ON DUPLICATE KEY UPDATE `value` = 1"
+                : $"DELETE FROM `weenie_properties_int` WHERE `object_Id` = {w} AND `type` = 9038");
+            Flt(12, merged.Shade); Flt(39, merged.Scale); Flt(76, merged.Translucency);
+            if (!string.IsNullOrEmpty(merged.Name))
+            {
+                var esc = merged.Name.Replace("\\", "\\\\").Replace("'", "''");
+                bake.Add($"INSERT INTO `weenie_properties_string` (`object_Id`,`type`,`value`) VALUES ({w},1,'{esc}') ON DUPLICATE KEY UPDATE `value` = '{esc}'");
+            }
+            if (merged.AnimParts != null && merged.AnimParts.Count > 0)
+            {
+                bake.Add($"DELETE FROM `weenie_properties_anim_part` WHERE `object_Id` = {w}");
+                foreach (var p in merged.AnimParts)
+                    bake.Add($"INSERT INTO `weenie_properties_anim_part` (`object_Id`,`index`,`animation_Id`) VALUES ({w},{p.Index},{p.GfxObj})");
+            }
+            if (merged.TextureMaps != null && merged.TextureMaps.Count > 0)
+            {
+                bake.Add($"DELETE FROM `weenie_properties_texture_map` WHERE `object_Id` = {w}");
+                foreach (var t in merged.TextureMaps)
+                    bake.Add($"INSERT INTO `weenie_properties_texture_map` (`object_Id`,`index`,`old_Id`,`new_Id`) VALUES ({w},{t.Index},{t.OldTex},{t.NewTex})");
+            }
+            return bake;
+        }
+
+        /// <summary>The head part index of a Setup = the highest (max-Z) non-null part, using the first placement
+        /// frame that has one entry per part. Part index->bone mapping varies per setup, so the head is NOT a fixed
+        /// index (e.g. 16 on the void-lord but 14 on the Mosswart). Returns -1 if no placement data.</summary>
+        private static int SetupHeadIndex(SetupModel setup)
+        {
+            var pf = setup.PlacementFrames.Values
+                .FirstOrDefault(p => p.AnimFrame?.Frames != null && p.AnimFrame.Frames.Count >= setup.Parts.Count);
+            if (pf == null) return -1;
+            int headIdx = -1; float maxZ = float.NegativeInfinity;
+            for (int i = 0; i < setup.Parts.Count; i++)
+                if (setup.Parts[i] != 0x010001EC && pf.AnimFrame.Frames[i].Origin.Z > maxZ) { maxZ = pf.AnimFrame.Frames[i].Origin.Z; headIdx = i; }
+            return headIdx;
+        }
+
+        /// <summary>Rough anatomical label per Setup part from placement position (part index->bone varies per setup,
+        /// so labels are GEOMETRIC, not authoritative): the max-Z real part = "head", others = [L|R ] upper/mid/
+        /// lower/foot by height + X sign, null parts (0x010001EC) = "empty".</summary>
+        private static string[] SetupPartLabels(SetupModel setup, int headIdx)
+        {
+            var labels = new string[setup.Parts.Count];
+            var pf = setup.PlacementFrames.Values
+                .FirstOrDefault(p => p.AnimFrame?.Frames != null && p.AnimFrame.Frames.Count >= setup.Parts.Count);
+            float zmin = float.MaxValue, zmax = float.MinValue, ymin = float.MaxValue, ymax = float.MinValue;
+            if (pf != null)
+                for (int i = 0; i < setup.Parts.Count; i++)
+                {
+                    var o = pf.AnimFrame.Frames[i].Origin;
+                    if (o.Z < zmin) zmin = o.Z; if (o.Z > zmax) zmax = o.Z;
+                    if (o.Y < ymin) ymin = o.Y; if (o.Y > ymax) ymax = o.Y;
+                }
+            // Only add a front/back axis when the body has real front-back spread relative to its height - i.e.
+            // long/flat creatures (armoredillo). A tall humanoid (height >> depth) stays without it, so its labels
+            // don't gain noise. +Y = forward (the facing direction); may read inverted on oddly-authored models.
+            bool useDepth = pf != null && (ymax - ymin) > 0.6f * (zmax - zmin);
+            for (int i = 0; i < setup.Parts.Count; i++)
+            {
+                if (i == headIdx) { labels[i] = "head"; continue; }
+                if (setup.Parts[i] == 0x010001EC) { labels[i] = "empty"; continue; }
+                if (pf == null) { labels[i] = "part " + i; continue; }
+                var o = pf.AnimFrame.Frames[i].Origin;
+                float zn = zmax > zmin ? (o.Z - zmin) / (zmax - zmin) : 0.5f;
+                string band = zn >= 0.78f ? "upper" : zn >= 0.5f ? "mid" : zn >= 0.22f ? "lower" : "foot";
+                string side = o.X < -0.06f ? "L " : o.X > 0.06f ? "R " : "";
+                string depth = "";
+                if (useDepth)
+                {
+                    float yn = ymax > ymin ? (o.Y - ymin) / (ymax - ymin) : 0.5f;
+                    depth = yn >= 0.70f ? " fwd" : yn <= 0.30f ? " back" : "";
+                }
+                labels[i] = side + band + depth;
+            }
+            return labels;
+        }
+
+        /// <summary>Parse a DataId: "0x02001234" (hex) or a plain decimal uint. Used by the appearance DataId levers.</summary>
+        private static bool TryParseDid(string s, out uint value)
+        {
+            s = (s ?? "").Trim();
+            if (s.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+                return uint.TryParse(s.Substring(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out value);
+            return uint.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out value);
+        }
+
+        /// <summary>Human-readable one-liner for a zone's DoT config (command echoes + show).</summary>
+        private static string DescribeDot(ZoneEffects e)
+        {
+            string dot;
+            if (!e.EffectiveDotEnabled) dot = "DoT off";
+            else
+            {
+                var amount = e.EffectiveDotPercent
+                    ? $"{e.EffectiveDotDamage:0.##} pct max health"
+                    : $"{e.EffectiveDotDamage:0.##} {(DamageType)e.EffectiveDotDamageType}";
+                dot = $"DoT ON: {amount} every {Math.Max(1.0, e.EffectiveDotIntervalSeconds):0.##}s";
+            }
+
+            string sup;
+            if (!e.EffectiveSuppressEnabled) sup = "Suppression off";
+            else sup = $"Suppression ON: Prodigal regen {(e.EffectiveSuppressProdigal ? "blocked" : "allowed")}, " +
+                       $"regen {e.EffectiveSuppressRegenMult * 100.0:0.##} pct";
+
+            return dot + "; " + sup;
+        }
+
+        private static readonly string[] DamageTypeNames =
+            { "slash", "pierce", "bludgeon", "cold", "fire", "acid", "electric", "health", "stamina", "mana", "nether" };
+
+        /// <summary>Parse a single-flag damage type by name (case-insensitive) or by raw flag int (what the
+        /// plugin sends); rejects Undef and multi-flag values.</summary>
+        private static bool TryParseDamageType(string s, out DamageType dt)
+        {
+            dt = DamageType.Undef;
+            if (string.IsNullOrWhiteSpace(s)) return false;
+            s = s.Trim();
+            // raw flag int (e.g. 16 = Fire) â€” the plugin combo sends these
+            if (int.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var iv))
+                dt = (DamageType)iv;
+            else if (!Enum.TryParse(s, true, out dt))
+                return false;
+            return dt != DamageType.Undef && Enum.IsDefined(typeof(DamageType), dt) && !dt.IsMultiDamage();
+        }
+
+        private static string NormalizeStat(string s)
+        {
+            s = s.Trim().ToLowerInvariant();
+            return ZoneStat.All.FirstOrDefault(k => k.Equals(s, StringComparison.OrdinalIgnoreCase));
+        }
+
+        /// <summary>Parse a CombatBodyPart by enum name (case-insensitive) or raw int; rejects Undefined.</summary>
+        private static bool TryParseBodyPart(string s, out CombatBodyPart part)
+        {
+            part = CombatBodyPart.Undefined;
+            if (string.IsNullOrWhiteSpace(s)) return false;
+            s = s.Trim();
+            if (int.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var iv))
+                part = (CombatBodyPart)iv;
+            else if (!Enum.TryParse(s, true, out part))
+                return false;
+            return part != CombatBodyPart.Undefined && Enum.IsDefined(typeof(CombatBodyPart), part);
+        }
+
+        /// <summary>Parse a DamageType MASK: raw flag int (multi-flag ok) or a single enum name.</summary>
+        private static bool TryParseDamageMask(string s, out int mask)
+        {
+            mask = 0;
+            if (string.IsNullOrWhiteSpace(s)) return false;
+            s = s.Trim();
+            if (int.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var iv) && iv > 0)
+            {
+                mask = iv;
+                return true;
+            }
+            if (Enum.TryParse<DamageType>(s, true, out var dt) && dt != DamageType.Undef)
+            {
+                mask = (int)dt;
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>Resolve a property id from a raw int or the matching Property{Int,Int64,Float,Bool} enum
+        /// name. Label comes back as "Name (id)" for command echoes.</summary>
+        private static bool TryParsePropId(string type, string s, out int id, out string label)
+        {
+            id = 0; label = null;
+            if (string.IsNullOrWhiteSpace(s)) return false;
+            s = s.Trim();
+
+            Type enumType = type switch
+            {
+                "int" => typeof(PropertyInt),
+                "int64" => typeof(PropertyInt64),
+                "float" => typeof(PropertyFloat),
+                "bool" => typeof(PropertyBool),
+                _ => null,
+            };
+            if (enumType == null) return false;
+
+            if (int.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var iv))
+            {
+                id = iv;
+                // Enum.IsDefined(type, int) THROWS when the enum's underlying type is not int (PropertyBool is
+                // ushort) - "Enum underlying type and the object must be same type" on every `prop bool <id>`,
+                // i.e. every Rank button click (owner 2026-09-03). Box through the enum's own type first.
+                if (iv <= 0 || iv > ushort.MaxValue) return false;   // every Property* enum is ushort - never let 65537 box to 1 (review 2026-09-03)
+                string enumName = null;
+                var boxed = Enum.ToObject(enumType, iv);
+                if (Enum.IsDefined(enumType, boxed)) enumName = boxed.ToString();
+                label = enumName != null ? $"{enumName} ({iv})" : $"#{iv}";
+                return true;
+            }
+
+            try
+            {
+                var parsed = Enum.Parse(enumType, s, true);
+                id = Convert.ToInt32(parsed);
+                label = $"{parsed} ({id})";
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static bool IsPropBlocked(string type, int id) => type switch
+        {
+            "int" => ZonePropGuard.IsBlockedInt(id),
+            "int64" => ZonePropGuard.IsBlockedInt64(id),
+            "float" => ZonePropGuard.IsBlockedFloat(id),
+            "bool" => ZonePropGuard.IsBlockedBool(id),
+            _ => true,
+        };
+
+        /// <summary>Wire-safe display string: the [[ZCS]] separators (| , ~ =) replaced with spaces.</summary>
+        private static string SurveySafe(string s)
+            => (s ?? "").Replace('|', ' ').Replace(',', ' ').Replace('~', ' ').Replace('=', ' ');
+
+        // â”€â”€ Quests tab ([[ZCQ]]) â”€â”€
+        private const double QuestPullCooldownSeconds = 60.0;
+        private static readonly ConcurrentDictionary<Session, DateTime> _questPulls = new();
+
+        /// <summary>[[ZCQ]] text fields keep commas (fields split on '|', k=v on FIRST '='); '~' only
+        /// matters inside the tg= list, escaped separately.</summary>
+        private static string QuestSafe(string s)
+            => (s ?? "").Replace('|', ' ').Replace('\r', ' ').Replace('\n', ' ');
+
+        /// <summary>NPC coords go on the wire as SIGNED DECIMALS - "30.3S, 94.8E" becomes
+        /// "|cy=-30.3|cx=94.8" (N/E positive, S/W negative) - never as coordinate-SHAPED text.
+        ///
+        /// PROVEN 2026-07-30: something in the client stack reacts to a coordinate-shaped substring in a
+        /// chat line and re-renders that line, bypassing the plugin's chat interception entirely. Evidence:
+        /// of 24 [[ZCQ]] lines, the 9 with resolved NPC coords ALWAYS appeared in the player's chat box and
+        /// the 15 with an empty co= never did - including C1-C6, which are st=live but have no coords, so
+        /// it tracks the coordinate text and nothing else. The plugin's log proved all 24 were offered to
+        /// its handler and eaten every time. Every other payload ([[ZC]], [[ZCM]], [[ZCA]], [[ZCS]] at 90
+        /// messages) carries no coordinates and has never leaked.
+        ///
+        /// The plugin reassembles "30.3S, 94.8E" from cy/cx for display. Empty or unparseable -> empty
+        /// fields, which is what an unplaced NPC already produced.</summary>
+        private static string QuestCoordFields(string coords)
+        {
+            var s = (coords ?? "").Trim();
+            var comma = s.IndexOf(',');
+            if (comma > 0 &&
+                TryCoordPart(s.Substring(0, comma), 'N', 'S', out var cy) &&
+                TryCoordPart(s.Substring(comma + 1), 'E', 'W', out var cx))
+            {
+                return "|cy=" + cy.ToString("0.###", CultureInfo.InvariantCulture) +
+                       "|cx=" + cx.ToString("0.###", CultureInfo.InvariantCulture);
+            }
+            return "|cy=|cx=";
+        }
+
+        /// <summary>"30.3S" -> -30.3 (given pos 'N', neg 'S'). False if it isn't that shape.</summary>
+        private static bool TryCoordPart(string part, char pos, char neg, out double value)
+        {
+            value = 0;
+            part = (part ?? "").Trim();
+            if (part.Length < 2) return false;
+            var hemi = char.ToUpperInvariant(part[part.Length - 1]);
+            if (hemi != pos && hemi != neg) return false;
+            if (!double.TryParse(part.Substring(0, part.Length - 1).Trim(),
+                                 NumberStyles.Float, CultureInfo.InvariantCulture, out value))
+                return false;
+            if (hemi == neg) value = -value;
+            return true;
+        }
+
+        /// <summary>One [[ZCQ]] line per quest. Static registry fields plus the REQUESTING player's live
+        /// progress: pr=solves/max while the task is started, cd=cooldown seconds remaining (0 = ready).</summary>
+        private static string BuildQuestPayload(string zone, ZoneControlManager.ZoneQuestRow q, int index, Session session)
+        {
+            var sb = new StringBuilder();
+            sb.Append("[[ZCQ]]zone=").Append(zone)
+              .Append("|i=").Append(index)
+              .Append("|w=").Append(QuestSafe(q.Wave))
+              .Append("|cat=").Append(QuestSafe(q.Category))
+              .Append("|st=").Append(QuestSafe(q.Stage))
+              .Append("|ok=").Append(q.Wired ? 1 : 0)
+              .Append("|t=").Append(QuestSafe(q.Title))
+              .Append("|npc=").Append(QuestSafe(q.NpcName))
+              .Append("|wcid=").Append(q.NpcWcid)
+              .Append("|lb=").Append(q.LandblockHex)
+              .Append(QuestCoordFields(q.Coords))
+              .Append("|n=").Append(q.Count)
+              .Append("|rep=").Append(q.RepeatHours)
+              .Append("|rw=").Append(QuestSafe(q.Reward))
+              .Append("|obj=").Append(QuestSafe(q.Objective))
+              .Append("|tg=").Append(string.Join("~",
+                  (q.Targets ?? "").Split('~').Select(t => QuestSafe(t).Trim()).Where(t => t.Length > 0)));
+
+            // Live per-player progress (only meaningful for live rows with a real stamp)
+            var qm = session?.Player?.QuestManager;
+            var pr = "";
+            var cd = 0;
+            if (qm != null && !string.IsNullOrEmpty(q.QuestKey) &&
+                string.Equals(q.Stage, "live", StringComparison.OrdinalIgnoreCase))
+            {
+                var reg = qm.GetQuest(q.QuestKey);
+                if (reg != null)
+                    pr = reg.NumTimesCompleted + "/" + q.Count;
+                if (!string.IsNullOrEmpty(q.CompletedKey))
+                {
+                    var next = qm.GetNextSolveTime(q.CompletedKey);
+                    if (next != TimeSpan.MinValue && next != TimeSpan.MaxValue)
+                        cd = (int)Math.Max(0, next.TotalSeconds);
+                }
+            }
+            sb.Append("|pr=").Append(pr).Append("|cd=").Append(cd);
+            return sb.ToString();
+        }
+
+        /// <summary>One survey SUMMARY line per landblock:
+        /// [[ZCS]]zone=x|lb=F559|gens=4|creatures=5|monsters=4|types=Drudge~3,Skeleton~1|g=wcid~name~count,...
+        /// (types = distinct MONSTER CreatureTypes with distinct-wcid counts, most common first;
+        /// g = the top-level placed generators grouped by wcid â€” lets the plugin tint the map by generator).</summary>
+        private static string BuildSurveySummaryPayload(string zone, ZoneControlManager.SurveyRow row)
+        {
+            var monsters = row.Creatures.Where(c => c.IsMonster).ToList();
+            var types = monsters
+                .GroupBy(c => string.IsNullOrEmpty(c.Type) ? "Other" : c.Type)
+                .OrderByDescending(g => g.Count())
+                .ThenBy(g => g.Key, StringComparer.OrdinalIgnoreCase);
+
+            var sb = new StringBuilder();
+            sb.Append("[[ZCS]]zone=").Append(zone)
+              .Append("|lb=").Append(row.Landblock.ToString("X4"))
+              .Append("|gens=").Append(row.Generators)
+              .Append("|creatures=").Append(row.Creatures.Count)
+              .Append("|monsters=").Append(monsters.Count)
+              .Append("|types=").Append(string.Join(",", types.Select(g => SurveySafe(g.Key) + "~" + g.Count())))
+              .Append("|g=").Append(string.Join(",", row.PlacedGenerators.Select(g => g.Wcid + "~" + SurveySafe(g.Name) + "~" + g.Count)))
+              .Append("|terr=").Append(row.Terrain ?? "")
+              .Append("|terrbase=").Append(row.TerrainBase ?? "");
+            return sb.ToString();
+        }
+
+        /// <summary>Survey DETAIL for one landblock:
+        /// [[ZCS]]zone=x|lb=F559|detail=1|c=wcid~name~type~isMonster,...|g=wcid~name~count,...</summary>
+        private static string BuildSurveyDetailPayload(string zone, ZoneControlManager.SurveyRow row)
+        {
+            var sb = new StringBuilder();
+            sb.Append("[[ZCS]]zone=").Append(zone)
+              .Append("|lb=").Append(row.Landblock.ToString("X4"))
+              .Append("|detail=1");
+
+            sb.Append("|c=").Append(string.Join(",", row.Creatures.Select(c =>
+                c.Wcid + "~" + SurveySafe(c.Name) + "~" + SurveySafe(string.IsNullOrEmpty(c.Type) ? "-" : c.Type) + "~" + (c.IsMonster ? 1 : 0))));
+
+            sb.Append("|g=").Append(string.Join(",", row.PlacedGenerators.Select(g =>
+                g.Wcid + "~" + SurveySafe(g.Name) + "~" + g.Count)));
+
+            return sb.ToString();
+        }
+
+        /// <summary>Builds the "[[ZCG]]" generator-knob payload for the plugin's Generator Settings rows:
+        /// w=wcid~name~delay~radius~stagger~init~max (delay = first generator entry's; -1 = no entries).</summary>
+        private static string BuildGenInfoPayload(uint wcid, ACE.Entity.Models.Weenie weenie)
+        {
+            var name = (weenie.GetName() ?? ("wcid " + wcid)).Replace('|', ' ').Replace('~', ' ').Replace('=', ' ');
+            var delay = weenie.PropertiesGenerator != null && weenie.PropertiesGenerator.Count > 0
+                ? (weenie.PropertiesGenerator[0].Delay ?? 0f) : -1f;
+            float F(int id) => (float)(weenie.GetProperty((PropertyFloat)id) ?? 0);
+            int I(int id) => weenie.GetProperty((PropertyInt)id) ?? 0;
+            return $"[[ZCG]]w={wcid}~found=1~{name}~{delay:0.####}~{F(43):0.####}~{F(9034):0.####}~{I(82)}~{I(81)}";
+        }
+
+        /// <summary>Builds the "[[ZCI]]" weenie base-data payload for the plugin's Body Parts / Resists /
+        /// Weapon tabs: body-part table, creature resist + armor-vs floats, wielded weapons, spell count.
+        /// All data comes from the WEENIE (authoring baseline), not a live instance.</summary>
+        /// <summary>
+        /// `mobcheck` - does this monster actually work in this zone?
+        ///
+        /// Zone Control scales a mob from the zone + tier Default with NO opt-in property, so most of
+        /// a monster is automatic. What is left is a thin IDENTITY layer, and every one of its gaps
+        /// fails SILENTLY: a null species just quietly removes slayer from the mob's own loot, an
+        /// unauthored magic skill just quietly gets every cast resisted. Nothing anywhere told a dev
+        /// any of that. This is that missing surface (2026-08-31).
+        ///
+        /// Read-only. It writes nothing and fixes nothing - it names what to fix.
+        ///
+        /// TWO RENDERERS, ONE EVALUATION (2026-09-01): <see cref="EvaluateMobCheck"/> does all the
+        /// reading; this method renders it as chat text and <see cref="BuildMobCheckPayload"/> renders
+        /// the SAME record as the [[ZCMC]] wire payload the Bestiary &gt; Readiness panel draws. They
+        /// cannot drift into disagreeing about whether a mob is ready, which they would have the first
+        /// time either side gained a check.
+        /// </summary>
+        /// <summary>
+        /// `tier` - the PER-TIER TUNING GENERATOR (owner 2026-09-01).
+        ///
+        /// Per-tier tuning has to happen, but plain stats have no runtime tier ramp: every read site
+        /// calls EvaluatedProfile.Get with no tier argument, and the _t25 anchor lerp serves loot BANDS
+        /// only. The two ways to close that were (a) register _t25 twins and move ~12 combat hot-path
+        /// read sites onto GetT, or (b) generate the fifteen per-tier Defaults at AUTHORING time and let
+        /// the already-working Default stack serve them. Owner chose (b).
+        ///
+        /// Why (b) is the better shape and not just the safer one:
+        ///   - ZERO combat code changes. It reuses the VariationDefault path that monster_level proved
+        ///     working in game on 2026-09-01.
+        ///   - A runtime lerp can only ever draw a STRAIGHT LINE. Player power does not grow in a
+        ///     straight line: Creature and Item augs climb to their caps at T15 and then stop, and from
+        ///     T16 all growth is Triune. Evaluating the curve at authoring time means the curve can be
+        ///     any shape at all - the engine never sees it.
+        ///   - The fifteen values stay VISIBLE in the store. A dev can read what T17 actually gets
+        ///     instead of inferring it from two anchors and a formula.
+        /// The cost is that retuning means re-running the command. That is one line.
+        ///
+        /// Curves:
+        ///   augs   (default) - interpolate on the AUG LADDER, so a stat tracks the thing that actually
+        ///                      gates a player's ability to fight at that tier. Front-loaded: T15 lands
+        ///                      ~44 pct of the way from T11 to T25, not the 29 pct a straight line gives.
+        ///   linear           - plain lerp on (tier-11)/14, matching how the loot bands behave.
+        ///
+        /// Writes ONLY the stat named. Everything else on each tier Default is untouched, and the v11
+        /// anchor still supplies every stat below these (AnchoredDefaultProfileFor).
+        /// </summary>
+        private static void HandleTierTune(List<string> args, ZcRank rank, Action<string> Msg)
+        {
+            if (args.Count < 2)
+            {
+                Msg("Usage: tier <stat> <t11value> <t25value> [--curve augs|linear] [--rank regular|leader|boss]");
+                Msg("       tier show <stat> [--rank r]      what each tier is authored at (that rank row)");
+                Msg("       tier clear <stat> [--rank r]     drop it from every tier Default (that rank row)");
+                Msg("       tier curves                      the aug ladder this interpolates on");
+                Msg("       --rank (2026-09-02): author the Leader / Boss / Regular ROW instead of the Default row.");
+                return;
+            }
+
+            var verb = args[1];
+
+            if (verb.Equals("curves", StringComparison.OrdinalIgnoreCase))
+            {
+                Msg("Aug ladder - the interpolation basis for --curve augs:");
+                Msg("  tier   creature    item  triune    life   TOTAL   fraction");
+                var p11 = AugPowerAt(MinBoundedTier);
+                var p25 = AugPowerAt(MaxTunedTier);
+                for (var t = MinBoundedTier; t <= MaxTunedTier; t++)
+                {
+                    var row = ACE.Server.Managers.WeaponScaling.WeaponScalingManager.GetTier(t);
+                    var pw = AugPowerAt(t);
+                    var frac = p25 > p11 ? (pw - p11) / (double)(p25 - p11) : 0.0;
+                    Msg($"  T{t,-4} {row?.MinWieldCreature ?? 0,8} {row?.MinWieldAugs ?? 0,7} {row?.MinWieldTriune ?? 0,7} {LifeAugCap,7} {pw,7}   {frac,7:0.000}");
+                }
+                Msg($"  Life is a CONSTANT {LifeAugCap} - a real capped player is 6000 + 4000 + 4000 = 14000 augs,");
+                Msg("  then 500 Triune per tier from T16 (owner 2026-09-01). It shifts the curve, not its shape.");
+                return;
+            }
+
+            if (verb.Equals("show", StringComparison.OrdinalIgnoreCase))
+            {
+                if (args.Count < 3) { Msg("Usage: tier show <stat>"); return; }
+                var showStat = NormalizeStat(args[2]);
+                if (showStat == null) { Msg($"Unknown stat '{args[2]}'."); return; }
+                Msg($"{showStat} across the tier Defaults{RankTag(rank)}:");
+                var any = false;
+                for (var t = MinBoundedTier; t <= MaxTunedTier; t++)
+                {
+                    var prof = ZoneControlManager.GetVariationDefault(t)?.Profile?.RankLayer(rank, create: false);
+                    if (prof?.Stats != null && prof.Stats.TryGetValue(showStat, out var c) && c != null)
+                    { Msg($"  T{t,-4} {c.Evaluate(1),14:0.####}"); any = true; }
+                    else Msg($"  T{t,-4} {"(not authored)",14}");
+                }
+                if (!any) Msg("  Nothing authored. It falls through to the v11 anchor, or to code defaults.");
+                return;
+            }
+
+            if (verb.Equals("clear", StringComparison.OrdinalIgnoreCase))
+            {
+                if (args.Count < 3) { Msg("Usage: tier clear <stat>"); return; }
+                var clrStat = NormalizeStat(args[2]);
+                if (clrStat == null) { Msg($"Unknown stat '{args[2]}'."); return; }
+                var cleared = 0;
+                for (var t = MinBoundedTier; t <= MaxTunedTier; t++)
+                {
+                    var removed = false;
+                    ZoneControlManager.MutateVariationDefault(t, d =>
+                    {
+                        var row = d.Profile.RankLayer(rank, create: false);
+                        if (row != null) removed = row.Stats.Remove(clrStat);
+                    });
+                    if (removed) cleared++;
+                }
+                Msg($"Cleared {clrStat} from {cleared} tier Default(s){RankTag(rank)}.");
+                return;
+            }
+
+            // tier <stat> <t11> <t25> [--curve augs|linear]
+            var stat = NormalizeStat(verb);
+            if (stat == null) { Msg($"Unknown stat '{verb}'. See 'statlist'."); return; }
+            if (args.Count < 4
+                || !double.TryParse(args[2], NumberStyles.Float, CultureInfo.InvariantCulture, out var v11)
+                || !double.TryParse(args[3], NumberStyles.Float, CultureInfo.InvariantCulture, out var v25))
+            { Msg("Usage: tier <stat> <t11value> <t25value> [--curve augs|linear]"); return; }
+
+            var useAugs = true;
+            for (var i = 4; i < args.Count; i++)
+            {
+                if (args[i].Equals("--curve", StringComparison.OrdinalIgnoreCase) && i + 1 < args.Count)
+                {
+                    var c = args[i + 1];
+                    if (c.Equals("linear", StringComparison.OrdinalIgnoreCase)) useAugs = false;
+                    else if (c.Equals("augs", StringComparison.OrdinalIgnoreCase)) useAugs = true;
+                    else { Msg($"Unknown curve '{c}'. Use augs or linear."); return; }
+                }
+            }
+
+            var pw11 = AugPowerAt(MinBoundedTier);
+            var pw25 = AugPowerAt(MaxTunedTier);
+
+            Msg($"{stat}{RankTag(rank)}: T{MinBoundedTier} {v11:0.####} -> T{MaxTunedTier} {v25:0.####}  (curve: {(useAugs ? "augs" : "linear")})");
+            for (var t = MinBoundedTier; t <= MaxTunedTier; t++)
+            {
+                double frac;
+                if (useAugs && pw25 > pw11)
+                    frac = (AugPowerAt(t) - pw11) / (double)(pw25 - pw11);
+                else
+                    frac = (t - MinBoundedTier) / (double)(MaxTunedTier - MinBoundedTier);
+
+                var value = v11 + (v25 - v11) * frac;
+                var tier = t;    // captured per iteration - a shared loop variable would author the last tier fifteen times
+                ZoneControlManager.MutateVariationDefault(tier, d =>
+                    d.Profile.RankLayer(rank, create: true).Stats[stat] = new StatCurve { Base = value, Growth = 1.0, Additive = false });
+                Msg($"  T{tier,-4} {value,14:0.####}");
+            }
+            Msg($"Authored on {MaxTunedTier - MinBoundedTier + 1} tier Defaults{RankTag(rank)}. Stamped stats land on RESPAWN.");
+        }
+
+        /// <summary>Top of the band the tuning generator writes. The ladders in ZoneModifiers clamp to
+        /// the same 25.</summary>
+        private const int MaxTunedTier = 25;
+        private const int MinBoundedTier = ZoneControlManager.MinBoundedVariation;
+
+        /// <summary>Life augs are capped and UNGATED, so every real player at cap carries the same
+        /// 4,000 (owner 2026-09-01: "6k creature, 4k item, 4k life is the max a real player has").
+        /// TierHitGate does not read them - Life cannot distinguish two players, so it is a constant
+        /// offset here rather than a variable.</summary>
+        private const int LifeAugCap = 4000;
+
+        /// <summary>
+        /// Total aug power a player is expected to hold at a tier: the LIVE wield ladder
+        /// (WeaponScalingManager, the same rows TierHitGate gates on, so the tuning basis and the gate
+        /// can never drift) plus the flat Life cap.
+        ///
+        /// The shape this produces is why the default curve is not linear: Creature and Item climb to
+        /// their caps by T15 and then stop, and from T16 every remaining point is Triune. Growth is
+        /// therefore about +1,000 per tier to T15 and +500 per tier after it.
+        /// </summary>
+        private static int AugPowerAt(int tier)
+        {
+            var row = ACE.Server.Managers.WeaponScaling.WeaponScalingManager.GetTier(tier);
+            if (row == null)
+                return LifeAugCap;
+            return row.MinWieldCreature + row.MinWieldAugs + row.MinWieldTriune + LifeAugCap;
+        }
+
+        private static void HandleMobCheck(string zoneName, uint mobWcid, Action<string> Msg)
+        {
+            var r = EvaluateMobCheck(zoneName, mobWcid);
+            if (r.Error != null) { Msg(r.Error); return; }
+
+            void Ok(string t) => Msg("  ok    " + t);
+            void Warn(string t) => Msg("  WARN  " + t);
+
+            Msg($"{r.MobName} ({mobWcid}) in {zoneName} v{r.Variation}");
+
+            if (r.ZoneEnabled) Ok($"zone enabled at variation {r.Variation}");
+            else Warn($"zone '{zoneName}' is DISABLED - nothing below applies to a live spawn");
+
+            if (r.LevelSource == MobCheckSource.Zone) Ok($"level {r.Level} (zone monster_level)");
+            else if (r.LevelSource == MobCheckSource.Weenie) Warn($"level {r.Level} comes from the weenie - monster_level is not authored");
+            else Warn("no level at all - weenie has none and monster_level is not authored");
+
+            if (r.CreatureTypeSource == MobCheckSource.Weenie) Ok($"creature type {r.CreatureTypeName}");
+            else if (r.CreatureTypeSource == MobCheckSource.Zone) Ok($"creature type {r.CreatureTypeName} (zone fallback)");
+            else Warn("NO creature type - no slayer weapon can ever roll off this mob");
+
+            if (r.SpellCount > 0)
+            {
+                if (r.HasMagicSkill) Ok($"{r.BookSpells} book spell(s) + {r.ZoneSpells} zone-added, magic_skill {r.MagicSkill}");
+                else Warn($"casts {r.SpellCount} spell(s) but magic_skill is NOT authored - players will resist them");
+            }
+            else Ok("no spells - magic_skill not needed");
+
+            if (r.Exempt) Msg("  --    EXEMPT (master switch off): this zone leaves it alone - it plays as its weenie says; the rows below are what it WOULD get");
+            Ok("rank: " + r.RankLabel);
+
+            if (r.CoreMissing.Count == 0) Ok($"all {r.CoreTotal} core stats authored");
+            else Warn($"{r.CoreMissing.Count} of {r.CoreTotal} core stats NOT authored (weenie value passes through): {string.Join(", ", r.CoreMissing)}");
+
+            // A look BAKED onto the weenie by bakemob/clonemob is global and leaves no zone bucket
+            // (clonemob deletes it), so an absent bucket is NOT evidence of a stock look - only that
+            // this ZONE does not override the look. Worded as fact, and never counted as an issue.
+            if (r.HasZoneAppearance) Ok("appearance authored for this wcid in this zone");
+            else Msg("  --    no per-zone appearance override; the look comes from the weenie");
+
+            Msg(r.Issues == 0
+                ? "  => ready."
+                : $"  => {r.Issues} thing(s) to fix.");
+        }
+
+        /// <summary>Where a mobcheck value came from.</summary>
+        private enum MobCheckSource { None = 0, Weenie = 1, Zone = 2 }
+
+        /// <summary>The whole readiness answer for one monster in one zone. Built once by
+        /// <see cref="EvaluateMobCheck"/>; rendered as chat by <see cref="HandleMobCheck"/> and as the
+        /// [[ZCMC]] wire payload by <see cref="BuildMobCheckPayload"/>.</summary>
+        private sealed class MobCheckResult
+        {
+            public string Error;
+            public string MobName = "";
+            public int Variation;
+            public bool ZoneEnabled;
+            public string RankSource = "none";   // zone | weenie | none (2026-09-02)
+            public int Level;
+            public MobCheckSource LevelSource;
+            public int CreatureType;
+            public string CreatureTypeName = "";
+            public MobCheckSource CreatureTypeSource;
+            public int BookSpells, ZoneSpells;
+            public int SpellCount => BookSpells + ZoneSpells;
+            public bool HasMagicSkill;
+            public int MagicSkill;
+            public string RankLabel = "";
+            public bool Exempt;   // master switch OFF for this wcid in this zone (2026-09-03) - information, never an issue
+            public List<string> CoreMissing = new();
+            public int CoreTotal;
+            public bool HasZoneAppearance;
+
+            /// <summary>Count of WARN rows - the same number the chat renderer prints as "N thing(s) to
+            /// fix". Rank and appearance are information and never count.</summary>
+            public int Issues
+            {
+                get
+                {
+                    var n = 0;
+                    if (!ZoneEnabled) n++;
+                    if (LevelSource != MobCheckSource.Zone) n++;
+                    if (CreatureTypeSource == MobCheckSource.None) n++;
+                    if (SpellCount > 0 && !HasMagicSkill) n++;
+                    if (CoreMissing.Count > 0) n++;
+                    return n;
+                }
+            }
+        }
+
+        /// <summary>Read every readiness fact for one monster in one zone. READ ONLY.</summary>
+        private static MobCheckResult EvaluateMobCheck(string zoneName, uint mobWcid)
+        {
+            var area = ZoneControlManager.GetArea(zoneName);
+            if (area == null) return new MobCheckResult { Error = $"No zone '{zoneName}'." };
+
+            var weenie = ACE.Database.DatabaseManager.World.GetCachedWeenie(mobWcid);
+            if (weenie == null) return new MobCheckResult { Error = $"No weenie {mobWcid}." };
+
+            var eval = ZoneControlManager.EvaluateForDisplay(zoneName, mobWcid);
+            bool Has(string stat) => eval != null && eval.Values.ContainsKey(stat);
+            double Val(string stat) => eval != null && eval.Values.TryGetValue(stat, out var v) ? v : 0.0;
+
+            var r = new MobCheckResult
+            {
+                MobName = weenie.GetName() ?? ("wcid " + mobWcid),
+                Variation = area.Variation,
+                ZoneEnabled = area.Enabled,
+            };
+
+            // level - no ZoneStat existed before 2026-08-31, so a retail weenie kept its own
+            var weenieLevel = weenie.GetProperty(PropertyInt.Level) ?? 0;
+            if (Has(ZoneStat.MonsterLevel)) { r.Level = (int)Val(ZoneStat.MonsterLevel); r.LevelSource = MobCheckSource.Zone; }
+            else if (weenieLevel > 0) { r.Level = weenieLevel; r.LevelSource = MobCheckSource.Weenie; }
+            else r.LevelSource = MobCheckSource.None;
+
+            // species - a null one silently removes slayer from this mob's OWN loot
+            var ctype = weenie.GetProperty(PropertyInt.CreatureType) ?? 0;
+            // CreatureType is `: uint` - IsDefined THROWS on a type mismatch rather than returning
+            // false, so the boxed value must be uint, not int.
+            if (ctype > 0 && System.Enum.IsDefined(typeof(ACE.Entity.Enum.CreatureType), (uint)ctype))
+            {
+                r.CreatureType = ctype;
+                r.CreatureTypeName = ((ACE.Entity.Enum.CreatureType)ctype).ToString();
+                r.CreatureTypeSource = MobCheckSource.Weenie;
+            }
+            else if (Has(ZoneStat.MonsterCreatureType))
+            {
+                var zct = (int)Val(ZoneStat.MonsterCreatureType);
+                r.CreatureType = zct;
+                r.CreatureTypeName = System.Enum.IsDefined(typeof(ACE.Entity.Enum.CreatureType), (uint)zct)
+                    ? ((ACE.Entity.Enum.CreatureType)zct).ToString() : zct.ToString();
+                r.CreatureTypeSource = MobCheckSource.Zone;
+            }
+            else r.CreatureTypeSource = MobCheckSource.None;
+
+            // casting - authored spell damage lands on the mob's own magic skill unless overridden
+            r.BookSpells = weenie.PropertiesSpellBook?.Count ?? 0;
+            r.ZoneSpells = eval?.SpellRules?.Count(sr => !sr.Disabled) ?? 0;
+            r.HasMagicSkill = Has(ZoneStat.MagicSkill);
+            r.MagicSkill = r.HasMagicSkill ? (int)Val(ZoneStat.MagicSkill) : 0;
+
+            // rank (2026-09-02 rank layers): what this WCID RESOLVES at in this zone - the zone bucket's
+            // rank bools first, then the weenie's - and where that came from. Unranked reads the Default
+            // row only (and so pays the Default row's xp_kill); information, not a fault.
+            var (mcRank, mcRankSrc) = ZoneControlManager.ResolveRankForWcid(area, mobWcid);
+            r.RankSource = mcRankSrc;
+            r.Exempt = area.Profile.ExemptWcids != null && area.Profile.ExemptWcids.Contains(mobWcid);
+            r.RankLabel = mcRank == ZcRank.None
+                ? "unranked - Default row only"
+                : $"{ZoneRank.Label(mcRank)} (from {mcRankSrc}) - reads the {ZoneRank.Label(mcRank)} rows over Default";
+
+            // the stats that actually make a T11 monster. Unauthored means the WEENIE value passes
+            // through at every read site - nothing is code-defaulted for creatures.
+            var core = new[]
+            {
+                ZoneStat.MaxHealth, ZoneStat.Strength, ZoneStat.Endurance, ZoneStat.Coordination,
+                ZoneStat.Quickness, ZoneStat.Focus, ZoneStat.Self, ZoneStat.AttackSkill,
+                ZoneStat.MeleeDefense, ZoneStat.MissileDefense, ZoneStat.MagicDefense,
+                ZoneStat.ArmorLevel, ZoneStat.AttackDamage,
+                // offense coverage (2026-09-02, mob->player lane): what makes a T11 monster HIT like one
+                ZoneStat.DamageRating, ZoneStat.CritRating, ZoneStat.CritDamageRating, ZoneStat.PercentHpBase,
+            };
+            r.CoreTotal = core.Length;
+            r.CoreMissing = core.Where(c => !Has(c)).ToList();
+
+            r.HasZoneAppearance = area.AppearanceByWcid != null && area.AppearanceByWcid.ContainsKey(mobWcid);
+            return r;
+        }
+
+        /// <summary>
+        /// [[ZCMC]] - the machine twin of `mobcheck`, for the plugin Bestiary &gt; Readiness panel.
+        /// Emitted by the `mobcheckget` verb; `mobcheck` itself stays human-readable chat so the command
+        /// is still usable with no plugin installed. Fields are FACTS, not prose - the panel owns its own
+        /// wording, which is what lets the UI text follow the plugin style rules with no server deploy.
+        /// APPEND-ONLY: add new fields at the end, never reorder or remove.
+        /// </summary>
+        private static string BuildMobCheckPayload(string zoneName, uint mobWcid)
+        {
+            var r = EvaluateMobCheck(zoneName, mobWcid);
+            var sb = new StringBuilder();
+            sb.Append("[[ZCMC]]wcid=").Append(mobWcid);
+            if (r.Error != null)
+                return sb.Append("|found=0").ToString();
+
+            static string Safe(string s) => (s ?? "").Replace('|', ' ').Replace(',', ' ').Replace('=', ' ').Replace('~', ' ');
+
+            sb.Append("|found=1")
+              .Append("|zone=").Append(Safe(zoneName))
+              .Append("|var=").Append(r.Variation)
+              .Append("|name=").Append(Safe(r.MobName))
+              .Append("|enabled=").Append(r.ZoneEnabled ? 1 : 0)
+              .Append("|lvl=").Append(r.Level)
+              .Append("|lvlsrc=").Append((int)r.LevelSource)
+              .Append("|ctype=").Append(r.CreatureType)
+              .Append("|ctypename=").Append(Safe(r.CreatureTypeName))
+              .Append("|ctypesrc=").Append((int)r.CreatureTypeSource)
+              .Append("|book=").Append(r.BookSpells)
+              .Append("|zsp=").Append(r.ZoneSpells)
+              .Append("|mskill=").Append(r.HasMagicSkill ? 1 : 0)
+              .Append("|mskillval=").Append(r.MagicSkill)
+              .Append("|rank=").Append(Safe(r.RankLabel))
+              .Append("|coretotal=").Append(r.CoreTotal)
+              .Append("|coremissing=").Append(string.Join(",", r.CoreMissing))
+              .Append("|look=").Append(r.HasZoneAppearance ? 1 : 0)
+              .Append("|issues=").Append(r.Issues)
+              // APPEND-ONLY (2026-09-02): where the rank came from - zone bucket | weenie | none
+              .Append("|rank_src=").Append(r.RankSource)
+              // APPEND-ONLY (2026-09-03): master switch state
+              .Append("|exempt=").Append(r.Exempt ? 1 : 0);
+            return sb.ToString();
+        }
+
+        private static string BuildMobInfoPayload(uint wcid)
+
+        {
+            var weenie = ACE.Database.DatabaseManager.World.GetCachedWeenie(wcid);
+            if (weenie == null)
+                return $"[[ZCI]]wcid={wcid}|found=0";
+
+            var sb = new StringBuilder();
+            sb.Append("[[ZCI]]wcid=").Append(wcid)
+              .Append("|found=1|name=").Append((weenie.GetName() ?? ("wcid " + wcid)).Replace('|', ' ').Replace(',', ' ').Replace('=', ' '));
+
+            // attributes (weenie InitLevel): st=str,end,coord,quick,focus,self
+            uint A(PropertyAttribute a) => weenie.PropertiesAttribute != null && weenie.PropertiesAttribute.TryGetValue(a, out var pa) ? pa.InitLevel : 0;
+            sb.Append("|st=")
+              .Append(A(PropertyAttribute.Strength)).Append(',')
+              .Append(A(PropertyAttribute.Endurance)).Append(',')
+              .Append(A(PropertyAttribute.Coordination)).Append(',')
+              .Append(A(PropertyAttribute.Quickness)).Append(',')
+              .Append(A(PropertyAttribute.Focus)).Append(',')
+              .Append(A(PropertyAttribute.Self));
+
+            // vitals (weenie InitLevel â€” the SQL-authored base): vt=health,stamina,mana
+            uint V(PropertyAttribute2nd a) => weenie.PropertiesAttribute2nd != null && weenie.PropertiesAttribute2nd.TryGetValue(a, out var pv) ? pv.InitLevel : 0;
+            sb.Append("|vt=")
+              .Append(V(PropertyAttribute2nd.MaxHealth)).Append(',')
+              .Append(V(PropertyAttribute2nd.MaxStamina)).Append(',')
+              .Append(V(PropertyAttribute2nd.MaxMana));
+
+            // skills: sk=attack(best of the weapon/magic attack skills),melee_d,missile_d,magic_d
+            uint S(Skill s) => weenie.PropertiesSkill != null && weenie.PropertiesSkill.TryGetValue(s, out var ps) ? ps.InitLevel : 0;
+            var attackSkill = new[]
+            {
+                S(Skill.HeavyWeapons), S(Skill.LightWeapons), S(Skill.FinesseWeapons), S(Skill.MissileWeapons),
+                S(Skill.TwoHandedCombat), S(Skill.UnarmedCombat), S(Skill.WarMagic), S(Skill.VoidMagic),
+            }.Max();
+            sb.Append("|sk=")
+              .Append(attackSkill).Append(',')
+              .Append(S(Skill.MeleeDefense)).Append(',')
+              .Append(S(Skill.MissileDefense)).Append(',')
+              .Append(S(Skill.MagicDefense));
+
+            // ratings: rt=damage_rating,damage_resist_rating,crit_chance,crit_damage,crit_resist,crit_damage_resist
+            // (plugin accepts 2 or 6 fields - back/forward compatible)
+            // crit_chance/crit_damage are EFFECTIVE bases (chance in percent / final Nx multiplier):
+            // the best wielded weapon's props when present, engine defaults 10 / 2 otherwise - matching
+            // the REPLACE semantics of the crit_rating/crit_damage_rating zone stats.
+            int I(PropertyInt p) => weenie.PropertiesInt != null && weenie.PropertiesInt.TryGetValue(p, out var iv) ? iv : 0;
+            double critChanceBase = 10.0, critDamageBase = 2.0;
+            if (weenie.PropertiesCreateList != null)
+            {
+                foreach (var cl in weenie.PropertiesCreateList)
+                {
+                    if ((cl.DestinationType & DestinationType.Wield) == 0)
+                        continue;
+                    var wieldItem = ACE.Database.DatabaseManager.World.GetCachedWeenie(cl.WeenieClassId);
+                    if (wieldItem?.PropertiesFloat == null)
+                        continue;
+                    if (wieldItem.PropertiesFloat.TryGetValue(PropertyFloat.CriticalFrequency, out var cfb))
+                        critChanceBase = Math.Max(critChanceBase, cfb * 100.0);
+                    if (wieldItem.PropertiesFloat.TryGetValue(PropertyFloat.CriticalMultiplier, out var cmb))
+                        critDamageBase = Math.Max(critDamageBase, 1.0 + cmb);
+                }
+            }
+            sb.Append("|rt=").Append(I(PropertyInt.DamageRating)).Append(',').Append(I(PropertyInt.DamageResistRating))
+              .Append(',').Append(critChanceBase.ToString(CultureInfo.InvariantCulture))
+              .Append(',').Append(critDamageBase.ToString(CultureInfo.InvariantCulture))
+              .Append(',').Append(I(PropertyInt.CritResistRating)).Append(',').Append(I(PropertyInt.CritDamageResistRating));
+
+            // body parts: part=<key>,<baseArmor>,<dval>,<dvar>,<dtype>
+            if (weenie.PropertiesBodyPart != null)
+            {
+                foreach (var kv in weenie.PropertiesBodyPart.OrderBy(k => (int)k.Key))
+                {
+                    sb.Append("|part=").Append((int)kv.Key).Append(',')
+                      .Append(kv.Value.BaseArmor).Append(',')
+                      .Append(kv.Value.DVal).Append(',')
+                      .Append(kv.Value.DVar.ToString(CultureInfo.InvariantCulture)).Append(',')
+                      .Append((int)kv.Value.DType);
+                }
+            }
+
+            // creature-level resist + armor-vs multipliers (default 1.0), slash..nether order
+            double F(PropertyFloat p) => weenie.PropertiesFloat != null && weenie.PropertiesFloat.TryGetValue(p, out var v) ? v : 1.0;
+            sb.Append("|rs=")
+              .Append(F(PropertyFloat.ResistSlash).ToString(CultureInfo.InvariantCulture)).Append(',')
+              .Append(F(PropertyFloat.ResistPierce).ToString(CultureInfo.InvariantCulture)).Append(',')
+              .Append(F(PropertyFloat.ResistBludgeon).ToString(CultureInfo.InvariantCulture)).Append(',')
+              .Append(F(PropertyFloat.ResistFire).ToString(CultureInfo.InvariantCulture)).Append(',')
+              .Append(F(PropertyFloat.ResistCold).ToString(CultureInfo.InvariantCulture)).Append(',')
+              .Append(F(PropertyFloat.ResistAcid).ToString(CultureInfo.InvariantCulture)).Append(',')
+              .Append(F(PropertyFloat.ResistElectric).ToString(CultureInfo.InvariantCulture)).Append(',')
+              .Append(F(PropertyFloat.ResistNether).ToString(CultureInfo.InvariantCulture));
+            sb.Append("|am=")
+              .Append(F(PropertyFloat.ArmorModVsSlash).ToString(CultureInfo.InvariantCulture)).Append(',')
+              .Append(F(PropertyFloat.ArmorModVsPierce).ToString(CultureInfo.InvariantCulture)).Append(',')
+              .Append(F(PropertyFloat.ArmorModVsBludgeon).ToString(CultureInfo.InvariantCulture)).Append(',')
+              .Append(F(PropertyFloat.ArmorModVsFire).ToString(CultureInfo.InvariantCulture)).Append(',')
+              .Append(F(PropertyFloat.ArmorModVsCold).ToString(CultureInfo.InvariantCulture)).Append(',')
+              .Append(F(PropertyFloat.ArmorModVsAcid).ToString(CultureInfo.InvariantCulture)).Append(',')
+              .Append(F(PropertyFloat.ArmorModVsElectric).ToString(CultureInfo.InvariantCulture)).Append(',')
+              .Append(F(PropertyFloat.ArmorModVsNether).ToString(CultureInfo.InvariantCulture));
+
+            // wielded weapons from the create list:
+            // wield=<wcid>,<name>,<damage>,<variance>,<dtypeMask>,<speed>[,<critFreq>,<critMult>]
+            // critFreq/critMult are the weapon's own props; -1 = unset (engine defaults 0.1 / 1.0 apply).
+            // Plugin accepts 6 or 8 fields - back/forward compatible.
+            if (weenie.PropertiesCreateList != null)
+            {
+                foreach (var cl in weenie.PropertiesCreateList)
+                {
+                    if ((cl.DestinationType & DestinationType.Wield) == 0)
+                        continue;
+                    var item = ACE.Database.DatabaseManager.World.GetCachedWeenie(cl.WeenieClassId);
+                    if (item?.PropertiesInt == null || !item.PropertiesInt.TryGetValue(PropertyInt.Damage, out var dmg))
+                        continue; // wielded but not a damage-dealing weapon (armor, clothing)
+                    var dvar = item.PropertiesFloat != null && item.PropertiesFloat.TryGetValue(PropertyFloat.DamageVariance, out var v) ? v : 0.0;
+                    var dtype = item.PropertiesInt.TryGetValue(PropertyInt.DamageType, out var t) ? t : 0;
+                    var speed = item.PropertiesInt.TryGetValue(PropertyInt.WeaponTime, out var sp) ? sp : 0;
+                    var critFreq = item.PropertiesFloat != null && item.PropertiesFloat.TryGetValue(PropertyFloat.CriticalFrequency, out var cf) ? cf : -1.0;
+                    var critMult = item.PropertiesFloat != null && item.PropertiesFloat.TryGetValue(PropertyFloat.CriticalMultiplier, out var cm) ? cm : -1.0;
+                    sb.Append("|wield=").Append(cl.WeenieClassId).Append(',')
+                      .Append((item.GetName() ?? "?").Replace('|', ' ').Replace(',', ' ').Replace('=', ' ')).Append(',')
+                      .Append(dmg).Append(',')
+                      .Append(dvar.ToString(CultureInfo.InvariantCulture)).Append(',')
+                      .Append(dtype).Append(',')
+                      .Append(speed).Append(',')
+                      .Append(critFreq.ToString(CultureInfo.InvariantCulture)).Append(',')
+                      .Append(critMult.ToString(CultureInfo.InvariantCulture));
+                }
+            }
+
+            sb.Append("|spells=").Append(weenie.PropertiesSpellBook?.Count ?? 0);
+
+            // per-spell book rows for the Spells tab: spell=<id>,<chancePct>,<school>,<name>
+            // (chance decoded from the 2.0-base encoding: 2.029 -> 2.9)
+            if (weenie.PropertiesSpellBook != null)
+            {
+                foreach (var s in weenie.PropertiesSpellBook.OrderBy(s => s.Key))
+                {
+                    var sp = new ACE.Server.Entity.Spell(s.Key);
+                    var chancePct = (s.Value > 2.0f ? s.Value - 2.0f : s.Value / 100.0f) * 100.0;
+                    var spName = (sp.NotFound ? "unknown" : sp.Name ?? "unknown")
+                        .Replace('|', ' ').Replace(',', ' ').Replace('=', ' ');
+                    sb.Append("|spell=").Append(s.Key).Append(',')
+                      .Append(chancePct.ToString("0.###", CultureInfo.InvariantCulture)).Append(',')
+                      .Append(sp.NotFound ? "" : sp.School.ToString()).Append(',')
+                      .Append(spName);
+                }
+            }
+            return sb.ToString();
+        }
+    }
+}
+

--- a/Source/ACE.Server/Entity/AddEnchantmentResult.cs
+++ b/Source/ACE.Server/Entity/AddEnchantmentResult.cs
@@ -117,9 +117,10 @@ namespace ACE.Server.Entity
                         // handle special case to prevent message: Pumpkin Shield casts Web of Defense on you, refreshing Aura of Defense
                         var spellDuration = equip ? double.PositiveInfinity : spell.Duration;
 
-                        if (!equip && caster is Player player && (player.AugmentationIncreasedSpellDuration + player.LuminanceAugmentSpellDurationCount ?? 0) > 0)
+                        if (!equip && caster is Player player && ((player.AugmentationIncreasedSpellDuration + player.LuminanceAugmentSpellDurationCount ?? 0) > 0 || player.GetZoneModifierBonus(ACE.Server.Managers.ZoneControl.ZoneModifiers.SpellDurationLevels) > 0))
                         {
-                            spellDuration *= 1.0f + (player.AugmentationIncreasedSpellDuration * 0.2f);
+                            spellDuration *= 1.0f + (player.AugmentationIncreasedSpellDuration * 0.2f)
+                                + (player.GetZoneModifierBonus(ACE.Server.Managers.ZoneControl.ZoneModifiers.SpellDurationLevels) * 0.2f);
                             spellDuration += (((caster as Player).LuminanceAugmentSpellDurationCount ?? 0) * 0.05f);
                         }
                         var entryDuration = entry.Duration == -1 ? double.PositiveInfinity : entry.Duration;

--- a/Source/ACE.Server/Entity/BaseDamageMod.cs
+++ b/Source/ACE.Server/Entity/BaseDamageMod.cs
@@ -49,7 +49,19 @@ namespace ACE.Server.Entity
             DamageBonus += weapon.EnchantmentManager.GetDamageBonus();
             VarianceMod *= weapon.EnchantmentManager.GetVarianceMod();
 
-            DamageMod = (float)(weapon.GetProperty(PropertyFloat.DamageMod) ?? 1.0f) + weapon.EnchantmentManager.GetDamageMod();
+            // Weapon aug-scaling: a stamped T11+ launcher's quality roll GRADES the damage
+            // modifier, then the weapon's TIER scales it by however many tier steps the wielder's
+            // item augs have actually unlocked (replace semantics — launchers scale through the
+            // mod, never a flat term); authored DamageMod is the fallback whenever the system is
+            // off or the launcher is unstamped legacy.
+            // (zone lock: outside authored areas the graded launcher mod is suppressed - the
+            // authored DamageMod fallback IS the base-stats behaviour the lock lands on)
+            var baseDamageMod = !Managers.ZoneControl.ZoneControlManager.WeaponPowerSuppressed(weapon, wielder)
+                    && Managers.WeaponScaling.WeaponScalingCombat.TryGetLauncherDamageMod(weapon, wielder as Player, out var gradedMod)
+                ? gradedMod
+                : (float)(weapon.GetProperty(PropertyFloat.DamageMod) ?? 1.0f);
+
+            DamageMod = baseDamageMod + weapon.EnchantmentManager.GetDamageMod();
 
             if (weapon.IsEnchantable)
             {
@@ -59,6 +71,7 @@ namespace ACE.Server.Entity
 
                 DamageMod += wielder.EnchantmentManager.GetDamageMod();
             }
+
         }
     }
 }

--- a/Source/ACE.Server/Entity/DamageEvent.cs
+++ b/Source/ACE.Server/Entity/DamageEvent.cs
@@ -106,6 +106,11 @@ namespace ACE.Server.Entity
         public float PkDamageResistanceMod;
 
         public float DamageMitigated;
+        // pct-of-max-HP floor readout (2026-09-02): the floor value computed for this hit, the damage before
+        // the floor was applied, and whether the floor won. Player defenders only; 0 / false otherwise.
+        public float DebugPctHpFloor;
+        public float DebugPreFloorDamage;
+        public bool DebugPctHpFloorWon;
 
         /// <summary>Amount of damage absorbed by Mana Barrier on the defending player this hit.</summary>
         public uint AmountAbsorbed;
@@ -139,6 +144,7 @@ namespace ACE.Server.Entity
 
         /// <summary>Flat luminance melee/missile damage bonus added to base damage (for diagnostics).</summary>
         public long DebugLuminanceFlatDamageBonus;
+        public float WeaponScalingFlatBonus;
 
         /// <summary>Damage immediately before combat-pet-only physical mitigation multipliers (same as final for player defenders).</summary>
         public float DebugDamagePrePetPhysicalMitigation;
@@ -205,6 +211,15 @@ namespace ACE.Server.Entity
 
             if (defender.Invincible)
                 return 0.0f;
+
+            // T11+ HIT GATE (owner 2026-08-31): an under-augmented player cannot land on a
+            // tier-11+ monster at all. Checked BEFORE Overpower on purpose - Overpower bypasses
+            // evade, so leaving it first would let it punch straight through the gate.
+            if (!ACE.Server.Managers.ZoneControl.TierHitGate.CanHitOrTell(attacker, defender))
+            {
+                Evaded = true;
+                return 0.0f;
+            }
 
             // overpower
             if (attacker.Overpower != null)
@@ -327,6 +342,36 @@ namespace ACE.Server.Entity
             BaseDamage += damageBonus;
             DebugLuminanceFlatDamageBonus = damageBonus;
 
+            // Weapon aug-scaling (T11 weapon relevance): per-strike flat = k(quality) x
+            // min(wielder's item augs, tier cap). LIVE read every event, never baked (plan §6.2).
+            // Lands here post-roll beside the aug flat — NOT in BaseDamageMod.DamageBonus, which
+            // launcher DamageMod would multiply ~3.6-3.9x on atlatls (§6.1). 0 when the master
+            // switch is off / weapon unstamped / attacker not a player.
+            if (playerAttacker != null)
+            {
+                // zone lock: outside authored areas the aug-scaling flat term is 0 (and Scheme C
+                // variance below rides it, so both vanish together)
+                WeaponScalingFlatBonus = Managers.ZoneControl.ZoneControlManager.WeaponPowerSuppressed(Weapon, playerAttacker)
+                    ? 0f
+                    : Managers.WeaponScaling.WeaponScalingCombat.GetFlatBonus(Weapon, playerAttacker);
+
+                // Scheme C (2026-08-03): when the weapon has an authored family variance, the
+                // WHOLE envelope (weenie base + aug term) rolls down from max by the quality-
+                // tightened fraction — replacing the base-only roll + flat add, which made every
+                // endgame hit land within the weenie's few-point spread. The luminance aug flat
+                // (damageBonus, already in BaseDamage) stays flat and crit-blind as always.
+                // Crits are untouched: max-forced at the full envelope (below).
+                if (WeaponScalingFlatBonus > 0
+                    && Managers.WeaponScaling.WeaponScalingCombat.TryGetEffectiveVariance(Weapon, out var schemeCVariance))
+                {
+                    var envelopeMax = BaseDamageMod.MaxDamage + WeaponScalingFlatBonus;
+                    BaseDamage = damageBonus
+                        + envelopeMax * (float)ThreadSafeRandom.Next(1.0f - (float)schemeCVariance, 1.0f);
+                }
+                else
+                    BaseDamage += WeaponScalingFlatBonus;
+            }
+
             // get damage modifiers
             PowerMod = attacker.GetPowerMod(Weapon);
             AttributeMod = attacker.GetAttributeMod(Weapon);
@@ -387,19 +432,29 @@ namespace ACE.Server.Entity
                         luminanceAugmentBonus = cachedLuminanceAugmentCount.Value * luminanceAugmentCritDamageMultiplier;
                     }
 
-                    // Update the CriticalDamageMod to include luminance augment bonus
+                    // ══ UNIFIED CRIT MODEL (owner 2026-08-29, "all 3 schools get the same crit
+                    // treatment"): a critical hit deals exactly CritX x A MAX NORMAL HIT, where the
+                    // max normal hit includes EVERY flat (weapon max, lum-aug flat, weapon-scaling
+                    // term) under the normal rating chain, and CritX = the Crushing Blow multiplier
+                    // (default 2.0 = the retail "twice the maximum damage" rule) plus the lum-aug
+                    // crit term. Crit Damage RATING stacks ON TOP (owner ruling); the defender's
+                    // Crit Damage Resist mitigates afterwards, unchanged.
+                    //
+                    // This REPLACES the 2026-08-01 composition where the lum-aug flat was crit-blind
+                    // and a launcher's multiplied k-slice crit in full - the asymmetry that made bow
+                    // crits land ~7x a normal hit and forced the player_crit_damage_cap clamp. The
+                    // clamp is RETIRED with it: CritX IS the ratio, the Crushing Blow band is the cap.
                     CriticalDamageMod = 1.0f + WorldObject.GetWeaponCritDamageMod(Weapon, attacker, attackSkill, defender) + luminanceAugmentBonus;
 
-                    // NEW: Apply enrage multiplier if attacker is a mob and enraged
+                    // Apply enrage multiplier if attacker is a mob and enraged
                     if (attacker.IsEnraged && !(attacker is Player))
-                    {
                         CriticalDamageMod *= attacker.EnrageDamageMultiplier ?? 1.0f;
-                        //Console.WriteLine($"[DEBUG] CriticalDamageMod After Mob Attacker Enrage Multiplier: {CriticalDamageMod}");
-                    }
 
-                    // Calculate damage before mitigation
-                    DamageBeforeMitigation = BaseDamageMod.MaxDamage * AttributeMod * PowerMod * SlayerMod * DamageRatingMod * CriticalDamageMod;
+                    // the full non-crit ceiling, ALL flats included, normal rating chain
+                    var maxNormalHit = (BaseDamageMod.MaxDamage + DebugLuminanceFlatDamageBonus + WeaponScalingFlatBonus)
+                                       * AttributeMod * PowerMod * SlayerMod * DamageRatingMod;
 
+                    DamageBeforeMitigation = maxNormalHit * CriticalDamageMod;
 
                     CriticalDamageRatingMod = Creature.GetPositiveRatingMod(attacker.GetCritDamageRating());
 
@@ -410,16 +465,27 @@ namespace ACE.Server.Entity
                     if (pkBattle)
                         DamageRatingMod = Creature.AdditiveCombine(DamageRatingMod, PkDamageMod);
 
-                    DamageBeforeMitigation *= Creature.AdditiveCombine(CriticalDamageRatingMod, 1.0f); // Apply only crit bonus
+                    DamageBeforeMitigation *= Creature.AdditiveCombine(CriticalDamageRatingMod, 1.0f); // Crit Damage Rating ON TOP
 
+                    // player_crit_damage_cap RETIRED here 2026-08-29 (owner): under the unified
+                    // model the Crushing Blow band bounds the ratio by construction, so the clamp
+                    // that contained the old bow inflation has nothing left to contain.
                 }
             }
 
             // armor rending and cleaving
+            // (zone lock: outside authored areas a ZC weapon's Armor Rend stamp reads as absent)
             var armorRendingMod = 1.0f;
-            if (Weapon != null && Weapon.HasImbuedEffect(ImbuedEffectType.ArmorRending))
+            if (Weapon != null && Weapon.HasImbuedEffect(ImbuedEffectType.ArmorRending)
+                && !Managers.ZoneControl.ZoneControlManager.WeaponPowerSuppressed(Weapon, attacker))
             {
                 armorRendingMod = WorldObject.GetArmorRendingMod(attackSkill);
+
+                // Zone Control loot: per-weapon armor-rend amount (fraction of armor ignored) replaces
+                // the skill-scaled formula (cap 0.6) for weapons stamped by ZoneLootMutator
+                var armorRendOverride = Weapon.GetProperty((PropertyFloat)ACE.Server.Managers.ZoneControl.ZoneLootMutator.ArmorRendOverridePropId);
+                if (armorRendOverride.HasValue)
+                    armorRendingMod = 1.0f - (float)Math.Clamp(armorRendOverride.Value, 0.0, 1.0);
             }
             else if (attacker is CombatPet && attacker.HasImbuedEffect(ImbuedEffectType.ArmorRending))
             {
@@ -556,6 +622,28 @@ namespace ACE.Server.Entity
                 //Console.WriteLine($"[DEBUG] Final Mob Defender Enrage Damage Reduction Applied: {damageReduction * 100}%, Final Damage: {Damage}");
             }
 
+            // v11+ percent-HP floor: a high-variation monster always deals at least a %HP chunk to a player,
+            // bypassing life-aug damage reduction. Whichever is larger — normal mitigated damage or the floor — wins.
+            // Stamina/Mana guard FIXED 2026-08-21 (owner ruling): the magic path already
+            // excludes vital-drain damage types (SpellProjectile.cs) but this one did not, so
+            // a mob whose melee attack is Stamina- or Mana-typed applied a HEALTH-percent
+            // floor to the wrong vital.
+            if (defender is Player pctHpPlayer && attacker != null
+                && DamageType != DamageType.Stamina && DamageType != DamageType.Mana)
+            {
+                var pctHpFloor = Creature.GetPercentHpFloorDamage(attacker, pctHpPlayer, IsCritical);
+                // Debug readout (2026-09-02, mob->player tuning): the floor used to win SILENTLY here - the
+                // extensive block showed only the final Damage, so a floored hit and a normal hit were
+                // indistinguishable in the log. Recorded for BuildExtensiveDebugLog's "pctHpFloor:" line.
+                DebugPctHpFloor = pctHpFloor;
+                DebugPreFloorDamage = Damage;
+                if (pctHpFloor > Damage)
+                {
+                    Damage = pctHpFloor;
+                    DebugPctHpFloorWon = true;
+                }
+            }
+
             DebugDamagePrePetPhysicalMitigation = Damage;
             DebugCombatPetPhysicalMitigationMultiplier = 1.0f;
             DebugCombatPetCritDamageTakenMultiplier = 1.0f;
@@ -581,6 +669,16 @@ namespace ACE.Server.Entity
             }
 
             DamageMitigated = DamageBeforeMitigation - Damage;
+
+            // Zone Control pct-HP damage special (key 44, gauntlets): flat pct of the defender's max HP,
+            // added AFTER DamageMitigated is booked so no crit/armor/DRR/pet mitigation touches it (and the
+            // mitigation figure does not go negative). Player attacker vs a zone-profiled monster only;
+            // the NO-KILL rule, immune bool and per-character cooldown live in Player.ZcTryPctHpDamage.
+            if (Damage > 0 && playerAttacker != null && playerDefender == null)
+            {
+                Damage += playerAttacker.ZcTryPctHpDamage(defender);
+                playerAttacker.ZcTryLifeOnHit(defender);            // key 48 Life on Hit (heals the attacker; cooldown inside)
+            }
 
             //Console.WriteLine($"[DEBUG] Final Damage: {Damage}");
             return Damage;
@@ -673,6 +771,14 @@ namespace ACE.Server.Entity
             AccuracyMod = attacker.GetAccuracyMod(Weapon);
 
             EffectiveAttackSkill = attacker.GetEffectiveAttackSkill();
+
+            // v11+ attack-skill floor: ensure endgame monsters can land hits vs very high player defense.
+            if (defender is Player v11Player)
+            {
+                var skillFloor = Creature.GetV11AttackSkillFloor(attacker, v11Player);
+                if (skillFloor > EffectiveAttackSkill)
+                    EffectiveAttackSkill = skillFloor;
+            }
 
             //var attackType = attacker.GetCombatType();
 
@@ -984,6 +1090,14 @@ namespace ACE.Server.Entity
             {
                 log.Info(BuildCombatPetOutgoingDebugLine(petAttacker, defender));
             }
+
+            // Weapon-scaling tuning aid: player -> mob OUTGOING hits — the case the defender-side
+            // logger above deliberately excludes (defender must be Player/CombatPet there).
+            if (ServerConfig.damage_event_debug_player_vs_mob.Value
+                && attacker is Player && defender != null && !(defender is Player))
+            {
+                log.Info(BuildExtensiveDebugLog(attacker, defender));
+            }
         }
 
         private string BuildCombatPetOutgoingDebugLine(CombatPet pet, Creature defender)
@@ -1020,7 +1134,7 @@ namespace ACE.Server.Entity
                 sb.AppendLine("weapon: <none>");
 
             if (BaseDamageMod != null)
-                sb.AppendLine($"baseDamage: rolled={BaseDamage} range={BaseDamageMod.Range} lumFlatBonus={DebugLuminanceFlatDamageBonus} bonus={BaseDamageMod.DamageBonus} mod={BaseDamageMod.DamageMod:F4} elemental={BaseDamageMod.ElementalBonus}");
+                sb.AppendLine($"baseDamage: rolled={BaseDamage} range={BaseDamageMod.Range} lumFlatBonus={DebugLuminanceFlatDamageBonus} wsFlatBonus={WeaponScalingFlatBonus:F1} bonus={BaseDamageMod.DamageBonus} mod={BaseDamageMod.DamageMod:F4} elemental={BaseDamageMod.ElementalBonus}");
             else
                 sb.AppendLine($"baseDamage: rolled={BaseDamage} (no BaseDamageMod) lumFlatBonus={DebugLuminanceFlatDamageBonus}");
 
@@ -1051,6 +1165,9 @@ namespace ACE.Server.Entity
             sb.AppendLine(
                 $"final: prePetPhysicalMit={DebugDamagePrePetPhysicalMitigation:F4} petCritMult={DebugCombatPetCritDamageTakenMultiplier:F4} petPhysicalMult={DebugCombatPetPhysicalMitigationMultiplier:F4} Damage={Damage:F4} mitigated(from preArmor pipeline)={DamageMitigated:F4}");
             sb.AppendLine($"defenderHealth: current={defender.Health.Current} max={defender.Health.MaxValue}");
+            // mob->player only (2026-09-02): the pct-of-max-HP floor, the pre-floor damage, and whether the floor won
+            if (defender is Player)
+                sb.AppendLine($"pctHpFloor: value={DebugPctHpFloor:F2} preFloor={DebugPreFloorDamage:F2} won={DebugPctHpFloorWon}");
 
             AppendLuminanceCombatSnapshot(sb, "Attacker luminance", attacker);
             AppendLuminanceCombatSnapshot(sb, "Defender luminance", defender);

--- a/Source/ACE.Server/Entity/GeneratorProfile.cs
+++ b/Source/ACE.Server/Entity/GeneratorProfile.cs
@@ -314,13 +314,14 @@ namespace ACE.Server.Entity
                     // unnoticed until a variation Default authored spawn-snapshot stats for the first time.
                     // Safe: Spawn_Scatter and Spawn_Default both open by overwriting Location outright, so
                     // this value only ever survives long enough to be resolved against.
+                    var generatorVariation = Generator.Location?.Variation;   // null while the generator has no Location yet
                     if (Generator.Location != null)
                         wo.Location = new ACE.Entity.Position(Generator.Location);
 
                     CreatureVariantHelper.MaybeApplyRandomVariant(creature, (float)ServerConfig.creature_variant_chance.Value);
-                    PrestigeManager.ApplyPrestigeScaling(creature, Generator.Location.Variation);
+                    PrestigeManager.ApplyPrestigeScaling(creature, generatorVariation);
                     Managers.ZoneControl.ZoneSpawnScaler.ApplyToSpawn(creature);
-                    Managers.Rifts.RiftManager.TryApplyRiftScaling(creature, Generator.Location.Variation);
+                    Managers.Rifts.RiftManager.TryApplyRiftScaling(creature, generatorVariation);
                 }
 
                 if (Biota.PaletteId.HasValue && Biota.PaletteId > 0)

--- a/Source/ACE.Server/Entity/GeneratorProfile.cs
+++ b/Source/ACE.Server/Entity/GeneratorProfile.cs
@@ -250,6 +250,13 @@ namespace ACE.Server.Entity
         /// </summary>
         public List<WorldObject> Spawn()
         {
+            // boss groups: gens sharing a BossGroupId keep ONE spawn alive between them across any
+            // number of landblocks. Deny = drop this attempt BEFORE creating the object (a denied
+            // profile just retries next cycle — must not enter the FirstSpawn failed-slot path).
+            var bossGroup = Generator.GetProperty(PropertyInt.BossGroupId);
+            if (bossGroup != null && !BossGroupManager.TryClaimSpawn(bossGroup.Value, Generator, Delay))
+                return null;
+
             var objects = new List<WorldObject>();
 
             if (RegenLocationType.HasFlag(RegenLocationType.Treasure))
@@ -298,8 +305,22 @@ namespace ACE.Server.Entity
                 ConsecutiveSpawnFailures = 0;
                 if (wo is Creature creature && creature.IsMonster && creature.Attackable)
                 {
+                    // PROVISIONAL LOCATION (2026-07-30): zone resolution keys on Location (landblock +
+                    // variation), but the Spawn_* handlers below don't assign one until after this block —
+                    // so every generator-spawned mob resolved landblock 0, matched no zone, and silently
+                    // received NO spawn snapshot: attributes, max health/stamina/mana, crit resist ratings,
+                    // prop stamps and APPEARANCE were all skipped. Placed (landblock_instance) mobs were
+                    // unaffected because WorldObjectFactory sets Location first, which is why this went
+                    // unnoticed until a variation Default authored spawn-snapshot stats for the first time.
+                    // Safe: Spawn_Scatter and Spawn_Default both open by overwriting Location outright, so
+                    // this value only ever survives long enough to be resolved against.
+                    if (Generator.Location != null)
+                        wo.Location = new ACE.Entity.Position(Generator.Location);
+
                     CreatureVariantHelper.MaybeApplyRandomVariant(creature, (float)ServerConfig.creature_variant_chance.Value);
                     PrestigeManager.ApplyPrestigeScaling(creature, Generator.Location.Variation);
+                    Managers.ZoneControl.ZoneSpawnScaler.ApplyToSpawn(creature);
+                    Managers.Rifts.RiftManager.TryApplyRiftScaling(creature, Generator.Location.Variation);
                 }
 
                 if (Biota.PaletteId.HasValue && Biota.PaletteId > 0)
@@ -342,6 +363,17 @@ namespace ACE.Server.Entity
 
                 else
                     success = Spawn_Default(obj);
+
+                if (bossGroup != null && success)
+                    BossGroupManager.OnBossSpawned(bossGroup.Value, Generator, obj);
+
+                // The one that answers "who spawned this mob" - every object, tagged with its generator.
+                if (Generator.GenDiag)
+                    log.Warn($"[GenDiag] SPAWN {obj.Name} [{obj.WeenieClassId}] 0x{obj.Guid} " +
+                             $"by 0x{Generator.Guid}:{Generator.Name} [{Generator.WeenieClassId}] " +
+                             $"success={success} where={RegenLocationType} " +
+                             $"gen.CurrentCreate={Generator.CurrentCreate} gen.MaxCreate={Generator.MaxCreate} " +
+                             $"loc={obj.Location}");
 
                 // if first spawn fails, don't continually attempt to retry
                 if (success || FirstSpawn)
@@ -410,6 +442,11 @@ namespace ACE.Server.Entity
         public bool Spawn_Scatter(WorldObject obj)
         {
             float genRadius = (float)(Generator.GetProperty(PropertyFloat.GeneratorRadius) ?? 0f);
+
+            // boss groups: a runtime radius override (plugin/command tuning) beats the weenie value
+            var scatterBossGroup = Generator.GetProperty(PropertyInt.BossGroupId);
+            if (scatterBossGroup != null && BossGroupManager.GetRadiusOverride(scatterBossGroup.Value) is float ovRadius)
+                genRadius = ovRadius;
             obj.Location = new ACE.Entity.Position(Generator.Location);
 
             // Skipping using same offset code above for offsetting scatter pos due to issues with rotation that were not expected at time content was rebuilt (Colo, others)
@@ -446,6 +483,20 @@ namespace ACE.Server.Entity
             var success = obj.EnterWorld();
 
             obj.ScatterPos = null;
+
+            // Fallback: scatter can exhaust all NumTries when the terrain within genRadius is largely non-walkable
+            // (water, steep slopes, cliffs) -> the child silently fails to spawn and the camp comes up short/empty.
+            // The generator's own position is known-valid (it spawned there), so retry once there (no scatter). Better
+            // to cluster a member at the center than to drop it entirely.
+            if (!success)
+            {
+                obj.Location = new ACE.Entity.Position(Generator.Location);
+                obj.Location.PositionZ += 0.05f;
+                success = obj.EnterWorld();
+
+                if (!success)
+                    log.Warn($"[GENERATOR] 0x{Generator.Guid}:{Generator.WeenieClassId} {Generator.Name}.Spawn_Scatter({obj.Name}) - scatter AND center fallback both failed");
+            }
 
             return success;
         }
@@ -562,7 +613,9 @@ namespace ACE.Server.Entity
                 log.Warn($"[GENERATOR] 0x{Generator.Guid}:{Generator.WeenieClassId} {Generator.Name}.RemoveTreasure(): container not found");
                 return;
             }
-            foreach (var spawned in Spawned.Keys)
+            // Snapshot first: inventoryObj.Destroy -> NotifyGenerator -> Spawned.Remove would
+            // mutate the dictionary we're enumerating.
+            foreach (var spawned in new List<uint>(Spawned.Keys))
             {
                 var inventoryObjGuid = new ObjectGuid(spawned);
                 if (!container.Inventory.TryGetValue(inventoryObjGuid, out var inventoryObj))
@@ -618,12 +671,18 @@ namespace ACE.Server.Entity
 
             Spawned.Remove(woi.Guid.Full);
 
+            var bossGroup = Generator.GetProperty(PropertyInt.BossGroupId);
+            if (bossGroup != null)
+                BossGroupManager.OnBossRemoved(bossGroup.Value, woi.Guid.Full);
+
             NextAvailable = DateTime.UtcNow.AddSeconds(Delay);
         }
 
         public void Reset()
         {
-            foreach (var rNode in Spawned.Values)
+            // Snapshot first: wo.Destroy raises NotifyOfEvent(Destruction) -> NotifyGenerator ->
+            // Spawned.Remove, which would mutate the dictionary we're enumerating.
+            foreach (var rNode in new List<WorldObjectInfo>(Spawned.Values))
             {
                 var wo = rNode.TryGetWorldObject();
 
@@ -648,7 +707,9 @@ namespace ACE.Server.Entity
 
         public void KillAll()
         {
-            foreach (var rNode in Spawned.Values)
+            // Snapshot first: Smite -> death -> NotifyGenerator can call Spawned.Remove, which would
+            // mutate the dictionary we're enumerating and throw "Collection was modified".
+            foreach (var rNode in new List<WorldObjectInfo>(Spawned.Values))
             {
                 var wo = rNode.TryGetWorldObject();
 
@@ -661,7 +722,10 @@ namespace ACE.Server.Entity
 
         public void DestroyAll(bool fromLandblockUnload = false)
         {
-            foreach (var rNode in Spawned.Values)
+            // Snapshot first: wo.Destroy raises NotifyOfEvent(Destruction) -> NotifyGenerator ->
+            // Spawned.Remove, which would mutate the dictionary we're enumerating and throw
+            // "Collection was modified" (aborting removeinst/landblock-unload mid-destroy).
+            foreach (var rNode in new List<WorldObjectInfo>(Spawned.Values))
             {
                 var wo = rNode.TryGetWorldObject();
 

--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -283,6 +283,8 @@ namespace ACE.Server.Entity
                 // swaps). Clear it so the rebuilt payload lands; restart the watchdog counters.
                 CreateWorldObjectsCompleted = false;
                 initSpawnAttempts = 0;
+                initSpawnStillRunningLogged = false;
+                initSpawnGaveUpLogged = false;   // each reload may log the watchdog outcome again
             }
 
             StartInitSpawnTask(variationId);

--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -125,6 +125,7 @@ namespace ACE.Server.Entity
         /// These are static objects visible to all players in this variation.
         /// </summary>
         private readonly List<WorldObject> _prestigeBoundaryMarkers = new List<WorldObject>();
+        private readonly List<WorldObject> _zoneBoundaryMarkers = new List<WorldObject>();
 
         private readonly ActionQueue actionQueue = new();
 
@@ -227,8 +228,16 @@ namespace ACE.Server.Entity
 
             lastActiveTime = DateTime.UtcNow;
 
+            // Void detection (2026-07-26): the watchdog below needs to know how long this instance has
+            // existed, NOT how long a spawn task has been running - a landblock whose Init never ran has
+            // no task to measure. See CheckInitSpawnWatchdog.
+            constructedTime = DateTime.UtcNow;
+
             var cellLandblock = DBObj.GetCellLandblock(Id.Raw | 0xFFFF);
             PhysicsLandblock = new Physics.Common.Landblock(cellLandblock, variation);
+
+            if (ServerConfig.landblock_lifecycle_diag_verbose.Value)
+                log.Warn($"[LbLife] CONSTRUCT {Id.Landblock:X4} v={variation?.ToString() ?? "null"} raw={Id.Raw:X8}");
         }
 
 
@@ -239,22 +248,135 @@ namespace ACE.Server.Entity
         /// <param name="reload"></param>
         public void Init(int? variationId, bool reload = false)
         {
+            initCalled = true;
+
+            if (ServerConfig.landblock_lifecycle_diag_verbose.Value)
+                log.Warn($"[LbLife] INIT {Id.Landblock:X4} v={variationId?.ToString() ?? "null"} reload={reload}");
+
             if (!reload)
                 PhysicsLandblock.PostInit();
-            
-            Task.Run(() =>
+            else
             {
-                //Console.WriteLine($"Landblock.Init({Id}) task started, variation: {VariationId}, v: {variationId}");
-                CreateWorldObjects(variationId);
-                
-                SpawnDynamicShardObjects();
+                // A deliberate reload (/reload-landblock) reuses THIS Landblock object. The
+                // CreateWorldObjectsCompleted guard below exists to swallow duplicate watchdog
+                // RETRIES of the same load - but on a reload it swallowed the fresh spawn payload
+                // too, leaving the block EMPTY (found 2026-07-21 testing terrain-override camp
+                // swaps). Clear it so the rebuilt payload lands; restart the watchdog counters.
+                CreateWorldObjectsCompleted = false;
+                initSpawnAttempts = 0;
+            }
 
-                SpawnEncounters();
-
-                SetEnvironmentConditions();
-            });
+            StartInitSpawnTask(variationId);
 
             //LoadMeshes(objects);
+        }
+
+        // Void-landblock root cause (2026-07-18, F658 v11): this spawn work used to run in a bare
+        // Task.Run. An exception thrown before CreateWorldObjects could enqueue its spawn action
+        // (DB instance/shard queries, object factory) killed the task with ZERO trace — the landblock
+        // stayed registered, ticking and walkable (physics is built in the ctor) but permanently
+        // EMPTY until its scheduled unload. TaskScheduler.UnobservedTaskException was not hooked, so
+        // nothing could ever surface it. The catch below makes the death visible and the heartbeat
+        // watchdog (CheckInitSpawnWatchdog) retries it.
+        private Task initSpawnTask;
+        private int? initSpawnVariationId;
+        private int initSpawnAttempts;
+        private DateTime initSpawnStartedTime;
+        private bool initSpawnStillRunningLogged;
+
+        // 2026-07-26 (F559 v11): the above only guards a task that STARTED. A landblock constructed but
+        // never Init()'d has initSpawnTask == null, so the watchdog returned on its first line every
+        // heartbeat and the block stayed a walkable void for the whole session - exactly the state found
+        // on F559 v11 (base variation ticking, not one v11 guid ever created). These two track the
+        // never-began case so the watchdog can heal it.
+        private readonly DateTime constructedTime;
+        private bool initCalled;
+        private bool neverInitLogged;
+
+        private void StartInitSpawnTask(int? variationId)
+        {
+            initSpawnVariationId = variationId;
+            initSpawnAttempts++;
+            initSpawnStartedTime = DateTime.UtcNow;
+            initSpawnStillRunningLogged = false;
+
+            initSpawnTask = Task.Run(() =>
+            {
+                try
+                {
+                    CreateWorldObjects(variationId);
+
+                    SpawnDynamicShardObjects();
+
+                    SpawnEncounters();
+
+                    SetEnvironmentConditions();
+                }
+                catch (Exception ex)
+                {
+                    log.Error($"[VoidHeal] Landblock {Id.Landblock:X4} (Var {VariationId?.ToString() ?? "null"}) init spawn task FAILED (attempt {initSpawnAttempts}) - block would be a void without retry: {ex}");
+                }
+            });
+        }
+
+        /// <summary>
+        /// Heartbeat watchdog for the init spawn task: if the task ended (faulted or otherwise) without
+        /// CreateWorldObjects completing, the landblock is a void — retry up to 3 times. A task still
+        /// running past the threshold is logged once (DB stall) but not retried until it ends.
+        /// </summary>
+        private static readonly TimeSpan initSpawnWatchdogThreshold = TimeSpan.FromSeconds(60);
+
+        private void CheckInitSpawnWatchdog(DateTime thisHeartBeat)
+        {
+            if (CreateWorldObjectsCompleted)
+                return;
+
+            // NEVER-BEGAN void (2026-07-26): no spawn task was ever started on this instance. The old
+            // guard bailed here on `initSpawnTask == null` and could never see this, which is how F559
+            // v11 stayed empty for an entire session while the player stood on it. Anything registered
+            // this long with nothing created is a void by definition - start the spawn work.
+            if (initSpawnTask == null)
+            {
+                if (constructedTime + initSpawnWatchdogThreshold > thisHeartBeat)
+                    return;
+
+                if (!neverInitLogged)
+                {
+                    neverInitLogged = true;
+                    log.Error($"[VoidHeal] Landblock {Id.Landblock:X4} (Var {VariationId?.ToString() ?? "null"}) has been registered for " +
+                              $"{(thisHeartBeat - constructedTime).TotalSeconds:N0}s with NO init spawn task (Init called={initCalled}) - " +
+                              $"walkable VOID, starting spawn now.");
+                }
+
+                StartInitSpawnTask(VariationId);
+                return;
+            }
+
+            if (initSpawnStartedTime + initSpawnWatchdogThreshold > thisHeartBeat)
+                return;
+
+            if (!initSpawnTask.IsCompleted)
+            {
+                if (!initSpawnStillRunningLogged)
+                {
+                    initSpawnStillRunningLogged = true;
+                    log.Warn($"[VoidHeal] Landblock {Id.Landblock:X4} (Var {VariationId?.ToString() ?? "null"}) init spawn task still running after {initSpawnWatchdogThreshold.TotalSeconds:N0}s (attempt {initSpawnAttempts})");
+                }
+                return;
+            }
+
+            if (initSpawnAttempts >= 3)
+            {
+                if (!initSpawnStillRunningLogged)
+                {
+                    initSpawnStillRunningLogged = true;
+                    log.Error($"[VoidHeal] Landblock {Id.Landblock:X4} (Var {VariationId?.ToString() ?? "null"}) init spawn task never completed after {initSpawnAttempts} attempts - GIVING UP, block is a VOID (faulted={initSpawnTask.IsFaulted})");
+                }
+                return;
+            }
+
+            log.Error($"[VoidHeal] Landblock {Id.Landblock:X4} (Var {VariationId?.ToString() ?? "null"}) init spawn task ended without completing spawns (faulted={initSpawnTask.IsFaulted}) - RETRYING (attempt {initSpawnAttempts + 1}/3)");
+            StartInitSpawnTask(initSpawnVariationId);
         }
 
         public void SetEnvironmentConditions()
@@ -322,13 +444,46 @@ namespace ACE.Server.Entity
                 
             //    Console.WriteLine($"From: {new StackTrace()}");
             //}
-            var objects = DatabaseManager.World.GetCachedInstancesByLandblock(Id.Landblock, variationId);
-            var shardObjects = DatabaseManager.Shard.BaseDatabase.GetStaticObjectsByLandblock(Id.Landblock, variationId);
+            // Greater Rifts: instance rows are per-variation EXACT-match and rift variations (negative) have
+            // none — load the run's configured source variation's rows instead. The source copy may be LIVE
+            // at the same time, so rift copies get the rows CLONED with fresh dynamic guids (static guids
+            // shared across two live landblocks break guid-keyed lookups: selection, attack targeting).
+            // Shard statics stay out of rift copies. The factory below still stamps every spawned object
+            // with THIS landblock's variation. Pass-through for non-rift loads.
+            var instanceVariationId = ACE.Server.Managers.Rifts.RiftManager.ResolveInstanceSourceVariation(variationId);
+
+            List<ACE.Database.Models.World.LandblockInstance> objects;
+            List<ACE.Database.Models.Shard.Biota> shardObjects;
+            if (!Nullable.Equals(instanceVariationId, variationId))
+            {
+                objects = ACE.Server.Managers.Rifts.RiftManager.CloneInstancesForRift(
+                    DatabaseManager.World.GetCachedInstancesByLandblock(Id.Landblock, instanceVariationId));
+                shardObjects = new List<ACE.Database.Models.Shard.Biota>();
+            }
+            else
+            {
+                objects = DatabaseManager.World.GetCachedInstancesByLandblock(Id.Landblock, variationId);
+                shardObjects = DatabaseManager.Shard.BaseDatabase.GetStaticObjectsByLandblock(Id.Landblock, variationId);
+
+                // Zone Control terrain-override redirection (owner 2026-07-21): a zone that overrides
+                // this block's terrain at this variation swaps its standalone camp GENERATORS for ones
+                // drawn from the zone's blocks whose REAL terrain matches the override ("mark it
+                // obsidian, get the obsidian camps"). Rows are cloned (cache untouched), positions and
+                // guids stay, linked/quest instances are never swapped. No-op without an override.
+                objects = Managers.ZoneControl.ZoneControlManager.RedirectInstancesForTerrainOverride(
+                    Id.Landblock, variationId, objects);
+            }
+
             var factoryObjects = WorldObjectFactory.CreateNewWorldObjects(objects, shardObjects, null, variationId);
 
 
             actionQueue.EnqueueAction(new ActionEventDelegate(ActionType.Landblock_CreateWorldObjects, () =>
             {
+                // idempotence: the [VoidHeal] watchdog can retry the init spawn task; if a previous
+                // attempt's action already populated the block, drop this duplicate payload.
+                if (CreateWorldObjectsCompleted)
+                    return;
+
                 // for mansion linking
                 var houses = new List<House>();
                 foreach (var fo in factoryObjects)
@@ -353,9 +508,15 @@ namespace ACE.Server.Entity
                     }
 
                     var res = AddWorldObject(fo, variationId);
-                    if (!res)
+                    if (!res && ServerConfig.spawn_diag_verbose.Value)
                     {
-                        Console.WriteLine($"Failed to add world object {fo.Name}, {fo.Guid} to landblock {Id.Landblock}");
+                        // WARN, not console: a static lost here is invisible/unusable until the landblock
+                        // reloads, and the console does not survive restarts (Guttering Ward-Lantern
+                        // incident, 2026-07-18 20:21 — fingerprint was lost with the console).
+                        log.Warn($"[SpawnDiag] CreateWorldObjects failed to add 0x{fo.Guid}:{fo.Name} " +
+                                 $"[{fo.WeenieClassId} - {fo.WeenieType}] to landblock {Id.Landblock:X4} " +
+                                 $"lbVar={VariationId?.ToString() ?? "null"} param={variationId?.ToString() ?? "null"} " +
+                                 $"loc={fo.Location}");
                     }
                     fo.ActivateLinks(objects, shardObjects, parent);
 
@@ -365,8 +526,16 @@ namespace ACE.Server.Entity
 
                 CreateWorldObjectsCompleted = true;
 
-                // Spawn prestige boundary markers after normal objects
+                if (ServerConfig.landblock_lifecycle_diag_verbose.Value)
+                    // pendingAdditions included: AddWorldObject always stages new objects there
+                    // (they merge into worldObjects NEXT tick), so worldObjects.Count alone reads
+                    // 0 on a healthy fresh spawn — a false void-block alarm (owner 2026-08-02).
+                    log.Warn($"[LbLife] SPAWN-COMPLETE {Id.Landblock:X4} v={VariationId?.ToString() ?? "null"} " +
+                             $"attempt={initSpawnAttempts} objects={worldObjects.Count + pendingAdditions.Count}");
+
+                // Spawn boundary markers after normal objects (two independent systems, each self-gating)
                 SpawnPrestigeBoundaryMarkers();
+                SpawnZoneBoundaryMarkers();
 
                 PhysicsLandblock.SortObjects();
             }, ActionPriority.Low));
@@ -430,12 +599,16 @@ namespace ACE.Server.Entity
                     return;
                 }
 
-                marker.Name = "Prestige Boundary";
+                marker.Name = "Boundary Marker";
                 marker.SetProperty(PropertyFloat.DefaultScale, 2.5f);
-                
+
                 // Prevent despawning - make it persistent like static objects
                 marker.SetProperty(PropertyBool.Stuck, true);
                 marker.TimeToRot = -1;  // Never rot/despawn
+
+                // Ephemeral: re-derived at every load — must never be saved to the shard (persisted
+                // markers become permanent ghosts; 7000+ had accumulated in biota before this guard).
+                marker.SuppressShardPersistence = true;
 
                 // Use physics system to calculate proper position (like encounters do)
                 var pos = new Physics.Common.Position();
@@ -519,6 +692,176 @@ namespace ACE.Server.Entity
         }
 
         /// <summary>
+        /// Spawns Zone Control boundary perimeter markers (lanterns). Standalone system: consults only
+        /// <see cref="Managers.ZoneControl.ZoneControlManager"/> — markers appear on the edges of allowed
+        /// (bounded-zone member) landblocks that face landblocks outside the bounded union.
+        /// </summary>
+        private void SpawnZoneBoundaryMarkers()
+        {
+            // Boot-time landblocks (permaload) can reach here before any command touched Zone Control.
+            Managers.ZoneControl.ZoneControlManager.EnsureLoaded();
+
+            // Only spawn when a bounded zone exists at this landblock's variation
+            if (!Managers.ZoneControl.ZoneControlManager.HasBoundedZonesAt(VariationId))
+                return;
+
+            if (log.IsDebugEnabled)
+                log.Debug($"[ZoneControl] Landblock {Id.Landblock:X4} (Var {VariationId}): Checking boundary markers...");
+
+            // Only spawn markers in allowed (member) landblocks
+            if (!Managers.ZoneControl.ZoneControlManager.IsLandblockAllowed(VariationId, Id.Landblock))
+            {
+                if (log.IsDebugEnabled)
+                    log.Debug($"[ZoneControl] Landblock {Id.Landblock:X4} is outside the bounded union - skipping boundary markers.");
+                return;
+            }
+
+            var weenie = DatabaseManager.World.GetCachedWeenie((uint)ACE.Entity.Enum.WeenieClassName.W_SHOLANTERN_CLASS);
+            if (weenie == null)
+            {
+                log.Warn($"[ZoneControl] SpawnZoneBoundaryMarkers: W_SHOLANTERN_CLASS weenie not found!");
+                return;
+            }
+
+            // Edge boundaries (inset 10m from actual edge)
+            const float edgeMin = 10.0f;
+            const float edgeMax = 182.0f;
+            const int markersPerEdge = 6;
+
+            // Calculate evenly spaced positions including corners
+            float edgeLength = edgeMax - edgeMin;
+            float spacing = edgeLength / (markersPerEdge - 1);
+
+            bool MarkerExistsAt(List<WorldObject> markers, float x, float y)
+            {
+                const float cornerEpsilon = 0.25f;
+                foreach (var existing in markers)
+                {
+                    if (existing?.Location == null)
+                        continue;
+                    if (Math.Abs(existing.Location.PositionX - x) < cornerEpsilon && Math.Abs(existing.Location.PositionY - y) < cornerEpsilon)
+                        return true;
+                }
+                return false;
+            }
+
+            void SpawnMarkerAtPosition(float x, float y)
+            {
+                if (MarkerExistsAt(_zoneBoundaryMarkers, x, y))
+                    return;
+                // Cosmetic only: when another boundary system already placed a lantern on this exact spot
+                // (e.g. an overlapping perimeter at the same variation), don't stack a second one on top.
+                if (MarkerExistsAt(_prestigeBoundaryMarkers, x, y))
+                    return;
+
+                var marker = WorldObjectFactory.CreateNewWorldObject(weenie);
+                if (marker == null)
+                {
+                    log.Warn($"[ZoneControl] Failed to create marker WorldObject");
+                    return;
+                }
+
+                marker.Name = "Boundary Marker";
+                marker.SetProperty(PropertyFloat.DefaultScale, 2.5f);
+
+                // Prevent despawning - make it persistent like static objects
+                marker.SetProperty(PropertyBool.Stuck, true);
+                marker.TimeToRot = -1;  // Never rot/despawn
+
+                // Ephemeral: re-derived from the bounded union at every load — must never be saved to the
+                // shard (persisted markers become permanent ghosts that ignore later boundary changes).
+                marker.SuppressShardPersistence = true;
+
+                // Cosmetic best-effort: perimeter lanterns on a water-facing edge can land over open water
+                // where placement finds no floor (NoValidPosition). Skip those quietly instead of a [SpawnDiag] WARN.
+                marker.SuppressSpawnPlacementDiag = true;
+
+                // Use physics system to calculate proper position (like encounters do)
+                var pos = new Physics.Common.Position();
+                pos.ObjCellID = (uint)(Id.Landblock << 16) | 1;
+                pos.Variation = VariationId;
+                pos.Frame = new Physics.Animation.AFrame(new Vector3(x, y, 0), Quaternion.Identity);
+                pos.adjust_to_outside();
+
+                // Get terrain Z height
+                pos.Frame.Origin.Z = PhysicsLandblock.GetZ(pos.Frame.Origin);
+
+                marker.Location = new Position(pos.ObjCellID, pos.Frame.Origin, pos.Frame.Orientation, pos.Variation);
+                marker.Location.Variation = VariationId;
+
+                if (AddWorldObject(marker, VariationId))
+                {
+                    _zoneBoundaryMarkers.Add(marker);
+                }
+                else
+                {
+                    marker.Destroy();
+                }
+            }
+
+            void SpawnMarkersOnEdge(float fixedCoord, bool isXFixed)
+            {
+                for (int i = 0; i < markersPerEdge; i++)
+                {
+                    float offset = edgeMin + (i * spacing);
+                    float x = isXFixed ? fixedCoord : offset;
+                    float y = isXFixed ? offset : fixedCoord;
+                    SpawnMarkerAtPosition(x, y);
+                }
+            }
+
+            bool ShouldSpawnOnEdge(ushort neighborLB)
+            {
+                return !Managers.ZoneControl.ZoneControlManager.IsLandblockAllowed(VariationId, neighborLB);
+            }
+
+            // Check each cardinal direction and spawn markers on edges facing outside landblocks
+            // East edge (X = edgeMax)
+            if (Id.LandblockX < 255 && ShouldSpawnOnEdge(Id.East.Landblock))
+                SpawnMarkersOnEdge(edgeMax, true);
+
+            // West edge (X = edgeMin)
+            if (Id.LandblockX > 0 && ShouldSpawnOnEdge(Id.West.Landblock))
+                SpawnMarkersOnEdge(edgeMin, true);
+
+            // North edge (Y = edgeMax)
+            if (Id.LandblockY < 255 && ShouldSpawnOnEdge(Id.North.Landblock))
+                SpawnMarkersOnEdge(edgeMax, false);
+
+            // South edge (Y = edgeMin)
+            if (Id.LandblockY > 0 && ShouldSpawnOnEdge(Id.South.Landblock))
+                SpawnMarkersOnEdge(edgeMin, false);
+
+            if (_zoneBoundaryMarkers.Count > 0)
+            {
+                log.Info($"[ZoneControl] Landblock {Id.Landblock:X4} (Var {VariationId}): Spawned {_zoneBoundaryMarkers.Count} boundary markers.");
+            }
+        }
+
+        /// <summary>
+        /// Despawns and re-derives this landblock's Zone Control perimeter markers. Enqueued by
+        /// <see cref="Managers.LandblockManager.EnqueueRefreshLoadedZoneBoundaryMarkers"/> whenever a
+        /// mutation changes the bounded union at this landblock's variation.
+        /// </summary>
+        public void RefreshZoneBoundaryMarkers()
+        {
+            actionQueue.EnqueueAction(new ActionEventDelegate(ActionType.Landblock_CreateWorldObjects, () =>
+            {
+                foreach (var marker in _zoneBoundaryMarkers.ToList())
+                {
+                    if (marker == null)
+                        continue;
+
+                    RemoveWorldObject(marker.Guid, false, false, false);
+                    marker.Destroy();
+                }
+
+                _zoneBoundaryMarkers.Clear();
+                SpawnZoneBoundaryMarkers();
+            }));
+        }
+
+        /// <summary>
         /// Corpses<para />
         /// This will be called from a separate task from our constructor. Use thread safety when interacting with this landblock.
         /// </summary>
@@ -551,6 +894,13 @@ namespace ACE.Server.Entity
 
             // get the encounter spawns for this landblock
             var encounters = DatabaseManager.World.GetCachedEncountersByLandblock(Id.Landblock);
+
+            // Zone Control terrain-override redirection (owner 2026-07-21): a zone that overrides this
+            // block's terrain at this variation swaps in encounter generators from the zone's blocks
+            // whose REAL terrain matches the override ("mark it obsidian, get the obsidian camps").
+            // No-op when no override applies; independent of the zone's Enabled flag.
+            encounters = Managers.ZoneControl.ZoneControlManager.RedirectEncountersForTerrainOverride(
+                Id.Landblock, VariationId, encounters);
 
             foreach (var encounter in encounters)
             {
@@ -882,6 +1232,8 @@ namespace ACE.Server.Entity
             {
                 var thisHeartBeat = DateTime.UtcNow;
 
+                CheckInitSpawnWatchdog(thisHeartBeat);
+
                 ProcessPendingWorldObjectAdditionsAndRemovals();
 
                 // Decay world objects
@@ -896,31 +1248,51 @@ namespace ACE.Server.Entity
                     }
                 }
 
-                if (!Permaload && HasNoKeepAliveObjects)
+                // players.Count guard: an occupied landblock must never go dormant or unload, even when the
+                // player-heartbeat SetActive refresh fails to reach it (observed on variant instances entered
+                // via a same-landblock variation teleport: lastActiveTime froze at creation, the instance went
+                // dormant at +1min — passive mobs — and unloaded at exactly +5min WITH the player inside,
+                // destroying every non-persisted creature; rift test-5's vanishing guardian, and the all-day
+                // 0148 cell-raw unloads in the 2026-07-11 log during authoring).
+                if (!Permaload && HasNoKeepAliveObjects && players.Count == 0)
                 {
-                    if (lastActiveTime + dormantInterval < thisHeartBeat)
+                    // Variation-instance guard: a player can be physically standing on this landblock
+                    // (or an adjacent one) while registered on a DIFFERENT variation instance, so this
+                    // instance's `players` list is empty even though someone is right here. Without this
+                    // the v11 instance the player is actually interacting with goes dormant at +1min ->
+                    // Monster AI + physics ticking suppressed -> mobs go passive (missiles/magic pass
+                    // through stale physics, no aggro/attack) while melee still works. Judge presence by
+                    // physical position across all variations, not the (drifting) instance bookkeeping.
+                    if (lastActiveTime + dormantInterval < thisHeartBeat && HasPhysicalPlayerOnOrAdjacent())
                     {
-                        if (!IsDormant)
+                        SetActive();
+                    }
+                    else
+                    {
+                        if (lastActiveTime + dormantInterval < thisHeartBeat)
                         {
-                            var spellProjectiles = worldObjects.Values.Where(i => i is SpellProjectile).ToList();
-                            foreach (var spellProjectile in spellProjectiles)
+                            if (!IsDormant)
                             {
-                                spellProjectile.PhysicsObj.set_active(false);
-                                spellProjectile.Destroy();
+                                var spellProjectiles = worldObjects.Values.Where(i => i is SpellProjectile).ToList();
+                                foreach (var spellProjectile in spellProjectiles)
+                                {
+                                    spellProjectile.PhysicsObj.set_active(false);
+                                    spellProjectile.Destroy();
+                                }
                             }
-                        }
 
-                        IsDormant = true;
-                    }
-                    if (lastActiveTime + UnloadInterval < thisHeartBeat)
-                    {
-                        // log.Info($"[Landblock Unload] Landblock {Id.Raw:X8} queuing for destruction. (UnloadInterval: {UnloadInterval})");
-                        LandblockManager.AddToDestructionQueue(this, this.VariationId);
-                    }
-                    else if (IsDormant && (DateTime.UtcNow.Second % 10 == 0)) // Log periodically if dormant but not unloading
-                    {
-                        // Debug logging to see why it's not unloading
-                        // log.Warn($"[Landblock Debug] {Id.Raw:X8} Dormant. Time until unload: {(lastActiveTime + UnloadInterval - thisHeartBeat).TotalSeconds:F1}s");
+                            IsDormant = true;
+                        }
+                        if (lastActiveTime + UnloadInterval < thisHeartBeat)
+                        {
+                            // log.Info($"[Landblock Unload] Landblock {Id.Raw:X8} queuing for destruction. (UnloadInterval: {UnloadInterval})");
+                            LandblockManager.AddToDestructionQueue(this, this.VariationId);
+                        }
+                        else if (IsDormant && (DateTime.UtcNow.Second % 10 == 0)) // Log periodically if dormant but not unloading
+                        {
+                            // Debug logging to see why it's not unloading
+                            // log.Warn($"[Landblock Debug] {Id.Raw:X8} Dormant. Time until unload: {(lastActiveTime + UnloadInterval - thisHeartBeat).TotalSeconds:F1}s");
+                        }
                     }
                 }
                 else if (!Permaload && thisHeartBeat.Second % 15 == 0)
@@ -1359,8 +1731,12 @@ namespace ACE.Server.Entity
                                 log.Debug($"[GENERATOR] Rate-limiter: {suppressed} similar generator placement failures were suppressed in the last 5m.");
                         }
                     }
-                    else if (wo.ProjectileTarget == null && wo is not SpellProjectile)
-                        Console.WriteLine($"AddWorldObjectInternal: couldn't spawn 0x{wo.Guid}:{wo.Name} [{wo.WeenieClassId} - {wo.WeenieType}] at {wo.Location}");
+                    else if (wo.ProjectileTarget == null && wo is not SpellProjectile && ServerConfig.spawn_diag_verbose.Value)
+                        // WARN, not console (see CreateWorldObjects) — non-generator statics failing physics
+                        // placement are rare and each one is a quest object someone can't use.
+                        log.Warn($"[SpawnDiag] AddWorldObjectInternal: couldn't spawn 0x{wo.Guid}:{wo.Name} " +
+                                 $"[{wo.WeenieClassId} - {wo.WeenieType}] at {wo.Location} | " +
+                                 $"lb={Id.Landblock:X4} lbVar={this.VariationId?.ToString() ?? "null"} param={VariationId?.ToString() ?? "null"}");
 
                     return false;
                 }
@@ -1479,6 +1855,44 @@ namespace ACE.Server.Entity
             {
                 // really remove it - send message to client to remove object
                 wo.EnqueueActionBroadcast(p => p.RemoveTrackedObject(wo, fromPickup));
+
+                // Ghost-mob safety net (2026-07-17): the broadcast above only reaches the object's
+                // KnownPlayers. That inverse link can be torn while a client still holds the CreateObject
+                // (transient variation refusal in ObjectMaint.AddKnownPlayer during leash teleports;
+                // stale-known CO resends never re-added it) — that client then keeps a frozen "ghost"
+                // that never receives this delete. Sweep every player on this landblock instance and its
+                // same-variation adjacents and send the delete to any player the object did NOT know:
+                // a delete for a guid the client doesn't hold is a no-op, so over-sending is harmless.
+                if (!fromPickup)
+                {
+                    var notified = new HashSet<uint>();
+                    if (wo.PhysicsObj != null)
+                        foreach (var kp in wo.PhysicsObj.ObjMaint.GetKnownPlayersValuesAsPlayer())
+                            notified.Add(kp.Guid.Full);
+
+                    var missed = 0;
+                    void SweepLandblock(Landblock lb)
+                    {
+                        foreach (var p in lb.players.ToList())
+                        {
+                            if (p == null || p.Guid == wo.Guid || !notified.Add(p.Guid.Full))
+                                continue;
+                            missed++;
+                            var player = p;
+                            player.EnqueueAction(new ActionEventDelegate(ActionType.WorldObjectNetworking_BroadcastOther,
+                                () => player.RemoveTrackedObject(wo, false)));
+                        }
+                    }
+
+                    SweepLandblock(this);
+                    foreach (var adj in Adjacents.ToList())
+                        if (adj != null)
+                            SweepLandblock(adj);
+
+                    if (missed > 0 && wo is Creature && ServerConfig.prestige_interaction_diag_verbose.Value)
+                        log.Warn($"[GhostMob] {wo.Name}(0x{wo.Guid.Full:X8}) destroy on lb 0x{Id.Landblock:X4} v={VariationId?.ToString() ?? "null"}: " +
+                                 $"delete sent to {missed} nearby same-variation player(s) missing from KnownPlayers (one-way CO healed).");
+                }
 
                 wo.PhysicsObj.DestroyObject();
             }
@@ -1608,6 +2022,41 @@ namespace ACE.Server.Entity
         }
 
         /// <summary>
+        /// True when an online player is physically standing on this landblock id or an adjacent one,
+        /// regardless of which variation instance they are registered on. Keeps a landblock awake when
+        /// variation-instance player bookkeeping drifts (this instance's `players` list can be empty even
+        /// with a player right here). Only reached once a block has passed its dormant threshold.
+        /// </summary>
+        /// <remarks>
+        /// Reads <see cref="LandblockManager.OccupiedLandblocks"/>, the online-player landblock set snapshotted
+        /// once per multi-threaded tick batch, so each call is O(9) rather than O(online players): with many
+        /// variation instances all re-checking every dormant interval, a raw GetAllOnline() scan here was
+        /// O(landblocks x players) on the tick path.
+        /// </remarks>
+        private bool HasPhysicalPlayerOnOrAdjacent()
+        {
+            var occupied = LandblockManager.OccupiedLandblocks;
+            if (occupied.Count == 0)
+                return false;
+
+            int thisX = (Id.Landblock >> 8) & 0xFF;
+            int thisY = Id.Landblock & 0xFF;
+            for (int dx = -1; dx <= 1; dx++)
+            {
+                for (int dy = -1; dy <= 1; dy++)
+                {
+                    int nx = thisX + dx;
+                    int ny = thisY + dy;
+                    if (nx < 0 || nx > 255 || ny < 0 || ny > 255)
+                        continue;
+                    if (occupied.Contains((ushort)((nx << 8) | ny)))
+                        return true;
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
         /// Sets a landblock to active state, with the current time as the LastActiveTime
         /// </summary>
         /// <param name="isAdjacent">Public calls to this function should always set isAdjacent to false</param>
@@ -1637,6 +2086,40 @@ namespace ACE.Server.Entity
             //log.Debug($"Landblock.Unload({landblockID:X8})");
 
             ProcessPendingWorldObjectAdditionsAndRemovals();
+
+            // Cross-variation guard (2026-08-23): objects that belong to a SIBLING variation instance of
+            // this landblock can be parked in THIS instance's physics cells (stale PhysicsObj.Position
+            // .Variation - see WorldObject_Teleport.cs "Final authoritative variation reconcile"). Tearing
+            // those cells down orphaned them: still in the sibling's worldObjects, never streamed to any
+            // client ("Tou Tou v11 empty after the base twin unloaded", 2026-08-23 12:24). Re-home them to
+            // their own variation's physics before anything here is released.
+            var rehomed = 0;
+            try
+            {
+                foreach (var cell in PhysicsLandblock.LandCells.Values.ToList())
+                    foreach (var pobj in cell.ObjectList.ToList())   // leave_cell below removes from ObjectList
+                    {
+                        var fwo = pobj?.WeenieObj?.WorldObject;
+                        if (fwo == null || fwo.IsDestroyed || fwo is Player || fwo.Location == null)
+                            continue;
+                        if (Managers.VariationManager.SameVariationForVisibility(fwo.Location.Variation, VariationId))
+                            continue;
+                        // out of OUR cells (shadows + cell membership), then back in under ITS variation
+                        pobj.remove_shadows_from_cells();
+                        pobj.leave_cell(true);
+                        if (pobj.Position != null)
+                            pobj.Position.Variation = fwo.Location.Variation;
+                        if (!fwo.AddPhysicsObj(fwo.Location.Variation))
+                            log.Warn($"[LbLife] UNLOAD {Id.Landblock:X4} v={VariationId?.ToString() ?? "null"}: re-home of 0x{fwo.Guid}:{fwo.Name} (v={fwo.Location.Variation?.ToString() ?? "null"}) did not re-enter physics");
+                        rehomed++;
+                    }
+            }
+            catch (Exception e)
+            {
+                log.Warn($"[LbLife] UNLOAD {Id.Landblock:X4} v={VariationId?.ToString() ?? "null"}: cross-variation re-home failed: {e.Message}");
+            }
+            if (rehomed > 0)
+                log.Warn($"[LbLife] UNLOAD {Id.Landblock:X4} v={VariationId?.ToString() ?? "null"}: re-homed {rehomed} object(s) belonging to a sibling variation out of this instance's physics cells");
 
             SaveDB();
             //Console.WriteLine($"Landblock.Unload({landblockID:X8}), removing {worldObjects.Count}");

--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -125,6 +125,25 @@ namespace ACE.Server.Entity
         /// These are static objects visible to all players in this variation.
         /// </summary>
         private readonly List<WorldObject> _prestigeBoundaryMarkers = new List<WorldObject>();
+
+        private double _empowerSourcesRefreshedAt = -1;
+        private List<Creature> _empowerSources = new();
+
+        /// <summary>The IsEmpowerSource creatures on this landblock, rescanned at most once per <paramref name="maxAgeSeconds"/>.
+        /// Shared by every CanBeEmpowered creature here, so the per-second aura check is O(sources) rather than a full
+        /// physics-object scan per creature. Called from the landblock's own tick thread only.</summary>
+        internal List<Creature> GetEmpowerSources(double now, double maxAgeSeconds)
+        {
+            if (now - _empowerSourcesRefreshedAt < maxAgeSeconds)
+                return _empowerSources;
+            var list = new List<Creature>();
+            foreach (var obj in GetWorldObjectsForPhysicsHandling())
+                if (obj is Creature c && c.GetProperty(ACE.Entity.Enum.Properties.PropertyBool.IsEmpowerSource) == true)
+                    list.Add(c);
+            _empowerSources = list;
+            _empowerSourcesRefreshedAt = now;
+            return list;
+        }
         private readonly List<WorldObject> _zoneBoundaryMarkers = new List<WorldObject>();
 
         private readonly ActionQueue actionQueue = new();
@@ -283,6 +302,7 @@ namespace ACE.Server.Entity
         private int initSpawnAttempts;
         private DateTime initSpawnStartedTime;
         private bool initSpawnStillRunningLogged;
+        private bool initSpawnGaveUpLogged;   // the terminal VOID log has its own latch (#30)
 
         // 2026-07-26 (F559 v11): the above only guards a task that STARTED. A landblock constructed but
         // never Init()'d has initSpawnTask == null, so the watchdog returned on its first line every
@@ -348,7 +368,11 @@ namespace ACE.Server.Entity
                               $"walkable VOID, starting spawn now.");
                 }
 
-                StartInitSpawnTask(VariationId);
+                // Init() never ran: PostInit() (physics cells, CurLandblock) has to precede the spawn task
+                if (!initCalled)
+                    Init(VariationId);
+                else
+                    StartInitSpawnTask(VariationId);
                 return;
             }
 
@@ -367,9 +391,9 @@ namespace ACE.Server.Entity
 
             if (initSpawnAttempts >= 3)
             {
-                if (!initSpawnStillRunningLogged)
+                if (!initSpawnGaveUpLogged)
                 {
-                    initSpawnStillRunningLogged = true;
+                    initSpawnGaveUpLogged = true;
                     log.Error($"[VoidHeal] Landblock {Id.Landblock:X4} (Var {VariationId?.ToString() ?? "null"}) init spawn task never completed after {initSpawnAttempts} attempts - GIVING UP, block is a VOID (faulted={initSpawnTask.IsFaulted})");
                 }
                 return;
@@ -482,7 +506,12 @@ namespace ACE.Server.Entity
                 // idempotence: the [VoidHeal] watchdog can retry the init spawn task; if a previous
                 // attempt's action already populated the block, drop this duplicate payload.
                 if (CreateWorldObjectsCompleted)
+                {
+                    // a fully built payload is being discarded: release its physics + dynamic guids
+                    foreach (var dup in factoryObjects)
+                        dup.Destroy(false);
                     return;
+                }
 
                 // for mansion linking
                 var houses = new List<House>();
@@ -584,7 +613,8 @@ namespace ACE.Server.Entity
             void SpawnMarkerAtPosition(float x, float y)
             {
                 const float cornerEpsilon = 0.25f;
-                foreach (var existing in _prestigeBoundaryMarkers)
+                // both marker systems can run on the same 11+ variation: never stack a lantern on a zone marker either
+                foreach (var existing in _prestigeBoundaryMarkers.Concat(_zoneBoundaryMarkers))
                 {
                     if (existing?.Location == null)
                         continue;
@@ -1885,16 +1915,34 @@ namespace ACE.Server.Entity
                     }
 
                     SweepLandblock(this);
-                    foreach (var adj in Adjacents.ToList())
-                        if (adj != null)
-                            SweepLandblock(adj);
 
                     if (missed > 0 && wo is Creature && ServerConfig.prestige_interaction_diag_verbose.Value)
                         log.Warn($"[GhostMob] {wo.Name}(0x{wo.Guid.Full:X8}) destroy on lb 0x{Id.Landblock:X4} v={VariationId?.ToString() ?? "null"}: " +
                                  $"delete sent to {missed} nearby same-variation player(s) missing from KnownPlayers (one-way CO healed).");
+                    // Adjacent instances tick on their own group threads and mutate their own `players` lists, so each
+                    // adjacent sweep runs ON THAT LANDBLOCK'S QUEUE with a read-only snapshot of who was already told.
+                    var alreadyNotified = new HashSet<uint>(notified);
+                    var deletedWo = wo;
+                    foreach (var adj in Adjacents.ToList())
+                    {
+                        if (adj == null)
+                            continue;
+                        var target = adj;
+                        target.EnqueueAction(new ActionEventDelegate(ActionType.WorldObjectNetworking_BroadcastOther, () =>
+                        {
+                            foreach (var p in target.players.ToList())
+                            {
+                                if (p == null || p.Guid == deletedWo.Guid || alreadyNotified.Contains(p.Guid.Full))
+                                    continue;
+                                var player = p;
+                                player.EnqueueAction(new ActionEventDelegate(ActionType.WorldObjectNetworking_BroadcastOther,
+                                    () => player.RemoveTrackedObject(deletedWo, false)));
+                            }
+                        }));
+                    }
                 }
 
-                wo.PhysicsObj.DestroyObject();
+                wo.PhysicsObj?.DestroyObject();
             }
         }
 
@@ -2038,6 +2086,8 @@ namespace ACE.Server.Entity
             var occupied = LandblockManager.OccupiedLandblocks;
             if (occupied.Count == 0)
                 return false;
+            // variation-aware: a player on the base twin must not keep every rift / prestige instance of this block alive
+            var myVariation = Managers.VariationManager.NormalizeBase(VariationId);
 
             int thisX = (Id.Landblock >> 8) & 0xFF;
             int thisY = Id.Landblock & 0xFF;
@@ -2049,7 +2099,7 @@ namespace ACE.Server.Entity
                     int ny = thisY + dy;
                     if (nx < 0 || nx > 255 || ny < 0 || ny > 255)
                         continue;
-                    if (occupied.Contains((ushort)((nx << 8) | ny)))
+                    if (occupied.Contains(((ushort)((nx << 8) | ny), myVariation)))
                         return true;
                 }
             }
@@ -2110,7 +2160,13 @@ namespace ACE.Server.Entity
                         if (pobj.Position != null)
                             pobj.Position.Variation = fwo.Location.Variation;
                         if (!fwo.AddPhysicsObj(fwo.Location.Variation))
+                        {
                             log.Warn($"[LbLife] UNLOAD {Id.Landblock:X4} v={VariationId?.ToString() ?? "null"}: re-home of 0x{fwo.Guid}:{fwo.Name} (v={fwo.Location.Variation?.ToString() ?? "null"}) did not re-enter physics");
+                            // AddPhysicsObj nulls PhysicsObj on failure; the sibling instance would NRE on its next tick,
+                            // so take the object out of the world instead of leaving a physics-less ghost behind
+                            fwo.Destroy(false);
+                            continue;
+                        }
                         rehomed++;
                     }
             }

--- a/Source/ACE.Server/Factories/LootGenerationFactory.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory.cs
@@ -940,7 +940,7 @@ namespace ACE.Server.Factories
             var materialMod = LootTables.getMaterialValueModifier(wo);
             var gemMod = LootTables.getGemMaterialValueModifier(wo);
 
-            var rngRange = itemValue_RandomRange[tier - 1];
+            var rngRange = TierTable.Entry(itemValue_RandomRange, tier);
 
             var rng = ThreadSafeRandom.Next(rngRange.min, rngRange.max);
 
@@ -979,7 +979,7 @@ namespace ACE.Server.Factories
             var materialMod = LootTables.getMaterialValueModifier(wo);
             var gemMod = LootTables.getGemMaterialValueModifier(wo);
 
-            var rngRange = itemValue_RandomRange[tier - 1];
+            var rngRange = TierTable.Entry(itemValue_RandomRange, tier);
 
             var minValue = (int)(rngRange.min * gemMod * materialMod * Math.Ceiling(tier / 2.0f));
             var maxValue = (int)(rngRange.max * gemMod * materialMod * Math.Ceiling(tier / 2.0f));
@@ -1373,7 +1373,7 @@ namespace ACE.Server.Factories
         {
             var tier = Math.Clamp(profile.Tier, 1, 10);
 
-            var tierRange = coinRanges[tier - 1];
+            var tierRange = TierTable.Entry(coinRanges, tier);
 
             // flat rng range, according to magloot corpse logs
             var rng = ThreadSafeRandom.Next(tierRange.min, tierRange.max);

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Aetheria.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Aetheria.cs
@@ -77,7 +77,7 @@ namespace ACE.Server.Factories
 
         private static void MutateAetheria(WorldObject wo, int tier)
         {
-            if (tier == 10)
+            if (tier >= 10)
             {
                 wo.ItemMaxLevel = AetheriaChance.Roll_ItemMaxLevel(tier);
 
@@ -140,7 +140,7 @@ namespace ACE.Server.Factories
             wo.ItemMaxLevel = AetheriaChance.Roll_ItemMaxLevel(profile);
             wo.IconOverlayId = IconOverlay_ItemMaxLevel[wo.ItemMaxLevel.Value - 1];
 
-            if (profile.Tier == 10 && wo.ItemMaxLevel >= 6)
+            if (profile.Tier >= 10 && wo.ItemMaxLevel >= 6)
             {
                 int roll = ThreadSafeRandom.Next(0, 2);
                 int rating = ThreadSafeRandom.Next(1, 4);

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Aetheria.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Aetheria.cs
@@ -79,7 +79,7 @@ namespace ACE.Server.Factories
         {
             if (tier >= 10)
             {
-                wo.ItemMaxLevel = AetheriaChance.Roll_ItemMaxLevel(tier);
+                wo.ItemMaxLevel = AetheriaChance.Roll_ItemMaxLevel(Math.Min(tier, 10));   // authored through T10; T11+ clamps to it
 
             }
             else

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Caster.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Caster.cs
@@ -198,6 +198,9 @@ namespace ACE.Server.Factories
                 MutateItemLevel(wo, profile);
             }
 
+            // standard T10+ mods override the rolled offense/defense/manac (owner 2026-08-15)
+            ApplyStandardWeaponMods(wo, profile.Tier);
+
             // long description
             wo.LongDesc = GetLongDesc(wo);
         }
@@ -373,6 +376,7 @@ namespace ACE.Server.Factories
                         magicMod = 5;
                     break;
                 case 10:
+                default:    // tiers above the last authored case clamp to the highest
                     chance = ThreadSafeRandom.Next(1, 1000);
                     if (chance > 950)
                         magicMod = 12;
@@ -382,19 +386,6 @@ namespace ACE.Server.Factories
                         magicMod = 10;
                     else
                         magicMod = 9;
-                    break;
-                default:
-                    chance = ThreadSafeRandom.Next(1, 1000);
-                    if (chance > 980)
-                        magicMod = 8;
-                    else if (chance > 900)
-                        magicMod = 7;
-                    else if (chance > 800)
-                        magicMod = 6;
-                    else if (chance > 700)
-                        magicMod = 5;
-                    else
-                        magicMod = 4;
                     break;
             }
 

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Chance.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Chance.cs
@@ -1,3 +1,5 @@
+using System;
+
 using ACE.Common;
 using ACE.Database.Models.World;
 using ACE.Server.Factories.Enum;
@@ -12,6 +14,9 @@ namespace ACE.Server.Factories
 
         private static int RollWieldDifficulty(int tier, TreasureWeaponType weaponType)
         {
+            // tiers above the last authored case (11) clamp to the highest authored values
+            tier = Math.Min(tier, 11);
+
             int wield = 0;
             int chance = ThreadSafeRandom.Next(1, 100);
 
@@ -94,6 +99,14 @@ namespace ACE.Server.Factories
                             else
                                 wield = 800;
                             break;
+                        case 11:
+                            if (chance < 60)
+                                wield = 1025;
+                            else if (chance < 90)
+                                wield = 1100;
+                            else
+                                wield = 1175;
+                            break;
                     }
                     break;
 
@@ -174,6 +187,15 @@ namespace ACE.Server.Factories
                             else
                                 wield = 800;
                             break;
+                        case 11:
+                            // stays >= 315 so tier 11 keeps selecting elemental missile weenies
+                            if (chance < 30)
+                                wield = 1025;
+                            else if (chance < 80)
+                                wield = 1100;
+                            else
+                                wield = 1175;
+                            break;
                     }
                     break;
 
@@ -250,6 +272,17 @@ namespace ACE.Server.Factories
                             else
                                 wield = 800;
                             break;
+                        case 11:
+                            // keeps the 25% wield-0 branch so tier 11 still rolls plain casters
+                            if (chance < 25)
+                                wield = 0;
+                            else if (chance < 50)
+                                wield = 1025;
+                            else if (chance < 85)
+                                wield = 1100;
+                            else
+                                wield = 1175;
+                            break;
                     }
                     break;
             }
@@ -258,6 +291,9 @@ namespace ACE.Server.Factories
 
         private static double GetMaxDamageMod(int tier, int maxDamageMod)
         {
+            // tiers above the last authored case (9) clamp to the highest authored values
+            tier = Math.Min(tier, 9);
+
             double damageMod = 0;
 
             switch (maxDamageMod)

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
@@ -28,7 +28,6 @@ namespace ACE.Server.Factories
             switch (profile.Tier)
             {
                 case 1:
-                default:
                     maxType = LootTables.ArmorType.ChainmailArmor;
                     break;
                 case 2:
@@ -46,6 +45,7 @@ namespace ACE.Server.Factories
                     break;
                 case 7:
                 case 8:
+                default:    // tiers above the last authored case clamp to the highest
                     maxType = LootTables.ArmorType.OlthoiAlduressaArmor;
                     break;
             }
@@ -162,7 +162,7 @@ namespace ACE.Server.Factories
             if (roll != null && profile.Tier == 9)
                 TryMutateGearRatingT9(wo, profile, roll);
 
-            if (roll != null && profile.Tier == 10)
+            if (roll != null && profile.Tier >= 10)
                 TryMutateGearRatingT10(wo, profile, roll);
 
             // item value
@@ -392,6 +392,7 @@ namespace ACE.Server.Factories
                             armorModValue = ThreadSafeRandom.Next(107, 124);
                         break;
                     case 8:
+                    default:    // tiers above the last authored case clamp to the highest
                         if (wo.ArmorType == (int)ArmorType.Cloth)
                             armorModValue = ThreadSafeRandom.Next(175, 200);
                         if (wo.ArmorType == (int)ArmorType.Leather
@@ -435,7 +436,7 @@ namespace ACE.Server.Factories
                     {
                         7 => ThreadSafeRandom.Next(0, 40),
                         8 => ThreadSafeRandom.Next(91, 115),
-                        9 => ThreadSafeRandom.Next(115, 140),
+                        >= 9 => ThreadSafeRandom.Next(115, 140),    // tiers above the last authored arm clamp to the highest
                         _ => 0,
                     };
                 }
@@ -866,7 +867,7 @@ namespace ACE.Server.Factories
                 TryMutateGearRating(wo, profile, roll);
             else if (roll != null && profile.Tier == 9)
                 TryMutateGearRatingT9(wo, profile, roll);
-            else if (roll != null && profile.Tier == 10)
+            else if (roll != null && profile.Tier >= 10)
                 TryMutateGearRatingT10(wo, profile, roll);
 
             // item value
@@ -884,7 +885,6 @@ namespace ACE.Server.Factories
             {
                 case 1:
                 case 2:
-                default:
                     cloakLevel = 1;
                     break;
                 case 3:
@@ -933,6 +933,7 @@ namespace ACE.Server.Factories
                         cloakLevel = 5;
                     break;
                 case 9:  // From data, no chance to get a lvl 1 cloak
+                default:    // tiers above the last authored case clamp to the highest
                     if (chance <= 451)
                         cloakLevel = 3;
                     else if (chance <= 920)
@@ -1064,7 +1065,7 @@ namespace ACE.Server.Factories
 
             // ensure wield requirement is level 180?
             if (roll.ArmorType != TreasureArmorType.Society)
-                SetWieldLevelReq(wo, 180);
+                SetWieldLevelReq(wo, 180, profile.Tier);
 
             return true;
 
@@ -1117,7 +1118,7 @@ namespace ACE.Server.Factories
                 return false;
             }
             if (roll.ArmorType != TreasureArmorType.Society)
-                SetWieldLevelReq(wo, 550);
+                SetWieldLevelReq(wo, 550, profile.Tier);
 
             return true;
         }
@@ -1163,7 +1164,7 @@ namespace ACE.Server.Factories
 
         private static bool TryMutateGearRatingT10(WorldObject wo, TreasureDeath profile, TreasureRoll roll)
         {
-            if (profile.Tier != 10)
+            if (profile.Tier < 10)  // tiers above 10 use the T10 (highest authored) ratings
                 return false;
 
             bool applied = false;
@@ -1176,7 +1177,7 @@ namespace ACE.Server.Factories
             {
                 void TryAssignRating(Action<int> assign)
                 {
-                    var val = GearRatingChance.RollT10(wo, profile, roll);
+                    var val = GearRatingChance.RollForTier(wo, profile, roll);
                     if (val > 0) assign(val);
                 }
 
@@ -1199,29 +1200,29 @@ namespace ACE.Server.Factories
             // 🎯 Armor/Underclothes/Cloaks
             else if (isArmorType)
             {
-                var netherResist = GearRatingChance.RollT10(wo, profile, roll);
+                var netherResist = GearRatingChance.RollForTier(wo, profile, roll);
                 if (netherResist > 0)
                     wo.GearNetherResistRating = netherResist;
 
                 if (ThreadSafeRandom.Next(0, 1) == 0)
                 {
-                    var dmg = GearRatingChance.RollT10(wo, profile, roll);
+                    var dmg = GearRatingChance.RollForTier(wo, profile, roll);
                     if (dmg > 0) wo.GearDamage = dmg;
                 }
                 else
                 {
-                    var dmgResist = GearRatingChance.RollT10(wo, profile, roll);
+                    var dmgResist = GearRatingChance.RollForTier(wo, profile, roll);
                     if (dmgResist > 0) wo.GearDamageResist = dmgResist;
                 }
 
                 if (ThreadSafeRandom.Next(0, 1) == 0)
                 {
-                    var crit = GearRatingChance.RollT10(wo, profile, roll);
+                    var crit = GearRatingChance.RollForTier(wo, profile, roll);
                     if (crit > 0) wo.GearCritDamage = crit;
                 }
                 else
                 {
-                    var critResist = GearRatingChance.RollT10(wo, profile, roll);
+                    var critResist = GearRatingChance.RollForTier(wo, profile, roll);
                     if (critResist > 0) wo.GearCritDamageResist = critResist;
                 }
 
@@ -1230,7 +1231,7 @@ namespace ACE.Server.Factories
             // 💍 Jewelry
             else if (isJewelry)
             {
-                var rating = GearRatingChance.RollT10(wo, profile, roll);
+                var rating = GearRatingChance.RollForTier(wo, profile, roll);
                 if (rating > 0)
                 {
                     if (ThreadSafeRandom.Next(0, 1) == 0)
@@ -1257,8 +1258,13 @@ namespace ACE.Server.Factories
             return applied;
         }
 
-        private static void SetWieldLevelReq(WorldObject wo, int level)
+        private static void SetWieldLevelReq(WorldObject wo, int level, int tier)
         {
+            // Tier 11+ loot carries NO character-level requirement (owner decision 2026-07-20).
+            // The T11 mutation scripts stamp none either; skill-based gates (RawSkill) are kept.
+            if (tier >= LootGenerationFactory.ZoneLootSetMinTier)
+                return;
+
             if (wo.WieldRequirements == WieldRequirement.Invalid)
             {
                 wo.WieldRequirements = WieldRequirement.Level;

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Gem.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Gem.cs
@@ -75,7 +75,7 @@ namespace ACE.Server.Factories
         {
             var spellLevelIdx = ThreadSafeRandom.Next(0, 1);
             var tier = Math.Clamp(profile.Tier, 1, 8);
-            var spellLevel = LootTables.GemSpellIndexMatrix[tier - 1][spellLevelIdx];
+            var spellLevel = TierTable.Entry(LootTables.GemSpellIndexMatrix, tier)[spellLevelIdx];
 
             var magicSchool = ThreadSafeRandom.Next(0, 1);
 

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Jewelry.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Jewelry.cs
@@ -87,7 +87,7 @@ namespace ACE.Server.Factories
             if (roll != null && profile.Tier == 9)
                 TryMutateGearRatingT9(wo, profile, roll);
 
-            if (roll != null && profile.Tier == 10)
+            if (roll != null && profile.Tier >= 10)
                 TryMutateGearRatingT10(wo, profile, roll);
 
             // item value

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Magic.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Magic.cs
@@ -69,7 +69,7 @@ namespace ACE.Server.Factories
 
                 AddActivationRequirements(wo, roll);
 
-                if (profile.Tier == 10 && wo.WeenieType == WeenieType.Caster)
+                if (profile.Tier >= 10 && wo.WeenieType == WeenieType.Caster)
                 {
                     TryMutateGearRatingForWeapons(wo, profile, roll);
                 }
@@ -375,7 +375,7 @@ namespace ACE.Server.Factories
                 lootQualityMod = 1.0f - profile.LootQualityMod;
 
             // 25% base chance for no epics for tier 7
-            if (profile.Tier == 10)
+            if (profile.Tier >= 10)
             {
                 if (ThreadSafeRandom.Next(1, (int)(80 * dropRateMod * lootQualityMod)) == 1)
                     numEpics = 1;
@@ -421,7 +421,7 @@ namespace ACE.Server.Factories
             if (ServerConfig.loot_quality_mod.Value && profile.LootQualityMod > 0 && profile.LootQualityMod < 1)
                 lootQualityMod = 1.0f - profile.LootQualityMod;
 
-            if (profile.Tier == 10)
+            if (profile.Tier >= 10)
             {
                 if (ThreadSafeRandom.Next(1, (int)(60 * dropRateMod * lootQualityMod)) == 1)
                     numLegendaries = 1;
@@ -556,7 +556,7 @@ namespace ACE.Server.Factories
 
         private static int RollItemMaxMana(int tier, int numSpells)
         {
-            var range = itemMaxMana_RandomRange[tier - 1];
+            var range = TierTable.Entry(itemMaxMana_RandomRange, tier);
 
             var rng = ThreadSafeRandom.Next(range.min, range.max);
 

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Melee.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Melee.cs
@@ -162,6 +162,9 @@ namespace ACE.Server.Factories
                 MutateItemLevel(wo, profile);
             }
 
+            // standard T10+ mods override the rolled offense/defense (owner 2026-08-15)
+            ApplyStandardWeaponMods(wo, profile.Tier);
+
             // long description
             wo.LongDesc = GetLongDesc(wo);
 

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Missile.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Missile.cs
@@ -151,6 +151,9 @@ namespace ACE.Server.Factories
                 MutateItemLevel(wo, profile);
             }
 
+            // standard T10+ mods override the rolled offense/defense (owner 2026-08-15)
+            ApplyStandardWeaponMods(wo, profile.Tier);
+
             // long description
             wo.LongDesc = GetLongDesc(wo);
 

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Rare.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Rare.cs
@@ -49,9 +49,10 @@ namespace ACE.Server.Factories
             // Check to make sure there *IS* a chance. Less than/equal to 0 would mean zero chance, so we can stop here
             if (rare_drop_rate_percent <= 0)
                 return null;
-            
-            rare_drop_rate_percent = Math.Min(rare_drop_rate_percent/100, 1); 
+
+            rare_drop_rate_percent = Math.Min(rare_drop_rate_percent/100, 1);
             int t1_chance = (int)Math.Round(1 / rare_drop_rate_percent); // Default PropertyManager value results in a 1 in 2,500 chance
+
             t1_chance = Math.Max(t1_chance - luck, 1);
 
             int tier = 0;

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Spells.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Spells.cs
@@ -203,7 +203,7 @@ namespace ACE.Server.Factories
         {
             var tierChances = roll.IsCaster ? EnchantmentChances_Caster : EnchantmentChances_Armor_MeleeMissileWeapon;
 
-            var chance = tierChances[profile.Tier - 1];
+            var chance = TierTable.Entry(tierChances, profile.Tier);
 
             var rng = ThreadSafeRandom.NextInterval(profile.LootQualityMod);
 

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Weapon.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Weapon.cs
@@ -44,10 +44,11 @@ namespace ACE.Server.Factories
 
         private static bool TryMutateGearRatingForWeapons(WorldObject wo, TreasureDeath profile, TreasureRoll roll)
         {
-            if (profile.Tier != 10)
+            // was == 10, which silently dropped weapon gear ratings at tier 11+
+            if (profile.Tier < 10)
                 return false;
 
-            int gearRating = GearRatingChance.RollT10(wo, profile, roll); // Make sure this supports weapon types
+            int gearRating = GearRatingChance.RollForTier(wo, profile, roll); // Make sure this supports weapon types
 
             if (gearRating == 0)
                 return false;

--- a/Source/ACE.Server/Factories/LootGenerationFactory_ZoneSet.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_ZoneSet.cs
@@ -1,0 +1,1393 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+
+using ACE.Common;
+using ACE.Database;
+using ACE.Database.Models.World;
+using ACE.Entity.Enum.Properties;
+using ACE.Entity.Models;
+using ACE.Server.Factories.Entity;
+using ACE.Server.Factories.Enum;
+using ACE.Server.Factories.Tables;
+using ACE.Server.Factories.Tables.Wcids;
+using ACE.Server.WorldObjects;
+
+namespace ACE.Server.Factories
+{
+    public static partial class LootGenerationFactory
+    {
+        // =====================================================================================
+        // Structured tier-11+ loot set ("T11" endgame loot)
+        //
+        // Every kill from a tier-11+ treasure profile drops one weapon per FAMILY (subtype/skill
+        // randomized inside the pick) plus a fixed gear allotment (armor / jewelry / cloak). All
+        // pieces roll BLANK (isMagical = false -> no legacy spell sets); useful cantrips/spells/
+        // procs come from the Zone Control post-roll mutation layer (ZoneLootMutator).
+        // Quality/tier come from the (QB-scaled) treasure profile passed in.
+        //
+        // This set is the DEFAULT behaviour of a tier-11+ profile and does NOT require Zone
+        // Control: the T11 profiles carry zero item/magic/mundane chances of their own, so this
+        // generator is what makes them drop anything at all. Drops are PER-SLOT (owner decision
+        // 2026-07-20, "no set enabler"): every equip slot has its own count, defaulting to 1 at
+        // tier 11+ and 0 below. A resolved zone profile overrides individual slot counts via the
+        // loot_slot_* stats; setting a slot to 0 turns just that slot off, and there is no
+        // separate enable flag. With Zone Control absent, tier-11+ mobs drop one of everything.
+        //
+        // Design doc: C:\AI\ZoneControl\ACE_Loot_Systems_DeepDive_2026-07-17.md §12-13
+        // =====================================================================================
+
+        /// <summary>
+        /// Lowest treasure tier that drops the structured set by default (no Zone Control needed).
+        /// </summary>
+        public const int ZoneLootSetMinTier = 11;
+
+        /// <summary>Death-treasure profile handed to a creature that dies inside a governed v11+ zone with NO
+        /// table of its own (owner 2026-08-23, zone loot floor): 73001 = the Tou Tou T11 profile.</summary>
+        public const uint ZoneLootFallbackProfile = 73001;
+
+        /// <summary>
+        /// Per-slot drop counts for one kill. Weapons = drops PER FAMILY (9 families). Each armor
+        /// slot counts pieces whose coverage includes that slot; a multi-slot piece (coat) credits
+        /// every slot it covers, so covered slots don't roll again.
+        /// </summary>
+        public class ZoneLootSetCounts
+        {
+            public int Weapons;
+            public int Helm, Chest, Shoulder, Bracer, Glove, Girth, UpperLeg, LowerLeg, Boot;
+            public int Shield;
+            public int Amulet, Ring, Bracelet, Trinket;
+            public int Cloak;
+
+            /// <summary>BUDGET MODE only: the exact weapon families to create, one weapon each. Null in
+            /// legacy mode, where Weapons is instead a MULTIPLIER over every family (1 = all nine).</summary>
+            public List<int> WeaponFamilyPicks;
+
+            public bool Any =>
+                (WeaponFamilyPicks != null && WeaponFamilyPicks.Count > 0) ||
+                Weapons > 0 || Helm > 0 || Chest > 0 || Shoulder > 0 || Bracer > 0 || Glove > 0 ||
+                Girth > 0 || UpperLeg > 0 || LowerLeg > 0 || Boot > 0 || Shield > 0 ||
+                Amulet > 0 || Ring > 0 || Bracelet > 0 || Trinket > 0 || Cloak > 0;
+
+            /// <summary>Tier default: one of everything at tier 11+, nothing below.</summary>
+            public static ZoneLootSetCounts TierDefault(int tier)
+            {
+                var n = tier >= ZoneLootSetMinTier ? 1 : 0;
+                return new ZoneLootSetCounts
+                {
+                    Weapons = n,
+                    Helm = n, Chest = n, Shoulder = n, Bracer = n, Glove = n,
+                    Girth = n, UpperLeg = n, LowerLeg = n, Boot = n,
+                    Shield = n, Amulet = n, Ring = n, Bracelet = n, Trinket = n, Cloak = n,
+                };
+            }
+        }
+
+        // Jewelry pools by equip slot. Crowns/coronets are deliberately excluded: they roll down
+        // the armor path (they have an armor level) and would duplicate the Head slot.
+        private static readonly WeenieClassName[] zoneSetNeckWcids =
+            { WeenieClassName.amulet, WeenieClassName.gorget, WeenieClassName.necklace, WeenieClassName.necklaceheavy };
+
+        private static readonly WeenieClassName[] zoneSetWristWcids =
+            { WeenieClassName.bracelet, WeenieClassName.braceletheavy };
+
+        private static readonly WeenieClassName[] zoneSetFingerWcids =
+            { WeenieClassName.ring, WeenieClassName.ringjeweled };
+
+        private static readonly WeenieClassName[] zoneSetTrinketWcids =
+        {
+            WeenieClassName.ace41483_compass, WeenieClassName.ace41484_goggles,
+            WeenieClassName.ace41487_mechanicalscarab, WeenieClassName.ace41486_puzzlebox,
+            WeenieClassName.ace41485_pocketwatch, WeenieClassName.ace41488_top,
+        };
+
+        // wcid -> ClothingPriority, read from the cached weenie so candidate pieces can be
+        // accepted/rejected by slot WITHOUT instantiating a WorldObject for each attempt.
+        private static readonly ConcurrentDictionary<WeenieClassName, ACE.Entity.Enum.CoverageMask> zoneSetCoverage = new();
+
+        private static ACE.Entity.Enum.CoverageMask GetZoneSetCoverage(WeenieClassName wcid)
+        {
+            return zoneSetCoverage.GetOrAdd(wcid, w =>
+            {
+                var weenie = DatabaseManager.World.GetCachedWeenie((uint)w);
+                return (ACE.Entity.Enum.CoverageMask)(weenie?.GetProperty(PropertyInt.ClothingPriority) ?? 0);
+            });
+        }
+
+        /// <summary>
+        /// Removes ALL wield requirements from a tier-11+ drop (owner 2026-07-20: level reqs first,
+        /// then ALL reqs -- an item-augmentation wield requirement will replace them later).
+        ///
+        /// This is a final sweep rather than a fix at each producer, because a requirement can
+        /// arrive from three independent places: a mutation script, factory code (e.g.
+        /// MutateCloak's ItemMaxLevel -> WieldDifficulty, SetWieldT10's MeleeDefense gate), or the
+        /// BASE WEENIE itself -- cloaks in particular ship with WieldRequirements = Level already
+        /// set, which no mutation ever clears. Patching producers one at a time misses that.
+        /// </summary>
+        /// <summary>Item augmentations required to wield any tier-11+ drop (owner 2026-07-20).</summary>
+        public const int ZoneLootSetWieldItemAugs = 2000;
+
+        /// <summary>
+        /// The tier-11+ wield gate: item augmentations (LumAugItemCount), replacing every
+        /// requirement StripWieldRequirements removed. Validated server-side by the
+        /// WieldRequirement.Int64Stat case. The client cannot render this requirement type, so
+        /// the LongDesc block appends the line instead.
+        ///
+        /// PER-TIER (T11 weapon relevance plan §7.10): the floor comes from the weaponscaling_data
+        /// tier table (minWieldAugs — the market-segmentation gate: minWield(Tn) = cap(Tn-1)),
+        /// editable live in the plugin's Weapons panel; a missing tier row or a 0 value falls back
+        /// to the legacy 2000 constant, preserving pre-plan behavior. Applies to ALL T11+ drops
+        /// (weapons, armor, jewelry) — the gate is the tier's, not the weapon system's.
+        /// </summary>
+        public static void ApplyT11WieldRequirement(WorldObject wo, int tier = 0)
+        {
+            if (wo == null)
+                return;
+
+            var minWield = ZoneLootSetWieldItemAugs;
+            var tierRow = ACE.Server.Managers.WeaponScaling.WeaponScalingManager.GetTier(tier);
+            if (tierRow != null && tierRow.MinWieldAugs > 0)
+                minWield = tierRow.MinWieldAugs;
+
+            wo.WieldRequirements = ACE.Entity.Enum.WieldRequirement.Int64Stat;
+            wo.WieldSkillType = (int)PropertyInt64.LumAugItemCount;
+            wo.WieldDifficulty = minWield;
+
+            // T16+ charm gates (owner 2026-08-15): the item-aug ladder purchase-caps at 4,000
+            // (reached at T15), so higher tiers freeze the item req and gate on growth charm
+            // counters instead — Triune Weave plus the weapon-family charm, both +500/tier.
+            // WEAPONS ONLY, and slots 3/4: slot 2 belongs to the forge's training requirement.
+            var isWeapon = wo is MeleeWeapon || wo is MissileLauncher || wo is Caster;
+            if (isWeapon && tierRow != null && tierRow.MinWieldTriune > 0)
+            {
+                wo.WieldRequirements3 = ACE.Entity.Enum.WieldRequirement.Int64Stat;
+                wo.WieldSkillType3 = (int)PropertyInt64.TriuneWeaveCount;
+                wo.WieldDifficulty3 = tierRow.MinWieldTriune;
+            }
+            if (isWeapon && tierRow != null && tierRow.MinWieldSkillCharm > 0)
+            {
+                wo.WieldRequirements4 = ACE.Entity.Enum.WieldRequirement.Int64Stat;
+                wo.WieldSkillType4 = (int)GetWieldCharmProperty(wo);
+                wo.WieldDifficulty4 = tierRow.MinWieldSkillCharm;
+            }
+
+            // Armor / jewelry / cloaks at T16+ (owner 2026-08-23: "4k item augs isn't enough - Item Augs +
+            // Triune Count"): slot 3 = Triune Weave count on the same 500 x (tier-15) ladder the weapons use.
+            // No family charm for non-weapons (none exists).
+            if (!isWeapon && tierRow != null && tierRow.MinWieldTriune > 0)
+            {
+                wo.WieldRequirements3 = ACE.Entity.Enum.WieldRequirement.Int64Stat;
+                wo.WieldSkillType3 = (int)PropertyInt64.TriuneWeaveCount;
+                wo.WieldDifficulty3 = tierRow.MinWieldTriune;
+            }
+
+            // The client cannot render Int64Stat requirements. WEAPONS show the gate in the
+            // Property Details section instead (AppraiseInfo, pinned bottom - owner 2026-08-01);
+            // armor/jewelry have no such section, so they keep this LongDesc line.
+            if (!isWeapon)
+                AppendLongDescLine(wo, WieldLineFor(wo));
+        }
+
+        /// <summary>LIVE re-stamp of a recorded NON-weapon's wield gates from the current tier row (owner 2026-08-23:
+        /// "change live and for existing pieces"). Called from ZoneStatResolver.Apply so every equip / login /
+        /// ladder apply refreshes slot 1 (item augs) and slot 3 (T16+ Triune Weave) and rewrites the LongDesc
+        /// line. Weapons are left to the weapon-scaling system. Returns the number of properties changed.</summary>
+        public static int RefreshWieldGate(WorldObject wo, int tier)
+        {
+            if (wo == null || wo is MeleeWeapon || wo is MissileLauncher || wo is Caster)
+                return 0;
+
+            // WIELD GATES IGNORE zonecontrol_enabled ON PURPOSE (owner 2026-08-23). Clearing them off the
+            // switch was built, then removed: a wield requirement is checked ONLY at the moment of equipping
+            // (Player_Inventory.DoHandleActionGetAndWieldItem -> CheckWieldRequirements) and never again -
+            // there is no login revalidation and no periodic sweep. An ungated window is therefore permanent
+            // for anyone who equips during it: switch off -> gate gone -> a 0-aug character equips a T25
+            // piece -> switch on -> the piece re-resolves to full ladder stats while the restored gate is
+            // never rechecked, because they are already wearing it. They keep it until they choose to
+            // unequip. Keeping the gate costs only cosmetics (a T25 piece asks 5,000 Triune while its stats
+            // read T10 in fallback); clearing it costs a hole. DO NOT re-add the clearing branch.
+            var tierRow = ACE.Server.Managers.WeaponScaling.WeaponScalingManager.GetTier(tier);
+            var minWield = tierRow != null && tierRow.MinWieldAugs > 0 ? tierRow.MinWieldAugs : ZoneLootSetWieldItemAugs;
+            var triune = tierRow != null ? tierRow.MinWieldTriune : 0;
+            var changed = 0;
+
+            if (wo.WieldRequirements != ACE.Entity.Enum.WieldRequirement.Int64Stat || wo.WieldSkillType != (int)PropertyInt64.LumAugItemCount || wo.WieldDifficulty != minWield)
+            {
+                wo.WieldRequirements = ACE.Entity.Enum.WieldRequirement.Int64Stat;
+                wo.WieldSkillType = (int)PropertyInt64.LumAugItemCount;
+                wo.WieldDifficulty = minWield;
+                changed++;
+            }
+            if (triune > 0)
+            {
+                if (wo.WieldRequirements3 != ACE.Entity.Enum.WieldRequirement.Int64Stat || wo.WieldSkillType3 != (int)PropertyInt64.TriuneWeaveCount || wo.WieldDifficulty3 != triune)
+                {
+                    wo.WieldRequirements3 = ACE.Entity.Enum.WieldRequirement.Int64Stat;
+                    wo.WieldSkillType3 = (int)PropertyInt64.TriuneWeaveCount;
+                    wo.WieldDifficulty3 = triune;
+                    changed++;
+                }
+            }
+            else if (wo.WieldRequirements3 == ACE.Entity.Enum.WieldRequirement.Int64Stat && wo.WieldSkillType3 == (int)PropertyInt64.TriuneWeaveCount)
+            {
+                wo.WieldRequirements3 = ACE.Entity.Enum.WieldRequirement.Invalid;
+                wo.WieldSkillType3 = null;
+                wo.WieldDifficulty3 = null;
+                changed++;
+            }
+
+            // rewrite the LongDesc gate block so the appraisal matches the live gate. The block sits in
+            // its own paragraph (blank line before it) and each requirement has its own line (owner 2026-08-23).
+            var want = WieldLineFor(wo);
+            var cur = wo.LongDesc ?? string.Empty;
+            if (!cur.Contains(want))
+            {
+                var kept = cur.Split('\n').Where(l => !l.StartsWith("Wield requires:")).ToList();
+                // drop the blank lines that separated the old gate block so we don't stack paragraphs
+                while (kept.Count > 0 && kept[^1].Trim().Length == 0) kept.RemoveAt(kept.Count - 1);
+                var head = string.Join("\n", kept).Trim('\n');
+                wo.LongDesc = head.Length > 0 ? head + "\n\n" + want : want;
+                changed++;
+            }
+            return changed;
+        }
+
+        /// <summary>The "Wield requires:" LongDesc block for a non-weapon: one line per requirement -
+        /// item augs, then the T16+ Triune gate when stamped (owner 2026-08-23).</summary>
+        private static string WieldLineFor(WorldObject wo)
+        {
+            var line = $"Wield requires: {wo.WieldDifficulty ?? 0:N0} Item Augmentations";
+            if (wo.WieldRequirements3 == ACE.Entity.Enum.WieldRequirement.Int64Stat &&
+                wo.WieldSkillType3 == (int)PropertyInt64.TriuneWeaveCount && (wo.WieldDifficulty3 ?? 0) > 0)
+                line += $"\nWield requires: {wo.WieldDifficulty3 ?? 0:N0} Triune Weave";
+            return line;
+        }
+
+        /// <summary>Standard weapon mods (owner 2026-08-15): every T10+ weapon and wand leaves
+        /// the loot/forge pipeline with EXACTLY +20 pct attack mod and +20 pct melee defense
+        /// (wands additionally 20 pct mana conversion), replacing the rolled values — so tier
+        /// difficulty can be tuned against KNOWN player mods ("predictable hit or not hit
+        /// levers"). New drops/forges only; existing items keep what they rolled.</summary>
+        public static void ApplyStandardWeaponMods(WorldObject wo, int tier)
+        {
+            if (wo == null || tier < 10)
+                return;
+            if (!(wo is MeleeWeapon || wo is MissileLauncher || wo is Caster))
+                return;
+
+            wo.WeaponOffense = 1.20;
+            wo.WeaponDefense = 1.20;
+            if (wo is Caster)
+                wo.ManaConversionMod = 0.20;
+        }
+
+        /// <summary>The weapon-family growth charm whose counter gates T16+ wield (owner
+        /// 2026-08-15): melee = Crashing Steel, launchers = True Shot, nether casters =
+        /// Nether Veil, every other caster = Battlemage's Wrath.</summary>
+        public static PropertyInt64 GetWieldCharmProperty(WorldObject wo)
+        {
+            if (wo is MissileLauncher)
+                return PropertyInt64.TrueShotCharmCount;
+            if (wo is Caster)
+                return wo.W_DamageType == ACE.Entity.Enum.DamageType.Nether
+                    ? PropertyInt64.NetherVeilCharmCount
+                    : PropertyInt64.BattlemagesWrathCharmCount;
+            return PropertyInt64.CrashingSteelCharmCount;
+        }
+
+        /// <summary>Append one line to an item's LongDesc (the LIVE description path - the
+        /// provenance line from ZoneLootMutator lands the same way). Idempotent per line text.</summary>
+        private static void AppendLongDescLine(WorldObject wo, string line)
+        {
+            if (wo == null || string.IsNullOrWhiteSpace(line))
+                return;
+            var cur = wo.LongDesc;
+            if (!string.IsNullOrEmpty(cur) && cur.Contains(line))
+                return;
+            wo.LongDesc = string.IsNullOrEmpty(cur) ? line : cur + "\n" + line;
+        }
+
+        /// <summary>
+        /// Stamp the aug-scaling identity on a tier-11+ WEAPON drop: a QUALITY percentile roll
+        /// (0-1000) and the loot TIER. That is ALL the item ever carries — k ranges, tier caps and
+        /// kc live in the weaponscaling_data config and resolve at swing time, so plugin edits
+        /// re-price every stamped weapon retroactively (plan §9.1). Stamped even while the master
+        /// switch is OFF (inert data; flipping Enabled later activates existing drops). Casters
+        /// are stamped too — inert until the caster wire-in.
+        /// </summary>
+        public static void ApplyWeaponAugScaleStamp(WorldObject wo, int tier)
+        {
+            if (wo == null || tier < ZoneLootSetMinTier)
+                return;
+            if (!(wo is MeleeWeapon || wo is MissileLauncher || wo is Caster))
+                return;
+
+            // Weighted grade roll (owner 2026-08-02): grade from the config weights table
+            // (S ~1-in-1000, A 5 / B 10 / C 15 / D 25 / F 44.9 seeds), uniform within the band.
+            var quality = ACE.Server.Managers.WeaponScaling.WeaponScalingManager.RollQuality();
+            wo.SetProperty(ACE.Entity.Enum.Properties.PropertyInt.WeaponAugScaleQuality, quality);
+            wo.SetProperty(ACE.Entity.Enum.Properties.PropertyInt.WeaponAugScaleTier, tier);
+
+            // Visible identity line (the sectioned composer with the original line is dead code -
+            // this is the live LongDesc path, same as the wield gate + provenance lines). Grade
+            // first for the at-a-glance read; the percent says how close to a perfect roll this
+            // copy came (owner 2026-08-01: the raw 0-1000 fraction confused even the owner).
+            // The grade line lives in the Property Details section (AppraiseInfo, pinned top -
+            // owner 2026-08-01), computed live from the quality prop; nothing baked here.
+        }
+
+        /// <summary>Final pass over a T11+ drop's description (owner 2026-08-01): drop the inherited
+        /// weenie flavor text (e.g. a bare "Claw" line), keep our known lines in stamp order, and
+        /// move the ZoneLootMutator provenance ("Dropped by ...") to the very bottom. Runs LAST in
+        /// the Creature_Death presentation sweep. Whitelist-based: a future line-adder must either
+        /// run after this or register its prefix here.</summary>
+        public static void FinalizeT11LongDesc(WorldObject wo)
+        {
+            var ld = wo?.LongDesc;
+            if (string.IsNullOrWhiteSpace(ld))
+                return;
+
+            var keep = new System.Text.StringBuilder();
+            var provenance = new System.Text.StringBuilder();
+            foreach (var raw in ld.Split('\n'))
+            {
+                var line = raw.Trim();
+                if (line.Length == 0)
+                    continue;
+                if (line.StartsWith("Dropped by") || line.StartsWith("Dropped in ") || line.StartsWith("Location:"))
+                    provenance.Append(provenance.Length > 0 ? "\n" : "").Append(line);
+                // A "Creature Augmentation:" line used to be regenerated here from prop 50213.
+                // The fixed base that stamped it was deleted 2026-08-22 - Creature Augs is now a
+                // plain banded cantrip (key 35) and stamps "Zone Cantrip: Creature Augs" like the
+                // other six augs. Legacy drops still carrying the old line fall through to the
+                // discard below, which is what we want: the line is stale by definition.
+                else if (line.StartsWith("Wield requires:") || line.StartsWith("Weapon Grade:") || line.StartsWith("Aug Scaling")
+                      || line.StartsWith("Zone Cantrip:"))
+                    keep.Append(keep.Length > 0 ? "\n" : "").Append(line);
+                // anything else = inherited weenie flavor text - discarded by design
+            }
+
+            if (provenance.Length > 0)
+                keep.Append(keep.Length > 0 ? "\n\n" : "").Append(provenance);
+            wo.LongDesc = keep.Length > 0 ? keep.ToString() : null;
+        }
+
+        public static void StripWieldRequirements(WorldObject wo)
+        {
+            if (wo == null)
+                return;
+
+            if (wo.WieldRequirements != ACE.Entity.Enum.WieldRequirement.Invalid)
+            {
+                wo.WieldRequirements = ACE.Entity.Enum.WieldRequirement.Invalid;
+                wo.WieldSkillType = null;
+                wo.WieldDifficulty = null;
+            }
+
+            if (wo.WieldRequirements2 != ACE.Entity.Enum.WieldRequirement.Invalid)
+            {
+                wo.WieldRequirements2 = ACE.Entity.Enum.WieldRequirement.Invalid;
+                wo.WieldSkillType2 = null;
+                wo.WieldDifficulty2 = null;
+            }
+        }
+
+        private static readonly ACE.Entity.Enum.Properties.PropertyFloat[] armorModVsProps =
+        {
+            ACE.Entity.Enum.Properties.PropertyFloat.ArmorModVsSlash,
+            ACE.Entity.Enum.Properties.PropertyFloat.ArmorModVsPierce,
+            ACE.Entity.Enum.Properties.PropertyFloat.ArmorModVsBludgeon,
+            ACE.Entity.Enum.Properties.PropertyFloat.ArmorModVsFire,
+            ACE.Entity.Enum.Properties.PropertyFloat.ArmorModVsCold,
+            ACE.Entity.Enum.Properties.PropertyFloat.ArmorModVsAcid,
+            ACE.Entity.Enum.Properties.PropertyFloat.ArmorModVsElectric,
+            ACE.Entity.Enum.Properties.PropertyFloat.ArmorModVsNether,
+        };
+
+        /// <summary>
+        /// Equalizes a tier-11+ armor piece's eight resistance multipliers to their mean (owner
+        /// 2026-07-20: one uniform protection value instead of eight per-element spreads). Budget-
+        /// neutral: the mean of the rolled mods, applied to every mod the piece actually has.
+        /// The stock client panel now renders its eight per-element lines with one identical
+        /// value each (panel takeover reverted 2026-07-21).
+        /// </summary>
+        /// <summary>
+        /// Tier-11+ deterministic gear budget (owner plan 2026-08-20/21): every non-weapon
+        /// piece of zone-set loot and /asforge gear carries the same fixed per-slot stats,
+        /// doubling per tier - "fixed base, variable extras", all drop variance lives in
+        /// cantrips so damage-taken tuning works against a known floor. C# is the DEFAULT
+        /// layer only; the cantrip stamps run AFTER this and layer on top (the armor_al_* zone knobs were removed 2026-08-23).
+        /// Shared by Creature_Death (loot sweep) and TestCharacterCommands (/asforge) so
+        /// premades match drops exactly. Classifier is ItemType: Armor=2 covers body armor
+        /// AND shields; Clothing=4 is shirt/pants/cloak (never authored AL); Jewelry=8
+        /// contributes no AL by engine rule (only WeenieType.Clothing is an armor layer).
+        /// </summary>
+        public static void ApplyT11GearStats(WorldObject wo, int tier, bool forceMax = false,
+            ACE.Server.Managers.ZoneScaling.EvaluatedProfile p = null, double? coreFrac = null)
+        {
+            if (wo == null || tier < ZoneLootSetMinTier)
+                return;
+
+            // THE ANCHORED LINEAR LADDER (owner 2026-08-21, supersedes the rejected doubling):
+            // T25 best-in-slot anchors - 2,500 armor PER PIECE; SET totals 2,500 Damage Resist /
+            // 1,500 CritDmgResist / CritResist / NetherResist. T11 BiS = half the anchor; per-tier
+            // value = base x (1 + (t-11)/14), so every stat exactly doubles across the T11->T25
+            // journey and armor steps a flat +100/tier.
+            //
+            // Armor v2 (owner 2026-08-21 afternoon, Cantrip_Band_Ladder v2 section 1): the
+            // GUARANTEED defensive core is the four resist ratings, ROLLED uniformly inside a
+            // per-tier window instead of written as a constant, FLAT across all 18 slots (the
+            // inherited 50/30/55 armor/clothing/jewelry weighting is dead). Per piece:
+            //   cap(t)  = anchor/18 x (1 + (t-11)/14)
+            //   step    = anchor/18/14            (FIXED T11 step, not per-tier cap/14)
+            //   floor   = cap - 1.5 step          (T11: cap - 0.5 step - no previous tier)
+            // Rounded at the END only: rounding the cap first breaks the 750-class T11 window
+            // (spec wants 40-42). Damage Rating and Max Health are NOT here any more - they are
+            // random chase lines (keys 28 / 19). Mobs are tuned against the FLOOR of the core.
+
+            // zone override surface for the anchors (core_anchor_dr / core_anchor_cdr); C# is the default
+            var anchorDr = p?.Get(ACE.Server.Managers.ZoneScaling.ZoneStat.CoreAnchorDr, 1250.0) ?? 1250.0;
+            var anchorCdr = p?.Get(ACE.Server.Managers.ZoneScaling.ZoneStat.CoreAnchorCdr, 750.0) ?? 750.0;
+
+            // Live stat resolution (owner 2026-08-22): the core four are GRADED. Window = the same
+            // formula (ZoneStatResolver.CoreWindow, fed the ZONE's evaluated anchor so the drop is
+            // identical to before), grade = uniform 0-1000 inside it (the core is uniform today and
+            // stays so - RollGrade's tier thirds are for the cantrip lines only), value = ValueFor.
+            // The grade is recorded in ZcModifiers; the Gear* prop is its cache. A piece is authored from
+            // scratch here, so any pre-existing record is cleared first.
+            ACE.Server.Managers.ZoneControl.ZoneStatResolver.Write(wo, null);
+            int RollCore(int coreKey, double anchor)
+            {
+                var (min, max) = ACE.Server.Managers.ZoneControl.ZoneStatResolver.CoreWindow(coreKey, tier, anchor);
+                int grade;
+                if (forceMax) grade = ACE.Server.Managers.ZoneControl.ZoneStatResolver.GradeMax;
+                // coreFrac: deterministic point inside the window (premade "Average" suits pass
+                // 0.5 = the midpoint). forceMax still wins above; null = the live random roll.
+                else if (coreFrac.HasValue) grade = (int)System.Math.Round(coreFrac.Value * ACE.Server.Managers.ZoneControl.ZoneStatResolver.GradeMax);
+                else grade = ThreadSafeRandom.Next(0, ACE.Server.Managers.ZoneControl.ZoneStatResolver.GradeMax);   // inclusive both ends
+                ACE.Server.Managers.ZoneControl.ZoneStatResolver.AddLine(wo, coreKey, grade);
+                return ACE.Server.Managers.ZoneControl.ZoneStatResolver.ValueFor(min, max, grade);
+            }
+
+            switch (wo.ItemType)
+            {
+                case ACE.Entity.Enum.ItemType.Armor:
+                    // RESOLVE-stage stat: armor_base_level on the tier Default, else 1100 + 100 x (tier-11).
+                    // This same call runs again inside ZoneStatResolver.Compute on every equip / login, so
+                    // re-authoring it re-prices EXISTING pieces - unlike the two protection knobs below.
+                    wo.ArmorLevel = ACE.Server.Managers.ZoneControl.ZoneStatResolver.BaseArmorLevel(tier);
+
+                    // Every element authored explicitly: ArmorModVs* defaults to 0.0 and
+                    // MULTIPLIES the piece AL - an absent prop is literally zero protection
+                    // for that element. Fill absent with armor_prot_base (default 1.0 = the
+                    // Average band), then equalize unless armor_prot_equalize is switched off.
+                    //
+                    // DROP-stage stats, BOTH of them: these are stamped onto the piece here and never read
+                    // again. Changing either moves NEW DROPS ONLY; nothing already in a backpack shifts.
+                    // (Armor_Base_Values_Plan_2026-08-24.md sections 2.2 / 2.3.)
+                    var protBase = ACE.Server.Managers.ZoneControl.ZoneStatResolver.ArmorProtBase(tier, p);
+                    foreach (var prop in armorModVsProps)
+                        if (!wo.GetProperty(prop).HasValue)
+                            wo.SetProperty(prop, protBase);
+                    EqualizeT11ArmorResists(wo, tier, p);
+                    break;
+
+                case ACE.Entity.Enum.ItemType.Clothing:
+                case ACE.Entity.Enum.ItemType.Jewelry:
+                    break;
+
+                default:
+                    // weapons / casters / ammo: the weapon-scaling system owns their STATS - but the
+                    // TIER is stamped here anyway as of 2026-08-25 (owner: "stamp ZcTier on weapons too").
+                    //
+                    // WHY. ZoneCraftGate.TierOf is max(ZcTier, WeaponAugScaleTier), and the entire T11+
+                    // crafting gate returns immediately when that reads 0. Weapons carried ONLY
+                    // WeaponAugScaleTier, so if that one stamp fails to land the gate is silently OFF for
+                    // every weapon on the shard - which is how an unguarded SetValue recipe (the Bag of
+                    // Abyssal-Touched Gems, recipe 527870098) can overwrite a rolled Biting Strike down to
+                    // 0.33 with nothing refusing it. On 2026-08-25 exactly 2 items on the shard carried
+                    // WeaponAugScaleTier and both were hand-made, so that was the live state, not a theory.
+                    //
+                    // The old rule "a weapon must not carry ZcTier" was a CONVENTION that documented
+                    // itself as a constraint. It is not one: both TierOf implementations take a plain max
+                    // and never branch on WHICH property is present, and the only code that decides "is
+                    // this armour" is ZoneStatResolver.Compute, which keys on ItemType + ArmorLevel and
+                    // not on ZcTier. So a weapon carrying ZcTier resolves its tier identically and cannot
+                    // accidentally acquire an ArmorLevel.
+                    //
+                    // Tested on ItemType, deliberately NOT on the runtime `wo is MeleeWeapon ||
+                    // MissileLauncher || Caster` that ApplyWeaponAugScaleStamp uses. Two INDEPENDENT
+                    // signals for the same fact: if a weapon somehow fails one test it still gets a tier
+                    // from the other. Belt and braces on purpose - the gate being live matters more than
+                    // tidiness about which property carries the row.
+                    //
+                    // Only the tier. No StampIdentity, no ZcResolvedVersion: the resolve stamp has to be
+                    // written AFTER the weapon's grades are recorded, and that happens later, in
+                    // ZoneLootMutator (StampWeaponResolve). Stamping a version here would mark the weapon
+                    // resolved before its record existed.
+                    if ((wo.ItemType & ACE.Entity.Enum.ItemType.WeaponOrCaster) != 0)
+                        wo.SetProperty(ACE.Entity.Enum.Properties.PropertyInt.ZcTier, tier);
+                    return;
+            }
+
+            // identity FIRST: tier + current ladder version, so StampGraded's key-25 path (TierOf) and
+            // Compute see the tier before any line lands
+            ACE.Server.Managers.ZoneControl.ZoneStatResolver.StampIdentity(wo, tier);
+
+            // Damage / Max Health left the fixed base (random pool now). REMOVE rather than skip:
+            // TryMutateGearRatingT10's coin-flip rolls would otherwise leak onto T11 drops.
+            // 2026-08-23: the same mutator also coin-flips Healing Boost (jewelry) and Crit
+            // Damage (armor) - a T11 bracelet shipped with Healing Boost 100 (the T10 rating) and
+            // no key-31 line. Strip every line-produced Gear* it can stamp; the ZcModifiers record is
+            // the only source of truth on T11+.
+            wo.RemoveProperty(ACE.Entity.Enum.Properties.PropertyInt.GearDamage);
+            wo.RemoveProperty(ACE.Entity.Enum.Properties.PropertyInt.GearMaxHealth);
+            wo.RemoveProperty(ACE.Entity.Enum.Properties.PropertyInt.GearHealingBoost);
+            wo.RemoveProperty(ACE.Entity.Enum.Properties.PropertyInt.GearCritDamage);
+
+            wo.SetProperty(ACE.Entity.Enum.Properties.PropertyInt.GearDamageResist, RollCore(ACE.Server.Managers.ZoneControl.ZoneStatResolver.CoreDamageResist, anchorDr));
+            wo.SetProperty(ACE.Entity.Enum.Properties.PropertyInt.GearCritDamageResist, RollCore(ACE.Server.Managers.ZoneControl.ZoneStatResolver.CoreCritDamageResist, anchorCdr));
+            wo.SetProperty(ACE.Entity.Enum.Properties.PropertyInt.GearCritResist, RollCore(ACE.Server.Managers.ZoneControl.ZoneStatResolver.CoreCritResist, anchorCdr));
+            wo.SetProperty(ACE.Entity.Enum.Properties.PropertyInt.GearNetherResist, RollCore(ACE.Server.Managers.ZoneControl.ZoneStatResolver.CoreNetherResist, anchorCdr));
+
+            // Gear Creature Augs used to get a fixed 30/20/12 x scale base here, written straight
+            // into prop 50213 alongside its own "Creature Augmentation:" LongDesc line. DELETED
+            // 2026-08-22 (owner): it pre-dated the 08-21 band pass and was never removed, so
+            // Creature Augs was the ONLY aug carrying a guaranteed floor on top of its banded
+            // cantrip. All seven aug keys (34 Item, 35 Creature, 36 Life, 37 War, 38 Void,
+            // 39 Melee, 40 Missile) now come from the cantrip roll alone, on the same [14-69]
+            // T11 band, so the set totals land on the authored 2500-at-T25 ladder instead of
+            // overshooting it into the gear_cap_line clamp.
+        }
+
+        /// <summary>
+        /// Gated on armor_prot_equalize since 2026-08-24 (default ON = the historical behaviour). OFF means
+        /// the elements keep whatever they rolled, so Poor and Unparalleled both survive instead of being
+        /// averaged toward the middle - that averaging, not any explicit exclusion, is why every T11+ piece
+        /// read as "Average" (plan section 1a).
+        ///
+        /// DROP-stage: this runs while a piece is being created and never afterwards, so flipping the stat
+        /// changes NEW DROPS ONLY. Existing gear keeps its stamped protections through every equip, login
+        /// and Apply Ladder. (Only armor_base_level is re-read at resolve time.)
+        ///
+        /// tier / p are OPTIONAL so the presentation-sweep call sites keep compiling unchanged: tier &lt;= 0
+        /// falls back to the piece's own stamped ZcTier, which by then is set, so the tier Default is still
+        /// honoured. A call with no profile cannot see a ZONE-level override - the tier Default layer is the
+        /// authoritative surface for this key.
+        /// </summary>
+        public static void EqualizeT11ArmorResists(WorldObject wo, int tier = 0,
+            ACE.Server.Managers.ZoneScaling.EvaluatedProfile p = null)
+        {
+            if (wo == null || (wo.ArmorLevel ?? 0) == 0)
+                return;
+
+            if (tier <= 0)
+                tier = ACE.Server.Managers.ZoneControl.ZoneStatResolver.TierOf(wo);
+            if (!ACE.Server.Managers.ZoneControl.ZoneStatResolver.ArmorProtEqualize(tier, p))
+                return;
+
+            var present = new List<ACE.Entity.Enum.Properties.PropertyFloat>();
+            var sum = 0.0;
+
+            foreach (var prop in armorModVsProps)
+            {
+                var val = wo.GetProperty(prop);
+                if (val.HasValue)
+                {
+                    present.Add(prop);
+                    sum += val.Value;
+                }
+            }
+
+            if (present.Count == 0)
+                return;
+
+            var mean = sum / present.Count;
+
+            foreach (var prop in present)
+                wo.SetProperty(prop, mean);
+        }
+
+        private enum ZoneSetFamily
+        {
+            Axe,        // skill: Heavy/Light/Finesse/TwoHanded
+            Dagger,     // skill: Heavy/Light/Finesse; MS or non-MS
+            Mace,       // skill: Heavy/Light/Finesse/TwoHanded; Mace or MaceJitte on 1H
+            Spear,      // skill: Heavy/Light/Finesse/TwoHanded
+            Staff,      // skill: Heavy/Light/Finesse
+            Sword,      // skill: Heavy/Light/Finesse/TwoHanded; MS or non-MS on 1H
+            Unarmed,    // skill: Heavy/Light/Finesse
+            Missile,    // bow / crossbow / atlatl
+            Caster,     // wand / orb / staff
+        }
+
+        private static readonly ZoneSetFamily[] zoneSetFamilies = (ZoneSetFamily[])System.Enum.GetValues(typeof(ZoneSetFamily));
+
+        /// <summary>Index of the two RANGED lanes inside <see cref="zoneSetFamilies"/>. Everything
+        /// else in that array is a MELEE family. Derived, not hardcoded, so reordering or extending
+        /// the enum cannot silently mis-lane the draw.</summary>
+        private static readonly int zoneSetMissileFamily = System.Array.IndexOf(zoneSetFamilies, ZoneSetFamily.Missile);
+        private static readonly int zoneSetCasterFamily = System.Array.IndexOf(zoneSetFamilies, ZoneSetFamily.Caster);
+
+        /// <summary>
+        /// BUDGET MODE sampler (owner 2026-08-24). Turns a total item budget plus category weights into
+        /// an ordinary ZoneLootSetCounts, so every existing creation path downstream is reused unchanged.
+        ///
+        /// For each of <paramref name="budget"/> items: weighted-pick a CATEGORY (weapon / armor /
+        /// jewelry / cloak - shield rides armor), then weighted-pick a SLOT inside it using the
+        /// per-slot weights carried on <paramref name="w"/>. Per-item sampling is what makes "on
+        /// average 3 armor" true: the split varies kill to kill and converges on the weights.
+        ///
+        /// 🔴 WEAPONS ARE DRAWN LANE-FIRST (owner 2026-08-31): "1/3 should be melee, 1/3 missile,
+        /// 1/3 caster - that's the goal". Every weapon pick chooses a LANE at equal weight, THEN a
+        /// family inside it. Within melee the seven families are still drawn WITHOUT REPLACEMENT
+        /// (three melee picks yield three different families, never three swords); missile and
+        /// caster are single families and DO repeat, which is what makes the thirds hold - see
+        /// the block comment at the weapon case. Armor and jewelry allow repeats too - two rings
+        /// is a legitimate roll.
+        ///
+        /// The budget is a CEILING, not a quota: armor coverage credit (one coat covering chest +
+        /// abdomen + upper arms) can satisfy several sampled slots with a single item, so the corpse
+        /// can land under budget. That is intended - the owner asked for "max drops".
+        /// </summary>
+        public static ZoneLootSetCounts RollBudgetedCounts(
+            ZoneLootSetCounts w, int budget,
+            double wWeapon, double wArmor, double wJewelry, double wCloak)
+        {
+            var result = new ZoneLootSetCounts { WeaponFamilyPicks = new List<int>() };
+            if (budget <= 0)
+                return result;
+
+            // slots per category, paired with their authored weight (0 = never)
+            var armorSlots = new (int Slot, double Weight)[]
+            {
+                (0, w.Helm), (1, w.Chest), (2, w.Shoulder), (3, w.Bracer), (4, w.Glove),
+                (5, w.Girth), (6, w.UpperLeg), (7, w.LowerLeg), (8, w.Boot), (9, w.Shield),
+            };
+            var jewelSlots = new (int Slot, double Weight)[]
+            {
+                (0, w.Amulet), (1, w.Ring), (2, w.Bracelet), (3, w.Trinket),
+            };
+
+            // melee families only - the two ranged lanes are single families that repeat, so they
+            // are never consumed and never need a free-list
+            var freeMelee = new List<int>();
+            for (var i = 0; i < zoneSetFamilies.Length; i++)
+                if (i != zoneSetMissileFamily && i != zoneSetCasterFamily)
+                    freeMelee.Add(i);
+
+            static double Sum((int Slot, double Weight)[] a)
+            {
+                var t = 0.0;
+                foreach (var e in a) if (e.Weight > 0) t += e.Weight;
+                return t;
+            }
+
+            static int PickSlot((int Slot, double Weight)[] a, double total)
+            {
+                var roll = ACE.Common.ThreadSafeRandom.Next(0.0f, (float)total);
+                var run = 0.0;
+                foreach (var e in a)
+                {
+                    if (e.Weight <= 0) continue;
+                    run += e.Weight;
+                    if (roll < run) return e.Slot;
+                }
+                for (var i = a.Length - 1; i >= 0; i--) if (a[i].Weight > 0) return a[i].Slot;
+                return -1;
+            }
+
+            for (var n = 0; n < budget; n++)
+            {
+                // rebuild category availability each pick: weapons fall out once all nine are drawn,
+                // and a category whose every slot is weighted 0 must never be chosen
+                var armorTotal = Sum(armorSlots);
+                var jewelTotal = Sum(jewelSlots);
+                var cats = new List<(int Cat, double Weight)>();
+                // w.Weapons gates the category on/off exactly like every other slot ("a slot at 0 is
+                // off"). Without this the weapon pool is always non-empty, so a sub-tier-11 profile -
+                // where TierDefault zeroes every slot - would drop WEAPONS ONLY instead of nothing.
+                // No free-list test any more: missile and caster repeat, so the weapon category can
+                // never run dry the way it did when all nine families were consumable.
+                if (wWeapon > 0 && w.Weapons > 0) cats.Add((0, wWeapon));
+                if (wArmor > 0 && armorTotal > 0) cats.Add((1, wArmor));
+                if (wJewelry > 0 && jewelTotal > 0) cats.Add((2, wJewelry));
+                if (wCloak > 0 && w.Cloak > 0) cats.Add((3, wCloak));
+                if (cats.Count == 0)
+                    break;
+
+                var catTotal = 0.0;
+                foreach (var c in cats) catTotal += c.Weight;
+                var catRoll = ACE.Common.ThreadSafeRandom.Next(0.0f, (float)catTotal);
+                var picked = cats[cats.Count - 1].Cat;
+                var acc = 0.0;
+                foreach (var c in cats)
+                {
+                    acc += c.Weight;
+                    if (catRoll < acc) { picked = c.Cat; break; }
+                }
+
+                switch (picked)
+                {
+                    case 0:   // weapon - LANE first (equal thirds), then the family inside the lane
+                        //
+                        // 🔴 WHY LANE-FIRST AND NOT A WEIGHT ON THE FAMILY DRAW. The obvious fix for
+                        // "melee is 7 of 9 families" is to weight the flat family pick - melee 1 each,
+                        // missile and caster 16. Measured, that DOES land 33.5/33.2/33.3 today, and it
+                        // is a fitted number that silently rots: because missile and caster were single
+                        // families drawn WITHOUT replacement they were hard-capped at one per corpse,
+                        // so the split moves with how many weapons a corpse drops. Same weight of 16 at
+                        // budget 10-14 gives melee 44.1 pct; at weapon category weight 4 it gives 45.1
+                        // pct. The thirds would quietly break every time someone touched an unrelated
+                        // Drop Table knob, with nothing in the GUI to say so.
+                        // Choosing the LANE first makes the ratio STRUCTURAL: measured 33.3/33.4/33.3
+                        // and flat across budget 4-6 / 7-9 / 10-14 and weapon weights 1, 2 and 4.
+                        //
+                        // 🔴 MISSILE AND CASTER MUST BE ALLOWED TO REPEAT. Capping either at one per
+                        // corpse re-introduces the exact bias this replaces (measured: missile capped
+                        // = 37.2 melee / 25.5 missile / 37.4 caster). Repeats are harmless - each entry
+                        // re-rolls its own sub-type downstream in CreateZoneSetWeapon, so two missile
+                        // picks are usually a bow and a crossbow, and CasterWcids is one pool anyway.
+                        // About 12.6 pct of corpses now carry two or more of one ranged lane; that is
+                        // the intended cost of a true third (owner ruled "caster repeats allowed").
+                    {
+                        var lanes = new List<int>(3);
+                        if (freeMelee.Count > 0) lanes.Add(0);   // melee - only while a family is left
+                        lanes.Add(1);                            // missile - repeats
+                        lanes.Add(2);                            // caster  - repeats
+                        var lane = lanes[ACE.Common.ThreadSafeRandom.Next(0, lanes.Count - 1)];
+                        if (lane == 0)
+                        {
+                            var fi = ACE.Common.ThreadSafeRandom.Next(0, freeMelee.Count - 1);
+                            result.WeaponFamilyPicks.Add(freeMelee[fi]);
+                            freeMelee.RemoveAt(fi);
+                        }
+                        else
+                            result.WeaponFamilyPicks.Add(lane == 1 ? zoneSetMissileFamily : zoneSetCasterFamily);
+                    }
+                        break;
+
+                    case 1:   // armor (shield included)
+                        switch (PickSlot(armorSlots, armorTotal))
+                        {
+                            case 0: result.Helm++; break;
+                            case 1: result.Chest++; break;
+                            case 2: result.Shoulder++; break;
+                            case 3: result.Bracer++; break;
+                            case 4: result.Glove++; break;
+                            case 5: result.Girth++; break;
+                            case 6: result.UpperLeg++; break;
+                            case 7: result.LowerLeg++; break;
+                            case 8: result.Boot++; break;
+                            case 9: result.Shield++; break;
+                        }
+                        break;
+
+                    case 2:   // jewelry
+                        switch (PickSlot(jewelSlots, jewelTotal))
+                        {
+                            case 0: result.Amulet++; break;
+                            case 1: result.Ring++; break;
+                            case 2: result.Bracelet++; break;
+                            case 3: result.Trinket++; break;
+                        }
+                        break;
+
+                    default:  // cloak
+                        result.Cloak++;
+                        break;
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Generates the full structured loot set for one kill, one category per configured slot,
+        /// all mutated against <paramref name="profile"/>.
+        /// </summary>
+        public static List<WorldObject> CreateZoneLootSet(TreasureDeath profile, ZoneLootSetCounts counts)
+        {
+            var items = new List<WorldObject>();
+
+            if (counts.WeaponFamilyPicks != null)
+            {
+                // budget mode: exactly the sampled families, ONE weapon each
+                foreach (var famIdx in counts.WeaponFamilyPicks)
+                {
+                    var family = (ZoneSetFamily)famIdx;
+                    var weapon = CreateZoneSetWeapon(profile, family);
+                    if (weapon != null)
+                        items.Add(weapon);
+                    else
+                        log.Warn($"[ZONELOOT] CreateZoneLootSet({profile.TreasureType}): failed to create {family} weapon");
+                }
+            }
+            else
+            {
+                // legacy mode: the count is a MULTIPLIER over every family - 1 yields all nine
+                for (var i = 0; i < counts.Weapons; i++)
+                {
+                    foreach (var family in zoneSetFamilies)
+                    {
+                        var weapon = CreateZoneSetWeapon(profile, family);
+                        if (weapon != null)
+                            items.Add(weapon);
+                        else
+                            log.Warn($"[ZONELOOT] CreateZoneLootSet({profile.TreasureType}): failed to create {family} weapon");
+                    }
+                }
+            }
+
+            AddZoneSetArmorSlots(items, profile, counts);
+
+            for (var i = 0; i < counts.Shield; i++)
+                AddZoneSetShield(items, profile);
+
+            for (var i = 0; i < counts.Amulet; i++)
+                AddZoneSetJewelryPiece(items, profile, zoneSetNeckWcids, "neck");
+            for (var i = 0; i < counts.Bracelet; i++)
+                AddZoneSetJewelryPiece(items, profile, zoneSetWristWcids, "wrist");
+            for (var i = 0; i < counts.Ring; i++)
+                AddZoneSetJewelryPiece(items, profile, zoneSetFingerWcids, "finger");
+            for (var i = 0; i < counts.Trinket; i++)
+                AddZoneSetJewelryPiece(items, profile, zoneSetTrinketWcids, "trinket");
+
+            for (var i = 0; i < counts.Cloak; i++)
+                AddZoneSetGearPiece(items, profile, TreasureItemType_Orig.Cloak);
+
+            return items;
+        }
+
+        /// <summary>
+        /// Walks the nine armor equip slots top-down, dropping pieces until every slot has met its
+        /// configured count. A multi-slot piece (an Amuli coat covers chest + abdomen + upper arms)
+        /// CREDITS every slot it covers, so covered slots don't roll again (owner decision
+        /// 2026-07-20) -- with all counts at 1 this yields one clean wearable set, 4-9 pieces.
+        /// </summary>
+        private static void AddZoneSetArmorSlots(List<WorldObject> items, TreasureDeath profile, ZoneLootSetCounts counts)
+        {
+            // top-down slot order; each entry pairs the CoverageMask bit with its configured count
+            var slots = new (ACE.Entity.Enum.CoverageMask mask, int target)[]
+            {
+                (ACE.Entity.Enum.CoverageMask.Head,               counts.Helm),
+                (ACE.Entity.Enum.CoverageMask.OuterwearChest,     counts.Chest),
+                (ACE.Entity.Enum.CoverageMask.OuterwearUpperArms, counts.Shoulder),
+                (ACE.Entity.Enum.CoverageMask.OuterwearLowerArms, counts.Bracer),
+                (ACE.Entity.Enum.CoverageMask.Hands,              counts.Glove),
+                (ACE.Entity.Enum.CoverageMask.OuterwearAbdomen,   counts.Girth),
+                (ACE.Entity.Enum.CoverageMask.OuterwearUpperLegs, counts.UpperLeg),
+                (ACE.Entity.Enum.CoverageMask.OuterwearLowerLegs, counts.LowerLeg),
+                (ACE.Entity.Enum.CoverageMask.Feet,               counts.Boot),
+            };
+
+            var credit = new int[slots.Length];
+
+            for (var s = 0; s < slots.Length; s++)
+            {
+                while (credit[s] < slots[s].target)
+                {
+                    // reject-sample the normal armor roll until it yields a piece covering this
+                    // slot. Coverage comes from the cached weenie, so rejects cost no object
+                    // creation.
+                    var armorType = TreasureArmorType.Undef;
+                    var wcid = WeenieClassName.undef;
+
+                    for (var attempt = 0; attempt < 50; attempt++)
+                    {
+                        // same two-step as the stock armor path (LootGenerationFactory.cs:1130-1131):
+                        // roll the armor TYPE for the tier, then a wcid within it
+                        var candidateType = ArmorTypeChance.Roll(profile.Tier);
+                        var candidate = ArmorWcids.Roll(profile, ref candidateType);
+
+                        if (candidate == WeenieClassName.undef)
+                            continue;
+
+                        var candidateCoverage = GetZoneSetCoverage(candidate);
+
+                        if ((candidateCoverage & slots[s].mask) == 0)
+                            continue;   // wrong slot (or a shield / non-clothing entry)
+
+                        armorType = candidateType;
+                        wcid = candidate;
+                        break;
+                    }
+
+                    if (wcid == WeenieClassName.undef)
+                    {
+                        log.Warn($"[ZONELOOT] CreateZoneLootSet({profile.TreasureType}): no armor wcid found covering {slots[s].mask}");
+                        break;
+                    }
+
+                    var roll = new TreasureRoll(TreasureItemType_Orig.Armor) { ArmorType = armorType, Wcid = wcid };
+                    var wo = CreateAndMutateWcid(profile, roll, false);
+
+                    if (wo == null)
+                    {
+                        log.Warn($"[ZONELOOT] CreateZoneLootSet({profile.TreasureType}): failed to create {slots[s].mask} armor ({wcid})");
+                        break;
+                    }
+
+                    items.Add(wo);
+
+                    // ONE PICK = ONE PIECE (owner 2026-08-30). This used to credit EVERY slot the
+                    // piece covered, so a coat satisfied chest + abdomen + upper arms with a single
+                    // item and the corpse landed well under its armor budget - measured against T10
+                    // that is the ONLY bucket that shrinks, because weapons / jewelry / cloak have no
+                    // coverage overlap. Retail T10 rolls each armor item independently
+                    // (ArmorWcids.Roll, no state between items - ten girths is a legal T10 corpse),
+                    // and the owner ruled T11 must match: "if t10 rolls independant, we need to do
+                    // the same for t11".
+                    // This REVERSES the 07-20 spec decision ("a multi-slot piece fills every slot it
+                    // covers -> one clean wearable set, no overlap"). Overlap is now expected and
+                    // intended: two pieces covering the same slot is a normal corpse, as at T10.
+                    // The slot WEIGHTS still steer which slot each pick asks for, so the Drop Table >
+                    // Slots tab keeps its meaning - what changed is only that satisfying one slot no
+                    // longer silently satisfies its neighbours.
+                    credit[s]++;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Shields carry no ClothingPriority, so they can never satisfy an armor slot and are
+        /// rolled separately here.
+        /// </summary>
+        private static void AddZoneSetShield(List<WorldObject> items, TreasureDeath profile)
+        {
+            for (var attempt = 0; attempt < 50; attempt++)
+            {
+                var armorType = ArmorTypeChance.Roll(profile.Tier);
+                var wcid = ArmorWcids.Roll(profile, ref armorType);
+
+                if (wcid == WeenieClassName.undef)
+                    continue;
+
+                var weenie = DatabaseManager.World.GetCachedWeenie((uint)wcid);
+
+                if ((weenie?.GetProperty(PropertyInt.CombatUse) ?? 0) != (int)ACE.Entity.Enum.CombatUse.Shield)
+                    continue;
+
+                var roll = new TreasureRoll(TreasureItemType_Orig.Armor) { ArmorType = armorType, Wcid = wcid };
+                var wo = CreateAndMutateWcid(profile, roll, false);
+
+                if (wo != null)
+                {
+                    items.Add(wo);
+                    return;
+                }
+            }
+
+            log.Warn($"[ZONELOOT] CreateZoneLootSet({profile.TreasureType}): failed to roll a shield");
+        }
+
+        /// <summary>
+        /// Renames a tier-11+ drop to "T11 - [base weenie name]" (owner decision 2026-07-20).
+        /// MaterialType is cleared because the CLIENT prepends the material adjective to the
+        /// displayed name ("Iron T11 - Frost Ken" otherwise) -- the trade-off is these drops
+        /// cannot be salvaged for material (acceptable: T11 gear is worn, not salvage fodder;
+        /// ItemWorkmanship stays, so tinkering ONTO the item still works).
+        /// </summary>
+        public static void ApplyT11NamePrefix(WorldObject wo)
+        {
+            if (wo == null)
+                return;
+
+            var weenie = DatabaseManager.World.GetCachedWeenie(wo.WeenieClassId);
+            var baseName = weenie?.GetProperty(ACE.Entity.Enum.Properties.PropertyString.Name) ?? wo.Name;
+
+            if (string.IsNullOrWhiteSpace(baseName) || baseName.StartsWith("T11 - "))
+                return;
+
+            wo.Name = $"T11 - {baseName}";
+            wo.MaterialType = null;
+        }
+
+        /// <summary>
+        /// Corpse display order for tier-11+ loot (owner decision 2026-07-20): quest/create-list
+        /// items are added to the corpse before treasure (see GenerateTreasure), and treasure
+        /// itself sorts casters, then missile launchers, then unarmed, then sword, then the other
+        /// melee families, then armor, shields, jewelry, cloaks. Lower = earlier. Stable-sorted,
+        /// so generation order is preserved within a group.
+        /// </summary>
+        public static int GetZoneLootDisplayOrder(WorldObject wo)
+        {
+            if (wo is Caster)
+                return 10;
+
+            if (wo is MissileLauncher || wo is Missile)
+                return 20;
+
+            if (wo is MeleeWeapon)
+            {
+                return wo.W_WeaponType switch
+                {
+                    ACE.Entity.Enum.WeaponType.Unarmed => 30,
+                    ACE.Entity.Enum.WeaponType.Sword => 40,
+                    ACE.Entity.Enum.WeaponType.Axe => 50,
+                    ACE.Entity.Enum.WeaponType.Dagger => 60,
+                    ACE.Entity.Enum.WeaponType.Mace => 70,
+                    ACE.Entity.Enum.WeaponType.Spear => 80,
+                    ACE.Entity.Enum.WeaponType.Staff => 90,
+                    _ => 95,
+                };
+            }
+
+            if (wo.IsShield)
+                return 110;
+
+            if ((wo.ArmorLevel ?? 0) > 0)
+                return 100;
+
+            if (wo.ItemType == ACE.Entity.Enum.ItemType.Jewelry)
+                return 120;
+
+            if (ACE.Server.Entity.Cloak.IsCloak(wo))
+                return 130;
+
+            if (wo is Clothing)
+                return 105;
+
+            return 200;     // coins, gems, anything uncategorized -> last
+        }
+
+        /// <summary>
+        /// Tints a tier-11+ weapon's name by its damage element (owner 2026-07-20, trial: "may
+        /// revert"). UiEffects drives the client's name-text tint; DamageType bits map 1:1 onto
+        /// UiEffects bits (Cold -> Frost, Electric -> Lightning, etc.). Weapons only; a weapon
+        /// with no damage type (e.g. a plain caster) keeps whatever it had.
+        /// </summary>
+        public static void ApplyT11ElementTint(WorldObject wo)
+        {
+            if (wo == null || !(wo is MeleeWeapon || wo is MissileLauncher || wo is Caster))
+                return;
+
+            var dt = wo.W_DamageType;
+            var fx = default(ACE.Entity.Enum.UiEffects);
+
+            if (dt.HasFlag(ACE.Entity.Enum.DamageType.Fire))     fx |= ACE.Entity.Enum.UiEffects.Fire;
+            if (dt.HasFlag(ACE.Entity.Enum.DamageType.Cold))     fx |= ACE.Entity.Enum.UiEffects.Frost;
+            if (dt.HasFlag(ACE.Entity.Enum.DamageType.Acid))     fx |= ACE.Entity.Enum.UiEffects.Acid;
+            if (dt.HasFlag(ACE.Entity.Enum.DamageType.Electric)) fx |= ACE.Entity.Enum.UiEffects.Lightning;
+            if (dt.HasFlag(ACE.Entity.Enum.DamageType.Nether))   fx |= ACE.Entity.Enum.UiEffects.Nether;
+            if (dt.HasFlag(ACE.Entity.Enum.DamageType.Slash))    fx |= ACE.Entity.Enum.UiEffects.Slashing;
+            if (dt.HasFlag(ACE.Entity.Enum.DamageType.Pierce))   fx |= ACE.Entity.Enum.UiEffects.Piercing;
+            if (dt.HasFlag(ACE.Entity.Enum.DamageType.Bludgeon)) fx |= ACE.Entity.Enum.UiEffects.Bludgeoning;
+
+            if (fx != 0)
+                wo.UiEffects = fx;
+        }
+
+        /// <summary>
+        /// The client's qualitative armor-protection labels, calibrated against observed client
+        /// output (0.40 -> Below Average; 0.84..1.18 -> Average; 1.30 -> Above Average).
+        /// </summary>
+        public static string ProtectionLabel(double mod)
+        {
+            if (mod < 0.2) return "Poor";
+            if (mod < 0.8) return "Below Average";
+            if (mod < 1.2) return "Average";
+            if (mod < 1.4) return "Above Average";
+            if (mod < 1.6) return "Superior";
+            if (mod < 1.8) return "Excellent";
+            return "Unparalleled";
+        }
+
+        /// <summary>
+        /// Splits a PascalCase enum name into words ("HeavyWeapons" -> "Heavy Weapons").
+        /// </summary>
+        private static string SpaceOutEnum(string name)
+        {
+            var sb = new System.Text.StringBuilder(name.Length + 4);
+            foreach (var c in name)
+            {
+                if (char.IsUpper(c) && sb.Length > 0)
+                    sb.Append(' ');
+                sb.Append(c);
+            }
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// CURRENTLY UNCALLED -- the full panel takeover was reverted (owner 2026-07-21): the
+        /// client renders its stock examine panel and AppraiseInfo no longer suppresses anything.
+        /// Kept as the skeleton for the planned replacement, which APPENDS a small block to the
+        /// bottom of the default panel (LongDesc renders last) instead of replacing it -- the
+        /// ratings-range, wield-requirement and provenance pieces here are the reuse candidates;
+        /// the armor/weapon stat lines duplicate what the stock panel already shows and go away.
+        /// ASCII only (old client cannot render anything else).
+        /// </summary>
+        public static void AppendRatingsAppraisalBlock(WorldObject wo, string droppedBy = null, int? variation = null, string zoneName = null)
+        {
+            if (wo == null)
+                return;
+
+            var sb = new System.Text.StringBuilder();
+
+            // ---- 1. ratings, at the very top (finally possible now that we own the panel)
+            var ratings = new List<(string label, int value)>();
+
+            void Collect(string label, int? value)
+            {
+                if (value.HasValue && value.Value > 0)
+                    ratings.Add((label, value.Value));
+            }
+
+            Collect("Damage", wo.GearDamage);
+            Collect("Damage Resist", wo.GearDamageResist);
+            Collect("Crit", wo.GearCrit);
+            Collect("Crit Resist", wo.GearCritResist);
+            Collect("Crit Damage", wo.GearCritDamage);
+            Collect("Crit Damage Resist", wo.GearCritDamageResist);
+            Collect("Nether Resist", wo.GearNetherResistRating);
+            Collect("Healing Boost", wo.GearHealingBoost);
+            Collect("Max Health", wo.GearMaxHealth);
+
+            if (ratings.Count > 0)
+            {
+                // category determines which tier-11 table produced the rolls (mirrors the
+                // category logic in GearRatingChance.RollT11 / TryMutateGearRatingT10)
+                var category =
+                    wo is MeleeWeapon || wo is MissileLauncher || wo is Caster ? Tables.GearRatingChance.GearRatingCategory.Weapon :
+                    (wo.ArmorLevel ?? 0) > 0 || wo.IsShield ? Tables.GearRatingChance.GearRatingCategory.Armor :
+                    wo.ItemType == ACE.Entity.Enum.ItemType.Jewelry ? Tables.GearRatingChance.GearRatingCategory.Jewelry :
+                    Tables.GearRatingChance.GearRatingCategory.Clothing;
+
+                var (min, max) = Tables.GearRatingChance.GetRangeT11(category);
+
+                sb.Append("Ratings:");
+
+                foreach (var (label, value) in ratings)
+                {
+                    // shield Max Health is a flat 100-200 roll, not a table roll
+                    var (lo, hi) = label == "Max Health" && wo.IsShield ? (100, 200) : (min, max);
+
+                    sb.Append($"\n* {label} {value} [{lo}-{hi}]");
+                }
+
+                sb.Append("\n\n");
+            }
+
+            // ---- 2. armor stats
+            if ((wo.ArmorLevel ?? 0) > 0)
+            {
+                sb.Append($"Armor Level: {wo.ArmorLevel}\n");
+
+                var mod = wo.GetProperty(ACE.Entity.Enum.Properties.PropertyFloat.ArmorModVsSlash);
+                if (mod.HasValue)
+                    sb.Append($"Protection: {ProtectionLabel(mod.Value)} ({(int)System.Math.Round(wo.ArmorLevel.Value * mod.Value)})\n");
+            }
+
+            // ---- 3. weapon stats (replaces the suppressed WeaponProfile section)
+            if (wo is MeleeWeapon || wo is MissileLauncher || wo is Caster)
+            {
+                if (wo.WeaponSkill != ACE.Entity.Enum.Skill.None)
+                    sb.Append($"Skill: {SpaceOutEnum(wo.WeaponSkill.ToString())}\n");
+
+                if ((wo.Damage ?? 0) > 0)
+                {
+                    var variance = wo.DamageVariance ?? 0.0;
+                    var maxDmg = wo.Damage.Value;
+                    var minDmg = (int)System.Math.Round(maxDmg * (1.0 - variance));
+                    sb.Append($"Damage: {minDmg} - {maxDmg}\n");
+                }
+
+                if ((wo.ElementalDamageBonus ?? 0) > 0)
+                    sb.Append($"Elemental Damage Bonus: +{wo.ElementalDamageBonus}\n");
+
+                if ((wo.DamageMod ?? 0) > 1.0)
+                    sb.Append($"Damage Modifier: x{wo.DamageMod:0.00}\n");
+
+                if ((wo.ElementalDamageMod ?? 0) > 1.0)
+                    sb.Append($"Elemental Damage: +{(int)System.Math.Round((wo.ElementalDamageMod.Value - 1.0) * 100)}%\n");
+
+                if ((wo.ManaConversionMod ?? 0) > 0)
+                    sb.Append($"Mana Conversion: +{(int)System.Math.Round(wo.ManaConversionMod.Value * 100)}%\n");
+
+                if ((wo.WeaponTime ?? 0) > 0)
+                    sb.Append($"Speed: {wo.WeaponTime}\n");
+
+                if ((wo.WeaponOffense ?? 0) > 1.0)
+                    sb.Append($"Attack Bonus: +{(int)System.Math.Round((wo.WeaponOffense.Value - 1.0) * 100)}%\n");
+
+                if ((wo.WeaponDefense ?? 0) > 1.0)
+                    sb.Append($"Melee Defense Bonus: +{(int)System.Math.Round((wo.WeaponDefense.Value - 1.0) * 100)}%\n");
+            }
+
+            // ---- 4. general info
+            // Value / Burden / "Covers" are NOT composed here: the client renders those three
+            // lines unconditionally (Value/EncumbranceVal ints are kept in the appraisal profile;
+            // Covers comes from the object description) -- adding them again would duplicate.
+            // Workmanship is intentionally NOT shown on T11 drops (owner 2026-07-20); the
+            // ItemWorkmanship property itself stays, so tinkering onto the gear still works.
+            if ((wo.ItemMaxLevel ?? 0) > 0)
+                sb.Append($"Item Levels: {wo.ItemMaxLevel}\n");
+
+            // the item-aug wield gate (client cannot render Int64Stat requirements)
+            if (wo.WieldRequirements == ACE.Entity.Enum.WieldRequirement.Int64Stat &&
+                wo.WieldSkillType == (int)PropertyInt64.LumAugItemCount)
+                sb.Append(WieldLineFor(wo)).Append('\n');
+
+            // aug-scaling identity (the per-wielder damage term itself shows live in the weapon
+            // panel via WeaponProfile; this line records the item's fixed roll)
+            if (wo.GetProperty(ACE.Entity.Enum.Properties.PropertyInt.WeaponAugScaleQuality) is int wsq)
+                sb.Append($"Aug Scaling Quality: {wsq:N0} / 1,000\n");
+
+            // ---- 5. provenance, at the very bottom: what dropped it, at which variant, and the
+            // Zone Control zone when one governed the kill (omitted otherwise)
+            if (!string.IsNullOrWhiteSpace(droppedBy))
+            {
+                sb.Append($"\nDropped by: {droppedBy}\n");
+                sb.Append($"Variant: {(variation.HasValue && variation.Value != 0 ? variation.Value.ToString() : "base")}");
+
+                if (!string.IsNullOrWhiteSpace(zoneName))
+                    sb.Append($"\nZone: {zoneName}");
+            }
+
+            wo.LongDesc = sb.ToString().TrimEnd('\n');
+        }
+
+        private static void AddZoneSetJewelryPiece(List<WorldObject> items, TreasureDeath profile, WeenieClassName[] pool, string slotName)
+        {
+            var wcid = pool[ThreadSafeRandom.Next(0, pool.Length - 1)];
+
+            var roll = new TreasureRoll(TreasureItemType_Orig.Jewelry) { Wcid = wcid };
+            var wo = CreateAndMutateWcid(profile, roll, false);
+
+            if (wo != null)
+                items.Add(wo);
+            else
+                log.Warn($"[ZONELOOT] CreateZoneLootSet({profile.TreasureType}): failed to create {slotName} jewelry ({wcid})");
+        }
+
+        private static void AddZoneSetGearPiece(List<WorldObject> items, TreasureDeath profile, TreasureItemType_Orig itemType)
+        {
+            // TreasureItemCategory.Item => isMagical = false throughout the mutation chain (blank gear)
+            var wo = CreateRandomLootObjects_New(profile, TreasureItemCategory.Item, itemType);
+
+            if (wo != null)
+                items.Add(wo);
+            else
+                log.Warn($"[ZONELOOT] CreateZoneLootSet({profile.TreasureType}): failed to create {itemType} piece");
+        }
+
+        private static WorldObject CreateZoneSetWeapon(TreasureDeath profile, ZoneSetFamily family)
+        {
+            var treasureRoll = new TreasureRoll(TreasureItemType_Orig.Weapon);
+
+            switch (family)
+            {
+                case ZoneSetFamily.Missile:
+                    switch (ThreadSafeRandom.Next(0, 2))
+                    {
+                        case 0:
+                            treasureRoll.WeaponType = TreasureWeaponType.Bow;
+                            switch (ThreadSafeRandom.Next(0, 2))
+                            {
+                                case 0: treasureRoll.Wcid = BowWcids_Aluvian.Roll(profile.Tier); break;
+                                case 1: treasureRoll.Wcid = BowWcids_Gharundim.Roll(profile.Tier); break;
+                                default: treasureRoll.Wcid = BowWcids_Sho.Roll(profile.Tier); break;
+                            }
+                            break;
+                        case 1:
+                            treasureRoll.WeaponType = TreasureWeaponType.Crossbow;
+                            treasureRoll.Wcid = CrossbowWcids.Roll(profile.Tier);
+                            break;
+                        default:
+                            treasureRoll.WeaponType = TreasureWeaponType.Atlatl;
+                            treasureRoll.Wcid = AtlatlWcids.Roll(profile.Tier);
+                            break;
+                    }
+                    break;
+
+                case ZoneSetFamily.Caster:
+                    treasureRoll.WeaponType = TreasureWeaponType.Caster;
+                    treasureRoll.Wcid = CasterWcids.Roll(profile.Tier);
+                    break;
+
+                default:
+                    RollZoneSetMeleeWeapon(family, treasureRoll);
+                    break;
+            }
+
+            if (treasureRoll.Wcid == WeenieClassName.undef)
+                return null;
+
+            // isMagical = false -> blank weapon (no spell sets); zone mutation layer adds the fun
+            return CreateAndMutateWcid(profile, treasureRoll, false);
+        }
+
+        private static void RollZoneSetMeleeWeapon(ZoneSetFamily family, TreasureRoll treasureRoll)
+        {
+            var canTwoHand = family == ZoneSetFamily.Axe || family == ZoneSetFamily.Mace ||
+                             family == ZoneSetFamily.Spear || family == ZoneSetFamily.Sword;
+
+            // 1 = Heavy, 2 = Light, 3 = Finesse, 4 = TwoHanded (folded into the family skill roll)
+            var skill = ThreadSafeRandom.Next(1, canTwoHand ? 4 : 3);
+
+            if (skill == 4)
+            {
+                var twoHandType = family switch
+                {
+                    ZoneSetFamily.Axe => TreasureWeaponType.TwoHandedAxe,
+                    ZoneSetFamily.Mace => TreasureWeaponType.TwoHandedMace,
+                    ZoneSetFamily.Spear => TreasureWeaponType.TwoHandedSpear,
+                    _ => TreasureWeaponType.TwoHandedSword,
+                };
+
+                treasureRoll.WeaponType = twoHandType;
+                treasureRoll.Wcid = TwoHandedWeaponWcids.RollForWeaponType(twoHandType);
+                return;
+            }
+
+            // subtype inner rolls: MS-vs-non for sword/dagger, jitte for mace
+            var subType = family switch
+            {
+                ZoneSetFamily.Axe => TreasureWeaponType.Axe,
+                ZoneSetFamily.Dagger => ThreadSafeRandom.Next(0, 1) == 0 ? TreasureWeaponType.Dagger : TreasureWeaponType.DaggerMS,
+                ZoneSetFamily.Mace => ThreadSafeRandom.Next(0, 1) == 0 ? TreasureWeaponType.Mace : TreasureWeaponType.MaceJitte,
+                ZoneSetFamily.Spear => TreasureWeaponType.Spear,
+                ZoneSetFamily.Staff => TreasureWeaponType.Staff,
+                ZoneSetFamily.Sword => ThreadSafeRandom.Next(0, 1) == 0 ? TreasureWeaponType.Sword : TreasureWeaponType.SwordMS,
+                _ => TreasureWeaponType.Unarmed,
+            };
+
+            var wcid = RollSkillTableForWeaponType(skill, subType);
+
+            // not every skill table carries every variant (e.g. a skill without jitte/MS tables):
+            // fall back to the family's base subtype, then to any skill that has it
+            if (wcid == WeenieClassName.undef && (subType == TreasureWeaponType.DaggerMS || subType == TreasureWeaponType.SwordMS || subType == TreasureWeaponType.MaceJitte))
+            {
+                subType = family switch
+                {
+                    ZoneSetFamily.Dagger => TreasureWeaponType.Dagger,
+                    ZoneSetFamily.Mace => TreasureWeaponType.Mace,
+                    _ => TreasureWeaponType.Sword,
+                };
+                wcid = RollSkillTableForWeaponType(skill, subType);
+            }
+
+            if (wcid == WeenieClassName.undef)
+            {
+                for (var altSkill = 1; altSkill <= 3 && wcid == WeenieClassName.undef; altSkill++)
+                {
+                    if (altSkill == skill) continue;
+                    wcid = RollSkillTableForWeaponType(altSkill, subType);
+                }
+            }
+
+            treasureRoll.WeaponType = subType;
+            treasureRoll.Wcid = wcid;
+        }
+
+        private static WeenieClassName RollSkillTableForWeaponType(int skill, TreasureWeaponType weaponType)
+        {
+            return skill switch
+            {
+                1 => HeavyWeaponWcids.RollForWeaponType(weaponType),
+                2 => LightWeaponWcids.RollForWeaponType(weaponType),
+                _ => FinesseWeaponWcids.RollForWeaponType(weaponType),
+            };
+        }
+    }
+}

--- a/Source/ACE.Server/Factories/WorldObjectFactory.cs
+++ b/Source/ACE.Server/Factories/WorldObjectFactory.cs
@@ -285,16 +285,34 @@ namespace ACE.Server.Factories
             // spawn direct landblock objects
             foreach (var instance in sourceObjects.Where(x => x.IsLinkChild == false))
             {
+                try
+                {
+                    CreateNewWorldObjectFromInstance(instance, sourceObjects, biotas, restrict_wcid, variationId, results);
+                }
+                catch (Exception ex)
+                {
+                    // A single bad instance (bad weenie data, a throw from prestige/zone scaling, etc.)
+                    // must not abort spawning of every remaining instance in this landblock — that
+                    // landblock then stays cached with the rest missing (generators included) for the
+                    // life of the process, since GetLandblock only calls Init() once per (lb, variant).
+                    log.Error($"CreateNewWorldObjects: failed to spawn instance 0x{instance.Guid:X8} (wcid {instance.WeenieClassId}): {ex}");
+                }
+            }
+            return results;
+        }
+
+        private static void CreateNewWorldObjectFromInstance(LandblockInstance instance, List<LandblockInstance> sourceObjects, List<Biota> biotas, uint? restrict_wcid, int? variationId, List<WorldObject> results)
+        {
                 var weenie = DatabaseManager.World.GetCachedWeenie(instance.WeenieClassId);
 
                 if (weenie == null)
                 {
                     log.Warn($"CreateNewWorldObjects: Database does not contain weenie {instance.WeenieClassId} for instance 0x{instance.Guid:X8} at {new Position(instance.ObjCellId, instance.OriginX, instance.OriginY, instance.OriginZ, instance.AnglesX, instance.AnglesY, instance.AnglesZ, instance.AnglesW)}");
-                    continue;
+                    return;
                 }
 
                 if (restrict_wcid != null && restrict_wcid.Value != instance.WeenieClassId)
-                    continue;
+                    return;
 
                 var guid = new ObjectGuid(instance.Guid);
 
@@ -326,7 +344,11 @@ namespace ACE.Server.Factories
                 }
 
                 if (worldObject is Creature creature)
+                {
                     PrestigeManager.ApplyPrestigeScaling(creature, variationId);
+                    Managers.ZoneControl.ZoneSpawnScaler.ApplyToSpawn(creature);
+                    Managers.Rifts.RiftManager.TryApplyRiftScaling(creature, variationId);
+                }
 
                 if (worldObject != null)
                 {
@@ -341,8 +363,6 @@ namespace ACE.Server.Factories
 
                     results.Add(worldObject);
                 }
-            }
-            return results;
         }
 
         /// <summary>

--- a/Source/ACE.Server/Managers/BossGroupManager.cs
+++ b/Source/ACE.Server/Managers/BossGroupManager.cs
@@ -1,0 +1,409 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+
+using Newtonsoft.Json;
+
+using ACE.Common;
+using ACE.Database;
+using ACE.Database.Models.Shard;
+using ACE.Entity.Enum.Properties;
+using ACE.Server.Entity.Actions;
+using ACE.Server.WorldObjects;
+
+namespace ACE.Server.Managers
+{
+    /// <summary>
+    /// Coordinates boss-group generators (PropertyInt.BossGroupId): any number of generators, placed
+    /// on any landblocks, share exactly ONE live spawn. The group has a single respawn clock — when
+    /// the boss dies, one delay (the generator profile's Delay, unless overridden) passes, then ONE
+    /// randomly-chosen candidate generator spawns the next boss ("combined" model, owner 2026-08-08).
+    ///
+    /// Generators poll via TryClaimSpawn from GeneratorProfile.Spawn; a denial simply drops that
+    /// spawn attempt and the generator retries on its next cycle, so the candidate set is naturally
+    /// limited to generators on LOADED landblocks. A boss destroyed without a Death notification
+    /// (landblock unload) is caught by the weak-reference liveness check instead of wedging the group.
+    ///
+    /// RUNTIME OVERRIDES (rev 2, 2026-08-08): per-group Delay / Radius / Enabled, persisted in the
+    /// shard store (config_properties_string key "bossgroup_data") and applied live — the plugin's
+    /// hunt-window tuning path. Weenie values remain the defaults when no override is set.
+    /// </summary>
+    public static class BossGroupManager
+    {
+        private class Candidate
+        {
+            public DateTime LastSeen;
+            public WeakReference<WorldObject> Gen;
+        }
+
+        private class GroupState
+        {
+            public WeakReference<WorldObject> AliveBoss;
+            public uint SpawnerGenGuid;
+            public DateTime LastDeath = DateTime.MinValue;
+            public uint? ChosenGenGuid;
+            public readonly Dictionary<uint, Candidate> Candidates = new Dictionary<uint, Candidate>();
+
+            /// <summary>Respawn <see cref="ForceRespawn"/> pending: the NEXT death/vanish event zeroes
+            /// the respawn clock instead of starting it.</summary>
+            public bool PendingForceRespawn;
+
+            // weenie defaults as last seen at claim time — the wire's "(weenie default N)" hint
+            public float DefaultDelay;
+            public float DefaultRadius;
+        }
+
+        /// <summary>Per-group runtime override, persisted in the shard store. Null field = no override
+        /// (weenie value applies).</summary>
+        public class GroupOverride
+        {
+            public float? Delay;
+            public float? Radius;
+            public bool Enabled = true;
+        }
+
+        private static readonly ConcurrentDictionary<int, GroupState> groups = new ConcurrentDictionary<int, GroupState>();
+
+        // ── overrides store ──────────────────────────────────────────────────
+        private const string StoreKey = "bossgroup_data";
+        private static readonly object storeLock = new object();
+        private static Dictionary<int, GroupOverride> overrides;   // lazy-loaded
+
+        private static void EnsureLoaded()
+        {
+            if (overrides != null) return;
+            lock (storeLock)
+            {
+                if (overrides != null) return;
+                string json = null;
+                if (DatabaseManager.ShardConfig.StringExists(StoreKey))
+                    json = DatabaseManager.ShardConfig.GetString(StoreKey)?.Value;
+                overrides = string.IsNullOrWhiteSpace(json)
+                    ? new Dictionary<int, GroupOverride>()
+                    : (JsonConvert.DeserializeObject<Dictionary<int, GroupOverride>>(json) ?? new Dictionary<int, GroupOverride>());
+            }
+        }
+
+        private static void SaveOverrides()
+        {
+            lock (storeLock)
+            {
+                var json = JsonConvert.SerializeObject(overrides);
+                if (DatabaseManager.ShardConfig.StringExists(StoreKey))
+                    DatabaseManager.ShardConfig.SaveString(new ConfigPropertiesString { Key = StoreKey, Value = json, Description = "Boss group runtime overrides (JSON)" });
+                else
+                    DatabaseManager.ShardConfig.AddString(StoreKey, json, "Boss group runtime overrides (JSON)");
+            }
+        }
+
+        private static GroupOverride GetOverrideOrNull(int groupId)
+        {
+            EnsureLoaded();
+            lock (storeLock)
+                return overrides.TryGetValue(groupId, out var ov) ? ov : null;
+        }
+
+        /// <summary>Mutate (creating if needed) a group's override and persist. Used by /bossgroup set etc.</summary>
+        public static void MutateOverride(int groupId, Action<GroupOverride> mutate)
+        {
+            EnsureLoaded();
+            lock (storeLock)
+            {
+                if (!overrides.TryGetValue(groupId, out var ov))
+                    overrides[groupId] = ov = new GroupOverride();
+                mutate(ov);
+                // an all-default override row is just noise — drop it
+                if (ov.Delay == null && ov.Radius == null && ov.Enabled)
+                    overrides.Remove(groupId);
+            }
+            SaveOverrides();
+        }
+
+        /// <summary>Radius override for a boss-group generator, read by Spawn_Scatter. Null = use the
+        /// weenie's GeneratorRadius.</summary>
+        public static float? GetRadiusOverride(int groupId) => GetOverrideOrNull(groupId)?.Radius;
+
+        // ── spawn coordination ───────────────────────────────────────────────
+
+        /// <summary>
+        /// Called by a boss-group generator that wants to spawn. Returns TRUE only for the group's
+        /// elected generator, and only when the group is enabled, no group boss is alive, and the
+        /// respawn delay (override ?? profile) has passed.
+        /// </summary>
+        public static bool TryClaimSpawn(int groupId, WorldObject generator, float delaySeconds)
+        {
+            var ov = GetOverrideOrNull(groupId);
+            var state = groups.GetOrAdd(groupId, _ => new GroupState());
+
+            lock (state)
+            {
+                var now = DateTime.UtcNow;
+                if (state.Candidates.TryGetValue(generator.Guid.Full, out var cand))
+                {
+                    cand.LastSeen = now;
+                    cand.Gen = new WeakReference<WorldObject>(generator);
+                }
+                else
+                    state.Candidates[generator.Guid.Full] = new Candidate { LastSeen = now, Gen = new WeakReference<WorldObject>(generator) };
+                state.DefaultDelay = delaySeconds;
+                state.DefaultRadius = (float)(generator.GetProperty(PropertyFloat.GeneratorRadius) ?? 0f);
+
+                if (ov != null && !ov.Enabled)
+                    return false;
+
+                if (state.AliveBoss != null)
+                {
+                    if (state.AliveBoss.TryGetTarget(out var boss) && !boss.IsDestroyed)
+                        return false;
+
+                    // boss vanished without a Death notification — treat as a death so the delay
+                    // applies (unless a force-respawn is pending)
+                    state.AliveBoss = null;
+                    state.LastDeath = state.PendingForceRespawn ? DateTime.MinValue : now;
+                    state.PendingForceRespawn = false;
+                }
+
+                var effDelay = ov?.Delay ?? delaySeconds;
+                if (now < state.LastDeath.AddSeconds(effDelay))
+                    return false;
+
+                // election: sticky random winner among recently-polling generators; re-pick if the
+                // winner went stale (its landblock unloaded)
+                var freshWindow = TimeSpan.FromSeconds(Math.Max(600, effDelay * 3));
+
+                if (state.ChosenGenGuid == null ||
+                    !state.Candidates.TryGetValue(state.ChosenGenGuid.Value, out var chosen) ||
+                    now - chosen.LastSeen > freshWindow)
+                {
+                    foreach (var stale in state.Candidates.Where(c => now - c.Value.LastSeen > freshWindow).Select(c => c.Key).ToList())
+                        state.Candidates.Remove(stale);
+
+                    if (state.Candidates.Count == 0)
+                        return false;
+
+                    var fresh = state.Candidates.Keys.ToList();
+                    state.ChosenGenGuid = fresh[ThreadSafeRandom.Next(0, fresh.Count - 1)];
+                }
+
+                return generator.Guid.Full == state.ChosenGenGuid.Value;
+            }
+        }
+
+        /// <summary>
+        /// Called after the elected generator successfully spawns the boss.
+        /// </summary>
+        public static void OnBossSpawned(int groupId, WorldObject generator, WorldObject boss)
+        {
+            var state = groups.GetOrAdd(groupId, _ => new GroupState());
+
+            lock (state)
+            {
+                state.AliveBoss = new WeakReference<WorldObject>(boss);
+                state.SpawnerGenGuid = generator.Guid.Full;
+                state.ChosenGenGuid = null;
+                state.PendingForceRespawn = false;
+            }
+        }
+
+        /// <summary>
+        /// Called when a generator is notified its boss-group spawn died (or was removed).
+        /// Starts the group's respawn clock — or zeroes it if a force-respawn is pending.
+        /// </summary>
+        public static void OnBossRemoved(int groupId, uint bossGuid)
+        {
+            if (!groups.TryGetValue(groupId, out var state))
+                return;
+
+            lock (state)
+            {
+                if (state.AliveBoss != null && state.AliveBoss.TryGetTarget(out var boss) && boss.Guid.Full != bossGuid)
+                    return; // not the boss this group is tracking
+
+                state.AliveBoss = null;
+                var force = state.PendingForceRespawn;
+                state.LastDeath = force ? DateTime.MinValue : DateTime.UtcNow;
+                state.PendingForceRespawn = false;
+                if (force)
+                    KickSpawnLocked(state);
+            }
+        }
+
+        /// <summary>
+        /// Immediately triggers the group's next spawn instead of waiting for a generator's regen tick
+        /// (/bossgroup respawn felt like "nothing happened" - gens only poll every RegenerationInterval,
+        /// and the profile that just lost its boss times itself out for a full Delay on top of that).
+        /// Elects a live candidate generator, then - on its own action queue, so all generator state is
+        /// touched on the right thread - clears the profile timeouts and runs a generate pass.
+        /// Caller must hold lock(state). Returns false when no live candidate is reachable.
+        /// </summary>
+        private static bool KickSpawnLocked(GroupState state)
+        {
+            var now = DateTime.UtcNow;
+            var freshWindow = TimeSpan.FromMinutes(15);
+            var live = new List<(uint Guid, WorldObject Gen)>();
+            foreach (var kvp in state.Candidates)
+            {
+                if (now - kvp.Value.LastSeen > freshWindow)
+                    continue;
+                if (kvp.Value.Gen != null && kvp.Value.Gen.TryGetTarget(out var gen) &&
+                    !gen.IsDestroyed && gen.CurrentLandblock != null)
+                    live.Add((kvp.Key, gen));
+            }
+            if (live.Count == 0)
+                return false;
+
+            var pick = live[ThreadSafeRandom.Next(0, live.Count - 1)];
+            state.ChosenGenGuid = pick.Guid;
+
+            var target = pick.Gen;
+            var chain = new ActionChain();
+            chain.AddAction(target, ActionType.BossGroupManager_KickSpawn, () =>
+            {
+                foreach (var profile in target.GeneratorProfiles)
+                    profile.NextAvailable = DateTime.UtcNow;
+                target.Generator_Generate();
+            });
+            chain.EnqueueChain();
+            return true;
+        }
+
+        /// <summary>The group's live boss, if any (for /bossgroup respawn to smite).</summary>
+        public static WorldObject GetAliveBoss(int groupId)
+        {
+            if (!groups.TryGetValue(groupId, out var state))
+                return null;
+            lock (state)
+            {
+                if (state.AliveBoss != null && state.AliveBoss.TryGetTarget(out var boss) && !boss.IsDestroyed)
+                    return boss;
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// /bossgroup respawn: zero the respawn clock, re-elect, and kick the spawn immediately. Call
+        /// BEFORE smiting the live boss — the pending flag makes the incoming death event zero the
+        /// clock and kick, instead of starting the delay. Returns TRUE when a spawn was kicked now
+        /// (no live boss); FALSE means either a smite is pending or no live candidate was reachable.
+        /// </summary>
+        public static bool ForceRespawn(int groupId)
+        {
+            var state = groups.GetOrAdd(groupId, _ => new GroupState());
+            lock (state)
+            {
+                state.ChosenGenGuid = null;
+                if (state.AliveBoss != null && state.AliveBoss.TryGetTarget(out var boss) && !boss.IsDestroyed)
+                {
+                    state.PendingForceRespawn = true;   // death lands async; the death event kicks
+                    return false;
+                }
+                state.AliveBoss = null;
+                state.LastDeath = DateTime.MinValue;
+                return KickSpawnLocked(state);
+            }
+        }
+
+        // ── status ───────────────────────────────────────────────────────────
+
+        /// <summary>Human-readable status for every boss group seen this session (/bossgroup status).</summary>
+        public static List<string> GetStatusLines()
+        {
+            var lines = new List<string>();
+
+            if (groups.IsEmpty)
+            {
+                lines.Add("No boss groups active yet - no BossGroupId generator has attempted a spawn this session.");
+                return lines;
+            }
+
+            foreach (var kvp in groups.OrderBy(k => k.Key))
+            {
+                var state = kvp.Value;
+                var ov = GetOverrideOrNull(kvp.Key);
+
+                lock (state)
+                {
+                    var now = DateTime.UtcNow;
+                    var freshWindow = TimeSpan.FromMinutes(15);
+                    var candidates = state.Candidates.Count(c => now - c.Value.LastSeen <= freshWindow);
+                    var effDelay = ov?.Delay ?? state.DefaultDelay;
+                    var knobs = $"delay {effDelay:0}s{(ov?.Delay != null ? " (override)" : "")}" +
+                                $", radius {(ov?.Radius ?? state.DefaultRadius):0}{(ov?.Radius != null ? " (override)" : "")}" +
+                                (ov != null && !ov.Enabled ? ", DISABLED" : "");
+
+                    if (ov != null && !ov.Enabled && GetAliveBossLocked(state) == null)
+                    {
+                        lines.Add($"Group {kvp.Key}: DISABLED - {candidates} candidate gen(s) polling ({knobs})");
+                    }
+                    else if (GetAliveBossLocked(state) is WorldObject boss)
+                    {
+                        lines.Add($"Group {kvp.Key}: ALIVE - {boss.Name} ({boss.WeenieClassId}) at {boss.Location?.ToString() ?? "unknown"} " +
+                                  $"(spawned by gen 0x{state.SpawnerGenGuid:X8}, {candidates} gen(s) polling, {knobs})");
+                    }
+                    else
+                    {
+                        var since = state.LastDeath == DateTime.MinValue
+                            ? "never spawned this session"
+                            : $"died {(int)(now - state.LastDeath).TotalSeconds}s ago";
+                        var chosen = state.ChosenGenGuid != null ? $", next spawn elected to gen 0x{state.ChosenGenGuid.Value:X8}" : "";
+                        lines.Add($"Group {kvp.Key}: DEAD - {since}, {candidates} candidate gen(s) polling{chosen} ({knobs})");
+                    }
+                }
+            }
+
+            return lines;
+        }
+
+        private static WorldObject GetAliveBossLocked(GroupState state)
+        {
+            if (state.AliveBoss != null && state.AliveBoss.TryGetTarget(out var boss) && !boss.IsDestroyed)
+                return boss;
+            return null;
+        }
+
+        /// <summary>[[ZCB]] wire lines for the plugin (one per group):
+        /// g=id~state~bossWcid~bossName~lbHex~x~y~z~secsSinceDeath~delay~radius~enabled~candidates~delayOv~radiusOv~defDelay~defRadius
+        /// state: 0 dead, 1 alive, 2 disabled. secsSinceDeath -1 = never spawned this session.</summary>
+        public static List<string> GetWireLines()
+        {
+            var lines = new List<string>();
+
+            foreach (var kvp in groups.OrderBy(k => k.Key))
+            {
+                var state = kvp.Value;
+                var ov = GetOverrideOrNull(kvp.Key);
+
+                lock (state)
+                {
+                    var now = DateTime.UtcNow;
+                    var freshWindow = TimeSpan.FromMinutes(15);
+                    var candidates = state.Candidates.Count(c => now - c.Value.LastSeen <= freshWindow);
+                    var boss = GetAliveBossLocked(state);
+                    var enabled = ov == null || ov.Enabled;
+
+                    var st = !enabled ? 2 : (boss != null ? 1 : 0);
+                    uint bw = 0; var bn = ""; var lb = ""; float x = 0, y = 0, z = 0;
+                    if (boss != null)
+                    {
+                        bw = boss.WeenieClassId;
+                        bn = (boss.Name ?? "").Replace('|', ' ').Replace('~', ' ').Replace('=', ' ');
+                        if (boss.Location != null)
+                        {
+                            lb = boss.Location.LandblockId.Landblock.ToString("X4");
+                            x = boss.Location.PositionX; y = boss.Location.PositionY; z = boss.Location.PositionZ;
+                        }
+                    }
+                    var since = state.LastDeath == DateTime.MinValue ? -1 : (int)(now - state.LastDeath).TotalSeconds;
+                    var effDelay = ov?.Delay ?? state.DefaultDelay;
+                    var effRadius = ov?.Radius ?? state.DefaultRadius;
+
+                    lines.Add($"[[ZCB]]g={kvp.Key}~{st}~{bw}~{bn}~{lb}~{x:0.#}~{y:0.#}~{z:0.#}~{since}~{effDelay:0.#}~{effRadius:0.#}~{(enabled ? 1 : 0)}~{candidates}" +
+                              $"~{(ov?.Delay != null ? 1 : 0)}~{(ov?.Radius != null ? 1 : 0)}~{state.DefaultDelay:0.#}~{state.DefaultRadius:0.#}");
+                }
+            }
+
+            return lines;
+        }
+    }
+}

--- a/Source/ACE.Server/Managers/BossGroupManager.cs
+++ b/Source/ACE.Server/Managers/BossGroupManager.cs
@@ -65,6 +65,9 @@ namespace ACE.Server.Managers
 
         private static readonly ConcurrentDictionary<int, GroupState> groups = new ConcurrentDictionary<int, GroupState>();
 
+        /// <summary>How long a polling generator stays a live election candidate; the status/wire readouts use the same window.</summary>
+        private static readonly TimeSpan CandidateFreshWindow = TimeSpan.FromMinutes(15);
+
         // ── overrides store ──────────────────────────────────────────────────
         private const string StoreKey = "bossgroup_data";
         private static readonly object storeLock = new object();
@@ -101,7 +104,12 @@ namespace ACE.Server.Managers
         {
             EnsureLoaded();
             lock (storeLock)
-                return overrides.TryGetValue(groupId, out var ov) ? ov : null;
+            {
+                if (!overrides.TryGetValue(groupId, out var ov))
+                    return null;
+                // snapshot: callers read the fields outside the lock while MutateOverride writes them under it
+                return new GroupOverride { Delay = ov.Delay, Radius = ov.Radius, Enabled = ov.Enabled };
+            }
         }
 
         /// <summary>Mutate (creating if needed) a group's override and persist. Used by /bossgroup set etc.</summary>
@@ -165,6 +173,8 @@ namespace ACE.Server.Managers
                 }
 
                 var effDelay = ov?.Delay ?? delaySeconds;
+                if (effDelay < 0)
+                    effDelay = 0;   // weenie data: DateTime.MinValue.AddSeconds(negative) would throw out of Spawn()
                 if (now < state.LastDeath.AddSeconds(effDelay))
                     return false;
 
@@ -240,7 +250,7 @@ namespace ACE.Server.Managers
         private static bool KickSpawnLocked(GroupState state)
         {
             var now = DateTime.UtcNow;
-            var freshWindow = TimeSpan.FromMinutes(15);
+            var freshWindow = CandidateFreshWindow;
             var live = new List<(uint Guid, WorldObject Gen)>();
             foreach (var kvp in state.Candidates)
             {
@@ -260,6 +270,9 @@ namespace ACE.Server.Managers
             var chain = new ActionChain();
             chain.AddAction(target, ActionType.BossGroupManager_KickSpawn, () =>
             {
+                // the action runs later on the target's queue; the generator can be reset or unloaded in between
+                if (target.IsDestroyed || target.GeneratorProfiles == null)
+                    return;
                 foreach (var profile in target.GeneratorProfiles)
                     profile.NextAvailable = DateTime.UtcNow;
                 target.Generator_Generate();
@@ -325,7 +338,7 @@ namespace ACE.Server.Managers
                 lock (state)
                 {
                     var now = DateTime.UtcNow;
-                    var freshWindow = TimeSpan.FromMinutes(15);
+                    var freshWindow = CandidateFreshWindow;
                     var candidates = state.Candidates.Count(c => now - c.Value.LastSeen <= freshWindow);
                     var effDelay = ov?.Delay ?? state.DefaultDelay;
                     var knobs = $"delay {effDelay:0}s{(ov?.Delay != null ? " (override)" : "")}" +
@@ -377,7 +390,7 @@ namespace ACE.Server.Managers
                 lock (state)
                 {
                     var now = DateTime.UtcNow;
-                    var freshWindow = TimeSpan.FromMinutes(15);
+                    var freshWindow = CandidateFreshWindow;
                     var candidates = state.Candidates.Count(c => now - c.Value.LastSeen <= freshWindow);
                     var boss = GetAliveBossLocked(state);
                     var enabled = ov == null || ov.Enabled;

--- a/Source/ACE.Server/Managers/LandblockManager.cs
+++ b/Source/ACE.Server/Managers/LandblockManager.cs
@@ -179,13 +179,14 @@ namespace ACE.Server.Managers
             if (landblockGroupPendingAdditions.IsEmpty)
                 return;
 
-            for (int i = landblockGroupPendingAdditions.Count - 1; i >= 0; i--)
+            // Snapshot keys and TryRemove-first: index-based ElementAt over a ConcurrentDictionary while
+            // physics worker threads TryAdd concurrently can skip an entry (delayed a tick) or process one
+            // TWICE (same landblock in two groups = double-ticked, and its group-removal at unload leaves
+            // a dead entry ticking forever). TryRemove guarantees exactly-once.
+            foreach (var pendingKey in landblockGroupPendingAdditions.Keys.ToList())
             {
-                var landlockToAdd = landblockGroupPendingAdditions.ElementAt(i).Value;
-                //if (landblockGroupPendingAdditions.ElementAt(i).Value.Id.ToString().StartsWith("019E"))
-                //{
-                //    Console.WriteLine("Adding landblock: " + landblockGroupPendingAdditions.ElementAt(i).Value.Id.ToString() + ", v:" + landblockGroupPendingAdditions.ElementAt(i).Value.VariationId + " to landblockGroups");
-                //}
+                if (!landblockGroupPendingAdditions.TryRemove(pendingKey, out var landlockToAdd))
+                    continue;
                 if (landlockToAdd.IsDungeon || landlockToAdd.VariationId.HasValue)
                 {
                     // Each dungeon exists in its own group
@@ -233,9 +234,6 @@ namespace ACE.Server.Managers
                         landblockGroups.Add(landblockGroup);
                     }
                 }
-
-                landblockGroupPendingAdditions.Remove(new VariantCacheId { Landblock = landlockToAdd.Id.Landblock, Variant = landlockToAdd.VariationId }, out _);                    
-                    
             }
 
             // Debugging todo: comment this out after enough testing
@@ -324,9 +322,33 @@ namespace ACE.Server.Managers
             }
         }
 
+        /// <summary>
+        /// Landblock ids holding at least one online player, snapshotted once at the start of each
+        /// multi-threaded tick batch. Per-landblock dormancy checks (Landblock.HasPhysicalPlayerOnOrAdjacent)
+        /// read this shared set instead of each rescanning every online player, turning what was an
+        /// O(landblocks x players) tick-path cost into a single O(players) build plus O(9) lookups.
+        /// Rebuilt before the parallel tick and only read during it, so no synchronization is needed.
+        /// </summary>
+        internal static HashSet<ushort> OccupiedLandblocks { get; private set; } = new();
+
+        private static void RefreshOccupiedLandblocks()
+        {
+            var set = new HashSet<ushort>();
+            foreach (var player in PlayerManager.GetAllOnline())
+            {
+                var loc = player.Location;
+                if (loc != null)
+                    set.Add((ushort)loc.LandblockId.Landblock);
+            }
+            OccupiedLandblocks = set;
+        }
+
         private static void TickMultiThreadedWork()
         {
             ProcessPendingLandblockGroupAdditions();
+
+            // Snapshot online-player landblocks once for this batch (read by Landblock dormancy checks below).
+            RefreshOccupiedLandblocks();
 
             if (ConfigManager.Config.Server.Threading.MultiThreadedLandblockGroupTicking)
             {
@@ -442,6 +464,14 @@ namespace ACE.Server.Managers
             return GetLandblock(new VariantCacheId() {Landblock = landblockId.Landblock, Variant = variationId }) != null;
         }
 
+        /// <summary>No-create lookup of the LOADED landblock instance for (landblock, variation) -
+        /// null when not loaded. Lets callers verify a held Landblock reference is still the live
+        /// one (see Player.ValidateCurrentLandblockTick's stale-instance void heal, 2026-08-10).</summary>
+        public static Landblock GetLoadedLandblock(LandblockId landblockId, int? variationId)
+        {
+            return GetLandblock(new VariantCacheId() { Landblock = landblockId.Landblock, Variant = variationId });
+        }
+
         /// <summary>
         /// Enqueues <see cref="Landblock.RefreshPrestigeBoundaryMarkers"/> on each matching loaded landblock (async per landblock queue); does not wait for completion.
         /// </summary>
@@ -467,6 +497,31 @@ namespace ACE.Server.Managers
         }
 
         /// <summary>
+        /// Enqueues <see cref="Landblock.RefreshZoneBoundaryMarkers"/> on each matching loaded landblock (async per landblock queue); does not wait for completion.
+        /// Called by ZoneControlManager whenever a mutation changes a variation's bounded union.
+        /// </summary>
+        /// <returns>Number of landblocks that had a refresh enqueued.</returns>
+        public static int EnqueueRefreshLoadedZoneBoundaryMarkers(int? variation = null)
+        {
+            var queued = 0;
+            var loaded = loadedLandblocks.Values.ToList();
+
+            foreach (var landblock in loaded)
+            {
+                if (landblock == null)
+                    continue;
+
+                if (variation.HasValue && landblock.VariationId != variation.Value)
+                    continue;
+
+                landblock.RefreshZoneBoundaryMarkers();
+                queued++;
+            }
+
+            return queued;
+        }
+
+        /// <summary>
         /// Returns a reference to a landblock, loading the landblock if not already active
         /// TODO: Make this Variation Aware
         /// </summary>
@@ -482,15 +537,33 @@ namespace ACE.Server.Managers
             {
                 // load up this landblock                    
                 landblock = new Landblock(landblockId, variation);
-                if(!AddUpdateLandblock(cacheKey, landblock))
+
+                // Both adds below used to `return landblock` on failure - handing back an instance whose
+                // physics was built in the ctor (so it is walkable) but whose Init() had NOT run, i.e. a
+                // permanent void. Losing an add almost always means another thread won the race, so the
+                // right answer is the WINNER's already-initialized landblock, not our orphan.
+                if (!AddUpdateLandblock(cacheKey, landblock))
                 {
-                    log.Error($"LandblockManager: failed to add {landblock.Id.Raw:X8}, v:{variation} to active landblocks!");
+                    log.Error($"LandblockManager: failed to add {landblock.Id.Raw:X8}, v:{variation} to active landblocks! Falling back to the cached instance.");
+                    var existing = GetLandblock(cacheKey);
+                    if (existing != null)
+                        return existing;
+
+                    // No winner to fall back on - initialize ours rather than return a void.
+                    log.Error($"LandblockManager: no cached instance for {landblock.Id.Raw:X8}, v:{variation} after a failed add - initializing the new one to avoid a void landblock.");
+                    landblock.Init(variation);
                     return landblock;
                 }
 
                 if (!loadedLandblocks.TryAdd(cacheKey, landblock))
                 {
-                    log.Error($"LandblockManager: failed to add {landblock.Id.Raw:X8}, v:{variation} to active landblocks!");
+                    log.Error($"LandblockManager: failed to add {landblock.Id.Raw:X8}, v:{variation} to active landblocks! Falling back to the cached instance.");
+                    var existing = GetLandblock(cacheKey);
+                    if (existing != null && !ReferenceEquals(existing, landblock))
+                        return existing;
+
+                    log.Error($"LandblockManager: no distinct cached instance for {landblock.Id.Raw:X8}, v:{variation} after a failed add - initializing to avoid a void landblock.");
+                    landblock.Init(variation);
                     return landblock;
                 }
 

--- a/Source/ACE.Server/Managers/LandblockManager.cs
+++ b/Source/ACE.Server/Managers/LandblockManager.cs
@@ -329,16 +329,16 @@ namespace ACE.Server.Managers
         /// O(landblocks x players) tick-path cost into a single O(players) build plus O(9) lookups.
         /// Rebuilt before the parallel tick and only read during it, so no synchronization is needed.
         /// </summary>
-        internal static HashSet<ushort> OccupiedLandblocks { get; private set; } = new();
+        internal static HashSet<(ushort Landblock, int? Variation)> OccupiedLandblocks { get; private set; } = new();
 
         private static void RefreshOccupiedLandblocks()
         {
-            var set = new HashSet<ushort>();
+            var set = new HashSet<(ushort Landblock, int? Variation)>();
             foreach (var player in PlayerManager.GetAllOnline())
             {
                 var loc = player.Location;
                 if (loc != null)
-                    set.Add((ushort)loc.LandblockId.Landblock);
+                    set.Add(((ushort)loc.LandblockId.Landblock, VariationManager.NormalizeBase(loc.Variation)));
             }
             OccupiedLandblocks = set;
         }
@@ -551,8 +551,7 @@ namespace ACE.Server.Managers
 
                     // No winner to fall back on - initialize ours rather than return a void.
                     log.Error($"LandblockManager: no cached instance for {landblock.Id.Raw:X8}, v:{variation} after a failed add - initializing the new one to avoid a void landblock.");
-                    landblock.Init(variation);
-                    return landblock;
+                    // fall through: register it in the group list below so it is ticked, watched and unloaded like any other
                 }
 
                 if (!loadedLandblocks.TryAdd(cacheKey, landblock))
@@ -563,8 +562,7 @@ namespace ACE.Server.Managers
                         return existing;
 
                     log.Error($"LandblockManager: no distinct cached instance for {landblock.Id.Raw:X8}, v:{variation} after a failed add - initializing to avoid a void landblock.");
-                    landblock.Init(variation);
-                    return landblock;
+                    // fall through: register it in the group list below so it is ticked, watched and unloaded like any other
                 }
 
                 bool res = landblockGroupPendingAdditions.TryAdd(cacheKey, landblock);

--- a/Source/ACE.Server/Managers/PlayerManager.cs
+++ b/Source/ACE.Server/Managers/PlayerManager.cs
@@ -543,6 +543,7 @@ namespace ACE.Server.Managers
 
             player.SendFriendStatusUpdates(false);
             player.CleanupPrestigeEffects();
+            player.CleanupZoneBoundaryEffects();
             player.HandleAllegianceOnLogout();
 
             return true;

--- a/Source/ACE.Server/Managers/RecipeManager.cs
+++ b/Source/ACE.Server/Managers/RecipeManager.cs
@@ -72,6 +72,24 @@ namespace ACE.Server.Managers
                 return;
             }
 
+            // ── Tier 11+ crafting gate (owner 2026-08-24) ─────────────────────────────────────
+            // T11+ gear drops FINISHED: the Zone Control loot mutator authors its specials against a
+            // tier ladder. A player tinker that writes any of those same properties is, at best, a
+            // weaker duplicate and, at worst, a downgrade - several custom recipes SetValue rather
+            // than add, so they overwrite a good roll with a flat constant in BOTH directions.
+            //
+            // Placed here deliberately: this is the ONLY entry point (the confirmation dialog
+            // re-enters this same method, Confirmation.cs:76-101), and it sits BEFORE
+            // CreateDestroyItems, so a blocked attempt costs the player no salvage.
+            // `source` is passed so the gate can read the SALVAGE's MaterialType - that is the row of the
+            // authorable layer-1 matrix (ZoneCraftGateStore).
+            if (ACE.Server.Managers.ZoneControl.ZoneCraftGate.IsBlocked(recipe, source, target, out var gateReason))
+            {
+                player.Session.Network.EnqueueSend(new GameMessageSystemChat(gateReason, ChatMessageType.Craft));
+                player.SendUseDoneEvent();
+                return;
+            }
+
             // verify requirements
             if (!VerifyRequirements(recipe, player, source, target))
             {

--- a/Source/ACE.Server/Managers/Rifts/RiftManager.cs
+++ b/Source/ACE.Server/Managers/Rifts/RiftManager.cs
@@ -543,14 +543,24 @@ namespace ACE.Server.Managers.Rifts
             var player = PlayerManager.GetOnlinePlayer(run.OwnerGuid);
             if (player != null)
             {
-                var best = player.GetProperty((PropertyInt)PropHighestClearedTier) ?? 0;
-                if (run.Tier > best)
+                // OnCreatureDeath runs on the rift instance's landblock thread; the owner may be standing in another
+                // landblock group (Leave keeps the run Active), so the property write and the inventory grant hop onto
+                // the owner's own queue and re-resolve the player there in case they logged off in between.
+                var ownerGuid = run.OwnerGuid; var clearedRun = run; var clearedCfg = cfg;
+                player.EnqueueAction(new ACE.Server.Entity.Actions.ActionEventDelegate(ACE.Server.Entity.Actions.ActionType.ControlFlowDelay, () =>
                 {
-                    player.SetProperty((PropertyInt)PropHighestClearedTier, run.Tier);
-                    Message(run, $"New personal best - Tier {run.Tier}!");
-                }
+                    var owner = PlayerManager.GetOnlinePlayer(ownerGuid);
+                    if (owner == null)
+                        return;
+                    var best = owner.GetProperty((PropertyInt)PropHighestClearedTier) ?? 0;
+                    if (clearedRun.Tier > best)
+                    {
+                        owner.SetProperty((PropertyInt)PropHighestClearedTier, clearedRun.Tier);
+                        Message(clearedRun, $"New personal best - Tier {clearedRun.Tier}!");
+                    }
 
-                GiveCurrencyReward(player, run, cfg);
+                    GiveCurrencyReward(owner, clearedRun, clearedCfg);
+                }));
             }
         }
 

--- a/Source/ACE.Server/Managers/Rifts/RiftManager.cs
+++ b/Source/ACE.Server/Managers/Rifts/RiftManager.cs
@@ -1,0 +1,784 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+
+using log4net;
+using Newtonsoft.Json;
+
+using ACE.Common;
+using ACE.Database;
+using ACE.Database.Models.Shard;
+using ACE.Entity;
+using ACE.Entity.Enum;
+using ACE.Entity.Enum.Properties;
+using ACE.Server.Factories;
+using ACE.Server.Managers.ZoneControl;
+using ACE.Server.Managers.ZoneScaling;
+using ACE.Server.Network.GameMessages.Messages;
+using ACE.Server.WorldObjects;
+
+namespace ACE.Server.Managers.Rifts
+{
+    /// <summary>
+    /// Greater Rifts: private, timed, tier-scaled dungeon runs. Each run owns an ephemeral NEGATIVE landblock
+    /// variation — the prestige system treats the entire negative range as retail tier 0 by construction, so
+    /// rifts share no code or state with prestige. Config lives in shard DB key <c>rift_config</c> (JSON);
+    /// runs are in-memory only. Solo (phase 1): one run per player, whole run owned by its opener.
+    /// </summary>
+    public static class RiftManager
+    {
+        private static readonly ILog log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+
+        private const string StoreKey = "rift_config";
+
+        /// <summary>Player PropertyInt: highest rift tier cleared (rift custom prop block 50400-50449).</summary>
+        public const int PropHighestClearedTier = 50400;
+
+        // first allocated variation is -1000 (leaves -1..-999 free for any future manual use)
+        private static int _nextVariation = -999;
+
+        private static readonly ConcurrentDictionary<int, RiftRun> _runsByVariation = new();
+        private static readonly ConcurrentDictionary<uint, RiftRun> _runsByOwner = new();
+        private static readonly ConcurrentDictionary<uint, ushort> _lastDungeonByOwner = new();
+
+        private static readonly object _configLock = new object();
+        private static volatile RiftConfig _config;
+
+        private static double _nextTickTime;
+
+        // time-remaining chat calls, in seconds remaining (descending)
+        private static readonly int[] TimeAnnounceThresholds = { 600, 300, 60 };
+
+        #region config store
+
+        public static RiftConfig Config
+        {
+            get
+            {
+                var cfg = _config;
+                if (cfg != null)
+                    return cfg;
+
+                lock (_configLock)
+                {
+                    if (_config == null)
+                        LoadConfig();
+                    return _config;
+                }
+            }
+        }
+
+        private static void LoadConfig()
+        {
+            RiftConfig cfg = null;
+            try
+            {
+                string json = null;
+                if (DatabaseManager.ShardConfig.StringExists(StoreKey))
+                    json = DatabaseManager.ShardConfig.GetString(StoreKey)?.Value;
+
+                if (!string.IsNullOrWhiteSpace(json))
+                    cfg = JsonConvert.DeserializeObject<RiftConfig>(json);
+            }
+            catch (Exception ex)
+            {
+                log.Error($"[RIFT] Failed to load {StoreKey}, starting with defaults. {ex}");
+            }
+
+            _config = cfg ?? new RiftConfig();
+        }
+
+        public static void SaveConfig()
+        {
+            lock (_configLock)
+            {
+                var jsonOut = JsonConvert.SerializeObject(Config);
+                if (DatabaseManager.ShardConfig.StringExists(StoreKey))
+                    DatabaseManager.ShardConfig.SaveString(new ConfigPropertiesString { Key = StoreKey, Value = jsonOut, Description = "Greater Rifts config (JSON)" });
+                else
+                    DatabaseManager.ShardConfig.AddString(StoreKey, jsonOut, "Greater Rifts config (JSON)");
+            }
+        }
+
+        public static void ReloadConfig()
+        {
+            lock (_configLock)
+                LoadConfig();
+        }
+
+        #endregion
+
+        #region registry / hot-path reads
+
+        /// <summary>Rift instances own the entire negative variation range. Single compare — hot-path safe.</summary>
+        public static bool IsRiftVariation(int? variation) => variation.HasValue && variation.Value < 0;
+
+        public static bool TryGetRun(int? variation, out RiftRun run)
+        {
+            run = null;
+            return variation.HasValue && variation.Value < 0 && _runsByVariation.TryGetValue(variation.Value, out run);
+        }
+
+        public static RiftRun GetRunByOwner(uint playerGuid)
+        {
+            return _runsByOwner.TryGetValue(playerGuid, out var run) ? run : null;
+        }
+
+        public static IReadOnlyCollection<RiftRun> GetActiveRuns() => _runsByVariation.Values.ToList();
+
+        /// <summary>
+        /// Landblock-loader hook: world-DB landblock instances (statics + monster generators) are
+        /// per-variation EXACT-match rows, and a rift's ephemeral negative variation has none. For rift
+        /// variations this returns the run's configured SOURCE variation (null = unlayered base rows) so the
+        /// private copy loads that population; every spawned object is still stamped with the rift's own
+        /// variation by the factory. Non-rift variations pass through untouched.
+        /// </summary>
+        public static int? ResolveInstanceSourceVariation(int? variationId)
+        {
+            if (!variationId.HasValue || variationId.Value >= 0)
+                return variationId;
+
+            if (_runsByVariation.TryGetValue(variationId.Value, out var run))
+                return run.SourceVariation;
+
+            // Unregistered negative variation: pass through to its own rows. This makes -1..-999 usable as
+            // DESIGN variations — admins author rift layouts there with the normal content tools (rows save
+            // at that variation, load back exactly, static guids, no cloning) and pool entries point at
+            // them via SourceVariation. A stale rift variation (<= -1000) just loads empty. Prestige
+            // ignores all negatives by construction.
+            return variationId;
+        }
+
+        /// <summary>
+        /// Clone source landblock-instance rows for a rift copy, remapping every static guid to a freshly
+        /// allocated dynamic guid (link parent/child references remapped consistently). The source rows'
+        /// home variation may be LIVE at the same time — two world objects must never share a guid, or
+        /// guid-keyed lookups (selection, attack targeting, ObjMaint) resolve to the wrong copy.
+        /// The cached source list is never mutated.
+        /// </summary>
+        public static List<ACE.Database.Models.World.LandblockInstance> CloneInstancesForRift(List<ACE.Database.Models.World.LandblockInstance> source)
+        {
+            var clones = new List<ACE.Database.Models.World.LandblockInstance>(source.Count);
+            var guidMap = new Dictionary<uint, uint>(source.Count);
+
+            foreach (var row in source)
+                guidMap[row.Guid] = GuidManager.NewDynamicGuid().Full;
+
+            foreach (var row in source)
+            {
+                var clone = new ACE.Database.Models.World.LandblockInstance
+                {
+                    Guid = guidMap[row.Guid],
+                    Landblock = row.Landblock,
+                    WeenieClassId = row.WeenieClassId,
+                    ObjCellId = row.ObjCellId,
+                    OriginX = row.OriginX, OriginY = row.OriginY, OriginZ = row.OriginZ,
+                    AnglesW = row.AnglesW, AnglesX = row.AnglesX, AnglesY = row.AnglesY, AnglesZ = row.AnglesZ,
+                    IsLinkChild = row.IsLinkChild,
+                    VariationId = row.VariationId,
+                };
+
+                foreach (var link in row.LandblockInstanceLink)
+                {
+                    clone.LandblockInstanceLink.Add(new ACE.Database.Models.World.LandblockInstanceLink
+                    {
+                        ParentGuid = guidMap.TryGetValue(link.ParentGuid, out var pg) ? pg : link.ParentGuid,
+                        ChildGuid = guidMap.TryGetValue(link.ChildGuid, out var cg) ? cg : link.ChildGuid,
+                    });
+                }
+
+                clones.Add(clone);
+            }
+
+            return clones;
+        }
+
+        /// <summary>
+        /// Spawn-site hook (GeneratorProfile / WorldObjectFactory): rift monster scaling, applied AFTER the
+        /// retail/Zone-Control spawn pass. No-op unless the variation belongs to a live run.
+        /// </summary>
+        public static void TryApplyRiftScaling(Creature creature, int? variation)
+        {
+            if (!variation.HasValue || variation.Value >= 0 || creature == null)
+                return;
+
+            if (!_runsByVariation.TryGetValue(variation.Value, out var run))
+                return;
+
+            if (!creature.IsMonster || !creature.Attackable)
+                return;
+
+            RiftScaling.Apply(creature, run, Config);
+        }
+
+        #endregion
+
+        #region open / enter / leave
+
+        /// <summary>Opens a rift run for a player. Returns null on success, else a player-facing error.</summary>
+        public static string OpenRun(Player player, int tier, ushort? dungeonOverride = null)
+        {
+            if (player == null)
+                return "No player.";
+            if (tier < 1)
+                return "Tier must be 1 or higher.";
+
+            var cfg = Config;
+
+            if (_runsByOwner.ContainsKey(player.Guid.Full))
+                return "You already have an open rift. Use /rift return to re-enter it, or /rift abandon to end it.";
+
+            if (_runsByVariation.Count >= cfg.MaxActiveRuns)
+                return "Too many rifts are open right now. Try again shortly.";
+
+            if (cfg.DungeonPool.Count == 0)
+                return "No rift dungeons are configured.";
+
+            RiftDungeonEntry dungeon;
+            if (dungeonOverride.HasValue)
+            {
+                dungeon = cfg.DungeonPool.FirstOrDefault(d => d.Landblock == dungeonOverride.Value);
+                if (dungeon == null)
+                    return $"Landblock {dungeonOverride.Value:X4} is not in the rift dungeon pool.";
+            }
+            else
+            {
+                var candidates = cfg.DungeonPool;
+                if (candidates.Count > 1 && _lastDungeonByOwner.TryGetValue(player.Guid.Full, out var lastLb))
+                {
+                    var filtered = candidates.Where(d => d.Landblock != lastLb).ToList();
+                    if (filtered.Count > 0)
+                        candidates = filtered;
+                }
+                dungeon = candidates[ThreadSafeRandom.Next(0, candidates.Count - 1)];
+            }
+
+            if (dungeon.Entry == null)
+                return $"Rift dungeon {dungeon.Name ?? dungeon.Landblock.ToString("X4")} has no entry position set.";
+
+            var variation = Interlocked.Decrement(ref _nextVariation);
+
+            // Defensive: rift variations only ever go more negative and reset on restart. Wrapping past
+            // int.MinValue would flip positive and collide with real variations. In practice this needs
+            // ~2 billion runs per process lifetime, but log loudly well before the boundary so it's caught.
+            if (variation < int.MinValue + 10_000)
+                log.Error($"[RIFT] _nextVariation is nearing int.MinValue ({variation}); restart the server to reset rift variation allocation before it wraps.");
+
+            var run = new RiftRun
+            {
+                RunId = -variation,
+                Variation = variation,
+                Tier = tier,
+                OwnerGuid = player.Guid.Full,
+                OwnerName = player.Name,
+                DungeonLb = dungeon.Landblock,
+                DungeonName = dungeon.Name ?? dungeon.Landblock.ToString("X4"),
+                Entry = dungeon.Entry,
+                GuardianPos = dungeon.Guardian ?? dungeon.Entry,
+                SourceVariation = dungeon.SourceVariation,
+                ReturnPos = RiftPos.FromPosition(player.Location),
+                ReturnVariation = player.Location?.Variation,
+                StartTime = Time.GetUnixTime(),
+                DurationSeconds = Math.Max(60, cfg.TimerSeconds),
+                ProgressRequired = Math.Max(1, cfg.ProgressBase + cfg.ProgressPerTier * tier),
+                ZoneName = $"rift_{-variation}",
+            };
+
+            // skip time announcements that are at/above the full duration
+            while (run.NextTimeAnnounceIdx < TimeAnnounceThresholds.Length &&
+                   TimeAnnounceThresholds[run.NextTimeAnnounceIdx] >= run.DurationSeconds)
+                run.NextTimeAnnounceIdx++;
+
+            RegisterRuntimeLootZone(run, cfg);
+
+            _runsByVariation[variation] = run;
+            _runsByOwner[player.Guid.Full] = run;
+            _lastDungeonByOwner[player.Guid.Full] = dungeon.Landblock;
+
+            log.Info($"[RIFT] Run {run.RunId}: {player.Name} opened tier {tier} in {run.DungeonName} ({run.DungeonLb:X4}) v{variation}");
+
+            Message(run, $"The rift swirls open - Tier {tier} ({run.DungeonName}). Slay its denizens! {FormatTime(run.DurationSeconds)} remaining.");
+            TeleportPlayer(player, run.Entry.ToPosition(variation));
+
+            return null;
+        }
+
+        /// <summary>Re-enter a live run (after death or /rift leave). Returns null on success.</summary>
+        public static string ReEnter(Player player)
+        {
+            var run = GetRunByOwner(player.Guid.Full);
+            if (run == null)
+                return "You have no open rift.";
+            if (run.State != RiftRunState.Active && run.State != RiftRunState.GuardianUp)
+                return "Your rift has ended.";
+            if (player.Location != null && player.Location.Variation == run.Variation)
+                return "You are already inside your rift.";
+
+            TeleportPlayer(player, run.Entry.ToPosition(run.Variation));
+            return null;
+        }
+
+        /// <summary>Teleport out of the rift without ending it. Returns null on success.</summary>
+        public static string Leave(Player player)
+        {
+            var run = GetRunByOwner(player.Guid.Full);
+            if (run == null || player.Location == null || player.Location.Variation != run.Variation)
+                return "You are not inside a rift.";
+
+            ReturnPlayer(player, run);
+            return null;
+        }
+
+        /// <summary>End the player's run early (counts as failed, immediate teardown). Returns null on success.</summary>
+        public static string Abandon(Player player)
+        {
+            var run = GetRunByOwner(player.Guid.Full);
+            if (run == null)
+                return "You have no open rift.";
+            if (!TryEndRun(run, RiftRunState.Failed))
+                return "Your rift has already ended.";
+
+            Message(run, "You abandon the rift.");
+            run.CloseAtTime = Time.GetUnixTime(); // next tick tears it down
+            return null;
+        }
+
+        /// <summary>Dev: force-close a run regardless of state.</summary>
+        public static bool ForceClose(RiftRun run)
+        {
+            if (run == null)
+                return false;
+            TryEndRun(run, RiftRunState.Failed);
+            run.CloseAtTime = 0;
+            CloseRun(run);
+            return true;
+        }
+
+        /// <summary>
+        /// Login guard, biota-level (same shape as Player.HandleNoLogLandblock, called right after it):
+        /// a player logging in inside a rift instance whose run is gone (or isn't theirs / has ended) is
+        /// relocated to their lifestone before entering the world.
+        /// </summary>
+        public static void HandleLoginInRiftInstance(ACE.Entity.Models.Biota biota)
+        {
+            if (biota == null || !biota.PropertiesPosition.TryGetValue(PositionType.Location, out var location))
+                return;
+
+            if (!location.VariationId.HasValue || location.VariationId.Value >= 0)
+                return;
+
+            if (_runsByVariation.TryGetValue(location.VariationId.Value, out var run) &&
+                run.OwnerGuid == biota.Id &&
+                (run.State == RiftRunState.Active || run.State == RiftRunState.GuardianUp))
+                return; // their rift is still live — let them come back in where they left
+
+            if (!biota.PropertiesPosition.TryGetValue(PositionType.Sanctuary, out var lifestone))
+                return;
+
+            var staleVariation = location.VariationId;
+            location.ObjCellId = lifestone.ObjCellId;
+            location.PositionX = lifestone.PositionX;
+            location.PositionY = lifestone.PositionY;
+            location.PositionZ = lifestone.PositionZ;
+            location.RotationX = lifestone.RotationX;
+            location.RotationY = lifestone.RotationY;
+            location.RotationZ = lifestone.RotationZ;
+            location.RotationW = lifestone.RotationW;
+            location.VariationId = lifestone.VariationId;
+
+            log.Info($"[RIFT] Player 0x{biota.Id:X8} logged in inside a closed rift instance (v{staleVariation}) - relocated to lifestone.");
+        }
+
+        #endregion
+
+        #region kill hook / progress / guardian
+
+        /// <summary>
+        /// Called once per creature death from Creature_Death.OnDeath. Fast-bails for the whole normal world
+        /// (variation null / >= 0). Runs on the instance landblock's thread, so run mutation is single-threaded.
+        /// </summary>
+        public static void OnCreatureDeath(Creature creature, Server.Entity.DamageHistoryInfo lastDamager)
+        {
+            var variation = creature?.Location?.Variation;
+            if (!variation.HasValue || variation.Value >= 0)
+                return;
+
+            if (creature is Player)
+                return;
+
+            if (!_runsByVariation.TryGetValue(variation.Value, out var run))
+                return;
+
+            if (run.State == RiftRunState.GuardianUp && creature.Guid.Full == run.GuardianGuid)
+            {
+                HandleCleared(run);
+                return;
+            }
+
+            if (run.State != RiftRunState.Active || !creature.IsMonster)
+                return;
+
+            var cfg = Config;
+            run.Progress += cfg.ProgressPerKill;
+
+            var pct = run.ProgressPercent;
+            var step = pct / 10;
+            if (step > run.LastAnnouncedStep && pct < 100)
+            {
+                run.LastAnnouncedStep = step;
+                Message(run, $"Rift progress: {pct}% ({FormatTime(RemainingSeconds(run))} remaining)");
+            }
+
+            if (run.Progress >= run.ProgressRequired)
+                SpawnGuardian(run, cfg);
+        }
+
+        private static void SpawnGuardian(RiftRun run, RiftConfig cfg)
+        {
+            var pool = cfg.GuardianPools.FirstOrDefault(p => p.Wcids.Count > 0 && run.Tier >= p.MinTier && run.Tier <= p.MaxTier)
+                    ?? cfg.GuardianPools.FirstOrDefault(p => p.Wcids.Count > 0);
+
+            if (pool == null)
+            {
+                log.Warn($"[RIFT] Run {run.RunId}: no guardian pool configured - treating full progress as a clear.");
+                HandleCleared(run);
+                return;
+            }
+
+            var wcid = pool.Wcids[ThreadSafeRandom.Next(0, pool.Wcids.Count - 1)];
+            var guardian = WorldObjectFactory.CreateNewWorldObject(wcid) as Creature;
+            if (guardian == null)
+            {
+                log.Error($"[RIFT] Run {run.RunId}: failed to create guardian wcid {wcid} - treating full progress as a clear.");
+                HandleCleared(run);
+                return;
+            }
+
+            RiftScaling.Apply(guardian, run, cfg, isGuardian: true);
+
+            // enter_world placement fails at an exact captured floor-z for scaled models (test-5: Vicky,
+            // scale 1.2, rejected the middle of a wide-open room at z=floor, placed fine at +0.25z), so the
+            // primary attempt spawns 0.25 above the configured spot — she settles onto the floor instantly.
+            // A failed EnterWorld leaves the WO retryable (AddPhysicsObj nulls PhysicsObj; the next add
+            // re-inits it), so walk a fallback ladder before conceding: nudged spot → exact spot → run
+            // entry → the owner's feet (a spot a player demonstrably fits).
+            var attempts = new List<Position>
+            {
+                (run.GuardianPos ?? run.Entry).ToPosition(run.Variation),
+                (run.GuardianPos ?? run.Entry).ToPosition(run.Variation),
+                run.Entry.ToPosition(run.Variation),
+            };
+            attempts[0].PositionZ += 0.25f;
+
+            var owner = PlayerManager.GetOnlinePlayer(run.OwnerGuid);
+            if (owner?.Location != null && owner.Location.Variation == run.Variation)
+                attempts.Add(new Position(owner.Location));
+
+            var entered = false;
+            foreach (var pos in attempts)
+            {
+                guardian.Location = pos;
+                if (guardian.EnterWorld())
+                {
+                    entered = true;
+                    break;
+                }
+                log.Warn($"[RIFT] Run {run.RunId}: guardian {wcid} placement failed at {pos} - trying fallback.");
+            }
+
+            if (!entered)
+            {
+                log.Error($"[RIFT] Run {run.RunId}: guardian {wcid} failed to enter world (all {attempts.Count} placements) - treating full progress as a clear.");
+                guardian.Destroy();
+                HandleCleared(run);
+                return;
+            }
+
+            // Same lock as TryEndRun: the timer (world thread) or /rift abandon can end the run while
+            // the guardian was being placed; an unlocked write here would overwrite that Failed state
+            // and the next tick would fail the run a second time.
+            lock (run)
+            {
+                if (run.State != RiftRunState.Active)
+                {
+                    log.Info($"[RIFT] Run {run.RunId}: run ended ({run.State}) while the guardian was spawning - guardian discarded.");
+                    guardian.Destroy();
+                    return;
+                }
+                run.GuardianGuid = guardian.Guid.Full;
+                run.State = RiftRunState.GuardianUp;
+            }
+            Message(run, $"The rift is at full power! {guardian.Name} has appeared - defeat it! {FormatTime(RemainingSeconds(run))} remaining.");
+            log.Info($"[RIFT] Run {run.RunId}: guardian {guardian.Name} ({wcid}) spawned.");
+        }
+
+        /// <summary>Atomic end-state transition: guardian death (instance thread) and timer expiry (world tick
+        /// thread) can race — exactly one wins.</summary>
+        private static bool TryEndRun(RiftRun run, RiftRunState endState)
+        {
+            lock (run)
+            {
+                if (run.State == RiftRunState.Cleared || run.State == RiftRunState.Failed)
+                    return false;
+                run.State = endState;
+                return true;
+            }
+        }
+
+        private static void HandleCleared(RiftRun run)
+        {
+            if (!TryEndRun(run, RiftRunState.Cleared))
+                return;
+
+            var cfg = Config;
+            run.CloseAtTime = Time.GetUnixTime() + Math.Max(5, cfg.GraceSeconds);
+
+            var elapsed = (int)(Time.GetUnixTime() - run.StartTime);
+            Message(run, $"Rift cleared in {FormatTime(elapsed)}! You will be returned in {Math.Max(5, cfg.GraceSeconds)} seconds.");
+            log.Info($"[RIFT] Run {run.RunId}: CLEARED tier {run.Tier} by {run.OwnerName} in {elapsed}s.");
+
+            var player = PlayerManager.GetOnlinePlayer(run.OwnerGuid);
+            if (player != null)
+            {
+                var best = player.GetProperty((PropertyInt)PropHighestClearedTier) ?? 0;
+                if (run.Tier > best)
+                {
+                    player.SetProperty((PropertyInt)PropHighestClearedTier, run.Tier);
+                    Message(run, $"New personal best - Tier {run.Tier}!");
+                }
+
+                GiveCurrencyReward(player, run, cfg);
+            }
+        }
+
+        private static void HandleFailed(RiftRun run)
+        {
+            if (!TryEndRun(run, RiftRunState.Failed))
+                return;
+
+            var cfg = Config;
+            run.CloseAtTime = Time.GetUnixTime() + Math.Max(5, cfg.GraceSeconds);
+            Message(run, $"The rift's power fades - time has run out. You keep what you have won, but the rift is lost. You will be returned in {Math.Max(5, cfg.GraceSeconds)} seconds.");
+            log.Info($"[RIFT] Run {run.RunId}: FAILED (timer) tier {run.Tier} by {run.OwnerName} at {run.ProgressPercent}%.");
+        }
+
+        private static void GiveCurrencyReward(Player player, RiftRun run, RiftConfig cfg)
+        {
+            if (cfg.CurrencyWcid == 0)
+                return;
+
+            var amount = (int)Math.Floor(cfg.CurrencyBase + cfg.CurrencyPerTier * run.Tier);
+            if (amount < 1)
+                return;
+
+            var token = WorldObjectFactory.CreateNewWorldObject(cfg.CurrencyWcid);
+            if (token == null)
+            {
+                log.Error($"[RIFT] Run {run.RunId}: failed to create reward currency wcid {cfg.CurrencyWcid}.");
+                return;
+            }
+
+            var maxStack = token.MaxStackSize ?? 1;
+            amount = Math.Min(amount, (int)maxStack);
+            if (amount > 1)
+                token.SetStackSize(amount);
+
+            if (player.TryCreateInInventoryWithNetworking(token))
+                Message(run, $"You receive {amount:N0} {token.Name} for clearing the rift!");
+            else
+                token.Destroy();
+        }
+
+        #endregion
+
+        #region tick / teardown
+
+        /// <summary>Called from WorldManager.UpdateGameWorld. Self-throttles to ~1/s; O(active runs).</summary>
+        public static void Tick()
+        {
+            if (_runsByVariation.IsEmpty)
+                return;
+
+            var now = Time.GetUnixTime();
+            if (now < _nextTickTime)
+                return;
+            _nextTickTime = now + 1;
+
+            foreach (var run in _runsByVariation.Values)
+            {
+                switch (run.State)
+                {
+                    case RiftRunState.Active:
+                    case RiftRunState.GuardianUp:
+                        // Keep the live instance warm for the whole run: SetActive blocks dormancy/unload
+                        // (the player-heartbeat refresh doesn't reliably reach variant instances — test-5
+                        // unload-under-player), and it must survive the owner being dead/outside mid-run.
+                        // GetLandblock re-materializes it if something still tore it down (re-entry works).
+                        LandblockManager.GetLandblock(new LandblockId((uint)((run.DungeonLb << 16) | 0xFFFF)),
+                            false, run.Variation, false)?.SetActive();
+
+                        while (run.NextTimeAnnounceIdx < TimeAnnounceThresholds.Length &&
+                               RemainingSeconds(run) <= TimeAnnounceThresholds[run.NextTimeAnnounceIdx])
+                        {
+                            Message(run, $"{FormatTime(TimeAnnounceThresholds[run.NextTimeAnnounceIdx])} remaining in the rift!");
+                            run.NextTimeAnnounceIdx++;
+                        }
+
+                        if (now >= run.EndTime)
+                            HandleFailed(run);
+                        break;
+
+                    case RiftRunState.Cleared:
+                    case RiftRunState.Failed:
+                        if (now >= run.CloseAtTime)
+                            CloseRun(run);
+                        break;
+                }
+            }
+        }
+
+        private static void CloseRun(RiftRun run)
+        {
+            if (!_runsByVariation.TryRemove(run.Variation, out _))
+                return; // already closed by another path
+
+            _runsByOwner.TryRemove(run.OwnerGuid, out _);
+
+            try
+            {
+                ZoneControlManager.RemoveRuntimeZone(run.ZoneName);
+            }
+            catch (Exception ex)
+            {
+                log.Error($"[RIFT] Run {run.RunId}: failed to remove runtime zone {run.ZoneName}. {ex}");
+            }
+
+            var player = PlayerManager.GetOnlinePlayer(run.OwnerGuid);
+            if (player != null && player.Location != null && player.Location.Variation == run.Variation)
+                ReturnPlayer(player, run);
+
+            log.Info($"[RIFT] Run {run.RunId}: closed ({run.State}). Instance {run.DungeonLb:X4} v{run.Variation} will unload when empty.");
+        }
+
+        private static void ReturnPlayer(Player player, RiftRun run)
+        {
+            var dest = run.ReturnPos?.ToPosition(run.ReturnVariation);
+            if (dest == null)
+            {
+                var fallback = player.Sanctuary ?? player.Instantiation;
+                if (fallback == null)
+                    return;
+                dest = new Position(fallback);
+            }
+
+            TeleportPlayer(player, dest);
+        }
+
+        #endregion
+
+        #region runtime loot zone
+
+        /// <summary>Register the run's ephemeral ZoneControl zone: tier-scaled loot stats on (dungeon, variation).
+        /// Never persisted; removed at teardown.</summary>
+        private static void RegisterRuntimeLootZone(RiftRun run, RiftConfig cfg)
+        {
+            var stats = new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var kv in cfg.LootStatBase)
+                stats[kv.Key] = kv.Value;
+
+            foreach (var kv in cfg.LootStatPerTier)
+            {
+                stats.TryGetValue(kv.Key, out var baseVal);
+                stats[kv.Key] = baseVal + kv.Value * run.Tier;
+            }
+
+            var area = new ControlledArea
+            {
+                Name = run.ZoneName,
+                Landblocks = new HashSet<ushort> { run.DungeonLb },
+                Variation = run.Variation,
+                Enabled = true,
+            };
+
+            var variant = area.Profile.Minion;
+            foreach (var kv in stats)
+            {
+                if (!ZoneStat.All.Contains(kv.Key, StringComparer.OrdinalIgnoreCase))
+                {
+                    log.Warn($"[RIFT] Ignoring unknown loot stat '{kv.Key}' in rift config.");
+                    continue;
+                }
+                variant.Stats[kv.Key] = new StatCurve { Base = kv.Value };
+            }
+
+            try
+            {
+                ZoneControlManager.RegisterRuntimeZone(area);
+            }
+            catch (Exception ex)
+            {
+                log.Error($"[RIFT] Run {run.RunId}: failed to register runtime zone. Loot scaling disabled for this run. {ex}");
+            }
+        }
+
+        #endregion
+
+        #region helpers
+
+        private static int RemainingSeconds(RiftRun run)
+        {
+            return (int)Math.Max(0, run.EndTime - Time.GetUnixTime());
+        }
+
+        public static string FormatTime(int seconds)
+        {
+            var t = TimeSpan.FromSeconds(Math.Max(0, seconds));
+            return t.TotalHours >= 1 ? $"{(int)t.TotalHours}:{t.Minutes:D2}:{t.Seconds:D2}" : $"{t.Minutes}:{t.Seconds:D2}";
+        }
+
+        private static void TeleportPlayer(Player player, Position dest)
+        {
+            // Do NOT pre-flip player.Location.Variation here (the old Portal.ActOnUse mirror). Teleport →
+            // UpdatePosition detects the landblock transfer as (cell changed || Location.Variation !=
+            // dest.Variation); pre-flipping erases the variation delta, so a same-landblock hop (opening a
+            // rift while standing inside the pool dungeon — the normal case) skips RelocateObjectForPhysics:
+            // the player never leaves the source instance and the rift instance never loads (test-2/3 bug).
+            // @televariant proves the plain path handles same-landblock variation hops correctly.
+            WorldManager.ThreadSafeTeleport(player, dest);
+        }
+
+        private static void Message(RiftRun run, string msg)
+        {
+            var player = PlayerManager.GetOnlinePlayer(run.OwnerGuid);
+            player?.Session?.Network.EnqueueSend(new GameMessageSystemChat($"[Rift] {msg}", ChatMessageType.Broadcast));
+        }
+
+        /// <summary>Player-facing status block for /rift.</summary>
+        public static string BuildStatus(Player player)
+        {
+            var run = GetRunByOwner(player.Guid.Full);
+            var best = player.GetProperty((PropertyInt)PropHighestClearedTier) ?? 0;
+
+            if (run == null)
+                return $"You have no open rift.{(best > 0 ? $" Highest tier cleared: {best}." : "")}";
+
+            var state = run.State switch
+            {
+                RiftRunState.Active => $"{run.ProgressPercent}% progress",
+                RiftRunState.GuardianUp => "the guardian awaits",
+                RiftRunState.Cleared => "CLEARED",
+                RiftRunState.Failed => "failed",
+                _ => run.State.ToString(),
+            };
+
+            return $"Rift Tier {run.Tier} ({run.DungeonName}): {state}, {FormatTime(RemainingSeconds(run))} remaining." +
+                   (best > 0 ? $" Highest tier cleared: {best}." : "");
+        }
+
+        #endregion
+    }
+}

--- a/Source/ACE.Server/Managers/Rifts/RiftModels.cs
+++ b/Source/ACE.Server/Managers/Rifts/RiftModels.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+
+using ACE.Entity;
+
+namespace ACE.Server.Managers.Rifts
+{
+    /// <summary>
+    /// JSON-serializable position for the rift config store. Variation is intentionally NOT stored —
+    /// it is supplied at run time (each run gets its own ephemeral negative variation).
+    /// </summary>
+    public class RiftPos
+    {
+        public uint Cell { get; set; }
+        public float X { get; set; }
+        public float Y { get; set; }
+        public float Z { get; set; }
+        public float QW { get; set; }
+        public float QX { get; set; }
+        public float QY { get; set; }
+        public float QZ { get; set; }
+
+        public Position ToPosition(int? variation)
+        {
+            return new Position(Cell, X, Y, Z, QX, QY, QZ, QW, false, variation);
+        }
+
+        public static RiftPos FromPosition(Position p)
+        {
+            if (p == null) return null;
+            return new RiftPos
+            {
+                Cell = p.Cell,
+                X = p.PositionX, Y = p.PositionY, Z = p.PositionZ,
+                QW = p.RotationW, QX = p.RotationX, QY = p.RotationY, QZ = p.RotationZ,
+            };
+        }
+    }
+
+    /// <summary>One curated dungeon in the rift pool. Single-landblock dungeons only (validated on add).</summary>
+    public class RiftDungeonEntry
+    {
+        public ushort Landblock { get; set; }
+        public string Name { get; set; }
+        /// <summary>Where the player lands when the rift opens.</summary>
+        public RiftPos Entry { get; set; }
+        /// <summary>Where the guardian spawns at 100% progress (falls back to Entry when unset).</summary>
+        public RiftPos Guardian { get; set; }
+        /// <summary>Which variation's world-DB instance rows (statics + monster generators) populate the rift
+        /// copy. Landblock instances are per-variation in this fork (exact match) — a rift's own negative
+        /// variation has no rows, so the instance loads THIS variation's population instead. Null = the
+        /// unlayered base rows. Captured from where the admin stands during /rift pool add here.</summary>
+        public int? SourceVariation { get; set; }
+    }
+
+    /// <summary>Guardian WCID pool for a tier band (inclusive).</summary>
+    public class RiftGuardianPool
+    {
+        public int MinTier { get; set; }
+        public int MaxTier { get; set; }
+        public List<uint> Wcids { get; set; } = new();
+    }
+
+    /// <summary>
+    /// Persisted rift configuration (shard DB key <c>rift_config</c>, JSON). All balance knobs live here and
+    /// are tunable live via /rift set — no server config properties, no weenie edits.
+    /// </summary>
+    public class RiftConfig
+    {
+        public List<RiftDungeonEntry> DungeonPool { get; set; } = new();
+        public List<RiftGuardianPool> GuardianPools { get; set; } = new();
+
+        /// <summary>Run length in seconds (default 15:00).</summary>
+        public int TimerSeconds { get; set; } = 900;
+        /// <summary>Seconds between clear/fail and eviction from the instance.</summary>
+        public int GraceSeconds { get; set; } = 60;
+        public int MaxActiveRuns { get; set; } = 40;
+
+        /// <summary>Kill points required to summon the guardian: Base + PerTier * tier.</summary>
+        public double ProgressBase { get; set; } = 40;
+        public double ProgressPerTier { get; set; } = 2;
+        /// <summary>Progress points per kill (flat for phase 1).</summary>
+        public double ProgressPerKill { get; set; } = 1;
+
+        /// <summary>Monster max health multiplier: HpGrowth ^ tier (geometric, uncapped by design).</summary>
+        public double HpGrowth { get; set; } = 1.08;
+        /// <summary>Additive DamageRating per tier (15 rating ≈ +15% damage).</summary>
+        public double DamageRatingPerTier { get; set; } = 3;
+        /// <summary>Extra max health multiplier on the guardian, applied on top of the tier curve.</summary>
+        public double GuardianHpMult { get; set; } = 6;
+        /// <summary>Extra flat DamageRating on the guardian.</summary>
+        public double GuardianDamageRatingBonus { get; set; } = 20;
+
+        /// <summary>Currency reward on clear: floor(Base + PerTier * tier) of CurrencyWcid, straight to inventory.
+        /// Wcid 0 disables. 300004 = Enlightened Coin.</summary>
+        public uint CurrencyWcid { get; set; } = 300004;
+        public double CurrencyBase { get; set; } = 5;
+        public double CurrencyPerTier { get; set; } = 1;
+
+        /// <summary>Zone loot stats stamped on the run's ephemeral zone: value = Base + PerTier * tier.
+        /// Keys are ZoneStat loot keys (weapon_cantrip_chance, bonus_currency, ...).
+        /// (loot_quality_mult / rare_chance_mult defaults removed 2026-08-23 with those stats.)</summary>
+        public Dictionary<string, double> LootStatBase { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+        public Dictionary<string, double> LootStatPerTier { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+    }
+
+    public enum RiftRunState
+    {
+        /// <summary>Filling the progress bar.</summary>
+        Active,
+        /// <summary>Guardian spawned, timer still running.</summary>
+        GuardianUp,
+        /// <summary>Guardian killed in time — success. Grace period, then eviction.</summary>
+        Cleared,
+        /// <summary>Timer expired first. Grace period, then eviction.</summary>
+        Failed,
+    }
+
+    /// <summary>One live rift run. In-memory only — a server restart discards active runs.</summary>
+    public class RiftRun
+    {
+        public int RunId { get; set; }
+        /// <summary>The run's private instance key. Always negative — prestige ignores the entire range.</summary>
+        public int Variation { get; set; }
+        public int Tier { get; set; }
+        public uint OwnerGuid { get; set; }
+        public string OwnerName { get; set; }
+
+        public ushort DungeonLb { get; set; }
+        public string DungeonName { get; set; }
+        public RiftPos Entry { get; set; }
+        public RiftPos GuardianPos { get; set; }
+        /// <summary>See <see cref="RiftDungeonEntry.SourceVariation"/> — copied at open so the landblock
+        /// loader can resolve it without touching config.</summary>
+        public int? SourceVariation { get; set; }
+
+        /// <summary>Where (and at which variation) the player is returned when the run ends.</summary>
+        public RiftPos ReturnPos { get; set; }
+        public int? ReturnVariation { get; set; }
+
+        public double StartTime { get; set; }
+        public int DurationSeconds { get; set; }
+        public double Progress { get; set; }
+        public double ProgressRequired { get; set; }
+
+        public RiftRunState State { get; set; } = RiftRunState.Active;
+        public uint GuardianGuid { get; set; }
+        /// <summary>Unix time at which the grace period ends and the run is torn down (0 = not ending yet).</summary>
+        public double CloseAtTime { get; set; }
+
+        /// <summary>Last whole 10%-step announced (progress chat throttle).</summary>
+        public int LastAnnouncedStep { get; set; }
+        /// <summary>Index into the time-remaining announcement thresholds already fired.</summary>
+        public int NextTimeAnnounceIdx { get; set; }
+
+        /// <summary>Name of the ephemeral ZoneControl runtime zone carrying this run's loot stats.</summary>
+        public string ZoneName { get; set; }
+
+        public double EndTime => StartTime + DurationSeconds;
+        public int ProgressPercent => ProgressRequired > 0 ? (int)Math.Min(100, Math.Floor(Progress * 100 / ProgressRequired)) : 0;
+    }
+}

--- a/Source/ACE.Server/Managers/Rifts/RiftScaling.cs
+++ b/Source/ACE.Server/Managers/Rifts/RiftScaling.cs
@@ -1,0 +1,67 @@
+using System;
+
+using ACE.Entity.Enum.Properties;
+using ACE.Server.WorldObjects;
+
+namespace ACE.Server.Managers.Rifts
+{
+    /// <summary>
+    /// Rift monster scaling. Deliberately self-contained: mimics the prestige approach (geometric max-health
+    /// growth + additive DamageRating) but reads only <see cref="RiftConfig"/> — no prestige tiers, clamps or
+    /// server-config properties are consulted. Applied at spawn on top of whatever the retail/Zone-Control
+    /// spawn path already did (rift variations are negative, so prestige scaling never engages).
+    /// </summary>
+    public static class RiftScaling
+    {
+        public static double GetHPModifier(RiftConfig cfg, int tier)
+        {
+            if (tier <= 0) return 1.0;
+            return Math.Pow(cfg.HpGrowth, tier);
+        }
+
+        public static int GetDamageRating(RiftConfig cfg, int tier)
+        {
+            if (tier <= 0) return 0;
+            return (int)Math.Round(cfg.DamageRatingPerTier * tier);
+        }
+
+        /// <summary>
+        /// Scale a freshly-spawned rift monster (per-instance biota — despawn naturally reverts; instance
+        /// landblocks are discarded whole when the run ends).
+        /// </summary>
+        public static void Apply(Creature creature, RiftRun run, RiftConfig cfg, bool isGuardian = false)
+        {
+            if (creature == null || creature is Player)
+                return;
+
+            // A weenie-level ForceEndgameSystems flag would make GetEffectiveVariation report a forced
+            // prestige variation instead of the run's negative one, splitting this mob off from the rift's
+            // zone resolution and live combat reads. Strip it for this instance.
+            if (creature.GetProperty(PropertyBool.ForceEndgameSystems) == true)
+                creature.RemoveProperty(PropertyBool.ForceEndgameSystems);
+
+            var hpMod = GetHPModifier(cfg, run.Tier);
+            if (isGuardian)
+                hpMod *= Math.Max(1.0, cfg.GuardianHpMult);
+
+            if (hpMod != 1.0)
+            {
+                var maxBefore = creature.Health.MaxValue;
+                var healthPct = maxBefore > 0 ? (float)creature.Health.Current / maxBefore : 1f;
+                creature.Health.StartingValue = (uint)Math.Clamp(Math.Round(creature.Health.StartingValue * hpMod), 1, uint.MaxValue);
+                var maxAfter = creature.Health.MaxValue;
+                creature.Health.Current = (uint)Math.Clamp((uint)Math.Round(healthPct * maxAfter), 0u, maxAfter);
+            }
+
+            var rating = GetDamageRating(cfg, run.Tier);
+            if (isGuardian)
+                rating += (int)Math.Round(cfg.GuardianDamageRatingBonus);
+
+            if (rating != 0)
+            {
+                var existing = creature.GetProperty(PropertyInt.DamageRating) ?? 0;
+                creature.SetProperty(PropertyInt.DamageRating, existing + rating);
+            }
+        }
+    }
+}

--- a/Source/ACE.Server/Managers/WeaponScaling/WeaponScalingCombat.cs
+++ b/Source/ACE.Server/Managers/WeaponScaling/WeaponScalingCombat.cs
@@ -1,0 +1,366 @@
+using System;
+
+using ACE.Entity.Enum;
+using ACE.Entity.Enum.Properties;
+using ACE.Server.WorldObjects;
+
+namespace ACE.Server.Managers.WeaponScaling
+{
+    /// <summary>
+    /// Swing-time resolution for the weapon aug-scaling system (T11 weapon relevance plan §6).
+    ///
+    /// A stamped weapon carries only QUALITY (0-1000) + TIER; everything else — k ranges, tier
+    /// caps, kc — resolves LIVE from <see cref="WeaponScalingManager.Current"/> (lock-free
+    /// snapshot read), and the wielder's aug counts are read fresh on every damage event, never
+    /// baked or cached (the Blood-Drinker-bakes-at-cast trap, deliberately avoided).
+    ///
+    /// Everything is gated on the master Enabled flag: disabled = every method returns 0 after
+    /// one volatile read + null check, and combat is byte-identical to pre-system behavior.
+    /// </summary>
+    public static class WeaponScalingCombat
+    {
+        /// <summary>The family key a weapon resolves against in the config's Scripts table —
+        /// derived from weapon properties at call time (nothing stamped): weight subtypes merge
+        /// by design, multi-strike splits via the MultiStrike attack flag, two-handed splits
+        /// cleaver/spear via thrust flags. Null = not a weapon we scale.</summary>
+        public static string GetFamilyKey(WorldObject weapon)
+        {
+            if (weapon == null)
+                return null;
+
+            if (weapon is Caster)
+                return (weapon.ElementalDamageMod ?? 1.0) > 1.0 ? "caster_elemental" : "caster_non_elemental";
+
+            if (weapon is MissileLauncher)
+            {
+                switch (weapon.AmmoType)
+                {
+                    case AmmoType.Arrow: return "bow";
+                    case AmmoType.Bolt: return "crossbow";
+                    case AmmoType.Atlatl: return "atlatl";
+                }
+                switch (weapon.W_WeaponType)
+                {
+                    case WeaponType.Bow: return "bow";
+                    case WeaponType.Crossbow: return "crossbow";
+                    case WeaponType.Thrown: return "atlatl";
+                }
+                return null;
+            }
+
+            if (!(weapon is MeleeWeapon))
+                return null;
+
+            var attackType = weapon.W_AttackType;
+            var multiStrike = (attackType & AttackType.MultiStrike) != 0;
+
+            switch (weapon.W_WeaponType)
+            {
+                case WeaponType.Sword: return multiStrike ? "sword_ms" : "sword";
+                case WeaponType.Dagger: return multiStrike ? "dagger_ms" : "dagger";
+                case WeaponType.Axe: return "axe";
+                case WeaponType.Mace: return "mace";       // jitte folds in
+                case WeaponType.Spear: return "spear";
+                case WeaponType.Staff: return "staff";
+                case WeaponType.Unarmed: return "unarmed";
+                case WeaponType.TwoHanded:
+                    // Both 2H families strike twice via stance; thrust-flagged = the spear line.
+                    var thrust = AttackType.Thrust | AttackType.DoubleThrust | AttackType.TripleThrust;
+                    return (attackType & thrust) != 0 ? "two_handed_spear" : "cleaver";
+            }
+            return null;
+        }
+
+        /// <summary>Resolve a stamped weapon's k coefficient + tier row under all the system gates
+        /// (enabled, stamped, known family, known tier). False = the weapon has no scaling
+        /// identity and every term is 0.
+        ///
+        /// TYPE-NEUTRAL as of the caster wire-in (2026-08-06). It used to reject casters outright,
+        /// which was fine while they were inert but would now block the very path they need. Each
+        /// TERM enforces its own exclusions instead — the pattern launchers already followed —
+        /// so the rule stays readable at the point it matters: flat/floor/variance/crit all
+        /// exclude BOTH launchers and casters, because those two lanes scale through a MOD
+        /// instead.</summary>
+        private static bool TryResolve(WorldObject weapon, out double k, out WeaponScalingTier tierRow)
+        {
+            k = 0;
+            tierRow = null;
+
+            if (weapon == null)
+                return false;
+
+            var cfg = WeaponScalingManager.Current;
+            if (!cfg.Enabled)
+                return false;
+
+            var quality = weapon.GetProperty(PropertyInt.WeaponAugScaleQuality);
+            if (quality == null)
+                return false;
+            var tier = weapon.GetProperty(PropertyInt.WeaponAugScaleTier);
+            if (tier == null)
+                return false;
+
+            var family = GetFamilyKey(weapon);
+            if (family == null)
+                return false;
+
+            if (!cfg.Scripts.TryGetValue(family, out var script))
+                return false;
+
+            foreach (var t in cfg.Tiers)
+                if (t.Tier == tier.Value) { tierRow = t; break; }
+            if (tierRow == null)
+                return false;
+
+            k = WeaponScalingManager.ResolveScriptK(script, quality.Value);
+            return true;
+        }
+
+        /// <summary>Scheme C (2026-08-03): the quality-tightened per-hit variance for a stamped
+        /// melee weapon. Non-crit hits roll the WHOLE envelope (base + term) down from max by
+        /// this fraction: v_eff = family Variance x (1 - TightenStrength x quality/1000).
+        /// False = old flat-hit behavior (launchers, casters, unstamped, disabled, or a store
+        /// without the Scheme C fields — Variance/TightenStrength default 0).
+        ///
+        /// SUB-GRADE SNAP REMOVED 2026-08-06 (owner: "those 2 weapons should not be identical
+        /// damage"). The 08-03 snap rounded quality to its sub-grade midpoint so every B+ rolled
+        /// the same floor as well as the same max. It existed to keep variance in step with k,
+        /// which back then resolved flat per sub-grade — now that k interpolates BETWEEN rungs
+        /// (see WeaponScalingManager.ResolveScriptK), a snapped variance would be the thing out of
+        /// step instead, freezing the min while the max slid. Continuous on every family again.</summary>
+        public static bool TryGetEffectiveVariance(WorldObject weapon, out double vEff)
+        {
+            vEff = 0;
+
+            if (weapon is MissileLauncher || weapon is Caster || !TryResolve(weapon, out _, out _))
+                return false;
+
+            var cfg = WeaponScalingManager.Current;
+            var family = GetFamilyKey(weapon);
+            if (family == null || !cfg.Scripts.TryGetValue(family, out var script) || script.Variance <= 0)
+                return false;
+
+            var quality = weapon.GetProperty(PropertyInt.WeaponAugScaleQuality) ?? 0;
+
+            vEff = WeaponScalingManager.EffectiveVariance(script.Variance, cfg.TightenStrength, quality);
+            return vEff > 0;
+        }
+
+        /// <summary>The per-strike flat damage term: k(quality) x min(wielder's item augs, tier cap).
+        /// 0 when disabled, unstamped, casters (inert until the caster wire-in), LAUNCHERS (their
+        /// quality grades the damage modifier instead — owner 2026-08-01), unknown family, or a
+        /// non-player wielder. Added post-roll in DamageEvent alongside the melee/missile aug
+        /// flat — NOT via BaseDamageMod.DamageBonus, which launcher DamageMod would multiply
+        /// ~3.6-3.9x on atlatls (plan §6.1 trap).</summary>
+        public static float GetFlatBonus(WorldObject weapon, Player wielder)
+        {
+            if (wielder == null || weapon is MissileLauncher || weapon is Caster
+                || !TryResolve(weapon, out var k, out var tierRow))
+                return 0f;
+
+            var augs = wielder.LuminanceAugmentItemCount ?? 0;
+            return (float)(k * Math.Min(augs, tierRow.Cap)) * EvNormalization(weapon);
+        }
+
+        /// <summary>LIVE EV normalization (owner 2026-08-03): editing a family's Variance
+        /// auto-rebalances its flat term, so wilder families never fall behind steady ones —
+        /// families all author the SAME k and stay equal in total expected damage at the
+        /// CB+CS reference build (p = 0.5 crit chance from the 400-skill imbue cap, M = 3.0
+        /// = 3.0, historically the player_crit_damage_cap, which was deleted 2026-08-29 - M stays
+        /// as this normalization's own constant): m = [(1-p)+pM] / [(1-p)(1-v_eff/2)+pM] = 2/(2-0.25v).
+        /// 1.0 for zero-variance weapons (launchers/casters/legacy) = exact old behavior.</summary>
+        private static float EvNormalization(WorldObject weapon)
+        {
+            if (!TryGetEffectiveVariance(weapon, out var vEff))
+                return 1f;
+            return (float)WeaponScalingManager.EvNormalization(vEff);
+        }
+
+        /// <summary>Launcher grading (owner 2026-08-01): bows have ALWAYS scaled through their
+        /// damage modifier — the multiplier applies to (ammo + Blood Drinker + elemental), and BD
+        /// is 0.5 x item augs, so the mod already couples the weapon to the wielder's augs. A flat
+        /// term on top double-dips, so launchers get NO flat term; instead the quality roll
+        /// RESOLVES the effective damage modifier directly: lerp(kMin, kMax, quality/1000) with
+        /// the launcher family's rows REINTERPRETED as the modifier band (T11 seed 3.00-3.40 —
+        /// grade F just above the legacy T10 authored 2.92, S ~+10% over it). REPLACE semantics:
+        /// the authored DamageMod property is the fallback whenever this returns false (system
+        /// disabled, unstamped legacy launcher, unknown family) — the kill switch restores
+        /// pre-system behavior exactly.</summary>
+        public static bool TryGetLauncherDamageMod(WorldObject weapon, Player holder, out float damageMod)
+        {
+            damageMod = 0f;
+
+            if (!(weapon is MissileLauncher))
+                return false;
+
+            return TryGetScaledMod(weapon, holder, WeaponScalingManager.Current.LauncherTierStep, out damageMod);
+        }
+
+        /// <summary>Caster grading (owner 2026-08-06: "Lets keep bow and caster weapons scaling
+        /// identical"). The exact launcher mechanism pointed at a different property: the quality
+        /// roll RESOLVES the effective ElementalDamageMod, which multiplies the whole spell damage
+        /// expression (SpellProjectile life :652 and war/void :767) just as the launcher's
+        /// DamageMod multiplies its own. Same REPLACE semantics — the authored ElementalDamageMod
+        /// is the fallback whenever this returns false, so the kill switch restores pre-system
+        /// behavior exactly.
+        ///
+        /// TWO THINGS THIS DOES NOT DO, both deliberate:
+        /// - It does NOT touch the damage-type match gate in GetCasterElementalDamageModifier
+        ///   (WorldObject_Weapon.cs:491). A caster still only boosts spells of its OWN element;
+        ///   scaling a mod that the gate zeroes out would change nothing.
+        /// - It therefore does NOTHING for caster_non_elemental — a plain Orb/Sceptre/Staff/Wand
+        ///   has no element to match, so its modifier is pinned at 1.0 forever. Those items do not
+        ///   scale BY CONSTRUCTION; that is a loot question, not a scaling one.</summary>
+        public static bool TryGetCasterElementalMod(WorldObject weapon, Player holder, out float elementalMod)
+        {
+            elementalMod = 0f;
+
+            if (!(weapon is Caster))
+                return false;
+
+            return TryGetScaledMod(weapon, holder, WeaponScalingManager.Current.CasterTierStep, out elementalMod);
+        }
+
+        /// <summary>Multiplicative caster composition (owner GO 2026-08-06,
+        /// CasterDamageShare_Plan): the wand's resolved mod MULTIPLIES the enchantment sum the
+        /// way the bow's DamageMod multiplies Blood Drinker, instead of sitting beside it as an
+        /// additive peer ~11x its size. modifier = wandMod x (1 + rescale x enchantments).
+        ///
+        /// The rescale (default 1/kMax = 0.6329) anchors S grade: an S wand's total is identical
+        /// to the old additive math at every aug count, and every other grade/tier re-grades
+        /// around that anchor — which is what finally makes the wand carry the owner's 25-35 pct
+        /// of total damage (it was ~3 pct under additive composition; T11 vs T14 measured ~1 pct
+        /// apart in game 2026-08-06).
+        ///
+        /// Pure math, no world state — the caller (WorldObject_Weapon) resolves the mod, gathers
+        /// the enchantment sum, and passes cfg.CasterAuraRescale; this exists as its own method
+        /// so the anchor property is unit-testable against plain configs.</summary>
+        public static float ComposeCasterModifier(double wandMod, double enchantments, double auraRescale)
+        {
+            return (float)(wandMod * (1.0 + auraRescale * enchantments));
+        }
+
+        /// <summary>The shared mod resolver behind both mod-scaled lanes: lerp(quality) x the tier
+        /// term. ONE path so the two lanes cannot drift apart (owner 2026-08-06: "This keeps
+        /// weapons simple"); they differ only in which step knob they pass and which property the
+        /// caller writes the result to.</summary>
+        private static bool TryGetScaledMod(WorldObject weapon, Player holder, double tierStep, out float mod)
+        {
+            mod = 0f;
+
+            if (!TryResolve(weapon, out var k, out var tierRow))
+                return false;
+
+            if (tierStep > 0)
+            {
+                // Floored at the tier's wield floor for the same reason GetExamineBonus is: the
+                // wield gate guarantees no real wielder is below it, so an unwielded examine
+                // (holder null, or a viewer short of the requirement) reads the honest minimum for
+                // any hands rather than a modifier this weapon can never actually produce. A no-op
+                // for a genuine wielder, who by definition already clears the floor.
+                var augs = Math.Max(tierRow.MinWieldAugs, holder?.LuminanceAugmentItemCount ?? 0);
+                k *= 1.0 + tierStep * LauncherTierSteps(WeaponScalingManager.Current, tierRow, augs);
+            }
+
+            mod = (float)k;
+            return true;
+        }
+
+        /// <summary>How many TIER STEPS this launcher's holder has actually unlocked (owner
+        /// 2026-08-06: "Bows should track min(augs, cap) like melee does").
+        ///
+        /// Gated by the WEAPON's own cap, so augs past it belong to a tier this weapon is not —
+        /// which reproduces melee's dead zone exactly: at 3,500 augs a T13 bow and a T25 bow
+        /// return the same step count, just as a T13 and T25 melee weapon already share the same
+        /// min(augs, cap). A higher tier you cannot fill is worth nothing in either lane.
+        ///
+        /// Counted off the AUTHORED tier rows rather than assuming the code seed's 500 spacing.
+        /// Caps are hand-authored and the store is authoritative — the live grade weights already
+        /// differ from the seed (A 3 / B 5 / F 50 vs A 5 / B 10 / F 44.9), so nothing here may
+        /// assume seed values.
+        ///
+        /// Takes a raw aug count rather than a Player so the whole rule is unit-testable without a
+        /// live world object; callers apply the wield floor.</summary>
+        public static int LauncherTierSteps(WeaponScalingConfig cfg, WeaponScalingTier tierRow, long augs)
+        {
+            var effective = Math.Min(augs, tierRow.Cap);
+
+            var unlocked = 0;
+            foreach (var t in cfg.Tiers)
+                if (t.Cap <= effective)
+                    unlocked++;
+
+            // The lowest tier is the baseline and adds nothing — T11 is 1.0x by construction.
+            return Math.Max(0, unlocked - 1);
+        }
+
+        /// <summary>The GUARANTEED-at-equip term: k(quality) x the tier's wield floor (capped).
+        /// Because the item-aug wield req means no possible wielder has fewer augs than the floor,
+        /// this is an honest minimum for ANY hands — shown as the weapon's "natural" damage to
+        /// every examiner, so drops read like real weapons without baking anything on the item
+        /// (owner 2026-08-01: baking would freeze the config at drop time and break both the
+        /// retroactive re-pricing and the kill switch's full revert).</summary>
+        public static float GetFloorBonus(WorldObject weapon)
+        {
+            if (weapon is MissileLauncher || weapon is Caster || !TryResolve(weapon, out var k, out var tierRow))
+                return 0f;
+
+            return (float)(k * Math.Min(tierRow.MinWieldAugs, tierRow.Cap)) * EvNormalization(weapon);
+        }
+
+        /// <summary>The UNWIELDED examine value (owner 2026-08-03): read the term off the
+        /// EXAMINER's own item augs, so a drop sitting in a corpse or pack reads as what it would
+        /// do in THAT player's hands rather than a stranger's. Never below
+        /// <see cref="GetFloorBonus"/> — the wield gate guarantees no real wielder has fewer augs
+        /// than the tier floor, so a sub-floor examiner would otherwise be shown a number this
+        /// weapon can never actually produce for anyone. Supersedes the 2026-08-01
+        /// tier-floor-for-every-examiner display.</summary>
+        public static float GetExamineBonus(WorldObject weapon, Player examiner)
+        {
+            var floor = GetFloorBonus(weapon);
+
+            if (examiner == null)
+                return floor;
+
+            return Math.Max(floor, GetFlatBonus(weapon, examiner));
+        }
+
+        /// <summary>The crit-damage term: kc(quality) x melee_missile_aug_crit_modifier x
+        /// min(matching combat augs, tier cap) — the aug-pegged crit floor. Composed via
+        /// Math.Max against the CriticalMultiplier/Crippling Blow path, so zone crit cards
+        /// stay the jackpot above it. 0 under the same gates as the flat term.</summary>
+        public static float GetCritDamageBonus(WorldObject weapon, Creature wielder)
+        {
+            if (!(wielder is Player player) || weapon == null)
+                return 0f;
+
+            var cfg = WeaponScalingManager.Current;
+            if (!cfg.Enabled)
+                return 0f;
+
+            var quality = weapon.GetProperty(PropertyInt.WeaponAugScaleQuality);
+            if (quality == null)
+                return 0f;
+            var tier = weapon.GetProperty(PropertyInt.WeaponAugScaleTier);
+            if (tier == null)
+                return 0f;
+            if (weapon is Caster)
+                return 0f;
+
+            WeaponScalingTier tierRow = null;
+            foreach (var t in cfg.Tiers)
+                if (t.Tier == tier.Value) { tierRow = t; break; }
+            if (tierRow == null)
+                return 0f;
+
+            var kc = WeaponScalingManager.ResolveFromQuality(cfg.KcMin, cfg.KcMax, quality.Value);
+            var count = weapon.IsMissileWeapon
+                ? player.LuminanceAugmentMissileCount ?? 0
+                : player.LuminanceAugmentMeleeCount ?? 0;
+            // Same per-aug crit modifier the aug crit bonus itself uses, so the peg stays honest
+            // if the server ever retunes it.
+            var modifier = ServerConfig.melee_missile_aug_crit_modifier.Value;
+            return (float)(kc * modifier * Math.Min(count, tierRow.Cap));
+        }
+    }
+}

--- a/Source/ACE.Server/Managers/WeaponScaling/WeaponScalingCombat.cs
+++ b/Source/ACE.Server/Managers/WeaponScaling/WeaponScalingCombat.cs
@@ -258,7 +258,7 @@ namespace ACE.Server.Managers.WeaponScaling
                 // (holder null, or a viewer short of the requirement) reads the honest minimum for
                 // any hands rather than a modifier this weapon can never actually produce. A no-op
                 // for a genuine wielder, who by definition already clears the floor.
-                var augs = Math.Max(tierRow.MinWieldAugs, holder?.LuminanceAugmentItemCount ?? 0);
+                var augs = Math.Max(tierRow.MinWieldAugs, holder?.EffectiveItemAugCount ?? 0);   // gems + Triune Weave, like every other aug read
                 k *= 1.0 + tierStep * LauncherTierSteps(WeaponScalingManager.Current, tierRow, augs);
             }
 

--- a/Source/ACE.Server/Managers/WeaponScaling/WeaponScalingCombat.cs
+++ b/Source/ACE.Server/Managers/WeaponScaling/WeaponScalingCombat.cs
@@ -158,7 +158,7 @@ namespace ACE.Server.Managers.WeaponScaling
                 || !TryResolve(weapon, out var k, out var tierRow))
                 return 0f;
 
-            var augs = wielder.LuminanceAugmentItemCount ?? 0;
+            var augs = wielder.EffectiveItemAugCount;   // gems + Triune Weave, matching the aug-caps rule everywhere else
             return (float)(k * Math.Min(augs, tierRow.Cap)) * EvNormalization(weapon);
         }
 
@@ -355,8 +355,8 @@ namespace ACE.Server.Managers.WeaponScaling
 
             var kc = WeaponScalingManager.ResolveFromQuality(cfg.KcMin, cfg.KcMax, quality.Value);
             var count = weapon.IsMissileWeapon
-                ? player.LuminanceAugmentMissileCount ?? 0
-                : player.LuminanceAugmentMeleeCount ?? 0;
+                ? player.EffectiveMissileAugCount
+                : player.EffectiveMeleeAugCount;
             // Same per-aug crit modifier the aug crit bonus itself uses, so the peg stays honest
             // if the server ever retunes it.
             var modifier = ServerConfig.melee_missile_aug_crit_modifier.Value;

--- a/Source/ACE.Server/Managers/WeaponScaling/WeaponScalingManager.cs
+++ b/Source/ACE.Server/Managers/WeaponScaling/WeaponScalingManager.cs
@@ -1,0 +1,798 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+using log4net;
+
+using Newtonsoft.Json;
+
+using ACE.Database;
+using ACE.Database.Models.Shard;
+
+namespace ACE.Server.Managers.WeaponScaling
+{
+    /// <summary>One tier band: the aug count the scaling term stops growing at, and the item-aug
+    /// floor required to wield the tier's weapons (the market-segmentation gate — NOT power gating;
+    /// power is self-gated by the per-wielder scaling itself).</summary>
+    public class WeaponScalingTier
+    {
+        public int Tier { get; set; }
+        public int Cap { get; set; }
+        public int MinWieldAugs { get; set; }
+
+        // Charm wield gates (owner 2026-08-15): item augs purchase-cap at 4,000, so T16+ weapons
+        // can't keep climbing the item-aug ladder. From T16 the item req FREEZES at 4,000 and
+        // these two climb instead, +500/tier each: Triune Weave, plus the weapon-family charm
+        // (Crashing Steel melee / True Shot launchers / Battlemage's Wrath elemental casters /
+        // Nether Veil nether casters). 0 = no charm gate (all tiers through T15).
+        /// <summary>
+        /// CREATURE aug requirement for the T11+ hit gate (owner 2026-08-31). Unlike MinWieldAugs this
+        /// is NOT a wield requirement - nothing stops you equipping the gear. It gates whether your
+        /// swings and spells can LAND on a monster at this variation (TierHitGate).
+        /// 4,000 at T11, +500/tier, frozen at the 6,000 purchase cap from T15 - above which TRIUNE
+        /// carries the ladder, exactly as it does for the item-aug wield gate.
+        /// </summary>
+        public int MinWieldCreature { get; set; }
+        public int MinWieldTriune { get; set; }
+        public int MinWieldSkillCharm { get; set; }
+    }
+
+    /// <summary>Per-loot-script k roll range. A weapon's stored QUALITY (0-1000) lerps between
+    /// KMin and KMax at swing time, so retuning the range re-prices every existing drop.</summary>
+    public class WeaponScalingScript
+    {
+        public double KMin { get; set; }
+        public double KMax { get; set; }
+
+        // Scheme C (2026-08-03): the family's authored per-hit variance. Non-crit melee hits
+        // roll the WHOLE envelope (weenie base + aug term) down from max by the quality-
+        // tightened fraction of this. 0 = inert (launchers/casters, or a store from before
+        // this field existed — the old flat-hit behavior is the fallback either way).
+        public double Variance { get; set; }
+
+        // Grade ladder (owner 2026-08-03, WeaponGradeLadder plan): k resolved from the weapon's
+        // SUB-GRADE, not lerped from quality. Sixteen AUTHORED values keyed by sub-grade name
+        // (S, A+, A, A-, ... F-) — the ladder is drawn, not derived, because the quality bands
+        // are wildly uneven in width (S->A is 50 quality points, D->F is 325) and a linear lerp
+        // inherited that geometry, bunching S/A/B within +7.5 pct of each other.
+        // NULL/EMPTY = this family falls back to the KMin/KMax lerp — that is the migration path
+        // for old stores AND the deliberate current state of launchers (their rows are a damage
+        // MOD band, retuned in the missile pass) and casters (inert).
+        public Dictionary<string, double> Grades { get; set; }
+
+        /// <summary>True when this family resolves off an authored ladder rather than the lerp.
+        /// Gates BOTH k resolution and the variance sub-grade snap, so the two never disagree.</summary>
+        [JsonIgnore]
+        public bool HasLadder => Grades != null && Grades.Count > 0;
+    }
+
+    public class WeaponScalingConfig
+    {
+        public bool Enabled { get; set; }
+
+        public List<WeaponScalingTier> Tiers { get; set; } = new();
+
+        public Dictionary<string, WeaponScalingScript> Scripts { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+
+        public double KcMin { get; set; }
+        public double KcMax { get; set; }
+
+        // Scheme C: how much of the family variance a perfect-quality weapon sheds.
+        // v_eff = Variance x (1 - TightenStrength x quality/1000); 0.7 = S keeps 30 pct of
+        // the family's wildness, F keeps ~83 pct. 0 (old stores) = no tightening.
+        public double TightenStrength { get; set; }
+
+        // Launcher tier scaling (owner 2026-08-06). A launcher's damage modifier gains this
+        // fraction per TIER STEP the wielder's item augs have actually unlocked, gated on
+        // min(augs, the weapon tier's Cap). Bows therefore inherit melee's dead zone: once a
+        // tier's cap climbs past what the player owns, a higher-tier bow gives nothing —
+        // exactly as a higher-tier melee weapon already gives nothing (owner: "Bows should
+        // track min(augs, cap) like melee does").
+        //
+        // T11 is the baseline and higher tiers only ADD. Nothing is ever subtracted, so item
+        // augs always pay and Blood Drinker is never touched.
+        //
+        // REPLACES the missile aug cap shipped and reverted the same day, which produced tier
+        // growth by clawing BACK over-cap Blood Drinker. That froze a T11 bow user's BD
+        // contribution at 1,250 no matter how many augs they bought (owner: "Everything
+        // dealing with Blood Drinker is supposed to stay uncapped. Capping BD destroys the
+        // purpose of increasing Item Augs completely"). Do not reintroduce a subtractive form.
+        //
+        // STRAIGHT step, deliberately not compounding — G^steps snowballs over 14 tiers
+        // (G=1.09 matches melee's upgrade feel but lands bows at 2.41x melee by T25).
+        //
+        // SIZED AT 0.06 for the tiers players are actually in. Owner 2026-08-06: melee should be
+        // "about 20-25 pct ahead starting out... Melee has to get close to mobs, missile shoots
+        // from distance so the 20 pct difference is fine", and on the far end, "T25 is years away
+        // — don't need to plan around that". So this is tuned on T11-T15, not on the asymptote.
+        //
+        // Melee sits 26 pct ahead at T11, which is the owner's target and is fixed by kMin/kMax:
+        // steps is 0 at T11 by construction, so this value CANNOT move the starting gap. Raising
+        // the bow's floor means editing the family's k range instead.
+        //
+        // Buys +4.0 pct per unlocked step at fixed augs against melee's +6.1 pct. The remaining
+        // gap matters less than it reads: the WIELD FLOOR means augs cannot be held fixed across
+        // many tiers anyway (at 3,500 augs only T11-T14 are wieldable), so the upgrade players
+        // actually experience is "bought augs, can now wield a better bow" — where bows already
+        // gain +11.6 pct per tier before this term exists at all.
+        //
+        // Far out this does cross over (bow ~38 pct ahead by T25 at full augs). Deliberately not
+        // designed around — revisit if the live ladder ever reaches those tiers.
+        //
+        // Bows also SHOULD have a smaller fixed-aug step than melee. Melee's +6.1 pct is
+        // recovering waste — a T11 melee user at 3,500 augs draws value from only 2,500 of
+        // them and the upgrade unlocks the rest. A bow user has no waste; BD is uncapped and
+        // fully multiplied, so all 3,500 already count. There is less there to hand back.
+        //
+        // INITIALIZED rather than defaulted to 0 so stores written before this field still get
+        // the scaling; an explicit 0 disables it.
+        public double LauncherTierStep { get; set; } = 0.06;
+
+        // The caster twin of LauncherTierStep (owner 2026-08-06: "Lets keep bow and caster
+        // weapons scaling identical. We will tune vs magic on mobs. This keeps weapons simple").
+        // Casters run the SAME mechanism as launchers — quality resolves the mod, the tier term
+        // multiplies it, min(augs, cap) gates it — driving ElementalDamageMod instead of
+        // DamageMod. It gets its OWN knob rather than sharing the launcher's (owner, same day:
+        // "Do the CasterTierStep - incase we want to tune caster different later"), defaulted
+        // EQUAL so the two lanes are identical until someone deliberately parts them.
+        //
+        // The physical-vs-magic balance is NOT tuned here — owner ruled it belongs on the mob
+        // side (magic defense/resists), because monster defenses differ between spell and
+        // physical and no weapon band can express that. Do not re-derive this from a
+        // caster-vs-bow damage ratio.
+        public double CasterTierStep { get; set; } = 0.06;
+
+        // Multiplicative composition rescale (owner GO 2026-08-06, CasterDamageShare_Plan):
+        // the caster modifier is wandMod x (1 + THIS x enchantmentSum) instead of the stock
+        // wandMod + enchantmentSum. Without it Spirit Drinker (+0.005/itemAug, +17.50 at the
+        // 3,500-aug reference) is an additive PEER ~11x the wand's own 1.24-1.58, making the
+        // wand ~8 pct of its own multiplier — T11 vs T14 measured ~1 pct apart in game, S vs
+        // F- +1.8 pct, when the owner's target is the weapon carrying 25-35 pct of total
+        // damage like melee's flat term and the bow's mod both do.
+        //
+        // 0.6329 = 1/kMax (1/1.58): solving kMax x (1 + r x A) = kMax + A gives r = 1/kMax
+        // INDEPENDENT of A — so an S-grade wand's total damage is bit-identical to the old
+        // additive math at EVERY aug count, and the change strictly re-grades everyone else
+        // around that anchor (lower grades lose, higher tiers finally gain their +6 pct/step).
+        // Retune this only in step with the caster band's kMax or the anchor property breaks.
+        public double CasterAuraRescale { get; set; } = 0.6329;
+
+        // Grade drop weights (owner 2026-08-02): the quality roll picks a GRADE from these
+        // weights, then rolls uniform INSIDE that grade's quality band — frequency decoupled
+        // from what a grade MEANS (the band cutoffs stay fixed; S is always the single perfect
+        // roll q=1000). Relative weights, normalized at roll time. Null/empty (old stores) =
+        // the legacy uniform 0-1000 roll.
+        public Dictionary<string, double> GradeWeights { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Weapon aug-scaling config: the plugin-tunable knobs for the T11+ weapon relevance system
+    /// (plan: C:\AI\ZoneControl\T11_WeaponRelevance_Plan_2026-07-31.md).
+    ///
+    /// Weapons store a QUALITY percentile + tier; the MEANING (k ranges, tier caps, wield floors)
+    /// lives here, resolved at swing time — so every knob edit retroactively re-prices existing
+    /// drops. Persisted as a single JSON blob in shard config (same pattern as zonecontrol_data).
+    ///
+    /// This manager is deploy-cold: nothing reads it in combat until the wire-in ships, and the
+    /// master Enabled flag (default OFF) gates that wire-in when it does.
+    /// </summary>
+    public static class WeaponScalingManager
+    {
+        private static readonly ILog log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+
+        private const string StoreKey = "weaponscaling_data";
+
+        /// <summary>Quality rolls span 0..1000 (permille, integer-friendly for the old client wire).</summary>
+        public const int QualityMax = 1000;
+
+        private static readonly object _lock = new object();
+        private static volatile bool _initialized;
+
+        // ── Grade tables ──
+        // DECLARED BEFORE _current ON PURPOSE: static field initializers run in declaration order,
+        // and _current calls BuildDefaults(), which seeds ladders off these. Move them below and
+        // the type initializer throws a NullReferenceException on first touch.
+
+        /// <summary>Grade quality bands — MUST match the ForgeGrade cutoffs (plugin + appraisal
+        /// labels). The weights table picks the grade; quality rolls uniform inside the band.
+        /// S is the single perfect roll (owner 2026-08-02: "S remains 100 pct of max").</summary>
+        public static readonly (string Grade, int QMin, int QMax)[] GradeBands =
+        {
+            ("S", 1000, 1000), ("A", 900, 999), ("B", 800, 899),
+            ("C", 650, 799), ("D", 500, 649), ("F", 0, 499),
+        };
+
+        /// <summary>SUB-grade bands (owner 2026-08-03): each full grade split into thirds, S left
+        /// alone as the single perfect roll. Costs NOTHING in the drop system — these are
+        /// sub-ranges of the existing <see cref="GradeBands"/>, so GradeWeights and per-grade drop
+        /// rates are untouched; the sub-grade is simply where inside the band the uniform roll
+        /// landed. Order is the LADDER order (best to worst) and the payload wire order — the
+        /// plugin indexes by position, so never reorder without bumping both sides.</summary>
+        public static readonly (string Grade, int QMin, int QMax, int QMid)[] SubGradeBands =
+        {
+            ("S",  1000, 1000, 1000),
+            ("A+",  967,  999,  983),
+            ("A",   933,  966,  950),
+            ("A-",  900,  932,  916),
+            ("B+",  867,  899,  883),
+            ("B",   833,  866,  850),
+            ("B-",  800,  832,  816),
+            ("C+",  750,  799,  775),
+            ("C",   700,  749,  725),
+            ("C-",  650,  699,  675),
+            ("D+",  600,  649,  625),
+            ("D",   550,  599,  575),
+            ("D-",  500,  549,  525),
+            ("F+",  333,  499,  416),
+            ("F",   167,  332,  250),
+            ("F-",    0,  166,   83),
+        };
+
+        /// <summary>Ladder step: +18 pct per FULL grade = three sub-grade steps, so one sub-grade
+        /// step is the cube root. Owner 2026-08-03; S sits on the same even step (the premium
+        /// variant was offered and declined).</summary>
+        public static readonly double LadderStep = Math.Pow(1.18, 1.0 / 3.0);
+
+        // Immutable-by-convention snapshot: mutations clone + swap; readers never see a torn config.
+        private static volatile WeaponScalingConfig _current = BuildDefaults();
+
+        /// <summary>Current config snapshot. Treat as read-only — all edits go through <see cref="Mutate"/>.</summary>
+        public static WeaponScalingConfig Current
+        {
+            get { Initialize(); return _current; }
+        }
+
+        public static void Initialize()
+        {
+            if (_initialized)
+                return;
+
+            lock (_lock)
+            {
+                if (_initialized)
+                    return;
+
+                try { Load(); }
+                catch (Exception ex) { log.Error($"WeaponScalingManager: failed to load store, using defaults. {ex}"); }
+
+                _initialized = true;
+            }
+        }
+
+        /// <summary>Locked launch defaults (plan §4, owner 2026-07-31): k 0.90-1.15 baseline with
+        /// per-script ratios, kc 0.60-0.80, caps T11=2500 +500/tier, minWieldAugs = previous tier's
+        /// cap (T11 exempt). Enabled = FALSE — the system is inert until deliberately switched on.
+        /// Script keys follow the T11 loot-script names; step 3 (loot stamping) must use the same keys.</summary>
+        public static WeaponScalingConfig BuildDefaults()
+        {
+            var cfg = new WeaponScalingConfig
+            {
+                Enabled = false,
+                KcMin = 0.60,
+                KcMax = 0.80,
+            };
+
+            // Tiers T11..T25: cap = 2500 + 500 * (tier - 11); minWieldAugs = previous tier's cap.
+            // T11's floor is the PRE-EXISTING live gate (2,000 item augs, owner 2026-07-20,
+            // LootGenerationFactory.ZoneLootSetWieldItemAugs) — not 0: every T11+ drop already
+            // requires it, and ApplyT11WieldRequirement now reads this table per tier.
+            for (var tier = 11; tier <= 25; tier++)
+            {
+                // Item augs purchase-cap at 4,000 (EmoteManager.AugmentationCaps), which the
+                // ladder reaches at T15. T16+ freezes the item req there and gates on charm
+                // counters instead: Triune Weave + the weapon-family charm, 500 each at T16,
+                // +500/tier (owner 2026-08-15).
+                cfg.Tiers.Add(new WeaponScalingTier
+                {
+                    Tier = tier,
+                    Cap = 2500 + 500 * (tier - 11),
+                    MinWieldAugs = tier == 11 ? 2000 : Math.Min(4000, 2500 + 500 * (tier - 12)),
+                    MinWieldCreature = Math.Min(6000, 4000 + 500 * (tier - 11)),
+                    MinWieldTriune = tier >= 16 ? 500 * (tier - 15) : 0,
+                    MinWieldSkillCharm = tier >= 16 ? 500 * (tier - 15) : 0,
+                });
+            }
+
+            // One key per weapon FAMILY, weight subtypes merged (owner 2026-08-01). k ranges are
+            // EQUAL WITHIN MECHANICS GROUPS (owner, same day): all weapons speed-cap at endgame
+            // (item-aug Alacrity aura -1 time/aug, WeaponTime floors at 0 in
+            // WorldObject_Weapon.GetWeaponSpeed), so authored per-family damage differences would just
+            // crown a best-in-slot — k encodes MECHANICS, not weapon identity. The discount rule
+            // follows what the weapon GIVES UP (owner, final):
+            //  - multi-strike gives up nothing (longer animation only) -> k discounted by strike count
+            //    for per-swing weapon-term parity with singles;
+            //  - TWO-HANDED gives up a SHIELD (AL + block + a gem/cantrip slot) -> NO discount: k
+            //    equals singles per hit, so both strikes carry it and every damage term doubles per
+            //    swing — the +100% weapon-term premium IS the shield compensation.
+            // Step-3 mapping: damage mutation file -> family key (heavy_X / light_finesse_X -> X;
+            // *_ms own rows; two_handed_cleaver -> cleaver; jitte -> mace; bow/xbow/atlatl elem +
+            // non-elem -> launcher key). CASTER rows are seeded for authoring but INERT until the
+            // caster wire-in ships (parity audit pending — caster damage rides ElementalDamageMod).
+            // Scheme C (2026-08-03, WeaponVariance_SchemeC_Plan): per-family authored variance
+            // (config-owned — loot's per-drop DamageVariance roll is display-legacy). k stays
+            // UNIFORM within mechanics groups: the EV normalization for variance is LIVE in
+            // WeaponScalingCombat.EvNormalization (owner ask: editing a Variance knob must
+            // auto-rebalance) — never bake it into these numbers, that would double-dip.
+            // GRADE LADDER (owner 2026-08-03): melee families resolve k from a 16-value authored
+            // ladder, seeded here at +18 pct per full grade (+5.67 pct per sub-grade) off an S
+            // anchor. KMin/KMax are KEPT on every row as the fallback (and as what launchers and
+            // casters still actually use) — a family drops back to the lerp the moment its ladder
+            // is cleared. Singles anchor S = 0.90; multi-strike anchors 0.40 = the same 0.444x
+            // per-swing discount the old 0.40/0.51 band encoded (they strike 2-3x per swing).
+            cfg.TightenStrength = 0.7;
+            void Melee(string key, double variance, double anchorS = 0.90, double kMin = 0.90, double kMax = 1.15)
+                => cfg.Scripts[key] = new WeaponScalingScript
+                {
+                    KMin = kMin,
+                    KMax = kMax,
+                    Variance = variance,
+                    Grades = BuildLadder(anchorS, variance, cfg.TightenStrength),
+                };
+
+            Melee("mace", 0.35);
+            Melee("sword", 0.40);
+            Melee("staff", 0.45);
+            Melee("cleaver", 0.50);
+            Melee("two_handed_spear", 0.50);
+            Melee("dagger", 0.55);
+            Melee("unarmed", 0.55);
+            Melee("spear", 0.60);
+            Melee("axe", 0.70);
+            Melee("sword_ms", 0.40, anchorS: 0.40, kMin: 0.40, kMax: 0.51);
+            Melee("dagger_ms", 0.55, anchorS: 0.40, kMin: 0.40, kMax: 0.51);
+            // CASTERS (owner 2026-08-06, wire-in): the elemental family's rows are REINTERPRETED
+            // as the ElementalDamageMod band, exactly as launchers reinterpret theirs as the
+            // DamageMod band. Band ported from the launcher construction so the two lanes scale
+            // IDENTICALLY:
+            //   real T10 casters roll 1.20-1.22   (every wield >= 500 falls to RollElementalDamageMod's
+            //                                      "// 550" default — T9/T10/T11 all roll the same,
+            //                                      i.e. casters had NO generational scaling at all)
+            //   S  = 1.22 x 1.299 = 1.58          (+29.9 pct over the T10 ceiling, bow's exact bump)
+            //   F- = 1.58 x 0.90/1.15 = 1.24      (same F->S ratio as melee, +27.8 pct)
+            // The 1.24 floor clears the 1.22 T10 ceiling by +1.6 pct — the same margin by which
+            // the launcher floor 3.13 clears its T10 ceiling 3.08. Both properties multiply their
+            // lane's WHOLE damage expression, so +29.9 pct on the mod is +29.9 pct on damage in
+            // both lanes; the parity is real, not just numerically parallel.
+            cfg.Scripts["caster_elemental"] = new WeaponScalingScript { KMin = 1.24, KMax = 1.58 };
+
+            // NON-elemental casters (a plain Orb/Sceptre/Staff/Wand from the wield==0 loot branch)
+            // carry NO element and NO ElementalDamageMod, and GetCasterElementalDamageModifier
+            // returns a flat 1.0 whenever the caster's damage type does not match the spell's — so
+            // there is nothing on this path to scale. Left on the old band deliberately: it is
+            // INERT, not tuned. These items do not scale by construction.
+            cfg.Scripts["caster_non_elemental"] = new WeaponScalingScript { KMin = 0.90, KMax = 1.15 };
+
+            // Grade drop weights (owner 2026-08-02): S stays ~1-in-1000; A 5 / B 10 / C 15
+            // owner-picked, D/F fill per the "gentle ladder" option.
+            cfg.GradeWeights["S"] = 0.1;
+            cfg.GradeWeights["A"] = 5;
+            cfg.GradeWeights["B"] = 10;
+            cfg.GradeWeights["C"] = 15;
+            cfg.GradeWeights["D"] = 25;
+            cfg.GradeWeights["F"] = 44.9;
+            // LAUNCHERS (owner 2026-08-01): kMin/kMax are REINTERPRETED as the EFFECTIVE DAMAGE
+            // MODIFIER band (replace semantics), not a flat-term coefficient — bows always scaled
+            // through their mod (it multiplies ammo + Blood Drinker + elemental, and BD is
+            // 0.5 x item augs, so the mod is already aug-coupled). No flat term (double-dip).
+            // Band RETUNED 2026-08-02 (owner, two passes): S = 4.00 (just past the pre-system
+            // authored 3.90), KMin = 4.00 x (0.90/1.15) = 3.13 — the SAME F->S ratio as the
+            // melee k band (+27.8 pct), so grades ladder identically across all weapon types.
+            // Floor still clears the real legacy T10 roll ceiling (T10 bows roll 2.84-3.08 in
+            // the mutation scripts). Per-hit parity caveat accepted 08-01/08-02; the deferred
+            // DPS session can retune — pure config.
+            foreach (var launcher in new[] { "bow", "crossbow", "atlatl" })
+                cfg.Scripts[launcher] = new WeaponScalingScript { KMin = 3.13, KMax = 4.00 };
+
+            return cfg;
+        }
+
+        private static void Load()
+        {
+            string json = null;
+            if (DatabaseManager.ShardConfig.StringExists(StoreKey))
+                json = DatabaseManager.ShardConfig.GetString(StoreKey)?.Value;
+
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                _current = BuildDefaults();
+                return;
+            }
+
+            var cfg = JsonConvert.DeserializeObject<WeaponScalingConfig>(json);
+            _current = cfg != null ? Normalize(cfg) : BuildDefaults();
+        }
+
+        /// <summary>Apply an edit to a CLONE of the current config, persist it, and publish the clone.
+        /// Combat effect (once wired in) is instant — same synchronous Save->swap shape as ZoneControlManager.</summary>
+        public static void Mutate(Action<WeaponScalingConfig> edit)
+        {
+            Initialize();
+            lock (_lock)
+            {
+                var clone = Clone(_current);
+                edit(clone);
+                Normalize(clone);
+                Save(clone);
+                _current = clone;
+            }
+        }
+
+        /// <summary>Discard in-memory state and re-read the store (or defaults when absent).</summary>
+        public static void Reload()
+        {
+            lock (_lock)
+            {
+                Load();
+                _initialized = true;
+            }
+        }
+
+        private static WeaponScalingConfig Clone(WeaponScalingConfig cfg)
+        {
+            return JsonConvert.DeserializeObject<WeaponScalingConfig>(JsonConvert.SerializeObject(cfg));
+        }
+
+        /// <summary>The live EV-normalization multiplier for an effective variance. THE one
+        /// definition — <see cref="WeaponScalingCombat"/> calls this at swing time and
+        /// <see cref="BuildLadder"/> calls it when generating rungs, so the ladder a knob writes
+        /// and the damage combat deals can never drift apart. (p = 0.5 crit chance, M = 3.0 crit
+        /// cap; see the plan's EV-normalization section before changing the constants.)</summary>
+        public static double EvNormalization(double vEff) => 2.0 / (2.0 - 0.25 * vEff);
+
+        /// <summary>v_eff for a family variance + tighten at a given quality.</summary>
+        public static double EffectiveVariance(double familyVariance, double tighten, int quality)
+        {
+            var t = Math.Max(0.0, Math.Min(1.0, quality / (double)QualityMax));
+            return familyVariance * (1.0 - tighten * t);
+        }
+
+        /// <summary>Generate the 16-value ladder from an S anchor, each rung one
+        /// <see cref="LadderStep"/> below the last IN DEALT DAMAGE — not in raw k.
+        ///
+        /// The distinction is load-bearing: dealt damage is k x augs x EvNormalization(v_eff), and
+        /// v_eff RISES as grade falls (lower grades shed less family variance), so EV normalization
+        /// quietly inflates the low rungs. A purely geometric k ladder therefore lands +5.6 pct at
+        /// the top and only +4.8 pct at the bottom — visibly uneven, which is the exact defect this
+        /// whole system was built to remove. Dividing the normalization back out makes every
+        /// observed step exactly +5.67 pct. Consequence: the ladder is FAMILY-SPECIFIC (an axe at
+        /// variance 0.70 gets different k than a mace at 0.35 for the same damage), which is why
+        /// this takes variance/tighten rather than being a shared constant table.</summary>
+        public static Dictionary<string, double> BuildLadder(double anchorS, double variance, double tighten)
+        {
+            var d = new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase);
+            var evAnchor = EvNormalization(EffectiveVariance(variance, tighten, QualityMax));
+            for (var i = 0; i < SubGradeBands.Length; i++)
+            {
+                var ev = EvNormalization(EffectiveVariance(variance, tighten, SubGradeBands[i].QMid));
+                d[SubGradeBands[i].Grade] = Math.Round(anchorS * evAnchor / (Math.Pow(LadderStep, i) * ev), 4);
+            }
+            return d;
+        }
+
+        /// <summary>Re-price an authored ladder for a new variance/tighten so DEALT DAMAGE is
+        /// unchanged. Because a rung is stored with EV normalization divided out, editing a
+        /// family's Variance would otherwise leave every rung compensating for the OLD variance —
+        /// the ladder would go uneven and shift level, breaking the owner's standing invariant
+        /// that "editing a Variance knob auto-rebalances" (the reason normalization was moved to
+        /// swing-time in the first place). Multiplying each rung by evOld/evNew preserves any
+        /// HAND-AUTHORED shape, which regenerating from the anchor would silently discard.</summary>
+        public static void RebaseLadder(WeaponScalingScript s, double oldVariance, double oldTighten,
+                                        double newVariance, double newTighten)
+        {
+            if (s == null || !s.HasLadder)
+                return;
+
+            foreach (var b in SubGradeBands)
+            {
+                if (!s.Grades.TryGetValue(b.Grade, out var k))
+                    continue;
+                var evOld = EvNormalization(EffectiveVariance(oldVariance, oldTighten, b.QMid));
+                var evNew = EvNormalization(EffectiveVariance(newVariance, newTighten, b.QMid));
+                if (evNew > 0)
+                    s.Grades[b.Grade] = Math.Round(k * evOld / evNew, 4);
+            }
+        }
+
+        /// <summary>The sub-grade band a quality roll lands in. Never null — F- catches 0.</summary>
+        public static (string Grade, int QMin, int QMax, int QMid) GetSubGradeBand(int quality)
+        {
+            var q = Math.Clamp(quality, 0, QualityMax);
+            foreach (var b in SubGradeBands)
+                if (q >= b.QMin)
+                    return b;
+            return SubGradeBands[SubGradeBands.Length - 1];
+        }
+
+        /// <summary>Sub-grade label ("B+") for a quality roll — the appraisal/plugin-facing name.
+        /// <see cref="GetQualityGrade"/> stays the FULL-grade label and still drives GradeWeights.</summary>
+        public static string GetQualitySubGrade(int quality) => GetSubGradeBand(quality).Grade;
+
+        /// <summary>Roll a drop's quality: weighted grade pick, then uniform inside the band.
+        /// Falls back to the legacy uniform 0-1000 roll when no weights are authored.</summary>
+        public static int RollQuality()
+        {
+            Initialize();
+            var weights = _current.GradeWeights;
+
+            var total = 0.0;
+            if (weights != null)
+                foreach (var b in GradeBands)
+                    if (weights.TryGetValue(b.Grade, out var w) && w > 0)
+                        total += w;
+            if (total <= 0)
+                return ACE.Common.ThreadSafeRandom.Next(0, QualityMax);   // legacy uniform
+
+            var pick = ACE.Common.ThreadSafeRandom.Next(0f, (float)total);
+            var acc = 0.0;
+            foreach (var b in GradeBands)
+            {
+                if (!weights.TryGetValue(b.Grade, out var w) || w <= 0)
+                    continue;
+                acc += w;
+                if (pick <= acc)
+                    return b.QMin >= b.QMax ? b.QMin : ACE.Common.ThreadSafeRandom.Next(b.QMin, b.QMax);
+            }
+            return QualityMax;   // float edge: pick landed exactly on total
+        }
+
+        /// <summary>Deserialized dictionaries lose the case-insensitive comparer, and hand-edited
+        /// values can arrive inverted or negative — repair rather than reject.</summary>
+        public static WeaponScalingConfig Normalize(WeaponScalingConfig cfg)
+        {
+            cfg.LauncherTierStep = Math.Max(0, cfg.LauncherTierStep);
+            cfg.CasterTierStep = Math.Max(0, cfg.CasterTierStep);
+            cfg.CasterAuraRescale = Math.Max(0, cfg.CasterAuraRescale);
+
+            cfg.Tiers ??= new List<WeaponScalingTier>();
+            cfg.Tiers.RemoveAll(t => t == null);
+            cfg.Tiers = cfg.Tiers.GroupBy(t => t.Tier).Select(g => g.First()).OrderBy(t => t.Tier).ToList();
+            foreach (var t in cfg.Tiers)
+            {
+                t.Cap = Math.Max(0, t.Cap);
+                t.MinWieldAugs = Math.Max(0, t.MinWieldAugs);
+                t.MinWieldCreature = Math.Max(0, t.MinWieldCreature);
+                t.MinWieldTriune = Math.Max(0, t.MinWieldTriune);
+                t.MinWieldSkillCharm = Math.Max(0, t.MinWieldSkillCharm);
+
+                // Migration for stores saved before the charm gates existed (owner 2026-08-15):
+                // a T16+ row with BOTH charm fields 0 predates the feature — seed the +500/tier
+                // ladders and pull the item req back to the 4,000 purchase cap it can't exceed.
+                if (t.Tier >= 16 && t.MinWieldTriune == 0 && t.MinWieldSkillCharm == 0)
+                {
+                    t.MinWieldTriune = 500 * (t.Tier - 15);
+                    t.MinWieldSkillCharm = 500 * (t.Tier - 15);
+                    t.MinWieldAugs = Math.Min(4000, t.MinWieldAugs);
+                }
+
+                // Migration for stores saved before MinWieldCreature existed (the column was added
+                // 2026-08-31 with the T11+ hit gate). The FRESH-config seed above authors this ladder,
+                // but an existing store was written without the field, so every live row loaded as 0 -
+                // and TierHitGate reads `MinWieldCreature > 0 && ...`, so a 0 SKIPS the check outright.
+                // The gate shipped ON on 2026-09-01 enforcing only Item augs and Triune, with the
+                // 4,000-6,000 Creature requirement - the largest component - silently inert. Found
+                // 2026-09-01 when `tier curves` printed a creature column of zeros and a suspiciously
+                // straight interpolation.
+                // 0 is read as UNSET rather than as an authored "no requirement", same assumption the
+                // charm migration above makes: the field was never reachable from any command, so no
+                // stored 0 can be deliberate.
+                if (t.Tier >= 11 && t.MinWieldCreature == 0)
+                    t.MinWieldCreature = Math.Min(6000, 4000 + 500 * (t.Tier - 11));
+            }
+
+            var scripts = new Dictionary<string, WeaponScalingScript>(StringComparer.OrdinalIgnoreCase);
+            if (cfg.Scripts != null)
+            {
+                foreach (var kv in cfg.Scripts)
+                {
+                    if (string.IsNullOrWhiteSpace(kv.Key) || kv.Value == null) continue;
+                    var s = kv.Value;
+                    s.KMin = Math.Max(0, s.KMin);
+                    s.KMax = Math.Max(0, s.KMax);
+                    if (s.KMax < s.KMin)
+                        (s.KMin, s.KMax) = (s.KMax, s.KMin);
+                    s.Variance = Math.Max(0, Math.Min(0.95, s.Variance));
+
+                    // Grade ladder: rebuild with the case-insensitive comparer (JSON loses it),
+                    // drop unknown sub-grade keys, clamp negatives. An EMPTY dictionary is
+                    // normalized to null so HasLadder and the payload agree on "no ladder".
+                    // A PARTIAL ladder is completed from the lerp at each missing sub-grade's
+                    // midpoint — never left half-authored, because ResolveScriptK would then
+                    // silently mix ladder rungs with lerp rungs and the ladder would be uneven
+                    // in a way nobody authored.
+                    if (s.Grades != null)
+                    {
+                        var ladder = new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase);
+                        foreach (var g in SubGradeBands)
+                            if (s.Grades.TryGetValue(g.Grade, out var k))
+                                ladder[g.Grade] = Math.Max(0, k);
+
+                        if (ladder.Count > 0)
+                        {
+                            foreach (var g in SubGradeBands)
+                                if (!ladder.ContainsKey(g.Grade))
+                                    ladder[g.Grade] = ResolveFromQuality(s.KMin, s.KMax, g.QMid);
+                            s.Grades = ladder;
+                        }
+                        else
+                            s.Grades = null;
+                    }
+
+                    scripts[kv.Key.Trim()] = s;
+                }
+            }
+            cfg.Scripts = scripts;
+
+            cfg.TightenStrength = Math.Max(0, Math.Min(1.0, cfg.TightenStrength));
+
+            var gradeWeights = new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase);
+            if (cfg.GradeWeights != null)
+                foreach (var kv in cfg.GradeWeights)
+                    if (!string.IsNullOrWhiteSpace(kv.Key))
+                        gradeWeights[kv.Key.Trim()] = Math.Max(0, kv.Value);
+            cfg.GradeWeights = gradeWeights;
+
+            // 2026-08-01 semantics migration: launcher rows became the EFFECTIVE DAMAGE MODIFIER
+            // band (replace semantics — quality grades the mod, no flat term). A store written
+            // before the change still carries flat-term-era coefficients (~0.9-1.15); resolving
+            // those AS the modifier would ~quarter launcher damage. Any launcher row entirely
+            // below 2.0 is unmistakably pre-migration (real launcher mods are T10 2.92+) and is
+            // bumped to the current defaults; deliberate values >= 2.0 are always respected.
+            foreach (var launcherKey in new[] { "bow", "crossbow", "atlatl" })
+            {
+                if (cfg.Scripts.TryGetValue(launcherKey, out var row) && row.KMax < 2.0)
+                {
+                    row.KMin = 3.13;
+                    row.KMax = 4.00;
+                }
+            }
+
+            cfg.KcMin = Math.Max(0, cfg.KcMin);
+            cfg.KcMax = Math.Max(0, cfg.KcMax);
+            if (cfg.KcMax < cfg.KcMin)
+                (cfg.KcMin, cfg.KcMax) = (cfg.KcMax, cfg.KcMin);
+
+            return cfg;
+        }
+
+        private static void Save(WeaponScalingConfig cfg)
+        {
+            var jsonOut = JsonConvert.SerializeObject(cfg);
+            if (DatabaseManager.ShardConfig.StringExists(StoreKey))
+                DatabaseManager.ShardConfig.SaveString(new ConfigPropertiesString { Key = StoreKey, Value = jsonOut, Description = "Weapon aug-scaling config (JSON)" });
+            else
+                DatabaseManager.ShardConfig.AddString(StoreKey, jsonOut, "Weapon aug-scaling config (JSON)");
+        }
+
+        // ── Resolve helpers (consumed by the step-3 combat wire-in; pure math is static for tests) ──
+
+        public static WeaponScalingTier GetTier(int tier)
+        {
+            return Current.Tiers.FirstOrDefault(t => t.Tier == tier);
+        }
+
+        /// <summary>Lerp a 0..1000 quality roll across [min, max]. Out-of-range quality clamps.</summary>
+        public static double ResolveFromQuality(double min, double max, int quality)
+        {
+            var q = Math.Clamp(quality, 0, QualityMax);
+            return min + (max - min) * (q / (double)QualityMax);
+        }
+
+        /// <summary>Letter grade for a quality roll — the at-a-glance "how good was this roll vs the
+        /// best possible" read. Grades the ROLL, not the damage, so it means the same thing on every
+        /// family. SCHOOL-STYLE bands (owner 2026-08-01, second revision — the letters now match the
+        /// percent intuition): S = a literally PERFECT 100 pct roll (1 in 1,001 — the chase item),
+        /// A 90+, B 80+, C 65+, D 50+, F below 50.</summary>
+        public static string GetQualityGrade(int quality)
+        {
+            var q = Math.Clamp(quality, 0, QualityMax);
+            if (q >= 1000) return "S";
+            if (q >= 900) return "A";
+            if (q >= 800) return "B";
+            if (q >= 650) return "C";
+            if (q >= 500) return "D";
+            return "F";
+        }
+
+        /// <summary>k for a script row + quality roll. On a family with an authored LADDER, k
+        /// INTERPOLATES BETWEEN the two nearest rungs — rungs are anchored at their sub-grade
+        /// midpoints, and a roll between two midpoints prices between their k values.
+        ///
+        /// REVISED 2026-08-06 (owner: "those 2 weapons should not be identical damage"), replacing
+        /// the 08-03 flat-per-sub-grade resolution. The defect the ladder was built to fix was never
+        /// interpolation itself — it was interpolating across RAW QUALITY, whose grade bands are
+        /// wildly uneven (S->A spans 50 quality points, D->F spans 325), which bunched S/A/B within
+        /// +7.5 pct of each other. Interpolating between EVENLY-SPACED RUNGS keeps that fix intact:
+        /// the rungs still sit +5.67 pct apart in dealt damage and S->F- is still 2.288x, but every
+        /// distinct roll now yields distinct damage, so the appraisal percent means something.
+        ///
+        /// Lerp is in k-space, which keeps every rung's authored value EXACT at its midpoint and
+        /// leaves only a second-order ripple in dealt damage between midpoints (EvNormalization
+        /// varies slightly across the gap). Rung fidelity matters more than perfect linearity
+        /// between them — the rungs are what is authored and what the Damage Chart displays.
+        ///
+        /// Ladder-less families (launchers' mod band, casters, pre-ladder stores) keep the legacy
+        /// KMin/KMax lerp across the full quality range.</summary>
+        public static double ResolveScriptK(WeaponScalingScript s, int quality)
+        {
+            if (!s.HasLadder)
+                return ResolveFromQuality(s.KMin, s.KMax, quality);
+
+            var q = Math.Clamp(quality, 0, QualityMax);
+
+            // SubGradeBands is ordered best -> worst, so midpoints DESCEND. Walk to the first rung
+            // whose midpoint the roll is at or above, then lerp against the rung one better.
+            for (var i = 0; i < SubGradeBands.Length; i++)
+            {
+                if (q < SubGradeBands[i].QMid)
+                    continue;
+
+                if (!s.Grades.TryGetValue(SubGradeBands[i].Grade, out var kLow))
+                    break;
+
+                if (i == 0)                       // at or above the S midpoint (q1000) — no rung above
+                    return kLow;
+
+                if (!s.Grades.TryGetValue(SubGradeBands[i - 1].Grade, out var kHigh))
+                    return kLow;
+
+                var span = SubGradeBands[i - 1].QMid - SubGradeBands[i].QMid;
+                if (span <= 0)
+                    return kLow;
+
+                var t = (q - SubGradeBands[i].QMid) / (double)span;
+                return kLow + (kHigh - kLow) * t;
+            }
+
+            // Below the worst rung's midpoint (F- sits at q83): F- is the floor, nothing beneath it.
+            return s.Grades.TryGetValue(SubGradeBands[SubGradeBands.Length - 1].Grade, out var kFloor)
+                ? kFloor
+                : ResolveFromQuality(s.KMin, s.KMax, q);
+        }
+
+        /// <summary>The weapon-term damage a roll actually produces, in the same units the combat
+        /// path deals it: k(quality) x EvNormalization(v_eff(quality)). Augs and tier cap are
+        /// deliberately excluded — they are wielder-side and identical for any two weapons being
+        /// compared, so this is the pure weapon contribution.</summary>
+        public static double DealtWeaponTerm(WeaponScalingScript s, double tighten, int quality)
+        {
+            if (s == null)
+                return 0;
+            var k = ResolveScriptK(s, quality);
+            if (s.Variance <= 0)
+                return k;                          // launchers/casters: no variance, no normalization
+            return k * EvNormalization(EffectiveVariance(s.Variance, tighten, quality));
+        }
+
+        /// <summary>Percent of a PERFECT roll's damage this quality delivers — the appraisal's
+        /// "pct of max" (owner 2026-08-06: "everyone really likes the percent and it needs to be
+        /// accurate"). Measures DAMAGE, not the quality percentile: the old display printed
+        /// quality/10, so an F- weapon read "0 pct of max" while dealing 41.7 pct of an S weapon's
+        /// damage, and — before the inter-rung lerp landed — two identical B+ weapons read 86 pct
+        /// and 88 pct. Range is therefore ~42-100 pct on a laddered family, not 0-100.</summary>
+        public static int RelativeDamagePercent(WeaponScalingScript s, double tighten, int quality)
+        {
+            var max = DealtWeaponTerm(s, tighten, QualityMax);
+            if (max <= 0)
+                return 0;
+            return (int)Math.Round(DealtWeaponTerm(s, tighten, quality) / max * 100.0);
+        }
+
+        /// <summary>The wielder-facing k for a script + quality roll, or null when the script is unknown
+        /// (unknown script = weapon contributes no scaling term; loud in logs at the wire-in, silent here).</summary>
+        public static double? ResolveK(string script, int quality)
+        {
+            if (string.IsNullOrWhiteSpace(script))
+                return null;
+            if (!Current.Scripts.TryGetValue(script, out var s))
+                return null;
+            return ResolveScriptK(s, quality);
+        }
+
+        public static double ResolveKc(int quality)
+        {
+            var cfg = Current;
+            return ResolveFromQuality(cfg.KcMin, cfg.KcMax, quality);
+        }
+    }
+}

--- a/Source/ACE.Server/Managers/WorldManager.cs
+++ b/Source/ACE.Server/Managers/WorldManager.cs
@@ -164,6 +164,8 @@ namespace ACE.Server.Managers
 
             Player.HandleNoLogLandblock(playerBiota, out var playerLoggedInOnNoLogLandblock);
 
+            Rifts.RiftManager.HandleLoginInRiftInstance(playerBiota);
+
             var stripAdminProperties = false;
             var addAdminProperties = false;
             var addSentinelProperties = false;
@@ -270,7 +272,17 @@ namespace ACE.Server.Managers
             var savedLoc = playerBiota.GetPosition(PositionType.Location, new ReaderWriterLockSlim());
             if (savedLoc != null)
             {
-                session.Player.Location.Variation = savedLoc.Variation;
+                // Variation 0 means the retail base world (ZoneControl + visibility convention), but the
+                // landblock/physics caches key 0 and null as SEPARATE instances. Restoring an explicit 0
+                // strands the player in an empty parallel copy of the landblock where the base mobs don't
+                // exist (presents as invisible/unattackable mobs every login until the save is healed).
+                if (savedLoc.Variation == 0)
+                {
+                    log.Warn($"{session.Player.Name}: saved Location had explicit variation 0 at 0x{savedLoc.Cell:X8}; normalizing to base (null)");
+                    session.Player.Location.Variation = null;
+                }
+                else
+                    session.Player.Location.Variation = savedLoc.Variation;
             }
             else
             {
@@ -510,6 +522,12 @@ namespace ACE.Server.Managers
             HouseManager.Tick();
 
             PowerballManager.Tick();
+
+            ACE.Server.Command.Handlers.ZoneControlCommands.PushTick();
+
+            ACE.Server.Command.Handlers.WeaponScalingCommands.PushTick();
+
+            Rifts.RiftManager.Tick();
 
             ServerPerformanceMonitor.RegisterEventEnd(ServerPerformanceMonitor.MonitorType.UpdateGameWorld_Entire);
             ServerPerformanceMonitor.RegisterCumulativeEvents();

--- a/Source/ACE.Server/Managers/WorldManager.cs
+++ b/Source/ACE.Server/Managers/WorldManager.cs
@@ -507,6 +507,13 @@ namespace ACE.Server.Managers
         /// <summary>
         /// Projected to run at a reasonable rate for gameplay (30-60fps)
         /// </summary>
+        /// <summary>Runs one subsystem tick; an exception is logged and swallowed so it can never take the world thread down.</summary>
+        private static void SafeTick(string name, Action tick)
+        {
+            try { tick(); }
+            catch (Exception ex) { log.Error($"[WorldManager] {name} threw: {ex}"); }
+        }
+
         public static bool UpdateGameWorld()
         {
             if (updateGameWorldRateLimiter.GetSecondsToWaitBeforeNextEvent() > 0)
@@ -523,11 +530,9 @@ namespace ACE.Server.Managers
 
             PowerballManager.Tick();
 
-            ACE.Server.Command.Handlers.ZoneControlCommands.PushTick();
-
-            ACE.Server.Command.Handlers.WeaponScalingCommands.PushTick();
-
-            Rifts.RiftManager.Tick();
+            SafeTick("ZoneControlCommands.PushTick", ACE.Server.Command.Handlers.ZoneControlCommands.PushTick);
+            SafeTick("WeaponScalingCommands.PushTick", ACE.Server.Command.Handlers.WeaponScalingCommands.PushTick);
+            SafeTick("RiftManager.Tick", Rifts.RiftManager.Tick);
 
             ServerPerformanceMonitor.RegisterEventEnd(ServerPerformanceMonitor.MonitorType.UpdateGameWorld_Entire);
             ServerPerformanceMonitor.RegisterCumulativeEvents();

--- a/Source/ACE.Server/Managers/ZoneControl/TierHitGate.cs
+++ b/Source/ACE.Server/Managers/ZoneControl/TierHitGate.cs
@@ -1,0 +1,146 @@
+using System;
+
+using ACE.Entity.Enum;
+using ACE.Entity.Enum.Properties;
+using ACE.Server.Managers.WeaponScaling;
+using ACE.Server.Network.GameMessages.Messages;
+using ACE.Server.WorldObjects;
+
+namespace ACE.Server.Managers.ZoneControl
+{
+    /// <summary>
+    /// The T11+ HIT GATE (owner 2026-08-31).
+    ///
+    /// A player may only land a hit on a tier-11-or-higher monster once their augmentation counters
+    /// reach that tier's requirement. Below it, every swing and every spell MISSES outright - all or
+    /// nothing, no partial damage, no probability.
+    ///
+    /// 🔴 WHY THIS IS NOT A SKILL THRESHOLD. The obvious design - author monster defenses just under
+    /// a best-in-slot player's attack skill - CANNOT produce this behaviour. Hit chance is a sigmoid,
+    /// P = 1/(1+exp(-0.03 x (A-D))) (SkillCheck.cs), so "defense = ceiling minus one" is a 50/50 coin
+    /// flip, and the span from never-hits to always-hits is only ~920 points (~9,000-11,500 with
+    /// defense scaling on). There is no value that makes a threshold binary. An aug counter is
+    /// already a step function, so the gate reads that instead.
+    ///
+    /// It is also immune to a pile of things a skill threshold would have to chase: uncapped
+    /// enlightenment, possibly-stacking aura categories, velvet tinkering, attribute ranks, and the
+    /// War Magic x1.11 that Void and Missile do not get.
+    ///
+    /// DIRECTION: player -> monster ONLY. Monsters always land on players regardless (owner: "players
+    /// should never resist or evade t11+ monsters, even in t25 bis gear"); that is already achieved by
+    /// authoring monster attack_skill / magic_skill at 100,000, which sits ~92,000 above player
+    /// defenses where the sigmoid saturates at a gap of 460.
+    ///
+    /// KEYED ON THE MONSTER'S VARIATION, never on the weapon's tier - otherwise an under-augmented
+    /// player dodges the whole gate by swinging a lower-tier weapon, which is the loophole it exists
+    /// to close.
+    /// </summary>
+    public static class TierHitGate
+    {
+        /// <summary>Below this variation the gate never applies - retail content is untouched.</summary>
+        public const int MinGatedVariation = 11;
+
+        /// <summary>
+        /// Can this attacker land on this target? TRUE for everything the gate does not cover, so a
+        /// caller can use it as a plain pre-condition.
+        ///
+        /// <paramref name="reason"/> is non-null ONLY on a block, and is shown to the player on EVERY
+        /// blocked swing (owner 2026-08-31 - a silent miss reads as bad luck, which defeats the point).
+        /// </summary>
+        public static bool CanHit(Creature attacker, Creature target, out string reason)
+        {
+            reason = null;
+
+            if (!ServerConfig.zc_tier_hit_gate_enabled.Value)
+                return true;
+
+            // Only PLAYERS are gated. Monster-on-player and monster-on-monster are never touched.
+            if (attacker is not Player player || target == null)
+                return true;
+
+            // The MONSTER's layer decides the requirement, not the weapon.
+            //
+            // GOVERNED MONSTERS ONLY (owner 2026-09-01, before shipping the gate ON). This used to key
+            // on target.Location.Variation alone, which meant the gate fired on ANY creature standing at
+            // v11+ - including one carrying ExemptFromZoneScaling, and including landblocks no enabled
+            // zone covers. An exempt vendor or quest NPC was therefore UNATTACKABLE by an
+            // under-augmented player, with no way to opt out, the moment the gate was switched on.
+            //
+            // ResolveForCreature is the single "may Zone Control touch this creature" gate and answers
+            // all four questions at once: not a Player, not a Pet, not ExemptFromZoneScaling, an ENABLED
+            // zone covers the landblock, and that zone's variation matches the creature's. If Zone
+            // Control does not govern the monster, the gate has no business gating it. Lock-free hot
+            // path (a hashset probe then a dictionary lookup), the same call the combat sites already
+            // make - see ZoneControlManager.ResolveForCreature.
+            if (ZoneControlManager.ResolveForCreature(target) == null)
+                return true;
+
+            // GetEffectiveVariation, not raw Location.Variation - every other Zone Control consumer
+            // resolves through it, and it is what honours the ForceEndgameSystems test hook. Reading
+            // the raw value here made the gate the one consumer that disagreed with the rest.
+            var variation = ZoneControlManager.GetEffectiveVariation(target);
+            if (variation < MinGatedVariation)
+                return true;
+
+            var row = WeaponScalingManager.GetTier(variation);
+            if (row == null)
+                return true;
+
+            // Effective counts, so growth charms count toward the gate exactly as they do everywhere
+            // else (Creature_Properties: Effective* = raw luminance + Triune Weave).
+            var creature = (long)player.EffectiveCreatureAugCount;
+            var item = (long)player.EffectiveItemAugCount;
+            var triune = player.GetProperty(PropertyInt64.TriuneWeaveCount) ?? 0;
+
+            // EVERY unmet requirement, one per line under a plain lead line (owner 2026-09-01).
+            //
+            // It used to return on the FIRST failure, so a player short on two counters was told about
+            // Creature only, farmed exactly that, came back, and was told about Item for the first
+            // time - one grind turned into two, reading as the goalposts moving. The message is the
+            // only feedback the gate ever gives, so it has to be complete.
+            //
+            // Requirements the player already MEETS are left out, and so is any counter this tier does
+            // not ask for at all (MinWieldTriune is 0 below T16 - printing "0 of 0" is noise). The list
+            // is exactly what is still to do.
+            var needCreature = row.MinWieldCreature > 0 && creature < row.MinWieldCreature;
+            var needItem = row.MinWieldAugs > 0 && item < row.MinWieldAugs;
+            var needTriune = row.MinWieldTriune > 0 && triune < row.MinWieldTriune;
+
+            if (!needCreature && !needItem && !needTriune)
+                return true;
+
+            // Built ONLY on a block - the pass path above allocates nothing. Lines are newline-joined
+            // and split by CanHitOrTell into one chat message each, rather than relying on the client
+            // to render a newline inside a single system message.
+            var sb = new System.Text.StringBuilder("You are not powerful enough to fight this creature.");
+            if (needCreature) sb.Append('\n').Append($"Creature augmentations: {creature:N0} of {row.MinWieldCreature:N0}");
+            if (needItem) sb.Append('\n').Append($"Item augmentations: {item:N0} of {row.MinWieldAugs:N0}");
+            if (needTriune) sb.Append('\n').Append($"Triune Weave: {triune:N0} of {row.MinWieldTriune:N0}");
+            reason = sb.ToString();
+            return false;
+        }
+
+        /// <summary>
+        /// CanHit plus the player-facing message. Every blocked swing says why - deliberately not
+        /// rate-limited (owner 2026-08-31: "This message can be displayed every swing / hit").
+        /// </summary>
+        public static bool CanHitOrTell(Creature attacker, Creature target)
+        {
+            if (CanHit(attacker, target, out var reason))
+                return true;
+
+            // One chat message PER LINE (owner 2026-09-01: lead line, then a line per unmet
+            // requirement). Sent separately rather than as one message containing newlines - the
+            // client is not relied on to break the line.
+            if (attacker is Player player && reason != null)
+            {
+                var net = player.Session?.Network;
+                if (net != null)
+                    foreach (var line in reason.Split('\n'))
+                        net.EnqueueSend(new GameMessageSystemChat(line, ChatMessageType.Broadcast));
+            }
+
+            return false;
+        }
+    }
+}

--- a/Source/ACE.Server/Managers/ZoneControl/ZoneAppearance.cs
+++ b/Source/ACE.Server/Managers/ZoneControl/ZoneAppearance.cs
@@ -1,0 +1,151 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ACE.Server.Managers.ZoneControl
+{
+    /// <summary>
+    /// A zone's COSMETIC override set — kept deliberately separate from the stat/prop profile so that
+    /// appearance is orthogonal to a monster's "true" stats and abilities. Every field is nullable: null
+    /// means "not overridden, inherit". A zone carries one <see cref="ControlledArea.AppearanceDefault"/>
+    /// plus per-WCID entries in <see cref="ControlledArea.AppearanceByWcid"/>; resolution LAYERS the two
+    /// (per-WCID non-null wins over the default), unlike the stat profile which REPLACES. Because this lives
+    /// outside <see cref="ACE.Server.Managers.ZoneScaling.ZoneVariantProfile"/>, setting a per-WCID
+    /// appearance never creates a stat override bucket, so it can't detach a monster from zone stat scaling.
+    ///
+    /// Recolor/resize levers stamp through per-instance property writes at (re)spawn. The DataId levers
+    /// (model/clothing/palette-base/tables) swap the actual model data — validated by DID class byte and, on
+    /// a full model swap, applied after clearing the base weenie's own overlay so it doesn't bleed through.
+    /// </summary>
+    public class ZoneAppearance
+    {
+        /// <summary>PropertyString.Name (1) display-name override (owner 2026-08-09). Set per-WCID
+        /// only (the command enforces --wcid; a zone-wide default would rename every mob identically).</summary>
+        public string Name { get; set; }
+
+        // ── Recolor / resize (per-instance property writes) ──
+        /// <summary>PropertyInt.PaletteTemplate (3): recolor via a ClothingBase's sub-palette option.</summary>
+        public int? PaletteTemplate { get; set; }
+
+        /// <summary>PropertyFloat.Shade (12): palette shade 0..1 (needs a ClothingBase to take).</summary>
+        public double? Shade { get; set; }
+
+        /// <summary>PropertyFloat.DefaultScale (39) = ObjScale: model size (1.0 = normal).</summary>
+        public double? Scale { get; set; }
+
+        /// <summary>PropertyFloat.Translucency (76): 0 = solid .. 1 = invisible.</summary>
+        public double? Translucency { get; set; }
+
+        /// <summary>PropertyInt.CreatureVariant (9038) shiny: true stamps 1 (shiny texture swap), false stamps 0.</summary>
+        public bool? Shiny { get; set; }
+
+        // ── Model / data swaps (DataId; validated by class byte in the applier) ──
+        /// <summary>PropertyDataId.Setup (1) 0x02: the base model (body parts). A model swap.</summary>
+        public uint? SetupTableId { get; set; }
+
+        /// <summary>PropertyDataId.MotionTable (2) 0x09: animations — swap alongside a new Setup or it won't animate.</summary>
+        public uint? MotionTable { get; set; }
+
+        /// <summary>PropertyDataId.SoundTable (3) 0x20: creature sounds.</summary>
+        public uint? SoundTable { get; set; }
+
+        /// <summary>PropertyDataId.PaletteBase (6) 0x04: whole-object base palette (recolors a bare model too).</summary>
+        public uint? PaletteBase { get; set; }
+
+        /// <summary>PropertyDataId.ClothingBase (7) 0x10: clothing/armor overlay (must match the Setup to render).</summary>
+        public uint? ClothingBase { get; set; }
+
+        /// <summary>PropertyDataId.Icon (8) 0x06: the examine/selection icon.</summary>
+        public uint? Icon { get; set; }
+
+        // ── Per-part body swaps (whole-set overrides: null = inherit; a non-null list REPLACES the target's
+        //    parts wholesale). Populated by copylook from a donor with custom parts (e.g. Tusgian's 21 anim +
+        //    27 texture rows). Part indices are relative to the Setup, so these travel with the donor's Setup. ──
+        /// <summary>weenie_properties_anim_part: each entry swaps a body-part slot's GfxObj model.</summary>
+        public List<AnimPartEntry> AnimParts { get; set; }
+
+        /// <summary>weenie_properties_texture_map: each entry swaps a part slot's texture (old -> new).</summary>
+        public List<TextureMapEntry> TextureMaps { get; set; }
+
+        public bool IsEmpty =>
+            string.IsNullOrEmpty(Name) &&
+            !PaletteTemplate.HasValue && !Shade.HasValue && !Scale.HasValue &&
+            !Translucency.HasValue && !Shiny.HasValue &&
+            !SetupTableId.HasValue && !MotionTable.HasValue && !SoundTable.HasValue &&
+            !PaletteBase.HasValue && !ClothingBase.HasValue && !Icon.HasValue &&
+            (AnimParts == null || AnimParts.Count == 0) && (TextureMaps == null || TextureMaps.Count == 0);
+
+        /// <summary>Reset every field to "not overridden" (used by clearappearance-all / the plugin's Revert all).</summary>
+        public void Clear()
+        {
+            Name = null;
+            PaletteTemplate = null; Shade = null; Scale = null; Translucency = null; Shiny = null;
+            SetupTableId = null; MotionTable = null; SoundTable = null;
+            PaletteBase = null; ClothingBase = null; Icon = null;
+            AnimParts = null; TextureMaps = null;
+        }
+
+        /// <summary>Total per-part overrides (anim + texture), for the plugin's "Body Parts: N swapped" row.</summary>
+        public int PartCount => (AnimParts?.Count ?? 0) + (TextureMaps?.Count ?? 0);
+
+        public ZoneAppearance Clone() => new ZoneAppearance
+        {
+            Name = Name,
+            PaletteTemplate = PaletteTemplate,
+            Shade = Shade,
+            Scale = Scale,
+            Translucency = Translucency,
+            Shiny = Shiny,
+            SetupTableId = SetupTableId,
+            MotionTable = MotionTable,
+            SoundTable = SoundTable,
+            PaletteBase = PaletteBase,
+            ClothingBase = ClothingBase,
+            Icon = Icon,
+            AnimParts = AnimParts?.Select(p => p.Clone()).ToList(),
+            TextureMaps = TextureMaps?.Select(t => t.Clone()).ToList(),
+        };
+
+        /// <summary>Returns a new set = this overlaid by <paramref name="overlay"/> (overlay's non-null fields win).
+        /// Used to layer a per-WCID entry over the zone default. Null args are treated as empty.</summary>
+        public static ZoneAppearance Merge(ZoneAppearance base_, ZoneAppearance overlay)
+        {
+            if (base_ == null && overlay == null) return null;
+            var result = base_?.Clone() ?? new ZoneAppearance();
+            if (overlay == null) return result;
+            if (!string.IsNullOrEmpty(overlay.Name)) result.Name = overlay.Name;
+            if (overlay.PaletteTemplate.HasValue) result.PaletteTemplate = overlay.PaletteTemplate;
+            if (overlay.Shade.HasValue) result.Shade = overlay.Shade;
+            if (overlay.Scale.HasValue) result.Scale = overlay.Scale;
+            if (overlay.Translucency.HasValue) result.Translucency = overlay.Translucency;
+            if (overlay.Shiny.HasValue) result.Shiny = overlay.Shiny;
+            if (overlay.SetupTableId.HasValue) result.SetupTableId = overlay.SetupTableId;
+            if (overlay.MotionTable.HasValue) result.MotionTable = overlay.MotionTable;
+            if (overlay.SoundTable.HasValue) result.SoundTable = overlay.SoundTable;
+            if (overlay.PaletteBase.HasValue) result.PaletteBase = overlay.PaletteBase;
+            if (overlay.ClothingBase.HasValue) result.ClothingBase = overlay.ClothingBase;
+            if (overlay.Icon.HasValue) result.Icon = overlay.Icon;
+            if (overlay.AnimParts != null) result.AnimParts = overlay.AnimParts.Select(p => p.Clone()).ToList();
+            if (overlay.TextureMaps != null) result.TextureMaps = overlay.TextureMaps.Select(t => t.Clone()).ToList();
+            return result;
+        }
+    }
+
+    /// <summary>One body-part model swap (weenie_properties_anim_part): part slot <see cref="Index"/> -> a
+    /// GfxObj (0x01) model in <see cref="GfxObj"/>. Plain serializable DTO for the zone store.</summary>
+    public class AnimPartEntry
+    {
+        public byte Index { get; set; }
+        public uint GfxObj { get; set; }
+        public AnimPartEntry Clone() => new AnimPartEntry { Index = Index, GfxObj = GfxObj };
+    }
+
+    /// <summary>One body-part texture swap (weenie_properties_texture_map): part slot <see cref="Index"/>,
+    /// <see cref="OldTex"/> -> <see cref="NewTex"/> (0x05 textures). Plain serializable DTO for the zone store.</summary>
+    public class TextureMapEntry
+    {
+        public byte Index { get; set; }
+        public uint OldTex { get; set; }
+        public uint NewTex { get; set; }
+        public TextureMapEntry Clone() => new TextureMapEntry { Index = Index, OldTex = OldTex, NewTex = NewTex };
+    }
+}

--- a/Source/ACE.Server/Managers/ZoneControl/ZoneControlManager.cs
+++ b/Source/ACE.Server/Managers/ZoneControl/ZoneControlManager.cs
@@ -1,0 +1,2373 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using log4net;
+using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
+using ACE.Database;
+using ACE.Database.Models.Shard;
+using ACE.DatLoader;
+using ACE.DatLoader.FileTypes;
+using ACE.Entity.Enum;
+using ACE.Entity.Enum.Properties;
+using ACE.Entity.Models;
+using ACE.Server.Managers.ZoneScaling;
+using ACE.Server.WorldObjects;
+
+namespace ACE.Server.Managers.ZoneControl
+{
+    /// <summary>
+    /// Owns controlled ZONES: named landblock sets, each governing one world Variation, with a per-zone on/off
+    /// toggle and a stat profile. A monster is governed when it stands on a zone's landblock AND its variation
+    /// equals the zone's Variation. No prestige/tier/boss concepts — one DEFAULT stat set for all monsters in
+    /// the zone, plus optional per-monster (WCID) overrides.
+    ///
+    /// Reuses the <see cref="ZoneScaling"/> models (<see cref="ZoneScalingProfile"/>, stat curves) purely as the
+    /// stat payload; the "default variant" is the profile's minion slot (the boss slot is unused post-decouple).
+    /// Consumers call <see cref="ResolveForCreature"/> and get a nullable <see cref="EvaluatedProfile"/>.
+    /// </summary>
+    public static class ZoneControlManager
+    {
+        private static readonly ILog log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+
+        private const string StoreKey = "zonecontrol_data";
+
+        /// <summary>The cantrip -> MODIFIER stat-key rename (2026-08-28). Stat keys are plain JSON
+        /// dictionary keys inside the blob, so a stored blob written before the rename still carries
+        /// cantrip_* keys; alias them to the modifier_* names before deserializing. The next save
+        /// writes the new names and this becomes a no-op. Quoted-token replaces only - the exact
+        /// old key in quotes - so nothing else in the blob can match.
+        ///
+        /// ALSO aliases the SERIALIZED PROFILE MEMBER names renamed in the identifier sweep
+        /// (ZoneVariantProfile.CustomModifiers / CustomModifierBands / CustomModifierSlots, formerly
+        /// CustomCantrip*): those C# property names ARE the blob's JSON keys, so without the alias a
+        /// pre-rename blob's zone pools would silently deserialize to empty.</summary>
+        private static string UpgradeLegacyStoreKeys(string json)
+        {
+            if (json.IndexOf("cantrip", StringComparison.OrdinalIgnoreCase) < 0)
+                return json;
+            return json
+                .Replace("\"weapon_cantrip_chance\"", "\"weapon_modifier_chance\"")
+                .Replace("\"armor_cantrip_chance\"", "\"armor_modifier_chance\"")
+                .Replace("\"cantrip_lines_min\"", "\"modifier_lines_min\"")
+                .Replace("\"cantrip_lines_max\"", "\"modifier_lines_max\"")
+                .Replace("\"cantrip_lines_chance_1\"", "\"modifier_lines_chance_1\"")
+                .Replace("\"cantrip_lines_chance_2\"", "\"modifier_lines_chance_2\"")
+                .Replace("\"cantrip_lines_chance_3\"", "\"modifier_lines_chance_3\"")
+                .Replace("\"cantrip_weight_trash\"", "\"modifier_weight_trash\"")
+                .Replace("\"cantrip_weight_mid\"", "\"modifier_weight_mid\"")
+                .Replace("\"cantrip_weight_chase\"", "\"modifier_weight_chase\"")
+                // serialized ZoneVariantProfile member renames (2026-08-28 identifier sweep)
+                .Replace("\"CustomCantrips\"", "\"CustomModifiers\"")
+                .Replace("\"CustomCantripBands\"", "\"CustomModifierBands\"")
+                .Replace("\"CustomCantripSlots\"", "\"CustomModifierSlots\"");
+        }
+
+        /// <summary>Variant instances begin at variation 11 (0 = normal world, 1..10 = retail layers).
+        /// Bounded zones (player boundaries) are only allowed at variant instances — Zone Control's own
+        /// constant, independent of any other system's tiering.
+        ///
+        /// SCOPE: the player-boundary minimum, and nothing else. It used to double as the endgame-content
+        /// floor inside GetEffectiveVariation, which meant retuning the boundary rule would silently move a
+        /// combat gate; that role now belongs to <see cref="VariationManager.EndgameMinVariation"/>. The two
+        /// happen to share the value 11 — they are not required to.</summary>
+        public const int MinBoundedVariation = 11;
+
+        /// <summary>Top of the endgame variation band. Used ONLY to size the precomputed anchored-Default
+        /// table (<see cref="GetAnchoredDefaultProfile"/>); it is the same 25 the three tier lerps in
+        /// ZoneModifiers clamp to (TierScale / CatalogBandAt / WeaponBandAt), stated once here so the
+        /// table cannot silently cover a narrower range than the ladders do.</summary>
+        public const int MaxEndgameVariation = 25;
+
+        // zone name (case-insensitive) -> zone
+        private static readonly Dictionary<string, ControlledArea> _areas = new(StringComparer.OrdinalIgnoreCase);
+        // RUNTIME zones (e.g. rift runs): live in the lock-free snapshot like any enabled zone, but are NEVER
+        // persisted to the shard store and stay out of the admin display index / arealist.
+        private static readonly Dictionary<string, ControlledArea> _runtimeAreas = new(StringComparer.OrdinalIgnoreCase);
+        // landblock -> zones covering it (ALL zones incl. disabled; used by the locked display/diagnostic paths)
+        private static readonly Dictionary<ushort, List<ControlledArea>> _areasByLandblock = new();
+        // memo of evaluated bundles for the DISPLAY path (EvaluateForDisplay), keyed "zoneName|default"/"zoneName|w<wcid>"
+        private static readonly Dictionary<string, EvaluatedProfile> _evalCache = new();
+
+        // ── Lock-free read snapshot ──
+        // The hot combat/effect resolve paths read this immutable snapshot with NO lock. It is rebuilt (copy-on-write)
+        // under _lock on every mutation and atomically swapped in. Readers may briefly observe the previous snapshot
+        // after an edit (same eventual-consistency the ~2s plugin sync already has) — never a torn/partial state.
+        private sealed class ZoneRef
+        {
+            public string Name;
+            public int Variation;
+            public int LandblockCount;                       // for most-specific tie-break
+            public EvaluatedProfile Default;                 // precomputed default stat set (rank None) - kept for the callers that want the zone floor
+            // RANK LAYERS (2026-09-02): the zone's stat set flattened for each rank (index = ZcRank),
+            // and each per-WCID bucket merged onto each rank chain. A monster's rank is read once
+            // per resolve (bucket PropBools first, then the creature's own bools) and indexes here.
+            public EvaluatedProfile[] ByRank;                // [None, Regular, Leader, Boss]
+            public Dictionary<uint, EvaluatedProfile[]> Wcid; // per-WCID, per rank
+            public Dictionary<uint, ZcRank> WcidRank;        // the rank a bucket AUTHORS via its PropBools (None = not authored there)
+            public HashSet<uint> ExemptWcids;                // master switch (2026-09-03): the zone does not govern these at all
+            public HashSet<uint> ExemptGenerators;           // master switch per generator (2026-09-03): nor anything these spawn
+            public ZoneEffects Effects;                      // immutable copy (readers never touch the live zone)
+            public ZoneAppearance AppearanceDefault;         // cosmetic default (separate from stats)
+            public Dictionary<uint, ZoneAppearance> AppearanceByWcid; // per-WCID cosmetic overlays
+        }
+
+        private sealed class Snapshot
+        {
+            public readonly HashSet<ushort> EnabledLandblocks;
+            public readonly Dictionary<ushort, List<ZoneRef>> ByLandblock;   // ENABLED zones only
+            // Player-boundary allowlists: variation -> union of landblocks of all BOUNDED zones at that
+            // variation, ENABLED OR NOT (the boundary is independent of the zone's stat controls).
+            // A variation with no entry has no Zone Control boundary (free roam / legacy fallback).
+            public readonly Dictionary<int, HashSet<ushort>> BoundedLandblocksByVariation;
+            // Terrain-override spawn redirection (owner 2026-07-21): variation -> lb -> override tag, and
+            // variation -> tag -> member landblocks whose BASE (DAT) terrain is that tag (encounter donors).
+            // Built for zones carrying overrides, ENABLED OR NOT (a mechanic of the zone's territory, like
+            // the boundary). Consumed by Landblock.SpawnEncounters via RedirectEncountersForTerrainOverride.
+            public readonly Dictionary<int, Dictionary<ushort, string>> TerrainOverridesByVariation;
+            public readonly Dictionary<int, Dictionary<string, List<ushort>>> TerrainDonorsByVariation;
+            public Snapshot(HashSet<ushort> enabled, Dictionary<ushort, List<ZoneRef>> byLb,
+                Dictionary<int, HashSet<ushort>> boundedByVar,
+                Dictionary<int, Dictionary<ushort, string>> terrOvByVar,
+                Dictionary<int, Dictionary<string, List<ushort>>> terrDonorsByVar)
+            {
+                EnabledLandblocks = enabled;
+                ByLandblock = byLb;
+                BoundedLandblocksByVariation = boundedByVar;
+                TerrainOverridesByVariation = terrOvByVar;
+                TerrainDonorsByVariation = terrDonorsByVar;
+            }
+            public static readonly Snapshot Empty =
+                new Snapshot(new HashSet<ushort>(), new Dictionary<ushort, List<ZoneRef>>(),
+                    new Dictionary<int, HashSet<ushort>>(),
+                    new Dictionary<int, Dictionary<ushort, string>>(),
+                    new Dictionary<int, Dictionary<string, List<ushort>>>());
+        }
+
+        private static volatile Snapshot _snapshot = Snapshot.Empty;
+
+        private static readonly object _lock = new object();
+        private static volatile bool _initialized;
+
+        private class Store
+        {
+            public List<ControlledArea> Areas { get; set; } = new();
+
+            /// <summary>Per-VARIATION Defaults (2026-07-30): variation -> the baseline layer every zone at
+            /// that variation inherits, per stat. Absent on older stores = no Defaults = prior behavior.</summary>
+            public Dictionary<int, VariationDefault> VariationDefaults { get; set; } = new();
+
+            /// <summary>Live stat resolution (2026-08-22): per-TIER ladder apply state. Absent / empty =
+            /// version 0 everywhere = no apply has ever run. See <see cref="GetLadderVersion"/>.</summary>
+            public Dictionary<int, LadderApply> LadderApplies { get; set; } = new();
+        }
+
+        /// <summary>One `ladder apply` state for a tier. Version is a counter an item compares its
+        /// ZcResolvedVersion against; AllowNerf = the last apply was passed --nerf, so re-resolution may
+        /// LOWER a stamped value (default: apply only raises - owner policy, plan 7b).</summary>
+        public class LadderApply
+        {
+            public int Version { get; set; }
+            public bool AllowNerf { get; set; }
+            public string AppliedBy { get; set; }
+            public DateTime AppliedUtc { get; set; }
+        }
+
+        // tier -> ladder apply state. Guarded by _lock; read through the volatile copy below (hot equip path).
+        private static readonly Dictionary<int, LadderApply> _ladderApplies = new();
+        private static volatile Dictionary<int, LadderApply> _ladderSnapshot = new();
+
+        // variation -> Default layer. Guarded by _lock; copied into the lock-free snapshot at rebuild.
+        private static readonly Dictionary<int, VariationDefault> _variationDefaults = new();
+
+        // variation -> the ANCHORED, toggle-applied Default stat layer that ITEMS resolve against
+        // (2026-09-01). Rebuilt under _lock in RebuildIndexes, published volatile, read lock-free on the
+        // equip path. See GetAnchoredDefaultProfile for why this exists.
+        private static volatile Dictionary<int, ZoneVariantProfile> _anchoredDefaults = new();
+
+        #region init / persistence
+
+        /// <summary>Public init hook for boot-time callers outside the command surface (e.g. landblock load
+        /// deriving its boundary perimeter): guarantees the shard store has been loaded and the lock-free
+        /// snapshot published. Cheap after the first call (volatile bool check).</summary>
+        public static void EnsureLoaded() => EnsureInitialized();
+
+        private static void EnsureInitialized()
+        {
+            if (_initialized)
+                return;
+
+            lock (_lock)
+            {
+                if (_initialized)
+                    return;
+
+                // Load() is atomic (build-then-commit), so a failure here leaves whatever was already
+                // loaded untouched - on first init that is genuinely empty, on a /zonecontrol reload it
+                // is the previous good state. Either way the store on disk is never overwritten by a
+                // half-read, because Save() only ever writes what a successful Load built.
+                try { Load(); }
+                catch (Exception ex) { log.Error($"ZoneControlManager: failed to load store; keeping the previously loaded zones ({_areas.Count} zone(s)). {ex}"); }
+
+                _initialized = true;
+            }
+        }
+
+        /// <summary>
+        /// Read the store and swap it in ATOMICALLY (owner 2026-08-23). The live collections are not
+        /// touched until the read AND the parse have both succeeded, so a DB blip mid-reload leaves the
+        /// zones exactly as they were instead of emptying them.
+        ///
+        /// This matters more than it looks: every mutation calls <see cref="Save"/>, which serializes
+        /// whatever is in memory. Under the old clear-then-read order, a failed reload left memory empty
+        /// AND the caller swallowed the exception ("starting empty"), so the next zone edit would write
+        /// that empty store straight over the real one in the shard DB. Silent, and unrecoverable without
+        /// a backup. Build first, commit last - the throw escapes and the previous state survives.
+        /// </summary>
+        private static void Load()
+        {
+            string json = null;
+            if (DatabaseManager.ShardConfig.StringExists(StoreKey))
+                json = DatabaseManager.ShardConfig.GetString(StoreKey)?.Value;
+
+            // Headroom readout at every start (2026-09-02): the store is one TEXT/MEDIUMTEXT cell, and a
+            // full cell fails every later edit. Say how full it is, and shout if the column is still TEXT.
+            {
+                var bytes = json == null ? 0 : System.Text.Encoding.UTF8.GetByteCount(json);
+                var cap = StoreValueCapacity();
+                if (cap > 0 && cap < 1_000_000)
+                    log.Warn($"[ZoneControl] config_properties_string.value is still a {cap:N0}-byte column (TEXT); the store is {bytes:N0} bytes. " +
+                             "Apply DatabaseSetupScripts/Updates/Shard/2026-09-02-00-ZoneControl-Store-Value-MediumText.sql (or run the ALTER) before it fills.");
+                else if (cap > 0)
+                    log.Info($"[ZoneControl] store loaded: {bytes:N0} bytes of {cap:N0} column capacity.");
+                if (cap > 0 && bytes > cap * 0.8)
+                    log.Warn($"[ZoneControl] store is at {bytes * 100.0 / cap:0} pct of the column - the next edits may fail to save.");
+            }
+
+            if (!string.IsNullOrWhiteSpace(json))
+                json = UpgradeLegacyStoreKeys(json);
+
+            var store = string.IsNullOrWhiteSpace(json)
+                ? new Store()
+                : (JsonConvert.DeserializeObject<Store>(json) ?? new Store());
+
+            // ── build into locals; nothing live is disturbed if any of this throws ──
+            var areas = new Dictionary<string, ControlledArea>(StringComparer.OrdinalIgnoreCase);
+            var variationDefaults = new Dictionary<int, VariationDefault>();
+            var ladderApplies = new Dictionary<int, LadderApply>();
+
+            foreach (var a in store.Areas)
+            {
+                if (a == null || string.IsNullOrWhiteSpace(a.Name)) continue;
+                a.Landblocks ??= new HashSet<ushort>();
+                a.TerrainOverrides ??= new Dictionary<ushort, string>();
+                a.Profile ??= new ZoneScalingProfile();
+                a.Effects ??= new ZoneEffects();
+                a.AppearanceDefault ??= new ZoneAppearance();
+                a.AppearanceByWcid ??= new Dictionary<uint, ZoneAppearance>();
+                MigrateAppearanceProps(a);
+                areas[a.Name] = a;
+            }
+
+            // Per-variation Defaults. Absent on pre-2026-07-30 stores -> empty -> zones resolve exactly as before.
+            if (store.VariationDefaults != null)
+            {
+                foreach (var kv in store.VariationDefaults)
+                {
+                    if (kv.Value == null) continue;
+                    kv.Value.Profile ??= new ZoneVariantProfile();
+                    kv.Value.Effects ??= new ZoneEffects();
+                    kv.Value.Appearance ??= new ZoneAppearance();
+                    variationDefaults[kv.Key] = kv.Value;
+                }
+            }
+
+            if (store.LadderApplies != null)
+                foreach (var kv in store.LadderApplies)
+                    if (kv.Value != null)
+                        ladderApplies[kv.Key] = kv.Value;
+
+            // ── commit: from here on nothing can throw ──
+            _areas.Clear();
+            foreach (var kv in areas) _areas[kv.Key] = kv.Value;
+            _variationDefaults.Clear();
+            foreach (var kv in variationDefaults) _variationDefaults[kv.Key] = kv.Value;
+            _ladderApplies.Clear();
+            foreach (var kv in ladderApplies) _ladderApplies[kv.Key] = kv.Value;
+            _evalCache.Clear();
+            _ladderSnapshot = new Dictionary<int, LadderApply>(_ladderApplies);
+
+            RebuildIndexes();
+        }
+
+        /// <summary>One-time carry-over: Phase 1 stamped appearance through the generic prop pipe (PaletteTemplate
+        /// int 3, Shade float 12, DefaultScale float 39, Translucency float 76, CreatureVariant int 9038). Move any
+        /// such props out of the stat/prop buckets into the dedicated appearance layer so cosmetic edits no longer
+        /// ride the per-WCID stat bucket. Idempotent: after the move there are no appearance-id props left to find.</summary>
+        private static void MigrateAppearanceProps(ControlledArea a)
+        {
+            MigrateAppearancePropsFromVariant(a.Profile.Minion, a.AppearanceDefault);
+
+            List<uint> emptiedStatBuckets = null;
+            foreach (var kv in a.Profile.WcidOverrides)
+            {
+                if (kv.Value == null) continue;
+                if (!a.AppearanceByWcid.TryGetValue(kv.Key, out var ap) || ap == null)
+                    a.AppearanceByWcid[kv.Key] = ap = new ZoneAppearance();
+
+                var moved = MigrateAppearancePropsFromVariant(kv.Value, ap);
+
+                // If pulling the appearance props emptied this per-WCID STAT bucket entirely, drop it so the mob
+                // resolves to the zone default again — a lingering empty bucket would otherwise keep detaching it
+                // from scaling (the very coupling this split removes, for data authored under Phase 1).
+                if (moved && VariantIsEmpty(kv.Value))
+                    (emptiedStatBuckets ??= new List<uint>()).Add(kv.Key);
+
+                if (ap.IsEmpty)
+                    a.AppearanceByWcid.Remove(kv.Key); // never created an appearance override we didn't need
+            }
+            if (emptiedStatBuckets != null)
+                foreach (var w in emptiedStatBuckets)
+                    a.Profile.WcidOverrides.Remove(w);
+        }
+
+        private static bool MigrateAppearancePropsFromVariant(ZoneScaling.ZoneVariantProfile vp, ZoneAppearance ap)
+        {
+            var moved = false;
+            if (vp?.PropInts != null)
+            {
+                if (vp.PropInts.TryGetValue(3, out var pal)) { ap.PaletteTemplate ??= (int)pal; vp.PropInts.Remove(3); moved = true; }
+                if (vp.PropInts.TryGetValue(9038, out var shiny)) { ap.Shiny ??= shiny != 0; vp.PropInts.Remove(9038); moved = true; }
+            }
+            if (vp?.PropFloats != null)
+            {
+                if (vp.PropFloats.TryGetValue(12, out var shade)) { ap.Shade ??= shade; vp.PropFloats.Remove(12); moved = true; }
+                if (vp.PropFloats.TryGetValue(39, out var scale)) { ap.Scale ??= scale; vp.PropFloats.Remove(39); moved = true; }
+                if (vp.PropFloats.TryGetValue(76, out var trans)) { ap.Translucency ??= trans; vp.PropFloats.Remove(76); moved = true; }
+            }
+            return moved;
+        }
+
+        /// <summary>True when a stat/prop variant bucket carries nothing at all — used to prune a per-WCID bucket
+        /// that held only appearance props before migration moved them to the appearance layer.</summary>
+        private static bool VariantIsEmpty(ZoneScaling.ZoneVariantProfile vp)
+        {
+            return (vp.Stats == null || vp.Stats.Count == 0)
+                && (vp.BodyParts == null || vp.BodyParts.Count == 0)
+                && (vp.PropInts == null || vp.PropInts.Count == 0)
+                && (vp.PropInt64s == null || vp.PropInt64s.Count == 0)
+                && (vp.PropFloats == null || vp.PropFloats.Count == 0)
+                && (vp.PropBools == null || vp.PropBools.Count == 0)
+                && (vp.CustomModifiers == null || vp.CustomModifiers.Count == 0)
+                && (vp.CustomModifierBands == null || vp.CustomModifierBands.Count == 0)
+                && (vp.CustomModifierSlots == null || vp.CustomModifierSlots.Count == 0)
+                && (vp.CustomSpecials == null || vp.CustomSpecials.Count == 0)
+                && (vp.CustomWeaponCards == null || vp.CustomWeaponCards.Count == 0)
+                && (vp.CurrencyDrops == null || vp.CurrencyDrops.Count == 0)
+                && (vp.SpellRules == null || vp.SpellRules.Count == 0);
+        }
+
+        /// <summary>
+        /// Capacity of config_properties_string.value in bytes (2026-09-02): TEXT = 65,535, MEDIUMTEXT =
+        /// 16,777,215. Read once from information_schema; -1 when the query fails (logged, never fatal).
+        /// WHY: the store JSON hit 62,843 bytes on a TEXT column that night and the next write failed
+        /// with ERROR 1406 - a plugin edit would have thrown the same way with nobody watching, and on a
+        /// non-strict SQL mode it would have TRUNCATED the JSON silently. Save() refuses to write past
+        /// the capacity; Load() logs the headroom at every start.
+        /// </summary>
+        private static long _storeCapacity = long.MinValue;   // MinValue = not queried yet
+        private static long StoreValueCapacity()
+        {
+            if (_storeCapacity != long.MinValue) return _storeCapacity;
+            try
+            {
+                using var ctx = new ACE.Database.Models.Shard.ShardDbContext();
+                var rows = ctx.Database.SqlQueryRaw<long>(
+                    "SELECT CAST(CHARACTER_OCTET_LENGTH AS SIGNED) AS `Value` FROM information_schema.COLUMNS " +   // OCTET: Save() compares UTF-8 BYTES (review 2026-09-03)
+                    "WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'config_properties_string' AND COLUMN_NAME = 'value'")
+                    .AsEnumerable().ToList();
+                _storeCapacity = rows.Count > 0 ? rows[0] : -1;
+            }
+            catch (Exception ex)
+            {
+                log.Warn($"[ZoneControl] could not read config_properties_string.value capacity: {ex.Message}");
+                _storeCapacity = -1;
+            }
+            return _storeCapacity;
+        }
+
+        private static void Save()
+        {
+            var store = new Store
+            {
+                Areas = _areas.Values.ToList(),
+                VariationDefaults = new Dictionary<int, VariationDefault>(_variationDefaults),
+                LadderApplies = new Dictionary<int, LadderApply>(_ladderApplies),
+            };
+            _ladderSnapshot = new Dictionary<int, LadderApply>(_ladderApplies);
+            var jsonOut = JsonConvert.SerializeObject(store);
+
+            // SIZE GUARD (2026-09-02): never hand the DB a value it cannot hold. The in-memory store keeps
+            // the edit (so the operator sees their number) but the DB keeps the LAST GOOD store, and the
+            // log says exactly why. The fix is the shard update 2026-09-02-00-ZoneControl-Store-Value-MediumText.sql.
+            var bytes = System.Text.Encoding.UTF8.GetByteCount(jsonOut);
+            var cap = StoreValueCapacity();
+            if (cap > 0 && bytes > cap)
+            {
+                log.Error($"[ZoneControl] STORE NOT SAVED: {bytes:N0} bytes exceeds config_properties_string.value capacity {cap:N0}. " +
+                          "Widen the column (ALTER TABLE config_properties_string MODIFY value MEDIUMTEXT) and re-save. The edit is in memory only until then.");
+                { _evalCache.Clear(); RebuildIndexes(); throw new InvalidOperationException($"Zone Control store is {bytes:N0} bytes; the DB column holds {cap:N0}. Widen config_properties_string.value to MEDIUMTEXT."); }   // keep the snapshot in step with the in-memory edit (review 2026-09-03 H3)
+            }
+            if (cap > 0 && bytes > cap * 0.8)
+                log.Warn($"[ZoneControl] store is {bytes:N0} of {cap:N0} bytes ({bytes * 100.0 / cap:0} pct of the column). Widen the column before it fills.");
+
+            try
+            {
+                if (DatabaseManager.ShardConfig.StringExists(StoreKey))
+                    DatabaseManager.ShardConfig.SaveString(new ConfigPropertiesString { Key = StoreKey, Value = jsonOut, Description = "Zone Control store (JSON)" });
+                else
+                    DatabaseManager.ShardConfig.AddString(StoreKey, jsonOut, "Zone Control store (JSON)");
+            }
+            catch (Exception ex)
+            {
+                log.Error($"[ZoneControl] STORE SAVE FAILED ({bytes:N0} bytes, column capacity {cap:N0}): {ex.GetBaseException().Message}");
+                throw;
+            }
+            _evalCache.Clear();
+            RebuildIndexes();
+        }
+
+        /// <summary>Called under _lock after any load/mutation. Rebuilds the locked display index AND the immutable
+        /// lock-free read snapshot, then atomically publishes the snapshot.</summary>
+        private static void RebuildIndexes()
+        {
+            // (1) Display index: every zone (incl. disabled), holding live ControlledArea refs (locked readers only).
+            _areasByLandblock.Clear();
+            foreach (var area in _areas.Values)
+                foreach (var lb in area.Landblocks)
+                {
+                    if (!_areasByLandblock.TryGetValue(lb, out var list))
+                        _areasByLandblock[lb] = list = new List<ControlledArea>();
+                    list.Add(area);
+                }
+
+            // (2) Lock-free snapshot: ENABLED zones only, fully precomputed + copied so readers touch nothing mutable.
+            var enabledLbs = new HashSet<ushort>();
+            var byLb = new Dictionary<ushort, List<ZoneRef>>();
+            var boundedByVar = new Dictionary<int, HashSet<ushort>>();
+            var terrOvByVar = new Dictionary<int, Dictionary<ushort, string>>();
+            var terrDonorsByVar = new Dictionary<int, Dictionary<string, List<ushort>>>();
+            foreach (var area in _areas.Values)
+            {
+                // Boundary allowlist: union the landblocks of every BOUNDED zone per variation —
+                // INDEPENDENT of Enabled (owner 2026-07-21): the wall stays up while the zone's stat
+                // controls are off. Enabled governs stats/mechanics/loot; Bounded governs the boundary.
+                // Runtime zones (rifts) are deliberately excluded — they never bound players.
+                if (area.Bounded)
+                {
+                    if (!boundedByVar.TryGetValue(area.Variation, out var set))
+                        boundedByVar[area.Variation] = set = new HashSet<ushort>();
+                    set.UnionWith(area.Landblocks);
+                }
+
+                // Terrain-override spawn redirection (owner 2026-07-21, independent of Enabled): record
+                // this zone's overrides and, for zones that HAVE overrides, classify every member block's
+                // BASE terrain once (DatManager caches the reads) as the donor index — "mark a block
+                // obsidian and it draws its encounter camps from the zone's real obsidian blocks".
+                if (area.TerrainOverrides is { Count: > 0 })
+                {
+                    if (!terrOvByVar.TryGetValue(area.Variation, out var ovMap))
+                        terrOvByVar[area.Variation] = ovMap = new Dictionary<ushort, string>();
+                    foreach (var kv in area.TerrainOverrides)
+                        ovMap[kv.Key] = kv.Value;
+
+                    if (!terrDonorsByVar.TryGetValue(area.Variation, out var donorMap))
+                        terrDonorsByVar[area.Variation] = donorMap = new Dictionary<string, List<ushort>>();
+                    foreach (var lb in area.Landblocks)
+                    {
+                        var baseTag = ClassifyLandblockTerrain(lb);
+                        if (string.IsNullOrEmpty(baseTag)) continue;
+                        if (!donorMap.TryGetValue(baseTag, out var list))
+                            donorMap[baseTag] = list = new List<ushort>();
+                        if (!list.Contains(lb)) list.Add(lb);
+                    }
+                }
+
+                if (!area.Enabled)
+                    continue;
+
+                var zr = BuildZoneRef(area);
+                foreach (var lb in area.Landblocks)
+                {
+                    enabledLbs.Add(lb);
+                    if (!byLb.TryGetValue(lb, out var list))
+                        byLb[lb] = list = new List<ZoneRef>();
+                    list.Add(zr);
+                }
+            }
+
+            // (3) Runtime zones (never persisted, not in the display index): same snapshot treatment as (2).
+            foreach (var area in _runtimeAreas.Values)
+            {
+                if (!area.Enabled)
+                    continue;
+
+                var zr = BuildZoneRef(area);
+                foreach (var lb in area.Landblocks)
+                {
+                    enabledLbs.Add(lb);
+                    if (!byLb.TryGetValue(lb, out var list))
+                        byLb[lb] = list = new List<ZoneRef>();
+                    list.Add(zr);
+                }
+            }
+
+            // (4) Anchored Default profiles for ITEM resolution. Built for the whole endgame band, not just
+            // the authored variations: a v20 zone with no Default of its own still has to resolve items
+            // against v11's anchor board, which is exactly the case that was falling through to the ladder.
+            var anchored = new Dictionary<int, ZoneVariantProfile>();
+            for (var v = MinBoundedVariation; v <= MaxEndgameVariation; v++)
+                AddAnchored(anchored, v);
+            foreach (var v in _variationDefaults.Keys)        // authored outside the band (none today) still resolves
+                AddAnchored(anchored, v);
+            _anchoredDefaults = anchored;                     // volatile publish
+
+            var previous = _snapshot;
+            _snapshot = new Snapshot(enabledLbs, byLb, boundedByVar, terrOvByVar, terrDonorsByVar); // volatile publish
+
+            // Boundary perimeter upkeep: markers spawn at landblock load, so when a mutation changes any
+            // variation's bounded union, already-loaded landblocks at that variation must re-derive their
+            // lantern perimeter. Refresh only enqueues per-landblock actions (no locks taken), so calling
+            // it here under _lock is safe.
+            foreach (var v in previous.BoundedLandblocksByVariation.Keys.Union(boundedByVar.Keys))
+            {
+                previous.BoundedLandblocksByVariation.TryGetValue(v, out var before);
+                boundedByVar.TryGetValue(v, out var after);
+                var changed = before == null ? after != null : (after == null || !before.SetEquals(after));
+                if (changed)
+                    LandblockManager.EnqueueRefreshLoadedZoneBoundaryMarkers(v);
+            }
+        }
+
+        /// <summary>Register (or replace) a RUNTIME zone: participates in lock-free resolution exactly like an
+        /// enabled saved zone, but is never written to the shard store and never appears in admin listings.
+        /// Used by transient systems (rift runs). Caller must remove it again via <see cref="RemoveRuntimeZone"/>.</summary>
+        public static void RegisterRuntimeZone(ControlledArea area)
+        {
+            if (area == null || string.IsNullOrWhiteSpace(area.Name))
+                return;
+
+            EnsureInitialized();
+            lock (_lock)
+            {
+                area.Landblocks ??= new HashSet<ushort>();
+                area.Profile ??= new ZoneScalingProfile();
+                area.Effects ??= new ZoneEffects();
+                area.Bounded = false; // runtime zones (rift runs) never bound players
+                _runtimeAreas[area.Name] = area;
+                RebuildIndexes();
+            }
+        }
+
+        /// <summary>Remove a runtime zone registered via <see cref="RegisterRuntimeZone"/>. No-op if absent.</summary>
+        public static void RemoveRuntimeZone(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                return;
+
+            EnsureInitialized();
+            lock (_lock)
+            {
+                if (_runtimeAreas.Remove(name))
+                    RebuildIndexes();
+            }
+        }
+
+        /// <summary>
+        /// Build the immutable per-zone read record. THIS is where the Default layer is applied: the
+        /// <c>VariationDefault -&gt; zone -&gt; wcid</c> merge happens once here, at snapshot-build time, and the
+        /// result is a fully-resolved <see cref="EvaluatedProfile"/> per bucket. The combat hot path therefore
+        /// stays exactly one dictionary lookup with ZERO per-hit merge cost — the whole point of doing it here.
+        ///
+        /// Runtime zones (rifts, negative variations) get no Default: <see cref="DefaultFor"/> returns null for
+        /// any variation without an authored entry, and rift variations never have one.
+        /// </summary>
+        private static ZoneRef BuildZoneRef(ControlledArea area)
+        {
+            var def = DefaultFor(area.Variation);
+
+            // RANK LAYERS (2026-09-02): one flattened chain per rank. Each layer is flattened for the
+            // rank FIRST (ForRank), then the layers merge in scope order - tier Default (with the v11
+            // anchor under it) -> zone -> per-WCID bucket - so a zone's Default row beats a tier's
+            // rank row (owner D2). Effects/Appearance below stay on the variation's own Default.
+            var byRank = new EvaluatedProfile[ZoneRank.All.Length];
+            var wcid = new Dictionary<uint, EvaluatedProfile[]>();
+            var wcidRank = new Dictionary<uint, ZcRank>();
+            foreach (var kv in area.Profile.WcidOverrides)
+            {
+                wcid[kv.Key] = new EvaluatedProfile[ZoneRank.All.Length];
+                wcidRank[kv.Key] = ZoneRank.FromPropBools(kv.Value?.PropBools);
+            }
+            // A rank that NO layer in this zone's chain authors (tier Default, its v11 anchor, the zone
+            // layer; buckets never carry Ranks) flattens to exactly the Default row, so its profiles are
+            // ALIASED to the None ones instead of re-merged - the rank rewrite made every Save ~4x the
+            // work under _lock for zones that author no rank row at all (review 2026-09-04 M3).
+            // EvaluatedProfile is immutable, so sharing the reference is safe. ZoneRank.All lists None first.
+            var ownDefault = def?.Profile;
+            var anchorDefault = area.Variation > 11 ? DefaultFor(11)?.Profile : null;
+            var zoneMinion = area.Profile.Minion;
+            bool RankAuthored(ZcRank r) => r == ZcRank.None
+                || ownDefault?.RankLayer(r) != null
+                || anchorDefault?.RankLayer(r) != null
+                || zoneMinion?.RankLayer(r) != null;
+            foreach (var rank in ZoneRank.All)
+            {
+                if (!RankAuthored(rank))
+                {
+                    byRank[(int)rank] = byRank[(int)ZcRank.None];
+                    foreach (var kv in area.Profile.WcidOverrides)
+                        wcid[kv.Key][(int)rank] = wcid[kv.Key][(int)ZcRank.None];
+                    continue;
+                }
+                var defProfile = AnchoredDefaultProfileFor(area.Variation, rank);
+                var zoneLayer = area.Profile.Minion?.ForRank(rank);
+                byRank[(int)rank] = EvaluateVariant(area.Name, ZoneVariantProfile.Merge(defProfile, zoneLayer));
+                // per-WCID = the rank chain + that monster's bucket (per stat, NOT a wholesale replacement)
+                foreach (var kv in area.Profile.WcidOverrides)
+                    wcid[kv.Key][(int)rank] = EvaluateVariant(area.Name, ZoneVariantProfile.Merge(defProfile, zoneLayer, kv.Value));
+            }
+
+            // appearance layers the same way: Default -> zone -> wcid, per field
+            var apZone = ZoneAppearance.Merge(def?.Appearance, area.AppearanceDefault) ?? new ZoneAppearance();
+            var apWcid = new Dictionary<uint, ZoneAppearance>();
+            if (area.AppearanceByWcid != null)
+                foreach (var kv in area.AppearanceByWcid)
+                {
+                    if (kv.Value == null || kv.Value.IsEmpty) continue;
+                    apWcid[kv.Key] = kv.Value.Clone();
+                }
+
+            return new ZoneRef
+            {
+                Name = area.Name,
+                Variation = area.Variation,
+                LandblockCount = area.Landblocks.Count,
+                Default = byRank[(int)ZcRank.None],
+                ByRank = byRank,
+                Wcid = wcid,
+                WcidRank = wcidRank,
+                ExemptWcids = area.Profile.ExemptWcids != null ? new HashSet<uint>(area.Profile.ExemptWcids) : new HashSet<uint>(),
+                ExemptGenerators = area.Profile.ExemptGenerators != null ? new HashSet<uint>(area.Profile.ExemptGenerators) : new HashSet<uint>(),
+                Effects = ZoneEffects.Merge(def?.Effects, area.Effects),
+                AppearanceDefault = apZone,
+                AppearanceByWcid = apWcid,
+            };
+        }
+
+        /// <summary>Flatten a variant profile's stat curves to an immutable EvaluatedProfile (flat: tier 1 = base).
+        /// Body-part overrides and prop stamps are deep-COPIED so lock-free readers never touch the live
+        /// (admin-mutable) dictionaries.</summary>
+        private static EvaluatedProfile EvaluateVariant(string zoneName, ZoneVariantProfile variantProfile)
+        {
+            var values = new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase);
+            Dictionary<int, ZoneBodyPart> bodyParts = null;
+            Dictionary<int, long> propInts = null, propInt64s = null;
+            Dictionary<int, double> propFloats = null;
+            Dictionary<int, bool> propBools = null;
+            List<int> customModifiers = null;
+            Dictionary<int, ModifierBand> modifierBands = null;
+            List<ZoneCurrencyDrop> currencyDrops = null;
+            List<ZoneSpellRule> spellRules = null;
+
+            if (variantProfile != null)
+            {
+                foreach (var kvp in variantProfile.Stats)
+                    values[kvp.Key] = kvp.Value.Evaluate(1);
+
+                // STAT OFF-FLAGS (2026-08-29): a merged toggle of FALSE makes the stat evaluate as
+                // ABSENT - Has() misses, every consumer falls back - which is what lets a zone or a
+                // single WCID exempt itself from a stat its tier Default authors. Applied here, once,
+                // so all three published shapes (zone default, per-wcid, display) agree.
+                if (variantProfile.StatToggles is { Count: > 0 })
+                    foreach (var kvp in variantProfile.StatToggles)
+                        if (!kvp.Value)
+                            values.Remove(kvp.Key);
+
+                if (variantProfile.BodyParts is { Count: > 0 })
+                {
+                    bodyParts = new Dictionary<int, ZoneBodyPart>(variantProfile.BodyParts.Count);
+                    foreach (var kvp in variantProfile.BodyParts)
+                        if (kvp.Value != null && !kvp.Value.IsEmpty)
+                            bodyParts[kvp.Key] = kvp.Value.Clone();
+                }
+
+                if (variantProfile.PropInts is { Count: > 0 }) propInts = new Dictionary<int, long>(variantProfile.PropInts);
+                if (variantProfile.PropInt64s is { Count: > 0 }) propInt64s = new Dictionary<int, long>(variantProfile.PropInt64s);
+                if (variantProfile.PropFloats is { Count: > 0 }) propFloats = new Dictionary<int, double>(variantProfile.PropFloats);
+                if (variantProfile.PropBools is { Count: > 0 }) propBools = new Dictionary<int, bool>(variantProfile.PropBools);
+                if (variantProfile.CustomModifiers is { Count: > 0 }) customModifiers = new List<int>(variantProfile.CustomModifiers);
+
+                if (variantProfile.CustomModifierBands is { Count: > 0 })
+                {
+                    modifierBands = new Dictionary<int, ModifierBand>(variantProfile.CustomModifierBands.Count);
+                    foreach (var kvp in variantProfile.CustomModifierBands)
+                        if (kvp.Value != null)
+                            modifierBands[kvp.Key] = kvp.Value.Clone();
+                }
+
+                if (variantProfile.CurrencyDrops is { Count: > 0 })
+                {
+                    currencyDrops = new List<ZoneCurrencyDrop>(variantProfile.CurrencyDrops.Count);
+                    foreach (var d in variantProfile.CurrencyDrops)
+                        if (d != null && d.Wcid != 0)
+                            currencyDrops.Add(d.Clone());
+                }
+
+                if (variantProfile.SpellRules is { Count: > 0 })
+                {
+                    spellRules = new List<ZoneSpellRule>(variantProfile.SpellRules.Count);
+                    foreach (var r in variantProfile.SpellRules)
+                        if (r != null && r.SpellId != 0)
+                            spellRules.Add(r.Clone());
+                }
+            }
+
+            return new EvaluatedProfile(zoneName, 1, ZoneVariant.Minion, values, bodyParts, propInts, propInt64s, propFloats, propBools, customModifiers, currencyDrops, spellRules, modifierBands,
+                variantProfile?.CustomModifierSlots, variantProfile?.CustomSpecials, variantProfile?.CustomWeaponCards);
+        }
+
+        // CopyEffects removed 2026-07-30 — ZoneEffects.Merge(default, zone) both layers AND clones.
+
+        /// <summary>The authored Default layer for a variation, or null when none exists (which is every
+        /// variation until one is authored, and always for rift/runtime negative variations). Call under
+        /// _lock, or from RebuildIndexes which already holds it.</summary>
+        private static VariationDefault DefaultFor(int variation)
+            => _variationDefaults.TryGetValue(variation, out var d) ? d : null;
+
+        /// <summary>
+        /// The Default STAT layer stack for a variation (owner 2026-08-30, the per-tier authoring
+        /// toggle): for endgame variations ABOVE 11, the v11 Default is the ANCHOR LAYER
+        /// underneath the variation's own Default. v11 holds the whole T11/T25 anchor board
+        /// (GetT lerps its base/_t25 pairs by tier), and a per-tier Default's flat values SHADOW
+        /// the lerp per stat (ZoneVariantProfile.Merge's shadow rule). Before this, a T12+ zone
+        /// merged DefaultFor(itsOwnVariation) alone - null in practice - so the anchors authored
+        /// on v11 never reached it at all (the gap found 2026-08-30: the anchored model only ever
+        /// worked at v11). v11 itself and retail variations (10 and below) are unchanged: one
+        /// layer, no anchor underlay. STATS ONLY - Effects/Appearance keep reading the
+        /// variation's own Default.
+        /// </summary>
+        private static ZoneVariantProfile AnchoredDefaultProfileFor(int variation, ZcRank rank = ZcRank.None)
+        {
+            // RANK LAYERS (2026-09-02): each Default is flattened for the rank BEFORE the anchor merge,
+            // so the tier's own Default row beats the v11 anchor's rank row (owner D2, applied between
+            // tiers exactly as between tier and zone). For rank None this is the pre-existing stack.
+            var own = DefaultFor(variation)?.Profile?.ForRank(rank);
+            if (variation <= 11)
+                return own;
+            var anchor = DefaultFor(11)?.Profile?.ForRank(rank);
+            if (anchor == null)
+                return own;
+            if (own == null)
+                return anchor;
+            return ZoneVariantProfile.Merge(anchor, own);
+        }
+
+        #endregion
+
+        #region resolution / public API
+
+        /// <summary>
+        /// The variation Zone Control resolves a world object on: its real Location variation, except that an
+        /// object carrying ForceEndgameSystems is treated as standing at its EndgameForcedVariation (floored to
+        /// v11), so a test dummy in the normal world can still be governed by a variant zone.
+        ///
+        /// Delegates to <see cref="VariationManager.GetEffectiveEndgameVariation"/> — the shared endgame-layer
+        /// resolver. This used to be a private copy floored on <see cref="MinBoundedVariation"/>, with an
+        /// identical copy in PrestigeManager; the two drifted apart when the prestige offset moved and broke
+        /// the ForceEndgameSystems test hook (2026-07-30). Kept as a named method because it is Zone Control's
+        /// own vocabulary and has 9 call sites here and in the command surface.
+        /// </summary>
+        public static int GetEffectiveVariation(WorldObject wo) => VariationManager.GetEffectiveEndgameVariation(wo);
+
+        /// <summary>
+        /// The single gate on "may Zone Control touch this creature at all". Every creature-facing resolver
+        /// below calls it, so the answer cannot drift between them.
+        ///
+        /// Players are out because zones scale MONSTERS. Pets are out by owner ruling 2026-08-25: "we can not
+        /// have ZoneControl over riding pets in anyway." A <see cref="CombatPet"/> is a non-Player Creature, so
+        /// it used to resolve like any monster - and because an authored profile REPLACES the weenie-base value
+        /// (Creature_Rating.GetDamageRating / GetDamageResistRating), a zone that authored damage_rating or
+        /// damage_resist_rating silently discarded everything the pet's bond level had earned it. Testing
+        /// <c>is Pet</c> catches CombatPet too (CombatPet : Pet : Creature) and covers pet weenies that do not
+        /// exist yet - none of the 72 combat-pet weenies carried ExemptFromZoneScaling, so the data-side flag
+        /// would have to be maintained forever. Bond bonuses, potency and the pet mitigation curves are the
+        /// pet system's own ladder and are not Zone Control's to re-price.
+        /// </summary>
+        private static bool IsZoneScalingExempt(Creature creature)
+            => creature == null
+            || creature is Player
+            || creature is Pet
+            || ExemptBoolOf(creature);   // cached bool read - no biota lock on the per-hit path (2026-09-04)
+
+        /// <summary>
+        /// Resolves the winning zone for a creature and evaluates its stat profile. Returns null when the
+        /// creature should NOT be zone-controlled: it's a player, it's a pet, it's exempt, no enabled zone
+        /// covers its landblock, or no covering zone's Variation matches the creature's current variation.
+        /// </summary>
+        public static EvaluatedProfile ResolveForCreature(Creature creature)
+        {
+            if (IsZoneScalingExempt(creature))
+                return null;
+
+            var best = FindZoneRef(creature);
+            if (best == null)
+                return null;
+
+            var rank = RankOf(best, creature);
+            return best.Wcid.TryGetValue(creature.WeenieClassId, out var wp) ? wp[(int)rank] : best.ByRank[(int)rank];
+        }
+
+        /// <summary>The winning ZoneRef for a creature from the lock-free snapshot, or null: no enabled zone
+        /// covers its landblock, or none at its variation. Most-specific (fewest landblocks) wins.</summary>
+        private static ZoneRef FindZoneRef(Creature creature)
+        {
+            // Fully lock-free: read the immutable published snapshot (no _lock, no EnsureInitialized on the hot path).
+            var snap = _snapshot;
+            var landblock = creature.Location?.LandblockId.Landblock ?? 0;
+
+            // Hot-path fast bail: most monsters are in landblocks with no enabled zone (O(1), no lock).
+            if (!snap.EnabledLandblocks.Contains(landblock) || !snap.ByLandblock.TryGetValue(landblock, out var list))
+                return null;
+
+            var effVar = GetEffectiveVariation(creature);
+
+            ZoneRef best = null;
+            foreach (var zr in list)
+            {
+                if (zr.Variation != effVar)
+                    continue;
+                // most-specific wins: fewer landblocks (a one-block dungeon beats a multi-block region)
+                if (best == null || zr.LandblockCount < best.LandblockCount)
+                    best = zr;
+            }
+            // MASTER SWITCH (owner 2026-09-03): a WCID the winning zone exempts is UNGOVERNED here - every
+            // caller (stats, props, effects, hit gate) sees "no zone" for it.
+            if (best != null && best.ExemptWcids.Contains(creature.WeenieClassId))
+                return null;
+            // ... and so is anything spawned by an exempt GENERATOR, however deep the generator chain
+            // (owner 2026-09-03: "exempt wins from either side"). Spawns carry their generator link
+            // (GeneratorProfile.Spawn sets obj.Generator), so this is a short pointer walk, no lookups.
+            if (best != null && best.ExemptGenerators.Count > 0)
+            {
+                var g = creature.Generator;
+                for (var depth = 0; g != null && depth < 8; depth++, g = g.Generator)
+                    if (best.ExemptGenerators.Contains(g.WeenieClassId))
+                        return null;
+            }
+            return best;
+        }
+
+        /// <summary>
+        /// A monster's RANK for stat resolution (2026-09-02): the zone's per-WCID bucket decides when it
+        /// authors a rank bool (so a dev can rank a retail mob inside one zone without touching its
+        /// weenie, and so the FIRST spawn already resolves ranked - the bucket bools are stamped onto
+        /// the creature only AFTER the stamped stats, ZoneSpawnScaler:123-129); else the creature's own
+        /// bools (weenie-baked, or stamped by an earlier spawn); else None = the Default row only.
+        /// </summary>
+        private static ZcRank RankOf(ZoneRef zr, Creature creature)
+        {
+            if (zr.WcidRank.TryGetValue(creature.WeenieClassId, out var authored) && authored != ZcRank.None)
+                return authored;
+            return RankFromCreatureBools(creature);
+        }
+
+        /// <summary>The creature's own rank bools, read ONCE per creature (review 2026-09-04 M2): the
+        /// three GetProperty(PropertyBool) calls this used to make each took the biota lock on the per-hit
+        /// resolve path. Cached on the Creature; any write to 50047-50050 through SetProperty /
+        /// RemoveProperty drops the cache (WorldObject_Properties.InvalidateZcBoolCache).</summary>
+        private static ZcRank RankFromCreatureBools(WorldObject wo)
+        {
+            if (wo is Creature c)
+            {
+                if (c.ZcRankCache < 0) ReadZcBools(c);
+                return (ZcRank)c.ZcRankCache;
+            }
+            ReadZcBoolsRaw(wo, out var rank, out _);
+            return rank;
+        }
+
+        private static bool ExemptBoolOf(Creature c)
+        {
+            if (c.ZcExemptCache < 0) ReadZcBools(c);
+            return c.ZcExemptCache == 1;
+        }
+
+        private static void ReadZcBools(Creature c)
+        {
+            ReadZcBoolsRaw(c, out var rank, out var exempt);
+            c.ZcRankCache = (int)rank;
+            c.ZcExemptCache = exempt ? 1 : 0;
+        }
+
+        /// <summary>One read-lock pass over the biota's bools for the four Zone Control flags. Boss beats
+        /// Leader beats Regular when more than one is set - the order the old read sites used.</summary>
+        private static void ReadZcBoolsRaw(WorldObject wo, out ZcRank rank, out bool exempt)
+        {
+            rank = ZcRank.None;
+            exempt = false;
+            var bools = wo.Biota?.PropertiesBool;
+            if (bools == null || bools.Count == 0)
+                return;
+            wo.BiotaDatabaseLock.EnterReadLock();
+            try
+            {
+                if (bools.TryGetValue(PropertyBool.ExemptFromZoneScaling, out var e) && e) exempt = true;
+                if (bools.TryGetValue((PropertyBool)ZoneStat.BoolIsZcBoss, out var b) && b) rank = ZcRank.Boss;
+                else if (bools.TryGetValue((PropertyBool)ZoneStat.BoolIsZcLeader, out var l) && l) rank = ZcRank.Leader;
+                else if (bools.TryGetValue((PropertyBool)ZoneStat.BoolIsZcMinion, out var m) && m) rank = ZcRank.Regular;
+            }
+            finally
+            {
+                wo.BiotaDatabaseLock.ExitReadLock();
+            }
+        }
+
+        /// <summary>The rank a LIVE creature resolves at, with its source: "zone" (the bucket authors it),
+        /// "weenie" (the creature's own bool), or "none". For the KILLXP log line and mobcheck.</summary>
+        public static (ZcRank Rank, string Source) ResolveRankForCreature(Creature creature)
+        {
+            var zr = creature != null && !IsZoneScalingExempt(creature) ? FindZoneRef(creature) : null;
+            if (zr != null && zr.WcidRank.TryGetValue(creature.WeenieClassId, out var authored) && authored != ZcRank.None)
+                return (authored, "zone");
+            var own = creature != null ? RankFromCreatureBools(creature) : ZcRank.None;
+            return (own, own == ZcRank.None ? "none" : "weenie");
+        }
+
+        /// <summary>The rank a WCID resolves at inside a zone, for display paths (payload, show, mobcheck)
+        /// where no live creature exists: bucket PropBools, else the WEENIE's bools, else None.</summary>
+        public static (ZcRank Rank, string Source) ResolveRankForWcid(ControlledArea area, uint wcid)
+        {
+            if (area?.Profile?.WcidOverrides != null
+                && area.Profile.WcidOverrides.TryGetValue(wcid, out var bucket))
+            {
+                var authored = ZoneRank.FromPropBools(bucket?.PropBools);
+                if (authored != ZcRank.None) return (authored, "zone");
+            }
+            var weenie = DatabaseManager.World.GetCachedWeenie(wcid);
+            if (weenie != null)
+            {
+                if (weenie.GetProperty((PropertyBool)ZoneStat.BoolIsZcBoss) == true) return (ZcRank.Boss, "weenie");
+                if (weenie.GetProperty((PropertyBool)ZoneStat.BoolIsZcLeader) == true) return (ZcRank.Leader, "weenie");
+                if (weenie.GetProperty((PropertyBool)ZoneStat.BoolIsZcMinion) == true) return (ZcRank.Regular, "weenie");
+            }
+            return (ZcRank.None, "none");
+        }
+
+        /// <summary>
+        /// Resolves the winning zone's DEFAULT stat profile for a creature, ignoring any per-WCID
+        /// override bucket. 🔴 STALE-RATIONALE WARNING (2026-08-29): the old justification — "a
+        /// per-WCID override REPLACES the whole default profile" — has been wrong since the merge
+        /// went PER-STAT on 2026-07-30, and reading zone-policy knobs through here silently ignores
+        /// per-WCID authoring (that bug bit the relief curves; they read ResolveForCreature now).
+        /// Remaining caller: Player_Combat.ZcSpecialKnob, where zone-level-only IS the intent
+        /// (player-gear special knobs found via the opposing monster).
+        /// </summary>
+        public static EvaluatedProfile ResolveZoneDefaultForCreature(Creature creature)
+        {
+            if (IsZoneScalingExempt(creature))
+                return null;
+
+            var best = FindZoneRef(creature);
+            if (best == null)
+                return null;
+            // zone-level for the creature's RANK (2026-09-02): still ignores its per-WCID bucket, which
+            // is this method's whole point, but a Leader reads the zone's Leader row like everyone else.
+            return best.ByRank[(int)RankOf(best, creature)];
+        }
+
+        /// <summary>
+        /// Resolves the winning zone's DEFAULT stat profile for a PLAYER standing somewhere - the
+        /// player-side twin of <see cref="ResolveZoneDefaultForCreature"/> (same landblock + variation
+        /// gating, same most-specific-wins, no per-WCID bucket). Used for the gear_cap_* knobs: the
+        /// caller falls back to its C# default when this is null, so a knob read through here applies
+        /// everywhere and a zone merely re-tunes it. Lock-free snapshot read; safe on the rating hot path.
+        /// </summary>
+        public static EvaluatedProfile ResolveZoneDefaultForPlayer(Player player)
+        {
+            if (player == null)
+                return null;
+
+            var snap = _snapshot;
+            var landblock = player.Location?.LandblockId.Landblock ?? 0;
+            if (!snap.EnabledLandblocks.Contains(landblock) || !snap.ByLandblock.TryGetValue(landblock, out var list))
+                return null;
+
+            var effVar = GetEffectiveVariation(player);
+
+            ZoneRef best = null;
+            foreach (var zr in list)
+            {
+                if (zr.Variation != effVar)
+                    continue;
+                if (best == null || zr.LandblockCount < best.LandblockCount)
+                    best = zr;
+            }
+
+            return best?.Default;
+        }
+
+        /// <summary>
+        /// THE WEAPON ZONE LOCK (owner 2026-08-30, "only allow T11-T25 weapons to work in specific
+        /// zones ... an 'allow anywhere' then flip to 'Only in Authored areas'"): true when this
+        /// weapon's CUSTOM power - aug-scaling terms, modifier cards, procs - must be suppressed
+        /// for this swing. Option A was ruled: the weapon still swings and lands at its BASE T11
+        /// stats (the authored fallback), it just loses everything Zone Control stamped on top.
+        ///
+        /// The gate: server toggle ON (zc_weapon_zone_lock, default OFF = allow anywhere, live
+        /// flip) + wielder is a PLAYER (monsters are never gated) + the weapon is ZC-stamped
+        /// (ZcTier 11+; retail items never carry the stamp, so they can never be suppressed) +
+        /// the player is NOT inside an enabled authored area at their effective variation
+        /// (ResolveZoneDefaultForPlayer == null - lock-free snapshot read, rating-hot-path safe).
+        ///
+        /// Read at every card/scaling COMBAT site; appraisal deliberately stays ungated - the
+        /// panel describes the item, the lock describes the location.
+        /// </summary>
+        public static bool WeaponPowerSuppressed(WorldObject weapon, Creature wielder)
+        {
+            if (!(wielder is Player player) || weapon == null)
+                return false;
+            // Config gates FIRST (review 2026-09-04): this runs at every card / scaling read site per swing,
+            // and the ZcTier read below takes the item's biota lock. In the default configuration (Zone
+            // Control on, lock off) the answer is "not suppressed" without touching the item at all.
+            var zcOn = ServerConfig.zonecontrol_enabled.Value;
+            if (zcOn && !ServerConfig.zc_weapon_zone_lock.Value)
+                return false;
+            if ((weapon.GetProperty(ACE.Entity.Enum.Properties.PropertyInt.ZcTier) ?? 0) < 11)
+                return false;
+            // MASTER SWITCH (owner 2026-08-30, "weapons need same treatment"): Zone Control OFF
+            // suppresses every ZC weapon's custom power EVERYWHERE - armor already dropped to its
+            // T10 fallback pricing on this toggle via live stat resolution, but weapon cards and
+            // scaling never had a fallback ladder, so the toggle silently skipped them. Base
+            // weapon stats are the fallback, same as the zone lock.
+            if (!zcOn)
+                return true;
+            return ResolveZoneDefaultForPlayer(player) == null;
+        }
+
+        /// <summary>
+        /// THE ARMOR ZONE LOCK (owner 2026-08-30, "do the same for armor"): true when this
+        /// PLAYER's worn ZC gear must stop contributing its Modifier LINES - the 50200-block
+        /// props (attributes, vitals pct, life on hit, spell duration, the slot specials) and
+        /// the ZC portion of the Gear* rating sums. Base armor stats (AL, protections,
+        /// Reinforced rank - frozen into the piece at drop) stay, mirroring the weapon rule's
+        /// base-stats fallback. Per-WEARER, not per-item: the caches isolate the ZC portion at
+        /// equip time (only ZcTier 11+ items feed it), so the read-time test needs no item.
+        /// NOTE: the master zonecontrol_enabled toggle is NOT part of this gate - armor already
+        /// re-prices onto the T10 fallback ladder when that is off (live stat resolution), and
+        /// zeroing lines on top would double-punish.
+        /// </summary>
+        public static bool WornPowerSuppressed(Creature wearer)
+        {
+            if (!ServerConfig.zc_armor_zone_lock.Value)
+                return false;
+            if (!(wearer is Player player))
+                return false;
+            return ResolveZoneDefaultForPlayer(player) == null;
+        }
+
+        /// <summary>Is this item ZC-stamped gear (ZcTier 11+) - the cache-build test that feeds
+        /// the ZC-only rating portion the armor zone lock subtracts.</summary>
+        public static bool IsZcGear(WorldObject wo)
+            => (wo?.GetProperty(ACE.Entity.Enum.Properties.PropertyInt.ZcTier) ?? 0) >= 11;
+
+        /// <summary>The appraisal line both weapon and armor panels pin while their power is
+        /// suppressed for the examiner (wording owner-approved 2026-08-30). ONE constant so the
+        /// two panels can never drift.</summary>
+        public const string ZoneLockedAppraisalLine = "- Zone Locked (Power Reduced)";
+
+        /// <summary>Resolves a creature's COSMETIC appearance from the governing zone: the zone default overlaid by
+        /// this monster's per-WCID entry (per-WCID non-null fields win). Returns null when no enabled zone governs
+        /// the creature at its variation, or the zone defines no appearance. INDEPENDENT of the stat resolution —
+        /// a per-WCID appearance never creates a stat bucket, so it can't detach the mob from zone stat scaling.</summary>
+        public static ZoneAppearance ResolveAppearanceForCreature(Creature creature)
+        {
+            if (IsZoneScalingExempt(creature))
+                return null;
+
+            var snap = _snapshot;
+            var landblock = creature.Location?.LandblockId.Landblock ?? 0;
+            if (!snap.EnabledLandblocks.Contains(landblock) || !snap.ByLandblock.TryGetValue(landblock, out var list))
+                return null;
+
+            var effVar = GetEffectiveVariation(creature);
+
+            ZoneRef best = null;
+            foreach (var zr in list)
+            {
+                if (zr.Variation != effVar) continue;
+                if (best == null || zr.LandblockCount < best.LandblockCount) best = zr;
+            }
+            if (best == null) return null;
+
+            best.AppearanceByWcid.TryGetValue(creature.WeenieClassId, out var wcidAp);
+            var merged = ZoneAppearance.Merge(best.AppearanceDefault, wcidAp);
+            return merged != null && !merged.IsEmpty ? merged : null;
+        }
+
+        /// <summary>
+        /// Resolves the winning zone's player EFFECTS for a player standing somewhere. Mirrors
+        /// <see cref="ResolveForCreature"/>'s landblock + variation gating, but: (a) it's FOR players, and
+        /// (b) it only considers zones whose <see cref="ZoneEffects.AnyActive"/> is true, so a stat-only zone
+        /// never wins effect resolution. Returns null when no enabled, effect-authoring zone covers the player.
+        /// Hot-path safe: bails on the lockless enabled-landblock set before touching the lock.
+        /// </summary>
+        public static ZoneEffects ResolveEffectsForPlayer(Player player)
+        {
+            if (player == null)
+                return null;
+
+            // Fully lock-free: read the immutable published snapshot.
+            var snap = _snapshot;
+            var landblock = player.Location?.LandblockId.Landblock ?? 0;
+
+            // Hot-path fast bail: most players are in landblocks with no enabled zone (O(1), no lock).
+            if (!snap.EnabledLandblocks.Contains(landblock) || !snap.ByLandblock.TryGetValue(landblock, out var list))
+                return null;
+
+            // Use the same effective-variation the monster resolver + here-readout use, so a zone that governs
+            // monsters at variation N also applies effects at variation N (no split-brain).
+            var effVar = GetEffectiveVariation(player);
+
+            ZoneRef best = null;
+            foreach (var zr in list)
+            {
+                if (zr.Variation != effVar)
+                    continue;
+                if (zr.Effects == null || !zr.Effects.AnyActive)
+                    continue;
+                // most-specific wins: fewer landblocks (a one-block dungeon beats a multi-block region)
+                if (best == null || zr.LandblockCount < best.LandblockCount)
+                    best = zr;
+            }
+
+            return best?.Effects;
+        }
+
+        /// <summary>True when at least one BOUNDED zone exists at this variation — enabled or not (the
+        /// boundary is independent of the zone's stat controls). Lock-free; safe on hot per-player paths.
+        /// When true, <see cref="IsLandblockAllowed"/> is Zone Control's boundary authority for the
+        /// variation (enforced by the player tick's CheckZoneBoundary — standalone, independent of any
+        /// other boundary system).</summary>
+        public static bool HasBoundedZonesAt(int? variation)
+        {
+            if (!variation.HasValue)
+                return false;
+            return _snapshot.BoundedLandblocksByVariation.ContainsKey(variation.Value);
+        }
+
+        /// <summary>Player-boundary allowlist check: a landblock is allowed at a variation when no bounded zone
+        /// exists there (free roam), or it belongs to any bounded zone at that variation (union; enabled
+        /// or not). Lock-free snapshot read.</summary>
+        public static bool IsLandblockAllowed(int? variation, ushort landblock)
+        {
+            if (!variation.HasValue)
+                return true;
+            if (!_snapshot.BoundedLandblocksByVariation.TryGetValue(variation.Value, out var allowed))
+                return true;
+            return allowed.Contains(landblock);
+        }
+
+        /// <summary>
+        /// Terrain-override encounter redirection (owner 2026-07-21). When a zone overrides this
+        /// landblock's terrain at this variation, the block's encounter spawns are drawn from the
+        /// zone's DONOR blocks — members whose real DAT terrain matches the override tag — so marking
+        /// a grass block "obsidian" makes it spawn the zone's obsidian camps. The block's own row
+        /// POSITIONS are kept (known-good spots); only the generator WCIDs are substituted. A block
+        /// with no rows of its own imports a random donor block's full layout. Returns the original
+        /// list untouched when no override applies or no donor exists. Lock-free snapshot read +
+        /// cached DB reads — safe from the landblock init task. Independent of Enabled.
+        /// </summary>
+        public static List<Database.Models.World.Encounter> RedirectEncountersForTerrainOverride(
+            ushort landblock, int? variationId, List<Database.Models.World.Encounter> own)
+        {
+            if (!variationId.HasValue)
+                return own;
+
+            var snap = _snapshot;
+            if (!snap.TerrainOverridesByVariation.TryGetValue(variationId.Value, out var ovMap) ||
+                !ovMap.TryGetValue(landblock, out var tag))
+                return own;
+
+            if (!snap.TerrainDonorsByVariation.TryGetValue(variationId.Value, out var donorMap) ||
+                !donorMap.TryGetValue(tag, out var donorLbs) || donorLbs.Count == 0)
+                return own;
+
+            // donor pool: every encounter row on the zone's true-<tag> blocks (weighted naturally by
+            // how often a generator appears there); the target block never donates to itself
+            var pool = new List<Database.Models.World.Encounter>();
+            foreach (var dlb in donorLbs)
+            {
+                if (dlb == landblock) continue;
+                var rows = DatabaseManager.World.GetCachedEncountersByLandblock(dlb);
+                if (rows != null) pool.AddRange(rows);
+            }
+            if (pool.Count == 0)
+                return own;
+
+            var result = new List<Database.Models.World.Encounter>();
+            if (own is { Count: > 0 })
+            {
+                // keep this block's own spawn spots, swap what spawns there
+                foreach (var e in own)
+                    result.Add(new Database.Models.World.Encounter
+                    {
+                        Landblock = e.Landblock,
+                        CellX = e.CellX,
+                        CellY = e.CellY,
+                        WeenieClassId = pool[Common.ThreadSafeRandom.Next(0, pool.Count - 1)].WeenieClassId,
+                    });
+            }
+            else
+            {
+                // no encounters of its own: import a random donor block's full layout
+                var donor = donorLbs[Common.ThreadSafeRandom.Next(0, donorLbs.Count - 1)];
+                var rows = DatabaseManager.World.GetCachedEncountersByLandblock(donor);
+                if (rows == null || rows.Count == 0)
+                    return own;
+                foreach (var e in rows)
+                    result.Add(new Database.Models.World.Encounter
+                    {
+                        Landblock = landblock,
+                        CellX = e.CellX,
+                        CellY = e.CellY,
+                        WeenieClassId = e.WeenieClassId,
+                    });
+            }
+
+            log.Debug($"[ZoneControl] terrain override '{tag}' redirected {result.Count} encounter(s) on 0x{landblock:X4} v{variationId} ({donorLbs.Count} donor block(s))");
+            return result;
+        }
+
+        /// <summary>True when the weenie carries a generator table (a camp/spawn generator).</summary>
+        private static bool IsGeneratorWeenie(uint wcid)
+        {
+            var weenie = DatabaseManager.World.GetCachedWeenie(wcid);
+            return weenie?.PropertiesGenerator is { Count: > 0 };
+        }
+
+        /// <summary>
+        /// Terrain-override redirection for PLACED generator instances — the live path on this server
+        /// (encounter_spawn_base_layer_only=true keeps world encounters off explicit variations, so
+        /// variant-zone camps come from per-variation landblock_instance generators). When a zone
+        /// overrides this landblock's terrain at this variation, every STANDALONE generator instance
+        /// on the block (no links, not a link child — quest chains and NPCs are never touched) keeps
+        /// its position and instance guid but has its generator weenie substituted with a random pick
+        /// from the zone's donor blocks (members whose real DAT terrain matches the override tag).
+        /// Cached rows are cloned, never mutated. Returns the original list untouched when no override
+        /// applies or no donor pool exists. Lock-free; safe from the landblock init path.
+        /// </summary>
+        public static List<Database.Models.World.LandblockInstance> RedirectInstancesForTerrainOverride(
+            ushort landblock, int? variationId, List<Database.Models.World.LandblockInstance> own)
+        {
+            if (own == null || own.Count == 0 || !variationId.HasValue)
+                return own;
+
+            var snap = _snapshot;
+            if (!snap.TerrainOverridesByVariation.TryGetValue(variationId.Value, out var ovMap) ||
+                !ovMap.TryGetValue(landblock, out var tag))
+                return own;
+
+            if (!snap.TerrainDonorsByVariation.TryGetValue(variationId.Value, out var donorMap) ||
+                !donorMap.TryGetValue(tag, out var donorLbs) || donorLbs.Count == 0)
+                return own;
+
+            // donor pool: standalone generator instances on the zone's true-<tag> blocks at this same
+            // variation (duplicates kept - a generator common on donor blocks should be common here)
+            var pool = new List<uint>();
+            foreach (var dlb in donorLbs)
+            {
+                if (dlb == landblock) continue;
+                var rows = DatabaseManager.World.GetCachedInstancesByLandblock(dlb, variationId);
+                if (rows == null) continue;
+                foreach (var r in rows)
+                    if (!r.IsLinkChild && r.LandblockInstanceLink.Count == 0 && IsGeneratorWeenie(r.WeenieClassId))
+                        pool.Add(r.WeenieClassId);
+            }
+            if (pool.Count == 0)
+                return own;
+
+            // Prefer generators NAMED for the tag ("T11 Tou Tou Obsidian Generator" for obsidian):
+            // real blocks are rarely terrain-pure - F75C carries Land gens on its grassy fringes, so
+            // an unfiltered donor pool leaked ~half off-theme camps (owner report 2026-07-21). Falls
+            // back to the full donor pool when nothing is named for the tag (e.g. the generic "Land"
+            // generators covering grass/dirt/rock).
+            var themed = new List<uint>();
+            foreach (var wcid in pool)
+            {
+                var name = DatabaseManager.World.GetCachedWeenie(wcid)?.GetName();
+                if (name != null && name.IndexOf(tag, StringComparison.OrdinalIgnoreCase) >= 0)
+                    themed.Add(wcid);
+            }
+            var themedPool = themed.Count > 0;
+            if (themedPool)
+                pool = themed;
+
+            var result = new List<Database.Models.World.LandblockInstance>(own.Count);
+            var swapped = 0;
+            foreach (var r in own)
+            {
+                if (r.IsLinkChild || r.LandblockInstanceLink.Count > 0 || !IsGeneratorWeenie(r.WeenieClassId))
+                {
+                    result.Add(r);
+                    continue;
+                }
+
+                result.Add(new Database.Models.World.LandblockInstance
+                {
+                    Guid = r.Guid,
+                    Landblock = r.Landblock,
+                    WeenieClassId = pool[Common.ThreadSafeRandom.Next(0, pool.Count - 1)],
+                    ObjCellId = r.ObjCellId,
+                    OriginX = r.OriginX, OriginY = r.OriginY, OriginZ = r.OriginZ,
+                    AnglesW = r.AnglesW, AnglesX = r.AnglesX, AnglesY = r.AnglesY, AnglesZ = r.AnglesZ,
+                    VariationId = r.VariationId,
+                });
+                swapped++;
+            }
+
+            if (swapped > 0)
+                log.Info($"[ZoneControl] terrain override '{tag}': swapped {swapped} generator instance(s) on 0x{landblock:X4} v{variationId} " +
+                         $"({(themedPool ? "themed" : "unfiltered")} pool {pool.Count} from {donorLbs.Count} donor block(s))");
+            return result;
+        }
+
+        /// <summary>Names of bounded zones at a variation, enabled or not (for command echoes / the
+        /// plugin's shared-travel-space line). Locked display path — human-paced callers only.</summary>
+        public static List<string> BoundedZoneNamesAt(int variation)
+        {
+            EnsureInitialized();
+            lock (_lock)
+            {
+                return _areas.Values
+                    .Where(a => a.Bounded && a.Variation == variation)
+                    .Select(a => a.Name)
+                    .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+            }
+        }
+
+        /// <summary>Evaluates a zone's profile: the default stat set, or a per-WCID override if one exists for
+        /// this creature (a full replacement, not layered). Stats are flat (no tier curve).</summary>
+        private static EvaluatedProfile Evaluate(ControlledArea area, uint? wcid = null)
+        {
+            var hasWcidOverride = wcid.HasValue && area.Profile.WcidOverrides.ContainsKey(wcid.Value);
+            // RANK LAYERS (2026-09-02): a WCID evaluates on ITS rank's chain (bucket bools, else weenie
+            // bools); the bare zone evaluates on the Default row. Cache is per rank as well.
+            var rank = wcid.HasValue ? ResolveRankForWcid(area, wcid.Value).Rank : ZcRank.None;
+            var cacheKey = area.Name + "|" + (hasWcidOverride ? "w" + wcid.Value : "default") + "|r" + (int)rank;
+
+            lock (_lock)
+            {
+                if (_evalCache.TryGetValue(cacheKey, out var cached))
+                    return cached;
+
+                // Same layering the combat snapshot uses, so the GUI/command readout matches what a mob
+                // actually gets: v11 anchors -> VariationDefault -> zone -> wcid, each flattened for the
+                // rank first, merged per stat.
+                var defProfile = AnchoredDefaultProfileFor(area.Variation, rank);
+                var zoneLayer = area.Profile.Minion?.ForRank(rank);
+                var variantProfile = hasWcidOverride
+                    ? ZoneVariantProfile.Merge(defProfile, zoneLayer, area.Profile.WcidOverrides[wcid.Value])
+                    : ZoneVariantProfile.Merge(defProfile, zoneLayer);
+
+                var eval = EvaluateVariant(area.Name, variantProfile);
+                _evalCache[cacheKey] = eval;
+                return eval;
+            }
+        }
+
+        /// <summary>
+        /// The fully-layered profile for a zone (and optionally one WCID), as a live-shaped
+        /// <see cref="ZoneVariantProfile"/> rather than a flattened <see cref="EvaluatedProfile"/> — so callers
+        /// that need the authored <see cref="StatCurve"/> (the plugin sync payload, command readouts) see the
+        /// SAME numbers combat resolves. Merges VariationDefault -&gt; zone -&gt; wcid. Null if no such zone.
+        /// </summary>
+        public static ZoneVariantProfile ResolveProfileForDisplay(string name, uint? wcid = null)
+        {
+            EnsureInitialized();
+            lock (_lock)
+            {
+                var area = FindArea(name);
+                if (area == null)
+                    return null;
+
+                // Bare zone: the UNFLATTENED merge, Ranks kept, so the plugin's tier / zone grids can show
+                // the Regular / Leader / Boss rows (AppendRankRows). A --wcid target: the SAME chain combat
+                // resolves for that monster (2026-09-03) - every layer flattened for ITS rank first, so a
+                // Leader's Damage Resist reads the Leader row, not the Default row.
+                if (!wcid.HasValue)
+                {
+                    // UNFLATTENED on purpose: AnchoredDefaultProfileFor goes through ForRank, which CLEARS Ranks, so the
+                    // tier Default's Regular / Leader / Boss rows never reached the zone-scope grid (review 2026-09-03).
+                    // Merge folds Ranks recursively, so the tier's rank rows survive under the zone's own.
+                    var tierOwn = DefaultFor(area.Variation)?.Profile;
+                    var tierAnchor = area.Variation > 11 ? DefaultFor(11)?.Profile : null;
+                    return ZoneVariantProfile.Merge(tierAnchor, tierOwn, area.Profile.Minion);
+                }
+
+                var rank = ResolveRankForWcid(area, wcid.Value).Rank;
+                var defProfile = AnchoredDefaultProfileFor(area.Variation, rank);
+                var zoneLayer = area.Profile.Minion?.ForRank(rank);
+                if (area.Profile.WcidOverrides.TryGetValue(wcid.Value, out var bucket))
+                    return ZoneVariantProfile.Merge(defProfile, zoneLayer, bucket);
+
+                return ZoneVariantProfile.Merge(defProfile, zoneLayer);
+            }
+        }
+
+        /// <summary>Which layer a stat's winning value came from, for provenance readouts:
+        /// "wcid" / "zone" / "default vN", or null when nothing authors it. Most specific wins.</summary>
+        public static string ResolveStatSource(string name, uint? wcid, string stat)
+        {
+            EnsureInitialized();
+            lock (_lock)
+            {
+                var area = FindArea(name);
+                if (area == null || string.IsNullOrEmpty(stat))
+                    return null;
+
+                if (wcid.HasValue
+                    && area.Profile.WcidOverrides.TryGetValue(wcid.Value, out var bucket)
+                    && bucket?.Stats != null && bucket.Stats.ContainsKey(stat))
+                    return "wcid";
+
+                // RANK LAYERS (2026-09-02): the WCID's rank row on a layer sits ABOVE that layer's
+                // Default row and BELOW the next more-local layer (owner D2). Same order as ForRank+Merge.
+                var rank = wcid.HasValue ? ResolveRankForWcid(area, wcid.Value).Rank : ZcRank.None;
+                var rankKey = ZoneRank.Key(rank);
+                static bool Authors(ZoneVariantProfile p, string s) => p?.Stats != null && p.Stats.ContainsKey(s);
+                static bool AuthorsRank(ZoneVariantProfile p, string key, string s)
+                    => p?.Ranks != null && p.Ranks.TryGetValue(key, out var r) && Authors(r, s);
+
+                if (rank != ZcRank.None && AuthorsRank(area.Profile.Minion, rankKey, stat))
+                    return "zone " + rankKey;
+                if (Authors(area.Profile.Minion, stat))
+                    return "zone";
+
+                var def = DefaultFor(area.Variation);
+                if (rank != ZcRank.None && AuthorsRank(def?.Profile, rankKey, stat))
+                    return "default v" + area.Variation + " " + rankKey;
+                if (Authors(def?.Profile, stat))
+                    return "default v" + area.Variation;
+
+                // the v11 anchor layer rides under every 12+ Default (AnchoredDefaultProfileFor)
+                if (area.Variation > 11)
+                {
+                    var anchor = DefaultFor(11);
+                    if (rank != ZcRank.None && AuthorsRank(anchor?.Profile, rankKey, stat))
+                        return "default v11 (anchor) " + rankKey;
+                    if (Authors(anchor?.Profile, stat))
+                        return "default v11 (anchor)";
+                }
+
+                return null;
+            }
+        }
+
+        /// <summary>Evaluate a zone's profile for display/inspection, ignoring the enabled flag. Null if no such zone.</summary>
+        public static EvaluatedProfile EvaluateForDisplay(string name, uint? wcid = null)
+        {
+            EnsureInitialized();
+            lock (_lock)
+            {
+                var area = FindArea(name);
+                return area != null ? Evaluate(area, wcid) : null;
+            }
+        }
+
+        /// <summary>
+        /// The zone that ACTUALLY governs a spot: enabled, its Variation matches <paramref name="variation"/>, and
+        /// most-specific (fewest landblocks) among the candidates — the same rule <see cref="ResolveForCreature"/>
+        /// uses. Returns null if nothing governs here. Use for the GUI "governed by" readout so it reflects the real
+        /// winner rather than just any covering zone.
+        /// </summary>
+        public static ControlledArea ResolveWinnerForLocation(ushort landblock, int variation)
+        {
+            EnsureInitialized();
+            lock (_lock)
+            {
+                ControlledArea best = null;
+                if (_areasByLandblock.TryGetValue(landblock, out var list))
+                {
+                    foreach (var area in list)
+                    {
+                        if (!area.Enabled || area.Variation != variation)
+                            continue;
+                        if (best == null || area.Landblocks.Count < best.Landblocks.Count)
+                            best = area;
+                    }
+                }
+                return best;
+            }
+        }
+
+        /// <summary>Zones whose landblock set contains <paramref name="landblock"/> (for "here"/diagnostics).</summary>
+        public static IReadOnlyList<ControlledArea> AreasCovering(ushort landblock)
+        {
+            EnsureInitialized();
+            lock (_lock)
+            {
+                return _areasByLandblock.TryGetValue(landblock, out var list) ? list.ToList() : new List<ControlledArea>();
+            }
+        }
+
+        #endregion
+
+        #region mutation
+
+        /// <summary>Zone lookup: case-insensitive, and accepts underscores in place of spaces so a typed
+        /// my_zone finds "My Zone" (names may contain spaces; commands without quotes can't). Call under _lock.</summary>
+        private static ControlledArea FindArea(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                return null;
+            if (_areas.TryGetValue(name, out var a))
+                return a;
+            if (name.IndexOf('_') >= 0 && _areas.TryGetValue(name.Replace('_', ' '), out a))
+                return a;
+            return null;
+        }
+
+        public static void UpsertArea(ControlledArea area)
+        {
+            EnsureInitialized();
+            lock (_lock)
+            {
+                area.Landblocks ??= new HashSet<ushort>();
+                area.Profile ??= new ZoneScalingProfile();
+                area.Effects ??= new ZoneEffects();
+                _areas[area.Name] = area;
+                Save();
+            }
+        }
+
+        /// <summary>
+        /// Atomically read-modify-write a zone: runs <paramref name="mutate"/> on the live zone object while
+        /// holding the manager lock, then persists. Use this for any change that mutates the zone's Profile or
+        /// Effects, so two admins editing the same zone at once can't race on the underlying dictionaries.
+        /// The mutate callback must only touch the passed <see cref="ControlledArea"/> (no re-entrant manager
+        /// calls). Returns false if the zone doesn't exist.
+        /// </summary>
+        public static bool MutateArea(string name, Action<ControlledArea> mutate)
+        {
+            EnsureInitialized();
+            lock (_lock)
+            {
+                var a = FindArea(name);
+                if (a == null)
+                    return false;
+                a.Landblocks ??= new HashSet<ushort>();
+                a.Profile ??= new ZoneScalingProfile();
+                a.Effects ??= new ZoneEffects();
+                mutate(a);
+                Save();
+                return true;
+            }
+        }
+
+        // ── per-variation Defaults (2026-07-30) ──
+
+        /// <summary>Read-only snapshot of a variation's Default, or null when none is authored.
+        /// RAW - the variation's OWN layer, with no v11 anchor underneath and no StatToggles applied.
+        /// That is what the authoring/display surface wants (an editor must show what is actually stored
+        /// on the row being edited, not a merged view). Anything that has to answer "what does an item at
+        /// this tier resolve to" wants <see cref="GetAnchoredDefaultProfile"/> instead.</summary>
+        public static VariationDefault GetVariationDefault(int variation)
+        {
+            EnsureInitialized();
+            lock (_lock)
+                return DefaultFor(variation);
+        }
+
+        /// <summary>
+        /// The Default stat layer an ITEM at this tier resolves against: <see cref="AnchoredDefaultProfileFor"/>
+        /// (v11 anchor board under the variation's own Default) with StatToggles applied, i.e. the same
+        /// numbers the creature path already sees. Null only for variations outside the endgame band.
+        ///
+        /// WHY (2026-09-01): ZoneStatResolver read the RAW <see cref="GetVariationDefault"/> at five sites.
+        /// Since exactly one Default is authored (v11), that returned null at every tier 12-25, so item
+        /// re-resolution silently fell through to the hardcoded ladder while DROPS - which read the zone's
+        /// evaluated profile, anchor already merged in by <see cref="BuildZoneRef"/> - used the authored
+        /// board. A T25 armour line therefore dropped on band (14,69) and resolved on (28,138): a clean 2x
+        /// on first equip, written with SET semantics and saved, with the appraisal text baked at drop
+        /// disagreeing forever. This is the resolve-side twin of the 2026-08-30 anchor fix, which only ever
+        /// covered the creature path.
+        ///
+        /// Lock-free by design: precomputed in <see cref="RebuildIndexes"/> and published volatile, because
+        /// the equip path reads it once per armour line (up to 11) plus twice per weapon card.
+        /// </summary>
+        public static ZoneVariantProfile GetAnchoredDefaultProfile(int variation)
+        {
+            EnsureInitialized();
+            return _anchoredDefaults.TryGetValue(variation, out var p) ? p : null;
+        }
+
+        /// <summary>Build one entry of the anchored-Default table. Call under _lock (RebuildIndexes holds it).
+        /// StatToggles are applied here EXACTLY as <see cref="EvaluateVariant"/> applies them for the creature
+        /// path - a merged toggle of FALSE removes the stat outright, so every consumer falls back - which is
+        /// what makes the documented per-stat opt-out ("the only way to exempt a zone/monster from an
+        /// inherited Default") finally true on the item side as well. Note the twin is NOT removed, matching
+        /// EvaluateVariant: toggling off one box of an anchored pair leaves the surviving _t25 twin, and the
+        /// two paths must agree even where the rule is odd.</summary>
+        private static void AddAnchored(Dictionary<int, ZoneVariantProfile> into, int variation)
+        {
+            if (into.ContainsKey(variation))
+                return;
+            var merged = AnchoredDefaultProfileFor(variation);
+            if (merged == null)
+                return;
+            // Merge() always allocates a fresh profile, but AnchoredDefaultProfileFor short-circuits to a
+            // LIVE layer when only one exists - copy before removing anything, or a toggle would mutate the
+            // authored store.
+            merged = ZoneVariantProfile.Merge(merged);
+            if (merged.StatToggles is { Count: > 0 })
+                foreach (var kv in merged.StatToggles)
+                    if (!kv.Value)
+                        merged.Stats.Remove(kv.Key);
+            into[variation] = merged;
+        }
+
+        // ── live stat resolution: ladder apply versions (2026-08-22) ──
+
+        /// <summary>Lock-free: the ladder apply state for a tier (version 0 / no nerf when never applied).
+        /// Called on every equip of a ZC-lined piece, so no lock and no init side effects beyond the first call.</summary>
+        public static LadderApply GetLadderVersion(int tier)
+        {
+            EnsureInitialized();
+            return _ladderSnapshot.TryGetValue(tier, out var la) ? la : new LadderApply();
+        }
+
+        /// <summary>Every tier with an apply on record, ascending.</summary>
+        public static List<KeyValuePair<int, LadderApply>> ListLadderVersions()
+        {
+            EnsureInitialized();
+            return _ladderSnapshot.OrderBy(kv => kv.Key).ToList();
+        }
+
+        /// <summary>`/zonecontrol ladder apply`: bump the version for one tier (or every tier 11-25 when
+        /// tier is null) so existing items re-resolve against the live ladder on their next equip.
+        /// allowNerf = the --nerf flag; without it re-resolution never lowers a stamped value.
+        /// Returns the tiers bumped. Persists immediately.</summary>
+        public static List<int> BumpLadder(int? tier, bool allowNerf, string by)
+        {
+            EnsureInitialized();
+            var bumped = new List<int>();
+            lock (_lock)
+            {
+                var tiers = tier.HasValue ? new[] { tier.Value } : Enumerable.Range(11, 15).ToArray();
+                foreach (var t in tiers)
+                {
+                    _ladderApplies.TryGetValue(t, out var cur);
+                    _ladderApplies[t] = new LadderApply
+                    {
+                        Version = (cur?.Version ?? 0) + 1,
+                        AllowNerf = allowNerf,
+                        AppliedBy = by,
+                        AppliedUtc = DateTime.UtcNow,
+                    };
+                    bumped.Add(t);
+                }
+                Save();
+            }
+            return bumped;
+        }
+
+        /// <summary>Variations that currently have an authored Default, ascending.</summary>
+        public static List<int> ListVariationDefaults()
+        {
+            EnsureInitialized();
+            lock (_lock)
+                return _variationDefaults.Keys.OrderBy(v => v).ToList();
+        }
+
+        /// <summary>
+        /// Atomically read-modify-write a variation's Default, creating it on first touch, then persist and
+        /// republish the snapshot (so every zone at that variation picks the change up live). Mirrors
+        /// <see cref="MutateArea"/>. Prunes the entry again if the mutation left it empty.
+        /// </summary>
+        public static void MutateVariationDefault(int variation, Action<VariationDefault> mutate)
+        {
+            EnsureInitialized();
+            lock (_lock)
+            {
+                if (!_variationDefaults.TryGetValue(variation, out var def) || def == null)
+                    _variationDefaults[variation] = def = new VariationDefault();
+
+                def.Profile ??= new ZoneVariantProfile();
+                def.Effects ??= new ZoneEffects();
+                def.Appearance ??= new ZoneAppearance();
+
+                mutate(def);
+
+                if (def.IsEmpty && string.IsNullOrWhiteSpace(def.Notes))
+                    _variationDefaults.Remove(variation);
+
+                Save();
+            }
+        }
+
+        /// <summary>Drop a variation's Default entirely. Returns false when there wasn't one.</summary>
+        public static bool ClearVariationDefault(int variation)
+        {
+            EnsureInitialized();
+            lock (_lock)
+            {
+                if (!_variationDefaults.Remove(variation))
+                    return false;
+                Save();
+                return true;
+            }
+        }
+
+        /// <summary>Deep-copy one variation's Default over another (seed v12 from v11, then tweak).
+        /// Returns false when the source has no Default.</summary>
+        public static bool CopyVariationDefault(int from, int to)
+        {
+            EnsureInitialized();
+            lock (_lock)
+            {
+                var src = DefaultFor(from);
+                if (src == null)
+                    return false;
+
+                _variationDefaults[to] = new VariationDefault
+                {
+                    // Merge against nothing = a clean deep copy with every nested value cloned
+                    Profile = ZoneVariantProfile.Merge(src.Profile),
+                    Effects = src.Effects?.Clone() ?? new ZoneEffects(),
+                    Appearance = src.Appearance?.Clone() ?? new ZoneAppearance(),
+                    Notes = src.Notes,
+                };
+                Save();
+                return true;
+            }
+        }
+
+        public static bool RemoveArea(string name)
+        {
+            EnsureInitialized();
+            lock (_lock)
+            {
+                var a = FindArea(name);
+                if (a == null) return false;
+                _areas.Remove(a.Name);
+                Save();
+                return true;
+            }
+        }
+
+        /// <summary>Rename a zone. Returns false if the old name is missing or the new name is taken by a
+        /// DIFFERENT zone (renaming a zone to a different casing of its own name is allowed).</summary>
+        public static bool RenameArea(string oldName, string newName)
+        {
+            EnsureInitialized();
+            lock (_lock)
+            {
+                if (string.IsNullOrWhiteSpace(newName))
+                    return false;
+                var area = FindArea(oldName);
+                if (area == null)
+                    return false;
+                if (_areas.TryGetValue(newName, out var clash) && !ReferenceEquals(clash, area))
+                    return false;
+                _areas.Remove(area.Name);
+                area.Name = newName;
+                _areas[newName] = area;
+                Save();
+                return true;
+            }
+        }
+
+        public static bool SetEnabled(string name, bool enabled)
+        {
+            EnsureInitialized();
+            lock (_lock)
+            {
+                var a = FindArea(name);
+                if (a == null) return false;
+                a.Enabled = enabled;
+                Save();
+                return true;
+            }
+        }
+
+        public static bool SetBounded(string name, bool bounded)
+        {
+            EnsureInitialized();
+            lock (_lock)
+            {
+                var a = FindArea(name);
+                if (a == null) return false;
+                a.Bounded = bounded;
+                Save();
+                return true;
+            }
+        }
+
+        public static bool SetVariation(string name, int variation)
+        {
+            EnsureInitialized();
+            lock (_lock)
+            {
+                var a = FindArea(name);
+                if (a == null) return false;
+                a.Variation = variation;
+                Save();
+                return true;
+            }
+        }
+
+        /// <summary>Set (tag non-null/non-empty) or clear (tag null/empty) a manual terrain override for one
+        /// landblock. Returns false only when the zone doesn't exist. Display-only — no snapshot rebuild needed,
+        /// but Save() persists it to the shard store so it survives restarts and shows on every client.</summary>
+        public static bool SetTerrainOverride(string name, ushort landblock, string tag)
+        {
+            EnsureInitialized();
+            lock (_lock)
+            {
+                var a = FindArea(name);
+                if (a == null) return false;
+                a.TerrainOverrides ??= new Dictionary<ushort, string>();
+                if (string.IsNullOrEmpty(tag))
+                    a.TerrainOverrides.Remove(landblock);
+                else
+                    a.TerrainOverrides[landblock] = tag;
+                Save();
+                return true;
+            }
+        }
+
+        public static bool AddLandblock(string name, ushort landblock)
+        {
+            EnsureInitialized();
+            lock (_lock)
+            {
+                var a = FindArea(name);
+                if (a == null) return false;
+                a.Landblocks.Add(landblock);
+                Save();
+                return true;
+            }
+        }
+
+        public static bool RemoveLandblock(string name, ushort landblock)
+        {
+            EnsureInitialized();
+            lock (_lock)
+            {
+                var a = FindArea(name);
+                if (a == null) return false;
+                var changed = a.Landblocks.Remove(landblock);
+                if (changed) Save();
+                return changed;
+            }
+        }
+
+        public static ControlledArea GetArea(string name)
+        {
+            EnsureInitialized();
+            lock (_lock)
+            {
+                return FindArea(name);
+            }
+        }
+
+        public static IReadOnlyList<ControlledArea> ListAreas()
+        {
+            EnsureInitialized();
+            lock (_lock)
+            {
+                return _areas.Values.ToList();
+            }
+        }
+
+        /// <summary>Distinct Creature WCIDs spawnable in a zone's landblocks at its variation (for the plugin's
+        /// per-monster override dropdown).</summary>
+        public static List<(uint Wcid, string Name, bool IsMonster)> GetAreaMobs(string name)
+        {
+            EnsureInitialized();
+            ControlledArea area;
+            lock (_lock)
+            {
+                area = FindArea(name);
+                if (area == null)
+                    return new List<(uint, string, bool)>();
+            }
+            return GetLandblockMobs(area.Landblocks, area.Variation);
+        }
+
+        /// <summary>Which of a zone's WCIDs carry a per-monster override, for the plugin's roster badges.
+        /// Bit 1 = stat/prop override (a non-empty WcidOverrides bucket - the full standalone stat set),
+        /// bit 2 = appearance override. A WCID absent from the map runs on the zone defaults.</summary>
+        public static Dictionary<uint, int> GetAreaMobOverrideFlags(string name)
+        {
+            EnsureInitialized();
+            var flags = new Dictionary<uint, int>();
+            lock (_lock)
+            {
+                var area = FindArea(name);
+                if (area == null)
+                    return flags;
+
+                foreach (var kv in area.Profile.WcidOverrides)
+                    if (kv.Value != null && !VariantIsEmpty(kv.Value))
+                        flags[kv.Key] = 1;
+
+                if (area.AppearanceByWcid != null)
+                    foreach (var kv in area.AppearanceByWcid)
+                        if (kv.Value != null && !kv.Value.IsEmpty)
+                            flags[kv.Key] = flags.TryGetValue(kv.Key, out var f) ? f | 2 : 2;
+            }
+            return flags;
+        }
+
+        /// <summary>Force a reload from the shard store (e.g. after out-of-band edits).</summary>
+        public static void Reload()
+        {
+            lock (_lock)
+            {
+                _initialized = false;
+                _questRows = null;   // quest registry re-reads from ace_world on next pull
+                EnsureInitialized();
+            }
+        }
+
+        // ── Quest registry (plugin "Quests" tab) ──
+        // Authored rows live in ace_world.zonecontrol_quest (one row per quest; each content wave's SQL
+        // artifact appends its own rows). The registry is display data only — stamps/emotes/KillQuest props
+        // are the real quest machinery. NPC coords are resolved from landblock_instance by npc_wcid so
+        // moving an NPC never stales the tab, and "wired" flags rows whose stamp or NPC is missing.
+
+        public sealed class ZoneQuestRow
+        {
+            public string Zone;
+            public string QuestKey;       // counter stamp; empty = planned-only row
+            public string CompletedKey;   // cooldown stamp
+            public string Title;
+            public string Category;       // kill | collect | story | boss | event
+            public string Wave;           // plan key (B1, A3, ...) for grouping/sorting
+            public string NpcName;
+            public uint NpcWcid;
+            public string Objective;
+            public string Targets;        // '~'-separated display list
+            public int Count;
+            public int RepeatHours;
+            public string Reward;
+            public string Stage;          // planned | testing | live
+            public int SortOrder;
+            // resolved at load:
+            public string LandblockHex = "";   // NPC's landblock, "F659"
+            public string Coords = "";         // NPC map coords, "30.3S, 94.9E"
+            public bool Wired = true;          // stamp exists (if keyed) AND npc placed (if wcid set)
+        }
+
+        private static List<ZoneQuestRow> _questRows;   // guarded by _lock; null = load on next request
+
+        /// <summary>Registry rows for one zone, sort_order then wave. Loads (and bootstraps the table) lazily.</summary>
+        public static List<ZoneQuestRow> GetZoneQuests(string zoneName)
+        {
+            List<ZoneQuestRow> rows;
+            lock (_lock)
+            {
+                if (_questRows == null)
+                    _questRows = LoadQuestRegistry();
+                rows = _questRows;
+            }
+            var area = GetArea(zoneName);
+            var name = area?.Name ?? zoneName;
+            return rows.Where(q => string.Equals(q.Zone, name, StringComparison.OrdinalIgnoreCase))
+                       .OrderBy(q => q.SortOrder)
+                       .ThenBy(q => q.Wave, StringComparer.OrdinalIgnoreCase)
+                       .ToList();
+        }
+
+        private static List<ZoneQuestRow> LoadQuestRegistry()
+        {
+            var result = new List<ZoneQuestRow>();
+            try
+            {
+                using var ctx = new ACE.Database.Models.World.WorldDbContext();
+                var conn = ctx.Database.GetDbConnection();
+                if (conn.State != System.Data.ConnectionState.Open)
+                    ctx.Database.OpenConnection();
+
+                using (var create = conn.CreateCommand())
+                {
+                    create.CommandText = @"CREATE TABLE IF NOT EXISTS `zonecontrol_quest` (
+                        `id`            INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                        `zone`          VARCHAR(64)  NOT NULL,
+                        `quest_key`     VARCHAR(64)  NULL,
+                        `completed_key` VARCHAR(64)  NULL,
+                        `title`         VARCHAR(64)  NOT NULL,
+                        `category`      VARCHAR(16)  NOT NULL,
+                        `wave`          VARCHAR(16)  NULL,
+                        `npc_name`      VARCHAR(64)  NULL,
+                        `npc_wcid`      INT UNSIGNED NULL,
+                        `objective`     VARCHAR(255) NOT NULL,
+                        `targets`       VARCHAR(255) NULL,
+                        `count`         INT          NULL,
+                        `repeat_hours`  INT          NULL,
+                        `reward`        VARCHAR(128) NULL,
+                        `stage`         VARCHAR(16)  NOT NULL DEFAULT 'planned',
+                        `sort_order`    INT          NOT NULL DEFAULT 0,
+                        `notes`         VARCHAR(255) NULL,
+                        KEY `idx_zone` (`zone`)
+                    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;";
+                    create.ExecuteNonQuery();
+                }
+
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = "SELECT `zone`, `quest_key`, `completed_key`, `title`, `category`, `wave`, " +
+                                      "`npc_name`, `npc_wcid`, `objective`, `targets`, `count`, `repeat_hours`, " +
+                                      "`reward`, `stage`, `sort_order` FROM `zonecontrol_quest`";
+                    using var rdr = cmd.ExecuteReader();
+                    while (rdr.Read())
+                    {
+                        result.Add(new ZoneQuestRow
+                        {
+                            Zone         = rdr.IsDBNull(0)  ? "" : rdr.GetString(0),
+                            QuestKey     = rdr.IsDBNull(1)  ? "" : rdr.GetString(1),
+                            CompletedKey = rdr.IsDBNull(2)  ? "" : rdr.GetString(2),
+                            Title        = rdr.IsDBNull(3)  ? "" : rdr.GetString(3),
+                            Category     = rdr.IsDBNull(4)  ? "" : rdr.GetString(4),
+                            Wave         = rdr.IsDBNull(5)  ? "" : rdr.GetString(5),
+                            NpcName      = rdr.IsDBNull(6)  ? "" : rdr.GetString(6),
+                            NpcWcid      = rdr.IsDBNull(7)  ? 0u : Convert.ToUInt32(rdr.GetValue(7)),
+                            Objective    = rdr.IsDBNull(8)  ? "" : rdr.GetString(8),
+                            Targets      = rdr.IsDBNull(9)  ? "" : rdr.GetString(9),
+                            Count        = rdr.IsDBNull(10) ? 0  : Convert.ToInt32(rdr.GetValue(10)),
+                            RepeatHours  = rdr.IsDBNull(11) ? 0  : Convert.ToInt32(rdr.GetValue(11)),
+                            Reward       = rdr.IsDBNull(12) ? "" : rdr.GetString(12),
+                            Stage        = rdr.IsDBNull(13) ? "planned" : rdr.GetString(13),
+                            SortOrder    = rdr.IsDBNull(14) ? 0  : Convert.ToInt32(rdr.GetValue(14)),
+                        });
+                    }
+                }
+
+                // Resolve NPC placement (coords + landblock) once per distinct wcid; prefer the base(NULL)
+                // row, else the lowest variation — coordinates are identical across mirrored rows.
+                var placements = new Dictionary<uint, (string lb, string co)>();
+                foreach (var wcid in result.Where(r => r.NpcWcid != 0).Select(r => r.NpcWcid).Distinct())
+                {
+                    using var cmd = conn.CreateCommand();
+                    cmd.CommandText = "SELECT `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z` FROM `landblock_instance` " +
+                                      "WHERE `weenie_Class_Id` = @w ORDER BY (`variation_Id` IS NULL) DESC, `variation_Id` LIMIT 1";
+                    var p = cmd.CreateParameter();
+                    p.ParameterName = "@w";
+                    p.Value = wcid;
+                    cmd.Parameters.Add(p);
+                    using var rdr = cmd.ExecuteReader();
+                    if (rdr.Read())
+                    {
+                        var cell = Convert.ToUInt32(rdr.GetValue(0));
+                        var pos = new ACE.Entity.Position(cell,
+                            Convert.ToSingle(rdr.GetValue(1)), Convert.ToSingle(rdr.GetValue(2)), Convert.ToSingle(rdr.GetValue(3)),
+                            0f, 0f, 0f, 1f);
+                        var co = ACE.Server.Entity.PositionExtensions.GetMapCoordStr(pos) ?? "";
+                        placements[wcid] = (((ushort)(cell >> 16)).ToString("X4"), co);
+                    }
+                }
+
+                foreach (var q in result)
+                {
+                    var stampOk = string.IsNullOrEmpty(q.QuestKey) || DatabaseManager.World.GetCachedQuest(q.QuestKey) != null;
+                    var npcOk = q.NpcWcid == 0 || placements.ContainsKey(q.NpcWcid);
+                    if (q.NpcWcid != 0 && placements.TryGetValue(q.NpcWcid, out var pl))
+                    {
+                        q.LandblockHex = pl.lb;
+                        q.Coords = pl.co;
+                    }
+                    // planned rows aren't expected to be wired yet — only flag testing/live rows
+                    q.Wired = string.Equals(q.Stage, "planned", StringComparison.OrdinalIgnoreCase) || (stampOk && npcOk);
+                }
+            }
+            catch (Exception ex)
+            {
+                log.Error($"[ZONECONTROL] LoadQuestRegistry failed: {ex.Message}");
+            }
+            return result;
+        }
+
+        #endregion
+
+        #region mob enumeration
+
+        private const int MaxGeneratorDepth = 6;
+
+        /// <summary>Distinct Creature WCIDs reachable (through any number of nested generator layers) on the
+        /// given landblocks at a specific variation, sorted by name. A live landblock at variation N loads
+        /// strictly VariationId==N; placed WCIDs are frequently GENERATOR weenies whose real spawns live in
+        /// nested PropertiesGenerator, so we walk that tree (depth-capped, cycle-safe) to actual Creature weenies.</summary>
+        private static List<(uint Wcid, string Name, bool IsMonster)> GetLandblockMobs(IEnumerable<ushort> landblocks, int variation)
+        {
+            var seen = new Dictionary<uint, (string Name, bool IsMonster, string Type)>();
+            var visited = new HashSet<uint>();
+            foreach (var lb in landblocks)
+            {
+                var instances = DatabaseManager.World.GetCachedInstancesByLandblock(lb, variation);
+                foreach (var inst in instances)
+                    ExpandGeneratorTree(inst.WeenieClassId, seen, visited, 0);
+            }
+
+            return seen.Select(kv => (kv.Key, kv.Value.Name, kv.Value.IsMonster))
+                .OrderBy(kv => kv.Item2, StringComparer.OrdinalIgnoreCase).ToList();
+        }
+
+        private static void ExpandGeneratorTree(uint wcid, Dictionary<uint, (string Name, bool IsMonster, string Type)> seen, HashSet<uint> visited, int depth)
+        {
+            if (depth > MaxGeneratorDepth || !visited.Add(wcid))
+                return;
+
+            var weenie = DatabaseManager.World.GetCachedWeenie(wcid);
+            if (weenie == null)
+                return;
+
+            if (weenie.WeenieType == WeenieType.Creature)
+            {
+                if (!seen.ContainsKey(wcid))
+                    seen[wcid] = (weenie.GetName() ?? ("wcid " + wcid), IsMonsterWeenie(weenie), GetCreatureTypeName(weenie));
+                // no return: creature-generators (Kingpin-style boss anchors) host their trash ring
+                // in their own generator profiles - walk them too or ring mobs never list
+            }
+
+            if (weenie.PropertiesGenerator != null)
+                foreach (var g in weenie.PropertiesGenerator)
+                    ExpandGeneratorTree(g.WeenieClassId, seen, visited, depth + 1);
+        }
+
+        /// <summary>The weenie's CreatureType enum name ("" when unset/invalid) — the survey's "Types" column.</summary>
+        private static string GetCreatureTypeName(Weenie weenie)
+        {
+            if (weenie.PropertiesInt == null || !weenie.PropertiesInt.TryGetValue(PropertyInt.CreatureType, out var ct) || ct == 0)
+                return "";
+            var typed = (CreatureType)ct;
+            return Enum.IsDefined(typeof(CreatureType), typed) ? typed.ToString() : "";
+        }
+
+        // ── Per-landblock survey (Territory tab) ──
+        // DB-backed (landblock_instance rows + weenie cache via the same generator-tree walk as the Monsters
+        // tab), so UNLOADED landblocks survey fine. Human-paced admin path — never called from combat.
+
+        public sealed class SurveyCreatureRow
+        {
+            public uint Wcid;
+            public string Name;
+            public string Type;
+            public bool IsMonster;
+        }
+
+        public sealed class SurveyPlacedRow
+        {
+            public uint Wcid;
+            public string Name;
+            public int Count;
+        }
+
+        public sealed class SurveyRow
+        {
+            public ushort Landblock;
+            public int Generators;                       // placed instances carrying a generator table
+            public List<SurveyCreatureRow> Creatures;    // distinct creatures reachable on this landblock
+            public List<SurveyPlacedRow> PlacedGenerators; // the generator instances, grouped by wcid
+            public string Terrain;                       // EFFECTIVE terrain shown on the map (override ?? DAT), "" if unknown
+            public string TerrainBase;                   // raw DAT-derived terrain (what "Auto/clear" reverts to), "" if unknown
+        }
+
+        /// <summary>The terrain tags the survey/plugin understand — the nine <see cref="ClassifyLandblockTerrain"/>
+        /// buckets. Used to validate manual terrain overrides.</summary>
+        public static readonly string[] TerrainTags =
+            { "water", "beach", "obsidian", "snow", "ice", "swamp", "grass", "dirt", "rock" };
+
+        /// <summary>Dominant terrain category of a landblock, read LIVE from the cell DAT (the same terrain the
+        /// physics engine loads). Classifies the 81 terrain vertices via <see cref="LandDefs.TerrainType"/> into
+        /// nine buckets — water 0x10-0x14, beach/sand 0x0A-0x0C, obsidian 0x06, snow 0x0F, ice 0x02, swamp 0x04,
+        /// grass {0x01,0x03,0x09}, dirt {0x05,0x07,0x08}, else rock {0x00,0x0D,0x0E} — and returns the dominant.
+        /// (Previously everything non-water/beach/obsidian collapsed to one "land" tag, so normal grassy/rocky
+        /// zones rendered a single flat green; the finer buckets let the map actually differentiate blocks.)
+        /// "" when the block isn't in the dat. Cached by DatManager, so repeated survey reads are cheap.</summary>
+        public static string ClassifyLandblockTerrain(ushort landblock)
+        {
+            CellLandblock cl;
+            try { cl = DatManager.CellDat.ReadFromDat<CellLandblock>(((uint)landblock << 16) | 0xFFFF); }
+            catch { return ""; }
+            if (cl?.Terrain == null || cl.Terrain.Count == 0) return "";
+
+            int water = 0, beach = 0, obsidian = 0, snow = 0, ice = 0, swamp = 0, grass = 0, dirt = 0, rock = 0;
+            foreach (var raw in cl.Terrain)
+            {
+                var tt = (raw >> 2) & 0x1F;   // TerrainType lives in bits 2-6 (same decode as LandblockStruct)
+                switch (tt)
+                {
+                    case 0x10: case 0x11: case 0x12: case 0x13: case 0x14: water++; break;    // running/standing/sea water
+                    case 0x0A: case 0x0B: case 0x0C: beach++; break;                          // sand: yellow/grey/rock-strewn
+                    case 0x06: obsidian++; break;                                             // obsidian plain (volcanic)
+                    case 0x0F: snow++; break;                                                 // snow
+                    case 0x02: ice++; break;                                                  // ice
+                    case 0x04: swamp++; break;                                                // marsh / sparse swamp
+                    case 0x01: case 0x03: case 0x09: grass++; break;                          // grassland / lush / patchy grass
+                    case 0x05: case 0x07: case 0x08: dirt++; break;                           // mud-rich / packed / patchy dirt
+                    default: rock++; break;                                                   // barren/sedimentary/semi-barren rock (0,D,E)
+                }
+            }
+
+            // Dominant category wins; ties resolve toward the more "notable" terrain (listed first) so a block
+            // that is, say, half grass / half water reads as water rather than washing back into a green sea.
+            var buckets = new (string Tag, int Count)[]
+            {
+                ("water", water), ("obsidian", obsidian), ("swamp", swamp), ("ice", ice), ("snow", snow),
+                ("beach", beach), ("rock", rock), ("dirt", dirt), ("grass", grass),
+            };
+            var bestTag = ""; var bestN = 0;
+            foreach (var b in buckets)
+                if (b.Count > bestN) { bestN = b.Count; bestTag = b.Tag; }
+            return bestN == 0 ? "" : bestTag;
+        }
+
+        /// <summary>Per-landblock content survey of a zone at its variation. Null when the zone doesn't exist.
+        /// One row per member landblock (ordered), each with distinct reachable creatures (name/type/monster)
+        /// and the placed generator instances grouped by wcid.</summary>
+        public static List<SurveyRow> SurveyArea(string name)
+        {
+            EnsureInitialized();
+            List<ushort> lbs;
+            int variation;
+            Dictionary<ushort, string> terrainOverrides;
+            lock (_lock)
+            {
+                var area = FindArea(name);
+                if (area == null)
+                    return null;
+                lbs = area.Landblocks.OrderBy(x => x).ToList();
+                variation = area.Variation;
+                // Snapshot the overrides so the (lock-free) survey loop below reads a stable copy.
+                terrainOverrides = area.TerrainOverrides != null
+                    ? new Dictionary<ushort, string>(area.TerrainOverrides)
+                    : new Dictionary<ushort, string>();
+            }
+
+            var rows = new List<SurveyRow>(lbs.Count);
+            foreach (var lb in lbs)
+            {
+                var seen = new Dictionary<uint, (string Name, bool IsMonster, string Type)>();
+                var visited = new HashSet<uint>();
+                var placed = new Dictionary<uint, SurveyPlacedRow>();
+                var gens = 0;
+
+                var instances = DatabaseManager.World.GetCachedInstancesByLandblock(lb, variation);
+                foreach (var inst in instances)
+                {
+                    ExpandGeneratorTree(inst.WeenieClassId, seen, visited, 0);
+
+                    var weenie = DatabaseManager.World.GetCachedWeenie(inst.WeenieClassId);
+                    if (weenie?.PropertiesGenerator is { Count: > 0 })
+                    {
+                        gens++;
+                        if (placed.TryGetValue(inst.WeenieClassId, out var row))
+                            row.Count++;
+                        else
+                            placed[inst.WeenieClassId] = new SurveyPlacedRow
+                            {
+                                Wcid = inst.WeenieClassId,
+                                Name = weenie.GetName() ?? ("wcid " + inst.WeenieClassId),
+                                Count = 1,
+                            };
+                    }
+                }
+
+                var baseTerrain = ClassifyLandblockTerrain(lb);
+                rows.Add(new SurveyRow
+                {
+                    Landblock = lb,
+                    Generators = gens,
+                    Creatures = seen
+                        .Select(kv => new SurveyCreatureRow { Wcid = kv.Key, Name = kv.Value.Name, Type = kv.Value.Type, IsMonster = kv.Value.IsMonster })
+                        .OrderBy(c => c.Name, StringComparer.OrdinalIgnoreCase).ToList(),
+                    PlacedGenerators = placed.Values.OrderBy(p => p.Name, StringComparer.OrdinalIgnoreCase).ToList(),
+                    // TerrainBase = the raw DAT terrain (what clearing an override reverts to); Terrain = the
+                    // effective value shown on the map (a manual override wins). Both are display-only.
+                    TerrainBase = baseTerrain,
+                    Terrain = terrainOverrides.TryGetValue(lb, out var ov) && !string.IsNullOrEmpty(ov)
+                        ? ov
+                        : baseTerrain,
+                });
+            }
+
+            return rows;
+        }
+
+        /// <summary>Distinct placed generator wcids (+ placement counts) across a zone's landblocks at
+        /// the zone's variation — the plugin Generator Settings discovery list ([[ZCL]], genlist).
+        /// Lean sibling of <see cref="SurveyArea"/>: no creature-tree expansion. Null = no such zone.</summary>
+        public static List<SurveyPlacedRow> GetPlacedGenerators(string name)
+        {
+            EnsureInitialized();
+            List<ushort> lbs;
+            int variation;
+            lock (_lock)
+            {
+                var area = FindArea(name);
+                if (area == null)
+                    return null;
+                lbs = area.Landblocks.OrderBy(x => x).ToList();
+                variation = area.Variation;
+            }
+
+            var placed = new Dictionary<uint, SurveyPlacedRow>();
+            foreach (var lb in lbs)
+                AccumulatePlacedGenerators(lb, variation, placed);
+            return placed.Values.OrderBy(p => p.Wcid).ToList();
+        }
+
+        /// <summary>Same scan for one landblock — genlist's fallback when the player is outside any zone.</summary>
+        public static List<SurveyPlacedRow> GetPlacedGeneratorsForLandblock(ushort landblock, int variation)
+        {
+            var placed = new Dictionary<uint, SurveyPlacedRow>();
+            AccumulatePlacedGenerators(landblock, variation, placed);
+            return placed.Values.OrderBy(p => p.Wcid).ToList();
+        }
+
+        private static void AccumulatePlacedGenerators(ushort lb, int variation, Dictionary<uint, SurveyPlacedRow> placed)
+        {
+            var instances = DatabaseManager.World.GetCachedInstancesByLandblock(lb, variation);
+            foreach (var inst in instances)
+            {
+                var weenie = DatabaseManager.World.GetCachedWeenie(inst.WeenieClassId);
+                if (!(weenie?.PropertiesGenerator is { Count: > 0 }))
+                    continue;
+                if (placed.TryGetValue(inst.WeenieClassId, out var row))
+                    row.Count++;
+                else
+                    placed[inst.WeenieClassId] = new SurveyPlacedRow
+                    {
+                        Wcid = inst.WeenieClassId,
+                        Name = weenie.GetName() ?? ("wcid " + inst.WeenieClassId),
+                        Count = 1,
+                    };
+            }
+        }
+
+        /// <summary>Mirrors Creature.IsMonster (Attackable || TargetingTactic != None) at the weenie level.</summary>
+        private static bool IsMonsterWeenie(Weenie weenie)
+        {
+            var attackable = weenie.PropertiesBool != null && weenie.PropertiesBool.TryGetValue(PropertyBool.Attackable, out var a) ? a : true;
+            if (attackable)
+                return true;
+            var tactic = weenie.PropertiesInt != null && weenie.PropertiesInt.TryGetValue(PropertyInt.TargetingTactic, out var t) ? t : 0;
+            return tactic != 0;
+        }
+
+        #endregion
+    }
+}

--- a/Source/ACE.Server/Managers/ZoneControl/ZoneControlModels.cs
+++ b/Source/ACE.Server/Managers/ZoneControl/ZoneControlModels.cs
@@ -1,0 +1,196 @@
+using System.Collections.Generic;
+using ACE.Server.Managers.ZoneScaling;
+
+namespace ACE.Server.Managers.ZoneControl
+{
+    /// <summary>
+    /// One controlled Zone: a named set of landblocks governed at a specific world Variation, with an on/off
+    /// toggle and a stat profile. A monster is governed by a zone when it stands on one of the zone's landblocks
+    /// AND its variation equals the zone's <see cref="Variation"/> (0 = the normal world; 11+ = variant instances).
+    ///
+    /// No prestige/tier/boss concepts: the stat payload is a single DEFAULT set applied to every monster in the
+    /// zone (the profile's default variant), plus optional per-monster (WCID) overrides.
+    /// </summary>
+    public class ControlledArea
+    {
+        /// <summary>Unique key (case-insensitive) — e.g. "tusker_barracks".</summary>
+        public string Name { get; set; }
+
+        /// <summary>Member landblocks (a dungeon's landblock, or every block of an overworld region).</summary>
+        public HashSet<ushort> Landblocks { get; set; } = new();
+
+        /// <summary>The world variation this zone governs. 0 = the normal (base) world; 11+ = variant instances.</summary>
+        public int Variation { get; set; }
+
+        /// <summary>Master switch. Off ⇒ the zone resolves to null (monsters revert to baseline; live stats instantly, HP on respawn).</summary>
+        public bool Enabled { get; set; }
+
+        /// <summary>When true (and the zone is Enabled), players at this zone's Variation may only roam the
+        /// landblocks of bounded zones at that variation (the union across such zones forms the variation's
+        /// player allowlist). Enforced by the boundary punishment loop, guide wisp and perimeter markers.
+        /// Only meaningful at variations 11+ (the command refuses retail variations); runtime zones never bound.</summary>
+        public bool Bounded { get; set; }
+
+        public string Notes { get; set; }
+
+        /// <summary>Manual terrain overrides for the Territory map, keyed by landblock → terrain tag
+        /// (water|beach|obsidian|snow|ice|swamp|grass|dirt|rock). The survey reports this tag instead of the
+        /// DAT-derived dominant terrain wherever present. Display-only: terrain drives nothing but map color, so
+        /// an admin can re-tag mixed grass/rock/obsidian blocks to whatever reads best for planning generators.</summary>
+        public Dictionary<ushort, string> TerrainOverrides { get; set; } = new();
+
+        /// <summary>Stat payload: the default set (profile default variant) for all monsters + per-WCID overrides.</summary>
+        public ZoneScalingProfile Profile { get; set; } = new();
+
+        /// <summary>Zone-wide rules applied to PLAYERS standing in the zone (independent of monster stats).</summary>
+        public ZoneEffects Effects { get; set; } = new();
+
+        /// <summary>COSMETIC appearance overrides, kept SEPARATE from Profile so they never touch a monster's
+        /// stats/abilities. <see cref="AppearanceDefault"/> applies to every governed monster; the
+        /// <see cref="AppearanceByWcid"/> entries LAYER on top of it per monster type (non-null fields win).
+        /// Missing on deserialize of older stores = empty (backward compatible). See ZoneAppearance.</summary>
+        public ZoneAppearance AppearanceDefault { get; set; } = new();
+        public Dictionary<uint, ZoneAppearance> AppearanceByWcid { get; set; } = new();
+
+        /// <summary>The cosmetic bucket to edit: the per-WCID overlay (auto-created when <paramref name="create"/>)
+        /// or the zone default when <paramref name="wcid"/> is null. Mirrors Profile.VariantForWcid.</summary>
+        public ZoneAppearance AppearanceFor(uint? wcid, bool create = false)
+        {
+            if (!wcid.HasValue) return AppearanceDefault ??= new ZoneAppearance();
+            AppearanceByWcid ??= new Dictionary<uint, ZoneAppearance>();
+            if (AppearanceByWcid.TryGetValue(wcid.Value, out var ap) && ap != null) return ap;
+            if (!create) return null;
+            AppearanceByWcid[wcid.Value] = ap = new ZoneAppearance();
+            return ap;
+        }
+    }
+
+    /// <summary>
+    /// The DEFAULT layer for one world variation (2026-07-30): the baseline every zone at that variation
+    /// inherits. Resolution is <c>VariationDefault -&gt; zone -&gt; wcid</c>, merged PER STAT — a zone that
+    /// authors nothing IS its variation's Default, and a zone that authors one stat overrides one stat.
+    ///
+    /// Progression across v11-v25 is expressed as 15 of these, each explicitly authored. The server never
+    /// derives a stat from the variation number (owner ruling: computed scaling is out).
+    ///
+    /// Runtime zones (rift runs) deliberately do NOT inherit — they live at negative variations and set
+    /// their own stats at registration, so a rift can never pick up Tide combat numbers.
+    /// </summary>
+    public class VariationDefault
+    {
+        /// <summary>Stat/prop/body-part/list payload — the same shape a zone carries.</summary>
+        public ZoneVariantProfile Profile { get; set; } = new();
+
+        /// <summary>Player effects (DoT etc.) inherited by zones at this variation. Nullable per field.</summary>
+        public ZoneEffects Effects { get; set; } = new();
+
+        /// <summary>Cosmetic baseline, overlaid by the zone's own appearance then per-WCID.</summary>
+        public ZoneAppearance Appearance { get; set; } = new();
+
+        public string Notes { get; set; }
+
+        public bool IsEmpty =>
+            (Profile == null || Profile.IsEmpty)
+            && (Effects == null || Effects.IsEmpty)
+            && (Appearance == null || Appearance.IsEmpty);
+    }
+
+    /// <summary>
+    /// Per-zone effects applied to PLAYERS inside the zone, evaluated each player heartbeat by
+    /// <see cref="ZoneControl.ZoneEffectManager"/>. Only <see cref="DotEnabled"/> is wired today; the
+    /// slow/charm fields are reserved placeholders so the wire format + store schema are forward-compatible.
+    /// </summary>
+    public class ZoneEffects
+    {
+        // Every field is NULLABLE (2026-07-30 Default layer): null means "not authored at THIS layer", so a
+        // variation Default can supply the DoT and an individual zone can override just the damage number
+        // without restating type/interval. The Effective* accessors below apply the defaults a caller needs.
+
+        // ── Damage over time ("the floor is lava") ──
+        /// <summary>When true, players in the zone take a periodic hit every <see cref="DotIntervalSeconds"/>.</summary>
+        public bool? DotEnabled { get; set; }
+
+        /// <summary>Amount applied PER TICK. Flat points normally, or a percent of the player's max health when
+        /// <see cref="DotPercent"/> is true (e.g. 5 = 5% of max health per tick).</summary>
+        public double? DotDamage { get; set; }
+
+        /// <summary>When true, <see cref="DotDamage"/> is a percent of the player's max health (drains Health).</summary>
+        public bool? DotPercent { get; set; }
+
+        /// <summary>Seconds between ticks (min 1). Applied by a per-player timer, independent of the 5s heartbeat.</summary>
+        public double? DotIntervalSeconds { get; set; }
+
+        /// <summary>ACE.Entity.Enum.DamageType as int (default Fire = 0x10). Stored as int to keep the model enum-free.
+        /// Stamina/Mana drain those pools; Health = "drained"; percent mode forces Health.</summary>
+        public int? DotDamageType { get; set; }
+
+        // ── Suppression (regen) ──
+        /// <summary>Master switch for the Suppression card: regen suppression for players in the zone.</summary>
+        public bool? SuppressEnabled { get; set; }
+
+        /// <summary>When true (the default while suppression is on), the Prodigal regen enchantment line
+        /// (Regeneration 3731 / Rejuvenation 3732 / Mana Renewal 3725) is excluded from the player's regen
+        /// math — a retail regen buff underneath still applies. Computed per vital tick, never cached.</summary>
+        public bool? SuppressProdigal { get; set; }
+
+        /// <summary>Scales players' natural POSITIVE regen ticks (all three vitals). 1 = normal, 0 = no regen.
+        /// Never scales a negative (degen) tick — suppression must not become a shield.</summary>
+        public double? SuppressRegenMult { get; set; }
+
+        // ── Reserved for later slices (NOT applied yet) ──
+        public bool? SlowEnabled { get; set; }
+        public double? SlowPercent { get; set; }
+        public bool? CharmEnabled { get; set; }
+
+        // ── Effective reads (the defaults that used to be field initializers) ──
+        public bool EffectiveDotEnabled => DotEnabled == true;
+        public double EffectiveDotDamage => DotDamage ?? 0.0;
+        public bool EffectiveDotPercent => DotPercent == true;
+        public double EffectiveDotIntervalSeconds => DotIntervalSeconds ?? 5.0;
+        public int EffectiveDotDamageType => DotDamageType ?? 0x10;
+
+        public bool EffectiveSuppressEnabled => SuppressEnabled == true;
+        public bool EffectiveSuppressProdigal => SuppressProdigal ?? true;
+        public double EffectiveSuppressRegenMult => System.Math.Clamp(SuppressRegenMult ?? 1.0, 0.0, 1.0);
+
+        /// <summary>True if any effect is active — used to skip zones that author no effects during resolution.</summary>
+        public bool AnyActive => DotEnabled == true || SuppressEnabled == true || SlowEnabled == true || CharmEnabled == true;
+
+        /// <summary>True when nothing at all is authored at this layer.</summary>
+        public bool IsEmpty =>
+            DotEnabled == null && DotDamage == null && DotPercent == null && DotIntervalSeconds == null
+            && DotDamageType == null && SuppressEnabled == null && SuppressProdigal == null
+            && SuppressRegenMult == null && SlowEnabled == null && SlowPercent == null && CharmEnabled == null;
+
+        public ZoneEffects Clone() => new ZoneEffects
+        {
+            DotEnabled = DotEnabled, DotDamage = DotDamage, DotPercent = DotPercent,
+            DotIntervalSeconds = DotIntervalSeconds, DotDamageType = DotDamageType,
+            SuppressEnabled = SuppressEnabled, SuppressProdigal = SuppressProdigal,
+            SuppressRegenMult = SuppressRegenMult,
+            SlowEnabled = SlowEnabled, SlowPercent = SlowPercent, CharmEnabled = CharmEnabled,
+        };
+
+        /// <summary>Per-FIELD layered merge: any authored (non-null) field on <paramref name="upper"/> wins,
+        /// everything else falls through to <paramref name="lower"/>. Returns a new instance.</summary>
+        public static ZoneEffects Merge(ZoneEffects lower, ZoneEffects upper)
+        {
+            if (lower == null) return upper?.Clone() ?? new ZoneEffects();
+            if (upper == null) return lower.Clone();
+            return new ZoneEffects
+            {
+                DotEnabled = upper.DotEnabled ?? lower.DotEnabled,
+                DotDamage = upper.DotDamage ?? lower.DotDamage,
+                DotPercent = upper.DotPercent ?? lower.DotPercent,
+                DotIntervalSeconds = upper.DotIntervalSeconds ?? lower.DotIntervalSeconds,
+                DotDamageType = upper.DotDamageType ?? lower.DotDamageType,
+                SuppressEnabled = upper.SuppressEnabled ?? lower.SuppressEnabled,
+                SuppressProdigal = upper.SuppressProdigal ?? lower.SuppressProdigal,
+                SuppressRegenMult = upper.SuppressRegenMult ?? lower.SuppressRegenMult,
+                SlowEnabled = upper.SlowEnabled ?? lower.SlowEnabled,
+                SlowPercent = upper.SlowPercent ?? lower.SlowPercent,
+                CharmEnabled = upper.CharmEnabled ?? lower.CharmEnabled,
+            };
+        }
+    }
+}

--- a/Source/ACE.Server/Managers/ZoneControl/ZoneCraftGate.cs
+++ b/Source/ACE.Server/Managers/ZoneControl/ZoneCraftGate.cs
@@ -1,0 +1,463 @@
+using System;
+using System.Collections.Generic;
+
+using ACE.Database.Models.World;
+using ACE.Entity.Enum;
+using ACE.Entity.Enum.Properties;
+using ACE.Server.Factories;
+using ACE.Server.WorldObjects;
+
+namespace ACE.Server.Managers.ZoneControl
+{
+    /// <summary>
+    /// Decides whether a crafting recipe may be applied to a Tier 11+ item.
+    ///
+    /// THE RULE (owner 2026-08-24): *"a weaker imbue cant go on, but not imbued could"*. So this is
+    /// NOT a blanket refusal. A recipe is refused only when it would REPLACE a value the item already
+    /// carries with something equal or worse. An item that rolled nothing for that property can still
+    /// receive the imbue - that is a real upgrade the player earned, and blocking it would be a nerf
+    /// with nothing behind it.
+    ///
+    /// WHY IT IS NEEDED. Player crafting fights the T11+ ladder three ways:
+    ///  1. COMPETITION. Vanilla imbues do not stack with our cards, they compete via Math.Max
+    ///     (WorldObject_Weapon.cs:362 / :470). skill.Base is clamped to 400 melee / 360 missile+magic
+    ///     (GetBaseSkillImbued), so at cap Critical Strike is a FLAT 0.50 crit chance and Crippling
+    ///     Blow a FLAT 6.0 crit mod for every player - constants, not a curve.
+    ///  2. OVERWRITE. Custom 527870xxx recipes SetValue rather than add, so they replace a rolled
+    ///     value in BOTH directions - a jackpot drop can be tinkered DOWN to a constant.
+    ///  3. REPEATS. Several custom recipes have no target guard and can be applied repeatedly.
+    ///
+    /// This is LAYER 2 of the design in Craft_Gate_Plan_2026-08-24.md. LAYER 1 - the authorable
+    /// (item type x salvage material) matrix in <see cref="ZoneCraftGateStore"/> - now sits ABOVE it:
+    ///
+    ///   0. COMPONENTS a blocked SOURCE WCID                             -> refuse, stop
+    ///   1. MATRIX     explicit Allow / Deny for (item type x material)  -> obey it, stop
+    ///   2. DOWNGRADE  the rule below                                    -> unchanged
+    ///   3. DEFAULT    allow
+    ///
+    /// The matrix is SPARSE and every cell starts Auto, so an install that has authored nothing behaves
+    /// EXACTLY as the layer-2-only gate did: no rule can match, and every decision falls straight
+    /// through to the downgrade rule.
+    ///
+    /// LAYER 0 was added 2026-08-25 for a fourth failure mode the other two cannot see: a component whose
+    /// recipes ADD to a property instead of setting it. Layer 2 compares incoming against current and can
+    /// only ever refuse a value that is no better, so it is structurally incapable of refusing an Add;
+    /// layer 1 is indexed by the salvage's MaterialType, which these components do not declare. Layer 0
+    /// is therefore a flat list of source WCIDs plus one toggle - see
+    /// <see cref="ZoneCraftGateStore.DefaultBlockedComponents"/>.
+    /// </summary>
+    public static class ZoneCraftGate
+    {
+        /// <summary>What a competing imbue is worth, and which property it fights over.
+        ///
+        /// CAREFUL - the two comparisons do NOT share semantics:
+        ///  * CRIT CHANCE is compared raw. CriticalFrequency 0.70 vs Critical Strike 0.50.
+        ///  * CRIT DAMAGE is compared as a MOD, and the engine then adds one:
+        ///    CriticalDamageMod = 1.0f + GetWeaponCritDamageMod(...)  (DamageEvent.cs:418).
+        ///    Our Crushing Blow card stores (N - 1) for an N-times multiplier, so an 8x card stores
+        ///    7.0 and Crippling Blow's 6.0 is really 7.0x. Comparing a DISPLAYED multiplier against
+        ///    the raw imbue mod would be wrong by exactly one, and would wave through a 6x card being
+        ///    "upgraded" to a 7x imbue while reporting the card as stronger. Compare stored-to-stored.
+        ///
+        /// The SAME trap caught Rend Power (fixed 2026-08-24): property 9056 stores a vuln FRACTION
+        /// and the engine computes rendingMod = 1 + fraction (WorldObject_Weapon.cs:657), while the
+        /// imbue's own ceiling MaxRendingMod is 2.5 - a rendingMod, not a fraction. Comparing a stored
+        /// fraction against 2.50 was wrong by exactly one: a weapon storing 2.0 (rendingMod 3.0, far
+        /// stronger than the imbue) read as 2.0 >= 2.50 = false and was ALLOWED to take a weaker
+        /// imbue. The stored-value equivalent of the imbue's ceiling is 1.50.
+        ///
+        /// Armor Rending is NOT affected: both sides are a fraction of armour ignored, and the skill
+        /// formula bottoms out at armorRendingMod 0.4 = fraction 0.6 (DamageEvent.cs:468), so 0.60 is
+        /// already in stored units.
+        ///
+        /// Pairing verified 2026-08-24 - the names are confusable and they are easy to swap:
+        ///   Critical Strike (imbue)  &lt;-&gt; Biting Strike (card)   both CRIT CHANCE
+        ///   Crippling Blow  (imbue)  &lt;-&gt; Crushing Blow (card)   both CRIT DAMAGE</summary>
+        private readonly struct Competing
+        {
+            public readonly int PropertyId;
+            public readonly double CappedValue;
+            public readonly string Label;
+
+            public Competing(int propertyId, double cappedValue, string label)
+            {
+                PropertyId = propertyId;
+                CappedValue = cappedValue;
+                Label = label;
+            }
+        }
+
+        /// <summary>Imbue effect -&gt; what it competes with. Effects absent here fight over nothing this
+        /// system authors (the three defense imbues, Spellbook), so they are always allowed.</summary>
+        private static readonly Dictionary<ImbuedEffectType, Competing> ImbueCompetes = new()
+        {
+            [ImbuedEffectType.CriticalStrike] = new((int)PropertyFloat.CriticalFrequency, 0.50, "Critical Frequency"),
+            [ImbuedEffectType.CripplingBlow] = new((int)PropertyFloat.CriticalMultiplier, 6.00, "Critical Multiplier"),
+            [ImbuedEffectType.ArmorRending] = new(ZoneLootMutator.ArmorRendOverridePropId, 0.60, "Armor Rending"),
+            [ImbuedEffectType.SlashRending] = new(ZoneLootMutator.RendingModOverridePropId, 1.50, "Rend Power"),
+            [ImbuedEffectType.PierceRending] = new(ZoneLootMutator.RendingModOverridePropId, 1.50, "Rend Power"),
+            [ImbuedEffectType.BludgeonRending] = new(ZoneLootMutator.RendingModOverridePropId, 1.50, "Rend Power"),
+            [ImbuedEffectType.AcidRending] = new(ZoneLootMutator.RendingModOverridePropId, 1.50, "Rend Power"),
+            [ImbuedEffectType.ColdRending] = new(ZoneLootMutator.RendingModOverridePropId, 1.50, "Rend Power"),
+            [ImbuedEffectType.ElectricRending] = new(ZoneLootMutator.RendingModOverridePropId, 1.50, "Rend Power"),
+            [ImbuedEffectType.FireRending] = new(ZoneLootMutator.RendingModOverridePropId, 1.50, "Rend Power"),
+            [ImbuedEffectType.NetherRending] = new(ZoneLootMutator.RendingModOverridePropId, 1.50, "Rend Power"),
+        };
+
+        /// <summary>Which imbue a vanilla recipe applies. The recipe data does NOT say: recipe 3863
+        /// has two mod rows and zero int/float/bool stat mods. The effect comes from the mod's DataId.
+        ///
+        /// AUTHORITATIVE SOURCE = the mutation scripts in Source/ACE.Server/Entity/Mutations/Recipes/,
+        /// named by DataId ("3800002A - Black Heart.txt"). The C# switch in RecipeManager.TryMutateNative
+        /// looks authoritative but is DEAD: useMutateNative is a const false (RecipeManager.cs:1562), so
+        /// TryMutate always takes the script path. This table was first derived from that dead switch and
+        /// consequently missed NetherRending, which has no case there but does have a script. If a DataId
+        /// is ever in doubt, read the .txt - not the switch.</summary>
+        private static readonly Dictionary<uint, ImbuedEffectType> DataIdToImbue = new()
+        {
+            [0x38000023] = ImbuedEffectType.CriticalStrike,     // Black Opal
+            [0x38000024] = ImbuedEffectType.CripplingBlow,      // Fire Opal
+            [0x38000025] = ImbuedEffectType.ArmorRending,       // Sunstone
+            [0x3800003A] = ImbuedEffectType.AcidRending,        // Emerald
+            [0x3800003B] = ImbuedEffectType.BludgeonRending,    // White Sapphire
+            [0x3800003C] = ImbuedEffectType.ColdRending,        // Aquamarine
+            [0x3800003D] = ImbuedEffectType.ElectricRending,    // Jet
+            [0x3800003E] = ImbuedEffectType.FireRending,        // Red Garnet
+            [0x3800003F] = ImbuedEffectType.PierceRending,      // Black Garnet
+            [0x38000040] = ImbuedEffectType.SlashRending,       // Imperial Topaz
+            [0x3800002A] = ImbuedEffectType.NetherRending,      // Black Heart (recipe 300001)
+        };
+
+        /// <summary>Properties the T11+ loot pipeline authors, for the custom-recipe path. A recipe
+        /// writing one of these is compared value-for-value against what the item already carries.</summary>
+        private static readonly HashSet<int> OwnedInts = new()
+        {
+            (int)PropertyInt.Cleaving,
+            ZoneLootMutator.SplitArrowCountIntId,
+        };
+
+        /// <summary>Properties where ANY replacement is a loss, so there is no "is it bigger" question
+        /// to ask. SlayerCreatureType is the case: a slayer stone at 1.75 passes a &gt;= test against a
+        /// rolled 1.5x card and silently RETARGETS which creature type the weapon slays, which is not a
+        /// magnitude at all. Present and being replaced = refuse.</summary>
+        private static readonly HashSet<int> OwnedIdentity = new()
+        {
+            (int)PropertyInt.SlayerCreatureType,
+        };
+
+        private static readonly HashSet<int> OwnedFloats = new()
+        {
+            (int)PropertyFloat.CriticalFrequency,
+            (int)PropertyFloat.CriticalMultiplier,
+            (int)PropertyFloat.SlayerDamageBonus,
+            (int)PropertyFloat.IgnoreShield,
+            ZoneLootMutator.RendingModOverridePropId,
+            ZoneLootMutator.ArmorRendOverridePropId,
+            ZoneLootMutator.SplitArrowRangeFloatId,
+            ZoneLootMutator.SplitArrowDmgFloatId,
+        };
+
+        /// <summary>The item's tier, as max(ZcTier, WeaponAugScaleTier).
+        ///
+        /// BOTH are checked because either one alone has been the whole gate's off switch. Weapons used to
+        /// carry ONLY WeaponAugScaleTier - ApplyT11GearStats returned for them before any tier stamp ran -
+        /// and on 2026-08-25 exactly two items on the shard carried that property, so this read 0 and the
+        /// gate was silently off for every weapon. ApplyT11GearStats now stamps ZcTier on weapons too
+        /// (LootGenerationFactory_ZoneSet.cs, default case), which is what makes the tier test below
+        /// actually fire on a weapon. Keep taking the max of both: they are two independent signals for
+        /// one fact, and a weapon that misses one still gets a tier from the other.</summary>
+        public static int TierOf(WorldObject wo)
+        {
+            if (wo == null)
+                return 0;
+            var zc = wo.GetProperty(PropertyInt.ZcTier) ?? 0;
+            var wep = wo.GetProperty(PropertyInt.WeaponAugScaleTier) ?? 0;
+            return zc > wep ? zc : wep;
+        }
+
+        /// <summary>Back-compat overload for any caller that has no salvage object to hand. With no
+        /// source there is no material, so LAYER 1 cannot match and the decision is layer 2's alone.</summary>
+        public static bool IsBlocked(Recipe recipe, WorldObject target, out string reason)
+            => IsBlocked(recipe, null, target, out reason);
+
+        /// <summary>True when this recipe must not be applied to this target. <paramref name="reason"/>
+        /// is player-facing and always states WHAT it would have overwritten - an unexplained refusal
+        /// is indistinguishable from a bug.
+        ///
+        /// <paramref name="source"/> is the SALVAGE being applied; its MaterialType is the matrix row.
+        /// It is optional only so the old two-argument call site keeps compiling.</summary>
+        public static bool IsBlocked(Recipe recipe, WorldObject source, WorldObject target, out string reason)
+        {
+            reason = null;
+            if (recipe == null || target == null)
+                return false;
+
+            // Master switch OFF bypasses the WHOLE gate - matrix and downgrade rule alike.
+            if (!ZoneCraftGateStore.Enabled)
+                return false;
+
+            var tier = TierOf(target);
+            if (tier < ZoneCraftGateStore.MinTier)
+                return false;
+
+            // ── LAYER 0: blocked crafting components, matched by SOURCE WCID (owner 2026-08-25) ──
+            //
+            // Sits above the matrix because it names ONE specific item, where a matrix cell names a whole
+            // (material x class) square - the more specific statement wins, so an Allow cell cannot rescue
+            // a blocked component. (Moot for the two default entries, which carry no MaterialType and so
+            // can never match a cell at all, but the ordering has to mean something for anything added
+            // later that DOES have one.)
+            //
+            // NOT restricted to CraftItemClass.Weapon even though the owner's ask said "T11+ weapon". The
+            // blocked components' cook_book rows only ever target weapons, so narrowing it buys nothing,
+            // and it would add a hole: any weapon Classify failed to bucket would sail through. Blocking
+            // on tier alone has no such gap.
+            if (ZoneCraftGateStore.BlockComponents && source != null
+                && ZoneCraftGateStore.IsBlockedComponent(source.WeenieClassId))
+            {
+                reason = $"{ComponentLabel(source)} cannot be applied to a Tier {tier} item - its bonus "
+                       + "adds on top of what the item already rolled. Ordinary tinkering still works.";
+                return true;
+            }
+
+            // ── LAYER 1: the authored matrix. Sparse, so an un-authored install never enters here. ──
+            var matrix = ResolveMatrix(source, target, out var cls, out var material);
+            if (matrix == CraftRuleMode.Allow)
+                return false;                       // explicit Allow skips the downgrade rule entirely
+            if (matrix == CraftRuleMode.Deny)
+            {
+                reason = $"{ZoneCraftGateStore.MaterialName(material)} may not be applied to a Tier {tier} "
+                       + $"{cls.ToString().ToLowerInvariant()}.";
+                return true;
+            }
+
+            // ── the vanilla imbues, whose effect comes from the mod DataId ──
+            if (recipe.IsImbuing() && TryGetImbue(recipe, out var effect)
+                && ImbueCompetes.TryGetValue(effect, out var competing))
+            {
+                var current = target.GetProperty((PropertyFloat)competing.PropertyId);
+                if (current.HasValue && current.Value >= competing.CappedValue)
+                {
+                    reason = $"This Tier {tier} item already has a stronger {competing.Label} "
+                           + $"({Show(competing.PropertyId, current.Value)}) than this would give it "
+                           + $"({Show(competing.PropertyId, competing.CappedValue)}).";
+                    return true;
+                }
+                return false;   // nothing there, or ours is weaker - let the player have it
+            }
+
+            // ── custom recipes, which SetValue real properties ──
+            if (WouldDowngrade(recipe, target, out var what, out var have, out var incoming, out var propId))
+            {
+                reason = OwnedIdentity.Contains(propId)
+                    ? $"This Tier {tier} item already has a {what} set, and this would replace it."
+                    : $"This Tier {tier} item already has a stronger {what} "
+                      + $"({Show(propId, have)}) than this would give it ({Show(propId, incoming)}).";
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>LAYER 1 lookup. Returns Auto - "the matrix has no opinion, ask layer 2" - whenever
+        /// anything needed to index it is missing: no salvage object, salvage with no MaterialType, or a
+        /// target the matrix has no column for. That is the whole reason an un-authored install is
+        /// byte-for-byte the old behaviour.</summary>
+        /// <summary>What to CALL a blocked component in the layer-0 refusal message.
+        ///
+        /// PREFERS MaterialType OVER Name, and the reason is a real bug the owner hit 2026-08-26: the
+        /// dev command /cisalvage RENAMES the bag it creates to "Salvage (100)"
+        /// (AdminCommands.HandleCISalvage), so the refusal read "The Salvage (100) cannot be applied"
+        /// and did not say WHICH salvage was refused. A player-looted bag is named properly, but the
+        /// material is the more reliable source either way - it is the thing the block is actually
+        /// keyed against conceptually, and it cannot be renamed.
+        ///
+        /// Falls back to Name for components that declare no MaterialType at all. That is not a rare
+        /// edge: it is exactly the two DEFAULT entries, the Fine Bandit Blade Hilt and the Finely
+        /// Oiled Bowstring, whose only ints are ItemType and 25 (verified 2026-08-25) - which is also
+        /// why layer 1 can never index them.</summary>
+        private static string ComponentLabel(WorldObject source)
+        {
+            var material = source.GetProperty(PropertyInt.MaterialType) ?? 0;
+            if (material > 0)
+            {
+                var name = Enum.GetName(typeof(MaterialType), (uint)material);
+                if (!string.IsNullOrEmpty(name))
+                    return Spaced(name);
+            }
+            return source.Name;
+        }
+
+        /// <summary>"WhiteQuartz" -> "White Quartz". The MaterialType enum names are CamelCase and go
+        /// straight into player-facing chat, so they need splitting or they read as a code identifier.
+        /// ASCII only - game text must stay ASCII.</summary>
+        private static string Spaced(string camel)
+        {
+            var sb = new System.Text.StringBuilder(camel.Length + 4);
+            for (var i = 0; i < camel.Length; i++)
+            {
+                if (i > 0 && char.IsUpper(camel[i]) && !char.IsUpper(camel[i - 1]))
+                    sb.Append(' ');
+                sb.Append(camel[i]);
+            }
+            return sb.ToString();
+        }
+
+        private static CraftRuleMode ResolveMatrix(WorldObject source, WorldObject target,
+            out CraftItemClass cls, out int material)
+        {
+            cls = CraftItemClass.Weapon;
+            material = 0;
+
+            var mat = source?.MaterialType;
+            if (!mat.HasValue || mat.Value == MaterialType.Unknown)
+                return CraftRuleMode.Auto;
+
+            var c = ZoneCraftGateStore.Classify(target);
+            if (!c.HasValue)
+                return CraftRuleMode.Auto;
+
+            cls = c.Value;
+            material = (int)mat.Value;
+            return ZoneCraftGateStore.GetMode(material, cls);
+        }
+
+        /// <summary>Which imbue a stock mutation DataId applies, for callers outside the gate (the admin
+        /// verbs and the wire payload name the imbue a material carries). Same map the decision uses -
+        /// there is deliberately only one copy.</summary>
+        public static bool TryGetImbueForDataId(uint dataId, out ImbuedEffectType effect)
+            => DataIdToImbue.TryGetValue(dataId, out effect);
+
+        /// <summary>What layer 2 would compare a given imbue against, for the `craft test` verb: the
+        /// property it competes over and the capped value the imbue is worth. False when the effect
+        /// fights over nothing this system authors (the three defense imbues, Spellbook).</summary>
+        public static bool TryDescribeImbue(ImbuedEffectType effect, out int propertyId, out string label,
+            out double cappedValue, out string shown)
+        {
+            propertyId = 0; label = null; cappedValue = 0; shown = null;
+            if (!ImbueCompetes.TryGetValue(effect, out var c))
+                return false;
+            propertyId = c.PropertyId;
+            label = c.Label;
+            cappedValue = c.CappedValue;
+            shown = Show(c.PropertyId, c.CappedValue);
+            return true;
+        }
+
+        /// <summary>Render a STORED property value the way the player reads it on the item (crit damage
+        /// gains its +1, crit chance becomes a percentage). Public so the admin `craft test` verb reports
+        /// the same numbers the refusal message would.</summary>
+        public static string ShowStored(int propertyId, double stored) => Show(propertyId, stored);
+
+        /// <summary>Crit damage is stored as (multiplier - 1) because the engine computes 1 + mod, so
+        /// show it the way the player reads it on the item.</summary>
+        private static string Show(int propId, double stored)
+        {
+            if (propId == (int)PropertyFloat.CriticalMultiplier)
+                return $"{stored + 1.0:0.##}x";
+            if (propId == (int)PropertyFloat.CriticalFrequency)
+                return $"{stored * 100.0:0.#} pct";
+            return $"{stored:0.##}";
+        }
+
+        /// <summary>Which imbue this recipe applies, read from its mod DataIds.</summary>
+        private static bool TryGetImbue(Recipe recipe, out ImbuedEffectType effect)
+        {
+            effect = ImbuedEffectType.Undef;
+            if (recipe.RecipeMod == null)
+                return false;
+
+            foreach (var mod in recipe.RecipeMod)
+            {
+                if (mod == null || mod.DataId == 0)
+                    continue;
+                if (DataIdToImbue.TryGetValue((uint)mod.DataId, out effect))
+                    return true;
+            }
+            return false;
+        }
+
+        /// <summary>Would this recipe write an owned property with a value no better than the item's?
+        /// Only SetValue-style mods can downgrade; an additive mod cannot make an item worse.</summary>
+        private static bool WouldDowngrade(Recipe recipe, WorldObject target,
+            out string what, out double have, out double incoming, out int propId)
+        {
+            what = null; have = 0; incoming = 0; propId = 0;
+            if (recipe.RecipeMod == null)
+                return false;
+
+            foreach (var mod in recipe.RecipeMod)
+            {
+                if (mod == null)
+                    continue;
+
+                if (mod.RecipeModsFloat != null)
+                {
+                    foreach (var m in mod.RecipeModsFloat)
+                    {
+                        if (m == null || !OwnedFloats.Contains(m.Stat) || !IsReplacing(m.Enum))
+                            continue;
+                        var cur = target.GetProperty((PropertyFloat)m.Stat);
+                        if (cur.HasValue && cur.Value >= m.Value)
+                        {
+                            what = PropName(m.Stat); have = cur.Value; incoming = m.Value; propId = m.Stat;
+                            return true;
+                        }
+                    }
+                }
+
+                if (mod.RecipeModsInt != null)
+                {
+                    foreach (var m in mod.RecipeModsInt)
+                    {
+                        if (m == null || !IsReplacing(m.Enum))
+                            continue;
+
+                        // identity props: replacing at all is a loss, magnitude is meaningless
+                        if (OwnedIdentity.Contains(m.Stat) && target.GetProperty((PropertyInt)m.Stat).HasValue)
+                        {
+                            what = PropName(m.Stat); have = 0; incoming = 0; propId = m.Stat;
+                            return true;
+                        }
+
+                        if (!OwnedInts.Contains(m.Stat))
+                            continue;
+                        var cur = target.GetProperty((PropertyInt)m.Stat);
+                        if (cur.HasValue && cur.Value >= m.Value)
+                        {
+                            what = PropName(m.Stat); have = cur.Value; incoming = m.Value; propId = m.Stat;
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>Operations that REPLACE a value, and can therefore downgrade.
+        /// SetValue(1) is the obvious one. CopyFromSourceToTarget(3) also replaces - and writes the
+        /// source's value or 0 when absent, so it can wipe a property outright. Add(2), AddSpell(7)
+        /// and the bit ops cannot make an authored value worse, so they are left alone.
+        /// (ModificationOperation, ACE.Entity/Enum/ModificationOperation.cs.)</summary>
+        private static bool IsReplacing(int modEnum) =>
+            modEnum == (int)ACE.Entity.Enum.ModificationOperation.SetValue
+         || modEnum == (int)ACE.Entity.Enum.ModificationOperation.CopyFromSourceToTarget;
+
+        private static string PropName(int propId)
+        {
+            if (propId == (int)PropertyFloat.CriticalFrequency) return "Critical Frequency";
+            if (propId == (int)PropertyFloat.CriticalMultiplier) return "Critical Multiplier";
+            if (propId == (int)PropertyFloat.SlayerDamageBonus) return "Slayer bonus";
+            if (propId == (int)PropertyFloat.IgnoreShield) return "Shield Cleaving";
+            if (propId == ZoneLootMutator.RendingModOverridePropId) return "Rend Power";
+            if (propId == ZoneLootMutator.ArmorRendOverridePropId) return "Armor Rending";
+            if (propId == (int)PropertyInt.Cleaving) return "Cleaving";
+            if (propId == ZoneLootMutator.SplitArrowCountIntId) return "Split Arrow count";
+            if (propId == ZoneLootMutator.SplitArrowRangeFloatId) return "Split Arrow range";
+            if (propId == ZoneLootMutator.SplitArrowDmgFloatId) return "Split Arrow damage";
+            if (propId == (int)PropertyInt.SlayerCreatureType) return "Slayer target";
+            return "property " + propId;
+        }
+    }
+}

--- a/Source/ACE.Server/Managers/ZoneControl/ZoneCraftGateStore.cs
+++ b/Source/ACE.Server/Managers/ZoneControl/ZoneCraftGateStore.cs
@@ -448,6 +448,11 @@ namespace ACE.Server.Managers.ZoneControl
         public static void SetMinTier(int tier)
         {
             EnsureInitialized();
+            if (tier < 1)
+            {
+                log.Warn($"ZoneCraftGateStore.SetMinTier({tier}) ignored: the tier must be 1 or more (Load rejects less).");
+                return;
+            }
             lock (_lock) { _minTier = tier; Save(); }
         }
 
@@ -637,6 +642,7 @@ namespace ACE.Server.Managers.ZoneControl
                     }
                     rows.Add(new ImbueMaterial(g.Key, MaterialName(g.Key), effect));
                 }
+                _catalog = rows;   // cache only a successful read; a transient DB failure must not pin an empty catalog
             }
             catch (Exception ex)
             {
@@ -644,7 +650,6 @@ namespace ACE.Server.Managers.ZoneControl
                 rows.Clear();
             }
 
-            _catalog = rows;
             return rows;
         }
 

--- a/Source/ACE.Server/Managers/ZoneControl/ZoneCraftGateStore.cs
+++ b/Source/ACE.Server/Managers/ZoneControl/ZoneCraftGateStore.cs
@@ -1,0 +1,653 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+
+using log4net;
+using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
+
+using ACE.Database;
+using ACE.Database.Models.Shard;
+using ACE.Database.Models.World;
+using ACE.Entity.Enum;
+using ACE.Server.Factories;
+using ACE.Server.WorldObjects;
+
+namespace ACE.Server.Managers.ZoneControl
+{
+    /// <summary>Which matrix COLUMN a target item sits in. The owner has ruled that jewelry, trinkets
+    /// and cloaks all read as "Armor" in the plugin UI, but they stay SEPARATE here so a rule can still
+    /// single one of them out - collapsing them at the data layer would make that impossible to author
+    /// later without a store migration.</summary>
+    public enum CraftItemClass
+    {
+        Weapon = 0,
+        Armor = 1,
+        Shield = 2,
+        Jewelry = 3,
+        Cloak = 4,
+    }
+
+    /// <summary>A matrix cell. <see cref="Auto"/> is the default and is NEVER stored - it means "no
+    /// opinion, fall through to the downgrade rule" (layer 2).</summary>
+    public enum CraftRuleMode
+    {
+        Auto = 0,
+        Allow = 1,
+        Deny = 2,
+    }
+
+    /// <summary>One authored cell: (material x item class) -> Allow / Deny. Persisted shape; the wire
+    /// and the JSON both use the NAMES, never the ordinals, so reordering either enum is safe.</summary>
+    public class CraftRule
+    {
+        /// <summary>PropertyInt.MaterialType (131) of the SALVAGE item.</summary>
+        public int Material { get; set; }
+        public string ItemType { get; set; }
+        public string Mode { get; set; }
+    }
+
+    /// <summary>
+    /// LAYER 1 of the T11+ crafting gate (Craft_Gate_Plan_2026-08-24.md): the authorable
+    /// (item type x salvage material) matrix that sits ABOVE the downgrade rule in
+    /// <see cref="ZoneCraftGate"/>. It also holds LAYER 0, the blocked-component list.
+    ///
+    ///   0. COMPONENTS explicit source-WCID block -> refuse, stop
+    ///   1. MATRIX     explicit Allow / Deny      -> obey it, stop
+    ///   2. DOWNGRADE  layer 2, unchanged         -> "a weaker imbue cant go on, but not imbued could"
+    ///   3. DEFAULT    allow
+    ///
+    /// The matrix is SPARSE: only non-Auto cells are stored, so an untouched install persists `{}` and
+    /// behaves exactly as the deployed layer-2-only gate does.
+    ///
+    /// PERSISTENCE follows <see cref="ZoneControlManager"/> exactly - one JSON blob in
+    /// ace_shard.config_properties_string, and <see cref="Load"/> builds into LOCALS and commits only
+    /// after the read and the parse have both succeeded. That ordering is not cosmetic: the zone store
+    /// was fixed on 2026-08-23 because clearing the live collections before the read meant a DB blip
+    /// emptied memory, and the next edit then wrote that empty store straight over the real one.
+    /// </summary>
+    public static class ZoneCraftGateStore
+    {
+        private static readonly ILog log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+
+        private const string StoreKey = "craftgate_data";
+
+        /// <summary>The matrix column order the wire publishes, and the order `craft list` prints.
+        /// APPEND-ONLY - the plugin renders columns from this list by NAME.</summary>
+        public static readonly CraftItemClass[] Columns =
+        {
+            CraftItemClass.Weapon,
+            CraftItemClass.Armor,
+            CraftItemClass.Shield,
+            CraftItemClass.Jewelry,
+            CraftItemClass.Cloak,
+        };
+
+        /// <summary>The crafting components blocked at MinTier+ out of the box (owner 2026-08-25):
+        ///
+        ///   719220045  Fine Bandit Blade Hilt   Add +0.175 CriticalMultiplier, Add +0.25 CriticalFrequency
+        ///   719220085  Finely Oiled Bowstring   Add +1.15  CriticalMultiplier, Add +0.25 CriticalFrequency
+        ///
+        /// WHY THESE NEED A LAYER OF THEIR OWN. Both write with ModificationOperation.Add, and layer 2 is
+        /// a DOWNGRADE rule - it can never refuse an Add, because an Add always increases. Layer 1 is
+        /// keyed by the salvage's MaterialType and NEITHER driver declares one (verified 2026-08-25: the
+        /// only ints on both weenies are ItemType 128 and 25), so the matrix cannot index them either.
+        /// Without layer 0 nothing in the gate reaches them and the bonuses stack, unbounded, on gear the
+        /// T11+ loot pipeline already finished.
+        ///
+        /// Stored and matched by SOURCE WCID, never by recipe id. The hilt drives EIGHT recipes
+        /// (527870063-67, 527870095-97) and the bowstring THREE (527870116-118) - only 527870063,
+        /// 527870096 and 527870118 write crit, but listing recipe ids would mean an eleven-row table that
+        /// a ninth hilt recipe walks straight past. One WCID closes every current and future recipe the
+        /// component feeds.</summary>
+        public static readonly uint[] DefaultBlockedComponents = { 719220045u, 719220085u };
+
+        /// <summary>One candidate for layer 0: a source WCID and the GROUP the plugin files it under.
+        ///
+        /// WHY A CATALOG EXISTS AT ALL. The store records only what IS blocked - an ALLOWED component is
+        /// simply absent from <see cref="Store.Components"/>. That is fine for the gate, which only ever
+        /// asks "is this one blocked?", but it means the plugin has nothing to draw an UNCHECKED row
+        /// from. The toggle UI needs the CANDIDATES, not just the current answer.
+        ///
+        /// WHY ONLY (Wcid, Group) AND NO DISPLAY TEXT. This table is published on the [[ZCCG]] wire,
+        /// which is ONE unchunked chat line (ZoneControlCommands.BuildCraftGatePayload -> Msg). The 49
+        /// names alone measure 907 characters and a prose description per row would add ~4.7 KB to that
+        /// single line. So the wire carries wcid~group (~1 KB) and the PLUGIN owns the display name and
+        /// the one-line explanation, compiled in - the same split the cantrip catalog already uses.
+        ///
+        /// The DB names could not have served anyway, which is the other half of the reason: TWELVE of
+        /// these weenies are named exactly "Foolproof" and three more are named "Salvage" (measured
+        /// 2026-08-26). A UI built on wire names would show twelve identical rows.
+        ///
+        /// GROUPING IS EDITORIAL, not derived. It cuts across data_Id, ItemType and recipe id in ways no
+        /// query reproduces, so it is authored here. A wrong auto-group is worse than no group.</summary>
+        public readonly struct ComponentCatalogEntry
+        {
+            public readonly uint Wcid;
+            public readonly string Group;
+            public ComponentCatalogEntry(uint wcid, string group) { Wcid = wcid; Group = group; }
+        }
+
+        /// <summary>Every component the owner has decided is a layer-0 CANDIDATE, with its group.
+        ///
+        /// This is NOT the blocked set - it is the menu. Membership in the blocked set is
+        /// <see cref="Store.Components"/>, published separately as `components=`. A WCID can be blocked
+        /// without being here (someone typed `craft components add`), and the plugin MUST still render
+        /// it - under "Other" - or the block would be invisible in the UI.
+        ///
+        /// Source: Component_Block_WCIDs_2026-08-25.md, applied 2026-08-26 as the 47-WCID list plus the
+        /// two entries in <see cref="DefaultBlockedComponents"/>.</summary>
+        public static readonly ComponentCatalogEntry[] ComponentCatalog =
+        {
+            // The two originals: crit bonuses written with ModificationOperation.Add, which layer 2 is
+            // structurally incapable of refusing and layer 1 cannot index (they declare no MaterialType).
+            new ComponentCatalogEntry(719220045u, "Default"),      // Fine Bandit Blade Hilt
+            new ComponentCatalogEntry(719220085u, "Default"),      // Finely Oiled Bowstring
+
+            // Elemental rends: 7 elements x 4 drivers (Salvaged, 100-bag, Foolproof, alt-Foolproof).
+            new ComponentCatalogEntry(21086u, "Rend"), new ComponentCatalogEntry(30260u, "Rend"),
+            new ComponentCatalogEntry(30104u, "Rend"), new ComponentCatalogEntry(36628u, "Rend"),
+            new ComponentCatalogEntry(21054u, "Rend"), new ComponentCatalogEntry(29577u, "Rend"),
+            new ComponentCatalogEntry(30099u, "Rend"), new ComponentCatalogEntry(36624u, "Rend"),
+            new ComponentCatalogEntry(21048u, "Rend"), new ComponentCatalogEntry(29574u, "Rend"),
+            new ComponentCatalogEntry(30097u, "Rend"), new ComponentCatalogEntry(36622u, "Rend"),
+            new ComponentCatalogEntry(21037u, "Rend"), new ComponentCatalogEntry(29571u, "Rend"),
+            new ComponentCatalogEntry(30094u, "Rend"), new ComponentCatalogEntry(36619u, "Rend"),
+            new ComponentCatalogEntry(21069u, "Rend"), new ComponentCatalogEntry(29580u, "Rend"),
+            new ComponentCatalogEntry(30102u, "Rend"), new ComponentCatalogEntry(36626u, "Rend"),
+            new ComponentCatalogEntry(21039u, "Rend"), new ComponentCatalogEntry(29572u, "Rend"),
+            new ComponentCatalogEntry(30095u, "Rend"), new ComponentCatalogEntry(36620u, "Rend"),
+            new ComponentCatalogEntry(21056u, "Rend"), new ComponentCatalogEntry(29578u, "Rend"),
+            new ComponentCatalogEntry(30100u, "Rend"), new ComponentCatalogEntry(36625u, "Rend"),
+
+            // Armor Rending - the Sunstone family. Fraction of the target's armour IGNORED.
+            new ComponentCatalogEntry(21079u, "ArmorRend"),
+            new ComponentCatalogEntry(30103u, "ArmorRend"),
+            new ComponentCatalogEntry(36627u, "ArmorRend"),
+
+            // The one imbue recipe shard-wide with NO requirement of any kind - it can overwrite freely.
+            new ComponentCatalogEntry(3110315u, "Combo"),          // Vial of Armor Rend
+
+            new ComponentCatalogEntry(21064u, "Nether"), new ComponentCatalogEntry(60000u, "Nether"),
+            new ComponentCatalogEntry(300011u, "Nether"), new ComponentCatalogEntry(64454645u, "Nether"),
+
+            // ILT proc converters: each writes a rend AND ProcSpell AND ResistanceModifier +2 as an ADD.
+            new ComponentCatalogEntry(527870013u, "Inscription"), new ComponentCatalogEntry(527870019u, "Inscription"),
+            new ComponentCatalogEntry(527870020u, "Inscription"), new ComponentCatalogEntry(527870021u, "Inscription"),
+            new ComponentCatalogEntry(527870022u, "Inscription"), new ComponentCatalogEntry(527870023u, "Inscription"),
+            new ComponentCatalogEntry(527870024u, "Inscription"), new ComponentCatalogEntry(527870031u, "Inscription"),
+
+            // Split arrows - both write SplitArrowCount +1 as an ADD, repeatable to 10.
+            new ComponentCatalogEntry(21085u, "Split"),            // Salvaged White Quartz (also Cleaving)
+            new ComponentCatalogEntry(21081u, "Split"),            // Salvaged Tiger Eye
+
+            new ComponentCatalogEntry(227190065u, "GemBag"),       // Bag of Abyssal-Touched Gems
+        };
+
+        /// <summary>The catalog, for the wire. Deliberately NOT filtered against the blocked set - the
+        /// plugin needs every candidate so it can draw the unticked rows.</summary>
+        public static IEnumerable<ComponentCatalogEntry> ComponentCatalogRows() => ComponentCatalog;
+
+        private class Store
+        {
+            /// <summary>Master switch. False bypasses the WHOLE gate (layer 2 included), so the gate can
+            /// be turned off without clearing authored rules.</summary>
+            [DefaultValue(true)]
+            public bool Enabled { get; set; } = true;
+
+            /// <summary>The tier at which the gate starts applying. Replaces the hardcoded
+            /// LootGenerationFactory.ZoneLootSetMinTier comparison; 11 is still the default.</summary>
+            [DefaultValue(LootGenerationFactory.ZoneLootSetMinTier)]
+            public int MinTier { get; set; } = LootGenerationFactory.ZoneLootSetMinTier;
+
+            /// <summary>Non-Auto cells only. Null (not []) when empty, so an untouched store is `{}`.</summary>
+            public List<CraftRule> Rules { get; set; }
+
+            /// <summary>LAYER 0's toggle. Defaults ON: the owner asked for these components to be
+            /// blocked, so the requested behaviour has to be what a fresh store does - a default of OFF
+            /// would mean the block only exists once somebody remembers to type a verb. Flipping it off
+            /// is one command and needs no rebuild, which is the whole point of it being a toggle.</summary>
+            [DefaultValue(true)]
+            public bool BlockComponents { get; set; } = true;
+
+            /// <summary>The blocked source WCIDs. NULL means "never authored - use
+            /// <see cref="DefaultBlockedComponents"/>"; a non-null list (INCLUDING an empty one) is the
+            /// owner's own list and is used verbatim. That distinction is why this is not a hardcode:
+            /// clearing the list to [] really does block nothing, and it survives a restart.</summary>
+            public List<uint> Components { get; set; }
+        }
+
+        /// <summary>Serializer settings that make the sparse store actually sparse: a store at every
+        /// default serializes to `{}`.</summary>
+        private static readonly JsonSerializerSettings SparseJson = new JsonSerializerSettings
+        {
+            NullValueHandling = NullValueHandling.Ignore,
+            DefaultValueHandling = DefaultValueHandling.Ignore,
+        };
+
+        private static readonly object _lock = new object();
+        private static volatile bool _initialized;
+
+        // ── lock-free read snapshot ──
+        // IsBlocked runs on the crafting path; it reads these volatiles with no lock. Mutations rebuild
+        // a fresh dictionary under _lock and swap it in, so a reader sees the old map or the new one,
+        // never a half-written one.
+        private static volatile Dictionary<(int Material, CraftItemClass Class), CraftRuleMode> _rules
+            = new Dictionary<(int, CraftItemClass), CraftRuleMode>();
+        private static volatile bool _enabled = true;
+        private static volatile int _minTier = LootGenerationFactory.ZoneLootSetMinTier;
+
+        // Layer 0. _components is always the EFFECTIVE set (the built-in default until the owner edits
+        // it); _componentsAuthored only decides whether Save writes the list or writes null, so a store
+        // that has never been touched stays `{}` and keeps tracking the default if it ever changes.
+        private static volatile bool _blockComponents = true;
+        private static volatile HashSet<uint> _components = new HashSet<uint>(DefaultBlockedComponents);
+        private static volatile bool _componentsAuthored;
+
+        #region init / persistence
+
+        public static void EnsureLoaded() => EnsureInitialized();
+
+        private static void EnsureInitialized()
+        {
+            if (_initialized)
+                return;
+
+            lock (_lock)
+            {
+                if (_initialized)
+                    return;
+
+                // Load() is atomic (build-then-commit): a failure leaves whatever was already loaded
+                // untouched, which on first init is the safe all-Auto default.
+                try { Load(); }
+                catch (Exception ex) { log.Error($"ZoneCraftGateStore: failed to load {StoreKey}; keeping the current matrix ({_rules.Count} rule(s)). {ex}"); }
+
+                _initialized = true;
+            }
+        }
+
+        /// <summary>Re-read the store from the shard. Same atomic build-then-commit as
+        /// ZoneControlManager.Load - nothing live is disturbed until the parse has succeeded.</summary>
+        public static void Reload()
+        {
+            lock (_lock)
+            {
+                Load();
+                _initialized = true;
+            }
+        }
+
+        private static void Load()
+        {
+            string json = null;
+            if (DatabaseManager.ShardConfig.StringExists(StoreKey))
+                json = DatabaseManager.ShardConfig.GetString(StoreKey)?.Value;
+
+            var store = string.IsNullOrWhiteSpace(json)
+                ? new Store()
+                : (JsonConvert.DeserializeObject<Store>(json) ?? new Store());
+
+            // ── build into locals; nothing live is disturbed if any of this throws ──
+            var rules = new Dictionary<(int, CraftItemClass), CraftRuleMode>();
+            if (store.Rules != null)
+            {
+                foreach (var r in store.Rules)
+                {
+                    if (r == null) continue;
+                    if (!Enum.TryParse<CraftItemClass>(r.ItemType, true, out var cls)) continue;
+                    if (!Enum.TryParse<CraftRuleMode>(r.Mode, true, out var mode)) continue;
+                    if (mode == CraftRuleMode.Auto) continue;   // sparse: Auto is never stored
+                    rules[(r.Material, cls)] = mode;
+                }
+            }
+            var minTier = store.MinTier > 0 ? store.MinTier : LootGenerationFactory.ZoneLootSetMinTier;
+
+            // Null = never authored, so track the built-in default. An authored EMPTY list is honoured as
+            // an empty list - "block nothing" has to be expressible, or the toggle is the only off switch.
+            var componentsAuthored = store.Components != null;
+            var components = new HashSet<uint>();
+            foreach (var c in store.Components ?? new List<uint>(DefaultBlockedComponents))
+                if (c != 0) components.Add(c);
+
+            // ── commit: from here on nothing can throw ──
+            _rules = rules;
+            _enabled = store.Enabled;
+            _minTier = minTier;
+            _blockComponents = store.BlockComponents;
+            _components = components;
+            _componentsAuthored = componentsAuthored;
+        }
+
+        private static void Save()
+        {
+            var list = _rules.Count == 0
+                ? null
+                : _rules.OrderBy(kv => kv.Key.Material).ThenBy(kv => (int)kv.Key.Class)
+                        .Select(kv => new CraftRule
+                        {
+                            Material = kv.Key.Material,
+                            ItemType = kv.Key.Class.ToString(),
+                            Mode = kv.Value.ToString(),
+                        }).ToList();
+
+            var store = new Store
+            {
+                Enabled = _enabled,
+                MinTier = _minTier,
+                Rules = list,
+                BlockComponents = _blockComponents,
+                // null when untouched, so an install that never edited the list keeps following the
+                // default pair rather than freezing today's copy of it into the shard.
+                Components = _componentsAuthored ? _components.OrderBy(w => w).ToList() : null,
+            };
+            var jsonOut = JsonConvert.SerializeObject(store, SparseJson);
+
+            if (DatabaseManager.ShardConfig.StringExists(StoreKey))
+                DatabaseManager.ShardConfig.SaveString(new ConfigPropertiesString { Key = StoreKey, Value = jsonOut, Description = "T11+ crafting gate matrix (JSON)" });
+            else
+                DatabaseManager.ShardConfig.AddString(StoreKey, jsonOut, "T11+ crafting gate matrix (JSON)");
+        }
+
+        #endregion
+
+        #region read
+
+        /// <summary>Master switch. False = the whole gate is bypassed, layer 2 included.</summary>
+        public static bool Enabled
+        {
+            get { EnsureInitialized(); return _enabled; }
+        }
+
+        /// <summary>The tier the gate starts applying at (default 11).</summary>
+        public static int MinTier
+        {
+            get { EnsureInitialized(); return _minTier; }
+        }
+
+        /// <summary>The authored cell for (material, item class), or Auto when nothing is authored.</summary>
+        public static CraftRuleMode GetMode(int material, CraftItemClass cls)
+        {
+            EnsureInitialized();
+            return _rules.TryGetValue((material, cls), out var m) ? m : CraftRuleMode.Auto;
+        }
+
+        /// <summary>Every authored (non-Auto) cell, in a stable order.</summary>
+        public static List<(int Material, CraftItemClass Class, CraftRuleMode Mode)> ListRules()
+        {
+            EnsureInitialized();
+            return _rules.OrderBy(kv => kv.Key.Material).ThenBy(kv => (int)kv.Key.Class)
+                         .Select(kv => (kv.Key.Material, kv.Key.Class, kv.Value)).ToList();
+        }
+
+        public static int RuleCount { get { EnsureInitialized(); return _rules.Count; } }
+
+        /// <summary>LAYER 0's toggle. False leaves the blocked list intact but stops consulting it, so the
+        /// owner can turn the block off for an evening without losing what was authored.</summary>
+        public static bool BlockComponents
+        {
+            get { EnsureInitialized(); return _blockComponents; }
+        }
+
+        /// <summary>Is this SALVAGE weenie on the blocked list? Membership only - the caller applies the
+        /// toggle, so `craft components` can still show the list while the block is off.</summary>
+        public static bool IsBlockedComponent(uint wcid)
+        {
+            EnsureInitialized();
+            return _components.Contains(wcid);
+        }
+
+        /// <summary>The blocked source WCIDs, ascending.</summary>
+        public static List<uint> BlockedComponents()
+        {
+            EnsureInitialized();
+            return _components.OrderBy(w => w).ToList();
+        }
+
+        /// <summary>True while the list is still the built-in default (nothing added or removed). Only
+        /// used to say so in the verb output and on the wire - the decision never branches on it.</summary>
+        public static bool ComponentsAreDefault { get { EnsureInitialized(); return !_componentsAuthored; } }
+
+        #endregion
+
+        #region write
+
+        /// <summary>Author one cell. Auto REMOVES the row (the matrix stays sparse). Returns false when
+        /// nothing changed, so a caller can say so instead of writing the shard for no reason.</summary>
+        public static bool SetMode(int material, CraftItemClass cls, CraftRuleMode mode)
+        {
+            EnsureInitialized();
+            lock (_lock)
+            {
+                var next = new Dictionary<(int, CraftItemClass), CraftRuleMode>(_rules);
+                var had = next.TryGetValue((material, cls), out var cur);
+                if (mode == CraftRuleMode.Auto)
+                {
+                    if (!had) return false;
+                    next.Remove((material, cls));
+                }
+                else
+                {
+                    if (had && cur == mode) return false;
+                    next[(material, cls)] = mode;
+                }
+                _rules = next;
+                Save();
+                return true;
+            }
+        }
+
+        public static void SetEnabled(bool on)
+        {
+            EnsureInitialized();
+            lock (_lock) { _enabled = on; Save(); }
+        }
+
+        public static void SetMinTier(int tier)
+        {
+            EnsureInitialized();
+            lock (_lock) { _minTier = tier; Save(); }
+        }
+
+        public static void SetBlockComponents(bool on)
+        {
+            EnsureInitialized();
+            lock (_lock) { _blockComponents = on; Save(); }
+        }
+
+        /// <summary>Add one source WCID to the blocked list. Any edit marks the list AUTHORED, so it stops
+        /// tracking the built-in default from that moment on - `components reset` is the way back.
+        /// Returns false when nothing changed, so the caller can say so instead of writing the shard.</summary>
+        public static bool AddComponent(uint wcid)
+        {
+            EnsureInitialized();
+            lock (_lock)
+            {
+                if (_components.Contains(wcid))
+                    return false;
+                var next = new HashSet<uint>(_components) { wcid };
+                _components = next;
+                _componentsAuthored = true;
+                Save();
+                return true;
+            }
+        }
+
+        public static bool RemoveComponent(uint wcid)
+        {
+            EnsureInitialized();
+            lock (_lock)
+            {
+                if (!_components.Contains(wcid))
+                    return false;
+                var next = new HashSet<uint>(_components);
+                next.Remove(wcid);
+                _components = next;
+                _componentsAuthored = true;
+                Save();
+                return true;
+            }
+        }
+
+        /// <summary>Forget the authored list and follow <see cref="DefaultBlockedComponents"/> again.</summary>
+        public static void ResetComponents()
+        {
+            EnsureInitialized();
+            lock (_lock)
+            {
+                _components = new HashSet<uint>(DefaultBlockedComponents);
+                _componentsAuthored = false;
+                Save();
+            }
+        }
+
+        #endregion
+
+        #region item classification
+
+        /// <summary>Which matrix column this target sits in, or null when the item is not something the
+        /// matrix has a column for (a container, a component, a gem) - such a target skips layer 1 and
+        /// falls through to the downgrade rule exactly as before.
+        ///
+        /// ORDER MATTERS. Cloak is tested before Jewelry and before the armour-level test because a
+        /// cloak carries an ArmorLevel and EquipMask.Jewelry includes EquipMask.Cloak; shields are
+        /// tested before armour for the same reason. This mirrors GetZoneLootDisplayOrder
+        /// (LootGenerationFactory_ZoneSet.cs), which is the classification the loot pipeline already
+        /// uses, so a piece lands in the same bucket on both sides.</summary>
+        public static CraftItemClass? Classify(WorldObject wo)
+        {
+            if (wo == null)
+                return null;
+
+            if (wo is MeleeWeapon || wo is MissileLauncher || wo is Missile || wo is Caster)
+                return CraftItemClass.Weapon;
+
+            if (wo.IsShield)
+                return CraftItemClass.Shield;
+
+            if (ACE.Server.Entity.Cloak.IsCloak(wo))
+                return CraftItemClass.Cloak;
+
+            if (wo.ItemType == ItemType.Jewelry)
+                return CraftItemClass.Jewelry;
+
+            if ((wo.ArmorLevel ?? 0) > 0 || wo is Clothing)
+                return CraftItemClass.Armor;
+
+            return null;
+        }
+
+        #endregion
+
+        #region material naming + catalog
+
+        /// <summary>Parse a material given by NAME (BlackOpal, "black opal", black_opal) or by numeric
+        /// MaterialType id. Name is the owner-facing form; the id is what the store and the wire carry.</summary>
+        public static bool TryParseMaterial(string s, out int material)
+        {
+            material = 0;
+            if (string.IsNullOrWhiteSpace(s))
+                return false;
+
+            var t = s.Trim();
+            if (int.TryParse(t, out var num) && num > 0 && Enum.IsDefined(typeof(MaterialType), (uint)num))
+            {
+                material = num;
+                return true;
+            }
+
+            var squashed = t.Replace(" ", "").Replace("_", "").Replace("-", "");
+            if (Enum.TryParse<MaterialType>(squashed, true, out var mt) && mt != MaterialType.Unknown)
+            {
+                material = (int)mt;
+                return true;
+            }
+            return false;
+        }
+
+        public static string MaterialName(int material)
+        {
+            var name = Enum.GetName(typeof(MaterialType), (uint)material);
+            return string.IsNullOrEmpty(name) ? "Material " + material : name;
+        }
+
+        /// <summary>One row of the material catalog the plugin renders as matrix rows: the salvage
+        /// material, its name, and (when it is a stock salvage whose recipe carries a mapped mutation
+        /// DataId) the imbue it applies.</summary>
+        public readonly struct ImbueMaterial
+        {
+            public readonly int Material;
+            public readonly string Name;
+            public readonly ImbuedEffectType Effect;
+
+            public ImbueMaterial(int material, string name, ImbuedEffectType effect)
+            {
+                Material = material; Name = name; Effect = effect;
+            }
+        }
+
+        private static volatile List<ImbueMaterial> _catalog;
+
+        /// <summary>The materials that carry an imbue (salvage_Type 2) recipe - 33 of the 78 MaterialType
+        /// values as of 2026-08-24. Read once from the world DB and cached: this is static content, and
+        /// the only callers are the admin verbs and the wire payload.
+        ///
+        /// Query equivalent:
+        ///   SELECT DISTINCT wi.value FROM cook_book cb JOIN recipe r ON r.id=cb.recipe_Id
+        ///   JOIN weenie_properties_int wi ON wi.object_Id=cb.source_W_C_I_D AND wi.type=131
+        ///   WHERE r.salvage_Type=2
+        ///
+        /// A DB failure returns an EMPTY list rather than throwing - the matrix does not depend on this,
+        /// it is a naming convenience for the UI, and a craft decision must never fail on it.</summary>
+        public static List<ImbueMaterial> ImbueMaterials()
+        {
+            var cached = _catalog;
+            if (cached != null)
+                return cached;
+
+            var rows = new List<ImbueMaterial>();
+            try
+            {
+                using var ctx = new WorldDbContext();
+
+                // material id -> the mutation DataIds of every salvage_Type 2 recipe that salvage feeds
+                var pairs = ctx.CookBook
+                    .Join(ctx.Recipe.Where(r => r.SalvageType == 2), cb => cb.RecipeId, r => r.Id,
+                          (cb, r) => new { cb.SourceWCID, r.Id })
+                    .Join(ctx.WeeniePropertiesInt.Where(wi => wi.Type == (ushort)ACE.Entity.Enum.Properties.PropertyInt.MaterialType),
+                          x => x.SourceWCID, wi => wi.ObjectId, (x, wi) => new { Material = wi.Value, RecipeId = x.Id })
+                    .Distinct().AsNoTracking().ToList();
+
+                var recipeIds = pairs.Select(p => p.RecipeId).Distinct().ToList();
+                var dataIds = ctx.RecipeMod.Where(m => recipeIds.Contains(m.RecipeId) && m.DataId != 0)
+                    .Select(m => new { m.RecipeId, m.DataId }).AsNoTracking().ToList()
+                    .GroupBy(m => m.RecipeId).ToDictionary(g => g.Key, g => g.Select(m => (uint)m.DataId).ToList());
+
+                foreach (var g in pairs.GroupBy(p => p.Material).OrderBy(g => g.Key))
+                {
+                    var effect = ImbuedEffectType.Undef;
+                    foreach (var rid in g.Select(p => p.RecipeId))
+                    {
+                        if (!dataIds.TryGetValue(rid, out var dids)) continue;
+                        foreach (var did in dids)
+                            if (ZoneCraftGate.TryGetImbueForDataId(did, out var e)) { effect = e; break; }
+                        if (effect != ImbuedEffectType.Undef) break;
+                    }
+                    rows.Add(new ImbueMaterial(g.Key, MaterialName(g.Key), effect));
+                }
+            }
+            catch (Exception ex)
+            {
+                log.Warn($"ZoneCraftGateStore: could not read the imbue material catalog; the matrix is unaffected. {ex.Message}");
+                rows.Clear();
+            }
+
+            _catalog = rows;
+            return rows;
+        }
+
+        #endregion
+    }
+}

--- a/Source/ACE.Server/Managers/ZoneControl/ZoneEffectManager.cs
+++ b/Source/ACE.Server/Managers/ZoneControl/ZoneEffectManager.cs
@@ -27,6 +27,9 @@ namespace ACE.Server.Managers.ZoneControl
         /// <summary>Floor on the authored interval so a misconfigured 0 can't hammer every frame.</summary>
         private const double MinIntervalSeconds = 1.0;
 
+        /// <summary>Retry delay after a resolve/apply exception - one error line per half minute instead of one per second.</summary>
+        private const double FailureBackoffSeconds = 30;
+
         public static void Tick(Player player, double currentUnixTime)
         {
             if (player == null)
@@ -50,6 +53,7 @@ namespace ACE.Server.Managers.ZoneControl
             catch (Exception ex)
             {
                 log.Error($"ZoneEffectManager.Tick resolve failed for {player.Name}: {ex}");
+                player.ZoneEffectNextTick = currentUnixTime + FailureBackoffSeconds;   // bound the log volume of a persistent fault
                 return;
             }
 
@@ -85,6 +89,7 @@ namespace ACE.Server.Managers.ZoneControl
             catch (Exception ex)
             {
                 log.Error($"ZoneEffectManager.ApplyDot failed for {player.Name}: {ex}");
+                player.ZoneEffectNextTick = ACE.Common.Time.GetUnixTime() + FailureBackoffSeconds;
             }
         }
     }

--- a/Source/ACE.Server/Managers/ZoneControl/ZoneEffectManager.cs
+++ b/Source/ACE.Server/Managers/ZoneControl/ZoneEffectManager.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Reflection;
+using log4net;
+using ACE.Entity.Enum;
+using ACE.Server.WorldObjects;
+
+namespace ACE.Server.Managers.ZoneControl
+{
+    /// <summary>
+    /// Applies per-zone PLAYER effects (currently damage-over-time; slow/charm reserved). Direct-applier model:
+    /// the server acts on the player each due tick with no spell/enchantment object, so effects are fully under
+    /// our control and stop the instant a player leaves the zone. Called EACH Player_Tick (per-frame) and
+    /// self-timed via <see cref="Player.ZoneEffectNextTick"/> so a zone can tick as fast as 1s regardless of the
+    /// 5s heartbeat, while players not in any zone cost only a cheap "not due yet" / landblock-set check.
+    /// </summary>
+    public static class ZoneEffectManager
+    {
+        private static readonly ILog log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+
+        /// <summary>The Prodigal regen enchantment line, excluded from players' regen math by the Suppression
+        /// card's Prodigal block: Regeneration 3731 (health), Rejuvenation 3732 (stamina), Mana Renewal 3725.
+        /// Consumed by Creature_Vitals.VitalHeartBeat via the uncached GetRegenerationMod overload.</summary>
+        public static readonly System.Collections.Generic.HashSet<int> ProdigalRegenSpells = new() { 3731, 3732, 3725 };
+
+        /// <summary>How often to re-check a player who isn't currently taking a zone tick (entering-zone latency cap).</summary>
+        private const double IdleRecheckSeconds = 1.0;
+        /// <summary>Floor on the authored interval so a misconfigured 0 can't hammer every frame.</summary>
+        private const double MinIntervalSeconds = 1.0;
+
+        public static void Tick(Player player, double currentUnixTime)
+        {
+            if (player == null)
+                return;
+
+            // Cheap gate: not due yet.
+            if (currentUnixTime < player.ZoneEffectNextTick)
+                return;
+
+            // Default: look again in 1s. Overwritten below to the effect interval when a tick actually lands.
+            player.ZoneEffectNextTick = currentUnixTime + IdleRecheckSeconds;
+
+            if (player.IsDead || player.Teleporting)
+                return;
+
+            ZoneEffects fx;
+            try
+            {
+                fx = ZoneControlManager.ResolveEffectsForPlayer(player);
+            }
+            catch (Exception ex)
+            {
+                log.Error($"ZoneEffectManager.Tick resolve failed for {player.Name}: {ex}");
+                return;
+            }
+
+            if (fx == null || !fx.EffectiveDotEnabled || fx.EffectiveDotDamage <= 0)
+                return;
+
+            ApplyDot(player, fx);
+
+            var interval = Math.Max(MinIntervalSeconds, fx.EffectiveDotIntervalSeconds);
+            player.ZoneEffectNextTick = currentUnixTime + interval;
+        }
+
+        /// <summary>One DoT hit: flat points, or a percent of the player's max health when DotPercent is set
+        /// (which forces Health damage). Vital selection + messaging live in Player.TakeZoneEffectDamage.</summary>
+        private static void ApplyDot(Player player, ZoneEffects fx)
+        {
+            double raw = fx.EffectiveDotPercent
+                ? player.Health.MaxValue * (fx.EffectiveDotDamage / 100.0)
+                : fx.EffectiveDotDamage;
+
+            var amount = (uint)Math.Round(raw);
+            if (amount == 0)
+                return;
+
+            var damageType = fx.EffectiveDotPercent ? DamageType.Health : (DamageType)fx.EffectiveDotDamageType;
+            if (damageType == DamageType.Undef)
+                damageType = DamageType.Fire;
+
+            try
+            {
+                player.TakeZoneEffectDamage(amount, damageType);
+            }
+            catch (Exception ex)
+            {
+                log.Error($"ZoneEffectManager.ApplyDot failed for {player.Name}: {ex}");
+            }
+        }
+    }
+}

--- a/Source/ACE.Server/Managers/ZoneControl/ZoneFallback.cs
+++ b/Source/ACE.Server/Managers/ZoneControl/ZoneFallback.cs
@@ -1,0 +1,64 @@
+﻿using ACE.Server.Managers.ZoneScaling;
+
+namespace ACE.Server.Managers.ZoneControl
+{
+    /// <summary>
+    /// The FALLBACK set: what a zone-mutated item resolves to when <c>zonecontrol_enabled</c> is OFF
+    /// (owner 2026-08-23). These are NOT "defaults" in the Zone Control sense - a Default is the
+    /// per-tier authored layer (Default 11 and up) that carries the T11-T25 LADDER. This is the other
+    /// thing entirely: the numbers gear reads when Zone Control is not authoring it at all.
+    ///
+    /// Every value here is T10 MAX-ROLLED gear, measured from the shard 2026-08-21 (Drexel / Nerd
+    /// Parade, the best-geared T10 characters - memory ref-t10-best-geared-baseline):
+    ///   armour  732 = their best single armour piece (their 12-piece sets totalled 5,969 / 6,482)
+    ///   DR       92 = worn GearDamageResist total
+    ///   CDR      73 = worn GearCritDamageResist total (also used for Crit Resist / Nether Resist)
+    ///   line    211 = worn GearDamage total, the highest of the per-line T10 totals we cap under
+    ///                 (Crit Damage was 201, Healing Boost 355 - owner picked the Damage figure)
+    ///
+    /// Switching the bool off re-resolves live items on their next equip / login (Live Stat Resolution
+    /// follows the ladder both directions), so this is reversible and touches nothing in the store.
+    /// </summary>
+    public static class ZoneFallback
+    {
+        /// <summary>Flat armour level per piece - no tier ladder off the switch.</summary>
+        public const int ArmorLevel = 732;
+
+        /// <summary>Core-four worn-set anchors (the CoreWindow divisor is still 18 pieces).</summary>
+        public const double AnchorDr = 92.0, AnchorCdr = 73.0;
+
+        /// <summary>Worn-gear hard caps, matching the anchors so a full set lands on the T10 total.</summary>
+        public const int CapDr = 92, CapCdr = 73, CapLine = 211;
+
+        /// <summary>
+        /// The worn total the LADDER's T11 line band produces (18 pieces x the 69 max of a 14-69 band),
+        /// i.e. the 1250-class anchor. Dividing CapLine by it gives the shrink factor below.
+        /// </summary>
+        private const double LadderLineWorn = 1250.0;
+
+        /// <summary>
+        /// Catalog band shrunk for the fallback: a maxed 18-piece set should land on CapLine by ADDITION,
+        /// not by slamming into the clamp (owner 2026-08-23 - otherwise every piece advertises +69 while
+        /// the set delivers 211). Scale = 211/1250, so the 14-69 class becomes 2-12 and the Armor Level
+        /// line's 50-250 becomes 8-42. PINNED lines (Crit Chance, Max Health Pct, Life on Hit, Reinforced -
+        /// the 1-3 bands) do not scale on the ladder either, so they pass through unchanged.
+        /// </summary>
+        public static (int Min, int Max) Band(ZoneModifiers.Def def)
+        {
+            if (def == null)
+                return (0, 0);
+            var (min, max) = def.Min <= def.Max ? (def.Min, def.Max) : (def.Max, def.Min);
+            if (!def.TierScaled)
+                return (min, max);
+            var scale = CapLine / LadderLineWorn;
+            return (System.Math.Max(1, (int)System.Math.Round(min * scale)),
+                    System.Math.Max(1, (int)System.Math.Round(max * scale)));
+        }
+
+        /// <summary>The fallback worn cap for one of the three gear_cap_* stats.</summary>
+        public static int GearCap(string capStat) =>
+            capStat == ZoneStat.GearCapDr ? CapDr
+          : capStat == ZoneStat.GearCapCdr ? CapCdr
+          : CapLine;
+    }
+}

--- a/Source/ACE.Server/Managers/ZoneControl/ZoneLootMutator.cs
+++ b/Source/ACE.Server/Managers/ZoneControl/ZoneLootMutator.cs
@@ -1,0 +1,990 @@
+﻿using System;
+using System.Collections.Generic;
+
+using ACE.Common;
+using ACE.Entity.Enum;
+using ACE.Entity.Enum.Properties;
+using ACE.Entity.Models;
+using ACE.Server.Factories.Tables;
+using ACE.Server.Managers.ZoneScaling;
+using ACE.Server.WorldObjects;
+
+namespace ACE.Server.Managers.ZoneControl
+{
+    /// <summary>
+    /// Zone Control loot: post-roll mutations applied per dropped item AFTER LootGenerationFactory has finished
+    /// rolling it. Enhances the monster's own loot, never replaces it — only the per-instance dropped object is
+    /// touched (weenies and treasure tables never are) — enhance-don't-replace, per-drop instance only.
+    /// </summary>
+    public static class ZoneLootMutator
+    {
+        /// <summary>
+        /// Mutations for an item rolled from the death-treasure table: provenance, forced weapon
+        /// properties, plus the low-chance special-property rolls.
+        /// <paramref name="killed"/> is the dying monster (slayer type source); <paramref name="lootTier"/>
+        /// is the effective treasure tier (levels the default proc spell). <paramref name="forceMax"/> = this
+        /// piece won the per-kill slot special (Armor v2): every cantrip line rolls at band MAX.
+        /// </summary>
+        public static void MutateLootItem(WorldObject wo, EvaluatedProfile p, Creature killed = null, int lootTier = 1, bool forceMax = false)
+        {
+            if (wo == null || p == null)
+                return;
+
+            // currency: coin stacks are never mutated (coin_mult removed 2026-08-23)
+            if (wo.WeenieType == WeenieType.Coin)
+                return;
+
+            // Zone Control origin: record where this item dropped as a readable sentence appended to the
+            // item's description (p.ScopeKey = the winning zone's name; the variation the zone matched on =
+            // the creature's effective variation; killed = the dropping monster). Every non-coin drop gets it.
+            if (!string.IsNullOrEmpty(p.ScopeKey))
+            {
+                // Two-line provenance (owner 2026-08-01). FinalizeT11LongDesc and the AppraiseInfo
+                // projection-insert anchor on the "Dropped by"/"Location:" prefixes - the three
+                // move together.
+                var variation = killed != null ? ZoneControlManager.GetEffectiveVariation(killed) : 0;
+                var origin = killed != null
+                    ? $"Dropped by: {killed.Name}\nLocation: {p.ScopeKey} v{variation}"
+                    : $"Location: {p.ScopeKey} v{variation}";
+                wo.LongDesc = string.IsNullOrEmpty(wo.LongDesc) ? origin : wo.LongDesc + "\n\n" + origin;
+            }
+
+            // (weapon_stat_mult, weapon_damage_min/max/roll, weapon_caster_elem_*, weapon_missile_elem_*
+            //  removed 2026-08-23 — weapon damage is owned by the weapon aug-scaling system)
+
+            var isWeapon = wo is MeleeWeapon || wo is MissileLauncher || wo is Caster;
+
+            // forced properties on rolled WEAPONS only (never other items)
+            if (isWeapon)
+            {
+                if (p.Get(ZoneStat.WeaponAttuned, 0) != 0)
+                    wo.Attuned = AttunedStatus.Attuned;
+                if (p.Get(ZoneStat.WeaponBonded, 0) != 0)
+                    wo.Bonded = BondedStatus.Bonded;
+                if (p.Get(ZoneStat.WeaponUnenchantable, 0) != 0)
+                    wo.ResistMagic = 9999;
+            }
+            else
+            {
+                // Armor-side twin (2026-08-28): the same three rules for every NON-weapon zone-set
+                // drop - armor, clothing, jewelry, cloaks - the population armor_modifier_chance
+                // already governs. Authored from Loot > Armor > Rules.
+                if (p.Get(ZoneStat.ArmorAttuned, 0) != 0)
+                    wo.Attuned = AttunedStatus.Attuned;
+                if (p.Get(ZoneStat.ArmorBonded, 0) != 0)
+                    wo.Bonded = BondedStatus.Bonded;
+                if (p.Get(ZoneStat.ArmorUnenchantable, 0) != 0)
+                    wo.ResistMagic = 9999;
+            }
+
+            // (weapon_workmanship_min/max and value_mult/min/max removed 2026-08-23)
+
+            TrySpecialRolls(wo, p, killed, lootTier, forceMax);
+        }
+
+        // ── special-property rolls ("fun stuff": independent 0..1 chance each; an item can win several) ──
+
+        // ACE.Server-only custom float prop ids (no ACE.Entity enum change — same pattern as the
+        // zone-cantrip prop block 50200-50399). Read hooks: WorldObject_Weapon.GetWeaponResistanceModifier
+        // (rend power) and DamageEvent.DoCalculateDamage (armor rend amount).
+        public const int RendingModOverridePropId = 9056;
+        public const int ArmorRendOverridePropId = 9057;
+        /// <summary>Cast on Strike damage B, ONE PER SLOT. Read hook: SpellProjectile.CalculateDamage,
+        /// where the value for whichever slot's spell fired REPLACES the rolled spell base and the flat
+        /// War/Void aug term. Their PRESENCE is also the display gate - stamped by this card and nothing
+        /// else, which is what keeps the ~11,700 live Ring-Glyph items out of the new appraisal line and
+        /// the new combat message.</summary>
+        public const int ProcArcDamagePropId = 9058;
+        public const int ProcRingDamagePropId = 9060;
+        /// <summary>Cast on Strike slot 2 (the RING). Slot 1 (the ARC) reuses the engine's own
+        /// ProcSpell/ProcSpellRate so every existing call site fires it unchanged; only the second slot
+        /// needs new storage. PropertyDataId - 9041 is the first free id after VisualOverrideCombatTable.</summary>
+        public const int ProcSpell2PropId = 9041;
+        /// <summary>Slot 2's own per-hit rate. TWO INDEPENDENT RATES, owner 2026-08-27: the arc and the
+        /// ring are separate entities and roll separately, so a weapon carrying both procs more often
+        /// than one carrying either.</summary>
+        public const int ProcRate2PropId = 9059;
+        /// <summary>Ceiling on the FLAT Melee+Missile+War+Void aug sum added to B. Stamped on the
+        /// weapon so the damage path can read it without a zone lookup. 0/absent = uncapped.</summary>
+        public const int ProcAugCapPropId = 9061;
+        /// <summary>Per-hit spread, per slot. Applied to the WHOLE base (B + augs) at hit time.</summary>
+        public const int ProcArcVariancePropId = 9062;
+        public const int ProcRingVariancePropId = 9063;
+        /// <summary>The RING's own aug cap (owner 2026-08-29: the shared stamp is retired - each proc
+        /// is its own thing). Prop 9061 is now the ARC's cap alone; the ring damage path reads this
+        /// first and falls back to 9061 so the pre-split test daggers keep their cap.</summary>
+        public const int ProcRingAugCapPropId = 9064;
+
+        /// <summary>
+        /// Card amount pairs: min only / max only = exact value, both = uniform roll in the range each
+        /// drop, reversed bounds auto-swap, everything clamped to [lo, hi]. Neither set = def.
+        /// </summary>
+        private static double RollRange(EvaluatedProfile p, string minStat, string maxStat, double def, double lo, double hi, int tier)
+            => RollRangeBand(p, minStat, maxStat, def, def, lo, hi, tier);
+
+        /// <summary>The Cast on Strike aug-cap fallback (owner 2026-08-30: "cap the cast on
+        /// strike... the same caps as the tier", then "we can have the floor at five hundred"):
+        /// each proc's aug cap ROLLS uniform between 500 and the drop tier's LIVE weapon-scaling
+        /// aug cap (2,500 at T11, +500/tier by default; read from the tunable config so a
+        /// tier-cap retune carries to new procs automatically). With base B a token 1-2, this
+        /// roll IS the drop's damage quality. forceMax (/wsforge) takes the ceiling. An authored
+        /// weapon_proc_*_aug_cap stat overrides with its exact value. A proc can no longer stamp
+        /// UNCAPPED by accident.</summary>
+        private static double ProcAugCapRoll(int tier, bool forceMax)
+        {
+            var t = WeaponScaling.WeaponScalingManager.GetTier(tier);
+            var cap = t != null && t.Cap > 0 ? t.Cap : 2500 + 500 * (Math.Clamp(tier, 11, 25) - 11);
+            if (cap <= 500)
+                return cap;
+            return forceMax ? cap : ThreadSafeRandom.Next(500f, (float)cap);
+        }
+
+        /// <summary>The Cleave / Split Arrows fallback band (owner 2026-08-29: "T11 floor +1 -
+        /// T25 max +10"): (1-2) at T11 lerping to (8-10) at T25.</summary>
+        private static (double Lo, double Hi) CleaveSplitBandAt(int tier)
+        {
+            var t = Math.Clamp((tier - 11) / 14.0, 0.0, 1.0);
+            return (1 + 7 * t, 2 + 8 * t);
+        }
+
+        private static double RollRangeBand(EvaluatedProfile p, string minStat, string maxStat, double defLo, double defHi, double lo, double hi, int tier)
+        {
+            // ANCHORED (2026-08-29): each end reads through GetT, so an authored _t25 twin walks the
+            // pair up the tier line. Historical one-box rule preserved: ONE authored box = that
+            // exact value; NEITHER authored = the (defLo, defHi) fallback band rolls.
+            var a = p.Has(minStat) ? p.GetT(minStat, defLo, tier) : (p.Has(maxStat) ? p.GetT(maxStat, defLo, tier) : defLo);
+            var b = p.Has(maxStat) ? p.GetT(maxStat, a, tier)
+                  : p.Has(minStat) ? a : defHi;
+            if (b < a)
+                (a, b) = (b, a);
+            a = Math.Clamp(a, lo, hi);
+            b = Math.Clamp(b, lo, hi);
+            return a >= b ? a : ThreadSafeRandom.Next((float)a, (float)b);
+        }
+
+        /// <summary>
+        /// 🔴 THE WEAPON CARD WRITE SITE - all six of them, one method (2026-08-25, weapon/armour parity).
+        ///
+        /// WHAT CHANGED AND WHY. Until this method existed each card computed its FINAL number inline
+        /// and wrote it straight onto the item. That number was then the only record of the roll: the
+        /// weapon carried no grade, so ZoneStatResolver.ApplyIfStale returned at its HasRecord guard and
+        /// a band retune could never reach a weapon already in someone's pack. Armour has not worked
+        /// that way since 2026-08-22 - an armour line records a GRADE 0-1000 and the property is a cache
+        /// resolved from that grade against the LIVE ladder. The owner's instruction was to make the two
+        /// identical ("full parity with weapons and armor"), so this does for a weapon card exactly what
+        /// ZoneModifiers.StampGraded does for an armour line:
+        ///     roll a grade -> resolve it inside the effective band -> write the property -> RECORD THE GRADE.
+        /// The grade is the truth; the property is its projection. RollBanded, which used to be the
+        /// number producer, is now only consulted through ZoneStatResolver.WeaponDropBand.
+        ///
+        /// PRECEDENCE at drop is unchanged and lives in ZoneStatResolver.WeaponDropBand: an authored
+        /// weapon_&lt;card&gt;_min/_max on the zone (which already has the tier Default merged into it)
+        /// wins outright, including the "one box = EXACT value, not a range" rule; otherwise the card's
+        /// T11-&gt;T25 ladder rung. The RESOLVE side reads the tier Default only - see WeaponResolveBand.
+        ///
+        /// TWO DELIBERATE BEHAVIOUR CHANGES, both of them the parity the owner asked for:
+        ///   - the roll inside an AUTHORED band is now the tier-weighted grade (T11 uniform, climbing to
+        ///     10/30/60 at T25) instead of RollRange's flat uniform draw. Armour lines have rolled that
+        ///     way since 2026-08-22; "push a tier and your gear also ROLLS better" now holds for a
+        ///     hand-tuned zone too, not only for a zone on the ladder fallback.
+        ///   - forceMax (this drop won the per-kill slot special) now reaches an authored band as well.
+        ///     It only ever reached the ladder fallback before, because RollRange had no notion of it.
+        ///
+        /// This does NOT change which cards roll. Every caller is behind its own Won(...) gate - all six
+        /// of them since 2026-08-25, when Rend Power gained weapon_rend_power_chance and stopped gating
+        /// on the presence of its own min/max pair - and Won() returns FALSE for an UNDEFINED stat:
+        /// unset means NEVER, not "0 pct". A zone that authors nothing rolls nothing, as before.
+        /// </summary>
+        /// <summary>Stamps the elemental icon underlay that goes with a rend, so a rended drop LOOKS
+        /// rended (owner 2026-08-27: a live-server rend shows a coloured background, our minted drops
+        /// showed none). The real imbue recipes set this via RecipeManager.IconUnderlay; stamping the
+        /// imbue bit without it produced a weapon that read as rended on appraisal but not in the pack.
+        ///
+        /// NetherRending is deliberately absent from RecipeManager's table - the fallback id is the one
+        /// DeveloperCommands already hardcodes for it in two places, so this stays consistent with the
+        /// rest of the codebase rather than inventing a third answer.
+        /// </summary>
+        public static void ApplyRendUnderlay(WorldObject wo, ImbuedEffectType rend)
+        {
+            if (ACE.Server.Managers.RecipeManager.IconUnderlay.TryGetValue(rend, out var underlayId))
+                wo.IconUnderlayId = underlayId;
+            else if (rend == ImbuedEffectType.NetherRending)
+                wo.IconUnderlayId = 0x060067A1;
+        }
+
+        /// <returns>The DISPLAY value that landed (Crushing Blow: the advertised multiplier, not the
+        /// stored one) - for a caller that reports what it stamped. TrySpecialRolls ignores it.</returns>
+        private static double StampWeaponCard(WorldObject wo, EvaluatedProfile p,
+            ZoneStatResolver.WeaponSpecial ws, int tier, bool forceMax)
+        {
+            var (lo, hi) = ZoneStatResolver.WeaponDropBand(p, ws, tier);
+            var grade = ZoneStatResolver.RollGrade(tier, forceMax);
+            var display = Math.Clamp(ZoneStatResolver.ValueForD(lo, hi, grade), ws.Band.Lo, ws.Band.Hi);
+            // EngineValue is the ONE display -> engine conversion in the server (Crushing Blow's
+            // "- 1.0"). Do not subtract anything here and do not pre-convert before calling: the
+            // resolver calls the same method on every equip, and a second subtraction anywhere would
+            // walk a 7.5x weapon down to 6.5x, then 5.5x, on every login, silently.
+            wo.SetProperty(ws.Prop, ZoneStatResolver.EngineValue(ws, display));
+            ZoneStatResolver.AddLine(wo, ws.Key, grade);
+            return display;
+        }
+
+        /// <summary>
+        /// THE FORGE'S DOOR into the one weapon-card write site above (owner 2026-09-01, `/wsforge
+        /// cards:premade`). A premade test weapon has to carry exactly what a drop at the tier carries -
+        /// same band precedence (WeaponDropBand), same grade roll (RollGrade: forceMax = band top for
+        /// bis, the tier-weighted random grade for avg), same EngineValue conversion, same recorded
+        /// grade line so a band retune re-resolves it. Routing the forge through this method instead of
+        /// letting it compute its own number is what keeps the two paths from drifting; the forge
+        /// must never re-implement the arithmetic. <paramref name="p"/> is the tier Default flattened
+        /// (see WeaponScalingCommands.TierDefaultProfile); pass an EMPTY profile, not null, when no
+        /// Default is authored and the ladder should rule.
+        /// </summary>
+        public static double StampWeaponCardForForge(WorldObject wo, EvaluatedProfile p,
+            ZoneStatResolver.WeaponSpecial ws, int tier, bool forceMax)
+            => StampWeaponCard(wo, p, ws, tier, forceMax);
+
+        // ── pre-applied craft deltas that land on a CARD's own property ────────────────────────────
+        // These two mirror the live Bandit Hilt recipe (527870063) and are stamped by the hilt block at
+        // the bottom of TrySpecialRolls, AFTER the cards, so they ADD on top of Biting Strike and
+        // Crushing Blow. They are consts rather than inline literals because ZoneStatResolver.Compute
+        // has to add the same amounts back when it re-resolves a hilted weapon - if these two numbers
+        // ever disagree, a hilted weapon's crit stats move every time it is equipped. One number, two
+        // readers.
+        public const double BanditHiltCritFrequencyBonus = 0.25;
+        public const double BanditHiltCritMultiplierBonus = 0.175;
+
+        /// <summary>
+        /// True when this weapon carries a Bandit Hilt - ours from the drop path, or one a player
+        /// applied later with the real recipe (both stamp the same marks, and both need the same
+        /// treatment at re-resolve time).
+        ///
+        /// The test is deliberately FOUR conditions rather than one. ManaStoneDestroyChance alone is a
+        /// real retail property and would false-positive on any weenie that happens to carry it, which
+        /// would hand that weapon a free +0.25 crit chance on its next equip. All four together -
+        /// melee, ivoryable, the hilt's completion marker, and the hilt's Two Handed Combat training
+        /// gate on the SECOND wield slot - are what the hilt recipe stamps and effectively nothing else does.
+        /// (The recipe REQUIRES ManaStoneDestroyChance &lt; 0.01 to apply, which is why stamping 0.01 is
+        /// the marker that blocks a second hilt.)
+        /// </summary>
+        public static bool HasBanditHilt(WorldObject wo)
+        {
+            if (wo == null || !(wo is MeleeWeapon))
+                return false;
+            if ((wo.GetProperty(PropertyFloat.ManaStoneDestroyChance) ?? 0.0) < 0.01)
+                return false;
+            if (wo.GetProperty(PropertyBool.Ivoryable) != true)
+                return false;
+            return (wo.GetProperty(PropertyInt.WieldSkillType2) ?? 0) == 46
+                && (wo.GetProperty(PropertyInt.WieldRequirements2) ?? 0) == 8;
+        }
+
+        // RollBanded (the old "authored min/max, else the tier ladder, else clamp" number producer)
+        // was DELETED 2026-08-25. Its two jobs were split so that a weapon can carry a GRADE the way an
+        // armour piece does: the PRECEDENCE half moved to ZoneStatResolver.WeaponDropBand (and gained a
+        // resolve-time twin, WeaponResolveBand), and the ROLL + WRITE half moved to StampWeaponCard
+        // above, which also records the grade. Nothing about which cards roll, or about what an
+        // authored min/max means, changed in the move - see StampWeaponCard for the two deliberate
+        // exceptions (grade-weighted rolls and forceMax now reach an authored band too).
+
+        // Split-arrow props (already in ACE.Entity — the custom bowstring system)
+        // public: the weapon forge (/wsforge cards) stamps the same split-arrow properties
+        public const int SplitArrowsBoolId = 9030;      // PropertyBool.SplitArrows
+        public const int SplitArrowCountIntId = 9031;   // PropertyInt.SplitArrowCount
+        public const int SplitArrowRangeFloatId = 9032; // PropertyFloat.SplitArrowRange
+        public const int SplitArrowDmgFloatId = 9033;   // PropertyFloat.SplitArrowDamageMultiplier
+
+        // Non-elemental imbues ALL excluded from the Rending card pool (owner 2026-07-13):
+        // CripplingBlow/CriticalStrike compete with the Crushing Blow / Biting Strike cards via
+        // Math.Max (6.0 crit mult / 50% crit chance at endgame skill), and ArmorRending has its own
+        // card — the pool is rends matching the weapon's damage type, nothing else.
+        private const ImbuedEffectType AllRends =
+            ImbuedEffectType.SlashRending | ImbuedEffectType.PierceRending | ImbuedEffectType.BludgeonRending |
+            ImbuedEffectType.AcidRending | ImbuedEffectType.ColdRending | ImbuedEffectType.ElectricRending |
+            ImbuedEffectType.FireRending | ImbuedEffectType.NetherRending;
+
+        /// <summary>Rend imbues that MATCH the weapon's own damage type (owner rule: a fire sword can only
+        /// get Fire Rend — a rend for an element the weapon can't deal is dead weight). Multi-type weapons
+        /// (e.g. slash/pierce) return every matching rend.</summary>
+        private static List<ImbuedEffectType> GetMatchingRends(DamageType dt)
+        {
+            var rends = new List<ImbuedEffectType>();
+            if (dt.HasFlag(DamageType.Slash)) rends.Add(ImbuedEffectType.SlashRending);
+            if (dt.HasFlag(DamageType.Pierce)) rends.Add(ImbuedEffectType.PierceRending);
+            if (dt.HasFlag(DamageType.Bludgeon)) rends.Add(ImbuedEffectType.BludgeonRending);
+            if (dt.HasFlag(DamageType.Acid)) rends.Add(ImbuedEffectType.AcidRending);
+            if (dt.HasFlag(DamageType.Cold)) rends.Add(ImbuedEffectType.ColdRending);
+            if (dt.HasFlag(DamageType.Electric)) rends.Add(ImbuedEffectType.ElectricRending);
+            if (dt.HasFlag(DamageType.Fire)) rends.Add(ImbuedEffectType.FireRending);
+            if (dt.HasFlag(DamageType.Nether)) rends.Add(ImbuedEffectType.NetherRending);
+            return rends;
+        }
+
+        // ── Cast on Strike spell tables (REPLACED ProcSpellPool, 2026-08-27) ──────────────────────
+        //
+        // The old pool was an 8x8 table indexed `Math.Clamp(lootTier, 1, list.Count) - 1` with every
+        // inner list Count == 8 and lootTier always >= 11 on this shard, so the index was ALWAYS 7 and
+        // 56 of 64 entries were unreachable. It also picked uniformly at random with no reference to
+        // the weapon, so a Fire sword could roll Frost Bolt - and then its Fire Rend would not apply,
+        // because the rend resolves off the SPELL's damage type. Both problems die with the table:
+        // the spell is now picked from the weapon's own W_DamageType, and the tier lives in the DAMAGE
+        // band, which is where every other card puts it and where a retune reaches weapons already in
+        // the world.
+        //
+        // IDS VERIFIED against ace_world.spell and confirmed by the owner 2026-08-27. Arcs are level 1
+        // (non_Tracking = 1, single projectile, no spread); rings are level 6 (spread_Angle = 360, 9
+        // projectiles). The LEVEL IS NOT A DAMAGE LEVER - B replaces the rolled base, so a level 1 arc
+        // and a level 7 arc hit identically. Level 1 was chosen so the displayed name stays clean; the
+        // numeral is stripped by ProcDisplayName below rather than by picking a higher spell, because
+        // "Incantation of" reads as level 8 just as loudly as "I" reads as level 1 (owner).
+        private static readonly (DamageType Dt, uint Arc, uint Ring)[] ProcSpellsByElement =
+        {
+            (DamageType.Slash,    2753, 1784),  // Blade Arc I        / Horizon's Blades
+            (DamageType.Pierce,   2718, 1786),  // Force Arc I        / Nuhmudira's Spines
+            (DamageType.Bludgeon, 2746, 1789),  // Shock Arc I        / Tectonic Rifts
+            (DamageType.Acid,     2711, 1783),  // Acid Arc I         / Searing Disc
+            (DamageType.Cold,     2725, 1787),  // Frost Arc I        / Halo of Frost
+            (DamageType.Electric, 2732, 1788),  // Lightning Arc I    / Eye of the Storm
+            (DamageType.Fire,     2739, 1785),  // Flame Arc I        / Cassius' Ring of Fire
+            (DamageType.Nether,   5369, 5361),  // Nether Arc I       / Clouded Soul (the VOID one)
+        };
+
+        /// <summary>The arc/ring pair matching the weapon's own damage type, in the same fixed order
+        /// GetMatchingRends uses so a multi-type weapon picks the same element for both cards. Returns
+        /// false for a weapon with no resolvable element (a plain bow takes its element from the ammo,
+        /// a generic caster has none) - those roll no proc, exactly as they roll no rend.</summary>
+        public static bool TryGetProcSpells(DamageType dt, out uint arc, out uint ring)
+        {
+            foreach (var row in ProcSpellsByElement)
+            {
+                if (dt.HasFlag(row.Dt))
+                {
+                    arc = row.Arc; ring = row.Ring;
+                    return true;
+                }
+            }
+            arc = 0; ring = 0;
+            return false;
+        }
+
+        /// <summary>Display name for a Cast on Strike spell, with the level marker stripped (owner
+        /// 2026-08-27: "level 1 reads as a weak spell. That isn't the case since we are adding augs to
+        /// the damage equation"). The client renders its OWN name from the DAT for anything it is handed
+        /// a spell id for, which is why AppraiseInfo also has to withhold the id - see BuildSpells.
+        /// Anything not on this table is not ours; callers fall back to the engine's Spell.Name.</summary>
+        public static bool TryGetProcDisplayName(uint spellId, out string name)
+        {
+            switch (spellId)
+            {
+                case 2753: name = "Blade Arc"; return true;
+                case 2718: name = "Force Arc"; return true;
+                case 2746: name = "Shock Arc"; return true;
+                case 2711: name = "Acid Arc"; return true;
+                case 2725: name = "Frost Arc"; return true;
+                case 2732: name = "Lightning Arc"; return true;
+                case 2739: name = "Flame Arc"; return true;
+                case 5369: name = "Nether Arc"; return true;
+                // The level 6 rings already carry no numeral, but they still belong on the table: it is
+                // what the combat-message and appraisal paths test to decide the line is OURS.
+                case 1784: name = "Horizon's Blades"; return true;
+                case 1786: name = "Nuhmudira's Spines"; return true;
+                case 1789: name = "Tectonic Rifts"; return true;
+                case 1783: name = "Searing Disc"; return true;
+                case 1787: name = "Halo of Frost"; return true;
+                case 1788: name = "Eye of the Storm"; return true;
+                case 1785: name = "Cassius' Ring of Fire"; return true;
+                case 5361: name = "Clouded Soul"; return true;
+                default: name = null; return false;
+            }
+        }
+
+        private static void TrySpecialRolls(WorldObject wo, EvaluatedProfile p, Creature killed, int lootTier, bool forceMax)
+        {
+            var isMelee = wo is MeleeWeapon;
+            var isMissile = wo is MissileLauncher;
+            var isWeapon = isMelee || isMissile || wo is Caster;
+
+            // ── PHASE 1 - ELIGIBILITY, then CHANCE ROLLS, all decided up front (2026-08-30, the
+            // modifier cap; eligibility split onto its own flags later that day for the FLOOR).
+            // Stamping used to happen inline with each roll; the cap needs the full winner list
+            // before anything writes, and the floor additionally needs to know which cards were
+            // ELIGIBLE BUT LOST their roll (its top-up pool), so eligibility computes separately
+            // from the roll. Eligibility rules are UNCHANGED and stay documented on each card's
+            // stamp block. A card that wins its roll but fails eligibility is NOT a winner and
+            // spends no cap slot (empty rend pool, invalid slayer creature type).
+            uint procArcId = 0, procRingId = 0;
+            var hasProcSlots = isWeapon && wo.ProcSpell == null && TryGetProcSpells(wo.W_DamageType, out procArcId, out procRingId);
+
+            // The rend pool computes whenever the drop is a weapon (it used to hide behind the
+            // chance roll) - the floor's top-up pool has to know rend eligibility even on a drop
+            // whose rend roll lost, and the pool is two cheap list ops.
+            var rendCandidates = isWeapon ? GetMatchingRends(wo.W_DamageType) : null;
+            rendCandidates?.RemoveAll(rend => (wo.GetImbuedEffects() & rend) != 0);
+            var eligRend = rendCandidates != null && rendCandidates.Count > 0;
+            var eligSlayer = isWeapon && wo.SlayerCreatureType == null && killed?.CreatureType != null &&
+                killed.CreatureType != ACE.Entity.Enum.CreatureType.Invalid;
+
+            var gotArc = hasProcSlots && WonT(p, ZoneStat.WeaponProcArcChance, lootTier);
+            var gotRing = hasProcSlots && WonT(p, ZoneStat.WeaponProcRingChance, lootTier);
+            var gotRend = eligRend && WonT(p, ZoneStat.WeaponImbueChance, lootTier);
+            var gotCleave = isMelee && WonT(p, ZoneStat.WeaponCleaveChance, lootTier);
+            var gotSplit = isMissile && WonT(p, ZoneStat.WeaponSplitChance, lootTier);
+            var gotBite = isWeapon && WonT(p, ZoneStat.WeaponBiteChance, lootTier);
+            var gotCrush = isWeapon && WonT(p, ZoneStat.WeaponCrushChance, lootTier);
+            var gotArmorRend = (isMelee || isMissile) && WonT(p, ZoneStat.WeaponArmorRendChance, lootTier);
+            // Shields block MELEE and MISSILE, never magic - so this gates exactly like armor rend
+            // (owner 2026-08-30: "why is shield cleaving on a wand"). It was `isWeapon`, which let
+            // casters roll it, and the card is INERT on a caster: the stamped PropertyFloat.IgnoreShield
+            // is only ever read by Creature_Combat.GetShieldMod(attacker, damageType, weapon), called
+            // from DamageEvent.cs - the physical path. The spell path uses a DIFFERENT overload,
+            // SpellProjectile.GetShieldMod(target, shield), which takes no weapon and consults the
+            // shield's AbsorbMagicDamage instead. So a caster rolling this got a dead card that still
+            // SPENT one of its weapon_modifier_cap slots - a 3-card T11 wand effectively dropped with 2.
+            // Eligibility also feeds the Min-floor top-up pool (CouldWinT), so the old gate let the
+            // floor FORCE a dead shield cleave onto a short caster drop as filler.
+            var gotShieldCleave = (isMelee || isMissile) && WonT(p, ZoneStat.WeaponShieldCleaveChance, lootTier);
+            var gotSlayer = eligSlayer && WonT(p, ZoneStat.WeaponSlayerChance, lootTier);
+
+            // ── PHASE 2 - THE BOUNDS (cap: owner 2026-08-30, "combo impossible at T11"; floor:
+            // same day, "need a hard min floor and max"). weapon_modifier_cap (anchored, unset =
+            // uncapped) is the max cards this drop carries; winners at >= 100 pct effective chance
+            // are ALWAYS INCLUDED (they skip the trim but spend their slots first), the rest trim
+            // at RANDOM - so junk cards genuinely dilute god-rolls, which is intended.
+            // weapon_modifier_min (anchored, unset = no floor) then tops a short drop up at random
+            // from the eligible losers - COUNT guaranteed, identity random.
+            var won = new[] { gotRend, gotSlayer, gotBite, gotCrush, gotArmorRend, gotShieldCleave, gotCleave, gotSplit, gotArc, gotRing };
+            // Index order matches `won` above. Bite and Crush stay isWeapon on purpose - magic crits
+            // exist, so those are live on a caster. Shield Cleave is (isMelee || isMissile) to match
+            // its roll gate: this array drives the Min-floor TOP-UP, so leaving it as isWeapon here
+            // would let the floor force a dead shield cleave onto a short caster drop even though the
+            // roll itself can no longer produce one.
+            var eligible = new[]
+            {
+                eligRend, eligSlayer, isWeapon, isWeapon, isMelee || isMissile, isMelee || isMissile,
+                isMelee, isMissile, hasProcSlots, hasProcSlots,
+            };
+            ApplyModifierBounds(p, ZoneStat.WeaponModifierMin, ZoneStat.WeaponModifierCap, lootTier, won, eligible, new[]
+            {
+                ZoneStat.WeaponImbueChance, ZoneStat.WeaponSlayerChance, ZoneStat.WeaponBiteChance,
+                ZoneStat.WeaponCrushChance, ZoneStat.WeaponArmorRendChance, ZoneStat.WeaponShieldCleaveChance,
+                ZoneStat.WeaponCleaveChance, ZoneStat.WeaponSplitChance,
+                ZoneStat.WeaponProcArcChance, ZoneStat.WeaponProcRingChance,
+            });
+            gotRend = won[0]; gotSlayer = won[1]; gotBite = won[2]; gotCrush = won[3]; gotArmorRend = won[4];
+            gotShieldCleave = won[5]; gotCleave = won[6]; gotSplit = won[7]; gotArc = won[8]; gotRing = won[9];
+
+            // Cast on Strike (melee/missile — procs fire from the swing path; never clobber an existing proc)
+            // CASTERS INCLUDED since 2026-08-25 (owner). The old condition was (isMelee || isMissile)
+            // and the comment on the card said procs "fire from the swing path, so casters never roll
+            // it". That was simply wrong: ProcSpell fires through TryProcEquippedItems, and the PLAYER
+            // MAGIC path calls it with the caster passed as the weapon - Player_Magic.cs:1426
+            // (TryProcEquippedItems(this, targetCreature, false, caster)) and SpellProjectile.cs:455
+            // (procs the ProjectileLauncher on impact). Monsters already did the same via
+            // Monster_Magic.cs. We also stamp ProcSpellSelfTargeted = false, which is exactly what
+            // those call sites match on - so a wand carrying a proc has always fired it. We just never
+            // stamped one. Nothing in the engine needed changing; this is one condition.
+            //
+            // WORTH MORE ON A WAND than on a sword, and that is a tuning fact, not a bug: a caster's
+            // "strike" is a spell cast at range, and casts come faster and safer than melee swings, so
+            // the same weapon_proc_rate buys more procs. Watch it before raising the rate.
+            // TWO INDEPENDENT SLOTS, 0/1/2 per item (owner 2026-08-27). Both are the weapon's OWN
+            // element - a Fire weapon can roll Flame Arc, Cassius' Ring of Fire, both or neither, and
+            // can never roll a Cold arc. Each slot has its own chance and its own per-hit rate.
+            //
+            // THE `wo.ProcSpell == null` GUARD STAYS and now gates BOTH slots: a weapon that already
+            // carries a proc is a player's Ring Glyph craft, and this card leaves it alone entirely
+            // rather than stacking a second spell onto someone else's work.
+            if (gotArc || gotRing)
+            {
+                // PER-SLOT knobs throughout (owner 2026-08-29: the shared spellcraft / aug cap stamps
+                // are retired - "each of those procs is its own thing"). Caps are stamped on the item
+                // rather than read from the zone at hit time, like every other card value.
+                if (gotArc)
+                {
+                    wo.ProcSpell = procArcId;
+                    wo.ProcSpellRate = Math.Clamp(p.GetT(ZoneStat.WeaponProcArcRate, 0.05, lootTier), 0.0, 1.0);
+                    wo.ProcSpellSelfTargeted = false;
+                    StampWeaponCard(wo, p, ZoneStatResolver.SpecProcArcDamage, lootTier, forceMax);
+                    var arcVar = Math.Clamp(p.GetT(ZoneStat.WeaponProcArcVariance, 0, lootTier), 0.0, 1.0);
+                    if (arcVar > 0)
+                        wo.SetProperty((PropertyFloat)ProcArcVariancePropId, arcVar);
+                    var arcCap = p.Has(ZoneStat.WeaponProcArcAugCap)
+                        ? p.GetT(ZoneStat.WeaponProcArcAugCap, 0, lootTier)
+                        : ProcAugCapRoll(lootTier, forceMax);
+                    if (arcCap > 0)
+                        wo.SetProperty((PropertyFloat)ProcAugCapPropId, arcCap);
+                }
+
+                if (gotRing)
+                {
+                    wo.SetProperty((PropertyDataId)ProcSpell2PropId, procRingId);
+                    wo.SetProperty((PropertyFloat)ProcRate2PropId,
+                        Math.Clamp(p.GetT(ZoneStat.WeaponProcRingRate, 0.05, lootTier), 0.0, 1.0));
+                    StampWeaponCard(wo, p, ZoneStatResolver.SpecProcRingDamage, lootTier, forceMax);
+                    var ringVar = Math.Clamp(p.GetT(ZoneStat.WeaponProcRingVariance, 0, lootTier), 0.0, 1.0);
+                    if (ringVar > 0)
+                        wo.SetProperty((PropertyFloat)ProcRingVariancePropId, ringVar);
+                    var ringCap = p.Has(ZoneStat.WeaponProcRingAugCap)
+                        ? p.GetT(ZoneStat.WeaponProcRingAugCap, 0, lootTier)
+                        : ProcAugCapRoll(lootTier, forceMax);
+                    if (ringCap > 0)
+                        wo.SetProperty((PropertyFloat)ProcRingAugCapPropId, ringCap);
+                }
+
+                if (gotArc || gotRing)
+                {
+                    // WITHOUT THIS THE CARD DOES NOTHING ON A MELEE CHARACTER. TryResistSpell:140-161
+                    // uses the weapon's ItemSpellcraft if set, else the WIELDER's skill in the spell's
+                    // school - and untrained War Magic (~600) against a T11 mob's authored
+                    // magic_defense of 1100 is resisted essentially every time. Authored, not a
+                    // literal: nothing on this shard is tuned yet, so it is a knob.
+                    // ItemSpellcraft is ONE property, so a weapon that rolled BOTH slots stamps the
+                    // HIGHER of the two per-slot spellcrafts; true per-slot resist is adjust-after.
+                    var craft = 0.0;
+                    if (gotArc)
+                        craft = Math.Max(craft, p.GetT(ZoneStat.WeaponProcArcSpellcraft, 9999, lootTier));
+                    if (gotRing)
+                        craft = Math.Max(craft, p.GetT(ZoneStat.WeaponProcRingSpellcraft, 9999, lootTier));
+                    if ((int)Math.Round(craft) > 0)
+                        wo.ItemSpellcraft = (int)Math.Round(craft);
+                }
+            }
+
+            // Rending card: a rend imbue matching the weapon's own damage type (fire sword or fire wand
+            // -> Fire Rend). Casters ARE eligible (elemental rends reduce the target's resistance, boosting
+            // magic damage). Weapons with no resolvable damage type (e.g. plain bows — element comes from
+            // the ammo — or generic casters) roll nothing via the empty-pool guard below.
+            //
+            // THE GATE (changed 2026-08-26, owner ruling "a Zone Control drop ALWAYS ends up with a rend
+            // matching its own damage type"). It used to be `wo.ImbuedEffect == ImbuedEffectType.Undef` -
+            // a STRICT equality on imbue slot 1, so ANY imbue at all, rend or not, vetoed the whole card.
+            // Two things were wrong with it:
+            //   - it was a veto by PRESENCE, not by conflict. A weapon carrying, say, CriticalStrike would
+            //     be refused its Fire Rend even though the two coexist happily (they are separate bits, and
+            //     the Armor Rend card twenty lines down already ORs its own imbue in alongside whatever
+            //     else is there). Nothing about a foreign imbue makes a matching rend wrong.
+            //   - it read slot 1 only, while every engine read site (GetImbuedEffects, and the AllRends test
+            //     on the Rend Power card below) ORs all five slots - so the gate and the readers disagreed.
+            // VERIFIED before removing it (2026-08-26) that the gate was in practice dead anyway: none of
+            // the 487 wcids across the ten weapon loot tables carries ImbuedEffect or ImbuedEffect2-5 in
+            // ace_world, and no mutation script the loot pipeline runs (Casters./MeleeWeapons./
+            // MissileWeapons./ArmorLevel.) writes ImbuedEffect - only the Recipes/ scripts do, and those
+            // are RecipeManager, i.e. player crafting long after the drop. So a weapon reaching this line
+            // from Creature_Death has always had a clean imbue field.
+            //
+            // WHAT REPLACED IT. No presence gate at all; instead the CANDIDATE POOL drops any rend the
+            // weapon already carries in ANY of the five slots, and the winner is OR'd in rather than
+            // assigned. That makes the card idempotent (re-running it can never duplicate or downgrade a
+            // rend) and non-destructive (a foreign imbue - CriticalStrike, ArmorRending, a defense imbue -
+            // survives untouched, which a plain `=` would have silently erased once the gate was gone).
+            // "Matched" means the same thing PlayerFactoryEx.AddRend means by it - a rend for an element
+            // the weapon can actually deal - except that GetMatchingRends is flag-based, so it handles
+            // multi-type weapons properly and covers Nether, which AddRend has no case for.
+            //
+            // The Won(...) chance roll STAYS. The owner drives "always" by setting weapon_imbue_chance to
+            // 1.0 in the store; that is a tuning value, not a code constant, and Won() still treats an
+            // undefined stat as NEVER so a zone that authors nothing keeps rolling nothing.
+            // RENDING + REND POWER ARE ONE MODIFIER (owner 2026-08-29: "we ended up with Rending and
+            // Rend Power two separate things. It's 1"). One gate - weapon_imbue_chance - and every
+            // rend the CARD stamps also rolls its power from the band (grade recorded, so a band
+            // retune still reaches it at re-resolve). weapon_rend_power_chance is RETIRED.
+            //
+            // NATURAL RENDS STAY VANILLA (owner ruling, same day): the old separate Rend Power roll
+            // could land on a rend the ordinary loot roll produced; that path is deliberately gone.
+            // Only card-stamped rends carry prop 9056, so making big rends rarer is now the Rending
+            // chance itself - the original "big rends rare without rends rare" knob folded into one.
+            if (gotRend)
+            {
+                var rend = rendCandidates[ThreadSafeRandom.Next(0, rendCandidates.Count - 1)];
+                wo.ImbuedEffect |= rend;
+                ApplyRendUnderlay(wo, rend);
+                StampWeaponCard(wo, p, ZoneStatResolver.SpecRendPower, lootTier, forceMax);
+            }
+
+            // Cleaving (melee): swing hits extra targets in a 180-degree arc.
+            // DECIDED 2026-08-29 (owner "T11 floor +1 - T25 max +10"): the unauthored fallback is
+            // a real tier band now, (1-2) at T11 -> (8-10) at T25, lerped like every other ladder.
+            // Authored stats (incl. _t25 anchors) still override per end via RollRange's GetT reads.
+            if (gotCleave)
+            {
+                var (defLo, defHi) = CleaveSplitBandAt(lootTier);
+                var targets = (int)Math.Round(RollRangeBand(p, ZoneStat.WeaponCleaveMin, ZoneStat.WeaponCleaveMax, defLo, defHi, 1, 10, lootTier));
+                wo.SetProperty(PropertyInt.Cleaving, targets + 1); // engine: CleaveTargets = Cleaving - 1
+            }
+
+            // Split Arrows (bows): shots fork to hit extra targets (the custom bowstring system).
+            // Same owner-ruled band as Cleave - the two are the melee/bow twins of one design.
+            if (gotSplit)
+            {
+                var (defLo, defHi) = CleaveSplitBandAt(lootTier);
+                var count = (int)Math.Round(RollRangeBand(p, ZoneStat.WeaponSplitMin, ZoneStat.WeaponSplitMax, defLo, defHi, 1, 10, lootTier));
+                wo.SetProperty((PropertyBool)SplitArrowsBoolId, true);
+                wo.SetProperty((PropertyInt)SplitArrowCountIntId, count);
+                wo.SetProperty((PropertyFloat)SplitArrowRangeFloatId,
+                    Math.Clamp(p.GetT(ZoneStat.WeaponSplitRange, 8.0, lootTier), 0.0, 50.0));
+                wo.SetProperty((PropertyFloat)SplitArrowDmgFloatId,
+                    Math.Clamp(p.GetT(ZoneStat.WeaponSplitDmg, 1.0, lootTier), 0.0, 1.0));
+            }
+
+            // Biting Strike: crit chance override (base 0.1). Unauthored magnitude follows the
+            // T11 -> T25 ladder (0.58-0.65 -> 0.78-0.88); the value is now the projection of a
+            // recorded grade, so a band retune reaches weapons already in the world.
+            if (gotBite)
+                StampWeaponCard(wo, p, ZoneStatResolver.SpecBite, lootTier, forceMax);
+
+            // Crushing Blow: the card value IS the final crit damage multiplier (2 = 2x, the floor),
+            // and the engine computes CriticalDamageMod = 1 + CriticalMultiplier, so the STORED number
+            // is (multiplier - 1). That subtraction used to sit inline right here.
+            // 🔴 IT NO LONGER DOES, AND MUST NOT COME BACK. The number is produced from a recorded
+            // grade now, and produced again on every equip re-stamp, so a subtraction at this site as
+            // well would apply the "- 1" twice on the very first login and once more on every ladder
+            // apply after that - a 7.5x weapon walking down to 6.5x, 5.5x, 4.5x with nothing logged.
+            // The one and only conversion lives in ZoneStatResolver.EngineValue, which both this
+            // write site (via StampWeaponCard) and the resolver call. The band table stays in display
+            // space; do not bake the offset into it either.
+            if (gotCrush)
+                StampWeaponCard(wo, p, ZoneStatResolver.SpecCrush, lootTier, forceMax);
+
+            // Armor Rend: stamps the REAL ArmorRending imbue (shows with the rend family on the item) plus
+            // a tunable amount = fraction of armor ignored; the override prop replaces the skill formula
+            // (which caps at 0.6) at hit time. OR'd in so it coexists with an elemental rend from above.
+            // MELEE/MISSILE ONLY: armor rending is a physical-armor effect and does nothing for magic, so
+            // casters (wands/orbs/staves) never roll it, regardless of the card's chance.
+            if (gotArmorRend)
+            {
+                wo.ImbuedEffect |= ImbuedEffectType.ArmorRending;
+                StampWeaponCard(wo, p, ZoneStatResolver.SpecArmorRend, lootTier, forceMax);
+            }
+
+            // Shield Cleaving: fraction of shield AL ignored (engine reads the value directly)
+            if (gotShieldCleave)
+                StampWeaponCard(wo, p, ZoneStatResolver.SpecShieldCleave, lootTier, forceMax);
+
+            // REMOVED 2026-08-25 (owner): the Phantom ("hollow") loot card. It stamped PropertyBool
+            // IgnoreMagicArmor + IgnoreMagicResist at drop time, behind weapon_phantom_chance.
+            // Only the CARD is gone. Both properties are RETAIL and are untouched, along with every
+            // engine read site (DamageEvent, Creature_Combat, Creature_BodyPart, Monster_Melee) and the
+            // appraisal line - the ~830 existing hollow weapons still work and still read as hollow.
+
+            // slayer attuned against the killed monster's own kind
+            if (gotSlayer)
+            {
+                wo.SlayerCreatureType = killed.CreatureType;
+                // damage multiplier vs that creature type, rolled per drop; floor 1.5x (a normal slayer),
+                // cap 10x (=1000%). One box = exact, both = roll in range; neither = the tier ladder
+                // (1.80-2.10 at T11 -> 2.40-3.00 at T25) instead of the old flat 1.5.
+                StampWeaponCard(wo, p, ZoneStatResolver.SpecSlayer, lootTier, forceMax);
+            }
+
+            // REMOVED 2026-08-25 (owner): the Paragon, Bandit Hilt and Oiled Bowstring loot cards.
+            // They stamped, at drop time, effects that already exist as player-obtainable content - the
+            // Paragon Weapons recipe, hilt recipe 527870063 and bowstring recipe 527870116. Only the
+            // drop-time CARDS are gone; the recipes and the Paragon gems are untouched and a player can
+            // still apply any of them by hand.
+            // NOTE for anyone deleting more: ZoneStatResolver's HasBanditHilt detection STAYS. It is not
+            // part of this card - it exists so a hilt a player applied AFTER the drop is re-added when a
+            // weapon re-resolves, and removing it would erase that player's bonus on their next equip.
+
+            // the zone-cantrip LINES on top of whatever the roll produced — the zone's pool only
+            // (prop-based ZoneModifiers catalog; retail cantrips deliberately excluded)
+            TryExtraModifier(wo, p, isWeapon, forceMax, lootTier);
+
+            // WEAPON RESOLVE IDENTITY, last, once the record is final (2026-08-25).
+            //
+            // Armour gets this from LootGenerationFactory.ApplyT11GearStats -> StampIdentity, but that
+            // method returns at its `default:` case for weapons and casters, so nothing ever stamped a
+            // weapon's ZcResolvedVersion. An unstamped weapon reads 0, which is a legitimate stamp
+            // value (tier ladder v0, Zone Control on), so a weapon that dropped on a v0 tier would look
+            // ALREADY RESOLVED for ever and skip the very first re-resolve it was owed.
+            //
+            // Only the version is stamped, never ZcTier: ZcTier is the armour-shaped tier property, and
+            // ZoneStatResolver.TierOf / ZoneCraftGate.TierOf both expect a weapon's row to arrive via
+            // WeaponAugScaleTier instead. That property is written a few lines later in the same
+            // Creature_Death sweep (ApplyWeaponAugScaleStamp), which is also why lootTier has to be
+            // passed in here rather than read off the item - at this instant the weapon has no tier
+            // property at all.
+            //
+            // Guarded on HasRecord, not on isWeapon, so it also covers a weapon carrying only armour-
+            // style cantrip lines (weapons have always been able to roll those through
+            // weapon_cantrip_chance, and they were never stamped either).
+            if (isWeapon && ZoneStatResolver.HasRecord(wo))
+                ZoneStatResolver.StampWeaponResolve(wo, lootTier);
+        }
+
+        /// <summary>
+        /// Armor line roll, one-row-per-Modifier model (owner 2026-08-29, ModifiersBandsMerge_Plan
+        /// REV 2 - armor's version of the Rending merge). Every non-special catalog LINE rolls its
+        /// OWN anchored chance (modifier_chance_&lt;key&gt; / _t25) independently on every eligible
+        /// piece. RETIRED with this: the armor_/weapon_modifier_chance master gates, the line-count
+        /// ladder (modifier_lines_*), the class weights (modifier_weight_*), the zone pool as the
+        /// membership test, and lines on WEAPONS entirely.
+        ///
+        /// CONSEQUENCES, accepted (owner: "we will adjust after"): no lines-per-piece guarantee - a
+        /// piece can roll zero lines or in principle every line whose chance hits; rarity lives in
+        /// each line's own chance now, not in a shared weight draw. Distinct-per-piece still holds
+        /// (each line rolls at most once - StampGraded replaces, never duplicates).
+        ///
+        /// Bands are unchanged: the zone's authored override (CustomModifierBands) wins over the
+        /// tier-scaled catalog band, the roll is a recorded GRADE, and forceMax (the piece carries
+        /// the per-kill slot special) stamps every line it rolls at band MAX.
+        /// </summary>
+        private static void TryExtraModifier(WorldObject wo, EvaluatedProfile p, bool isWeapon, bool forceMax, int lootTier = 11)
+        {
+            if (isWeapon)
+                return;   // weapon drops no longer roll armor-style lines (weapon_modifier_chance retired 2026-08-29)
+
+            // PHASE 1 (2026-08-30, the modifier cap): decide every line's chance roll first, so the
+            // cap can trim the full winner list before anything stamps - same shape as the weapon
+            // cards in TrySpecialRolls. The list holds every SLOT-ELIGIBLE line, winner or not
+            // (2026-08-30 late, the modifier floor: the losers are the floor's top-up pool).
+            var pieceMask = ZoneModifiers.PieceMask(wo);
+            var lineDefs = new List<ZoneModifiers.Def>();
+            foreach (var def in ZoneModifiers.AllDefs)
+            {
+                if (def.SlotSpecial)
+                    continue;
+                // per-line slot rule (owner 2026-08-22): zone / Default override per key, else the catalog's ArmorOnly / JewelryOnly
+                if (!ZoneModifiers.SlotAllowed(ZoneModifiers.EffectiveSlotMask(def, p.ModifierSlots), pieceMask))
+                    continue;
+                lineDefs.Add(def);
+            }
+
+            // PHASE 2: armor_modifier_min / armor_modifier_cap (anchored, unset = no floor /
+            // uncapped) - lines at >= 100 pct effective chance are always included and spend their
+            // slots first, the rest trim at random; a short piece then tops up at random from the
+            // eligible losers. Same rules as the weapon cards.
+            var lineWon = new bool[lineDefs.Count];
+            var lineElig = new bool[lineDefs.Count];
+            var lineChances = new string[lineDefs.Count];
+            for (int i = 0; i < lineDefs.Count; i++)
+            {
+                lineElig[i] = true;                       // slot-filtered above - every entry is eligible
+                lineChances[i] = ZoneModifiers.LineChanceStat(lineDefs[i].Key);
+                lineWon[i] = WonT(p, lineChances[i], lootTier);
+            }
+            ApplyModifierBounds(p, ZoneStat.ArmorModifierMin, ZoneStat.ArmorModifierCap, lootTier, lineWon, lineElig, lineChances);
+
+            for (int i = 0; i < lineDefs.Count; i++)
+            {
+                if (!lineWon[i])
+                    continue;
+                var def = lineDefs[i];
+
+                var (min, max) = p.ModifierBands.TryGetValue(def.Key, out var band)
+                    ? (band.Min, band.Max) : ZoneModifiers.CatalogBandAt(def, lootTier);   // hardcoded fallback is tier-scaled (2026-08-23)
+
+                // insurance against hand-edited store bands - an inverted band must not throw mid-loot
+                if (min > max) (min, max) = (max, min);
+
+                // Live stat resolution (owner 2026-08-22): roll a GRADE 0-1000 (tier-weighted thirds,
+                // Option A: T11 uniform, climbing to 10/30/60 at T25) and stamp it through the record;
+                // the prop value is ValueFor(grade) inside the effective band. Key 49 Reinforced routes
+                // to the plain Stamp inside StampGraded (earned + frozen, never in the record).
+                var grade = ZoneStatResolver.RollGrade(lootTier, forceMax);
+                ZoneModifiers.StampGraded(wo, def, grade, (min, max));
+            }
+        }
+
+        /// <summary>
+        /// True when the card is switched ON at this scope, the profile defines the chance stat, AND the
+        /// 0..1 roll comes up a winner.
+        ///
+        /// 🔴 THE EXPLICIT OFF SWITCH LIVES HERE, NOT AT THE CALL SITES (2026-08-25, weapon/armour parity).
+        /// Every chance-gated weapon card - all fourteen, including the seven with no band of their own
+        /// (Paragon, Cast on Strike, Cleave, Split Arrows, Bandit Hilt, Bowstring) - already
+        /// passes through this one method, so one test covers the lot. Repeating it per call site would
+        /// be seventeen chances to miss one, and the one missed would fail silently: the card would keep
+        /// rolling while the plugin's checkbox said it was off, which is the exact class of bug this
+        /// change exists to kill.
+        ///
+        /// WHY A SEPARATE FLAG AND NOT "clear the chance stat". Clearing works at the tier Default,
+        /// because there is nothing under it. At ZONE scope it does NOT: the zone layer is merged ON TOP
+        /// of the Default (ZoneVariantProfile.Merge), so a cleared zone key means INHERIT and the
+        /// Default's chance sails straight through. An explicit false beats the inherited chance; it
+        /// also leaves the zone's own tuned chance value sitting untouched in the store, so an off/on
+        /// cycle is lossless.
+        ///
+        /// SCOPING - this method is NOT weapon-only. Its non-weapon caller is the extra-cantrip roll,
+        /// which passes armor_cantrip_chance for a non-weapon drop. That name can never be a key in the
+        /// toggle map (ZoneStat.IsWeaponCardChance rejects it at authoring time, and the map is the only
+        /// writer), so WeaponCardEnabled misses the lookup and returns true: armour is untouched.
+        /// </summary>
+        private static bool WonT(EvaluatedProfile p, string chanceStat, int tier)
+        {
+            // Off beats everything, including an inherited chance - checked BEFORE Has() so it reads as
+            // the master switch it is, and so it costs one dictionary miss on the overwhelmingly common
+            // "nothing authored anywhere" path.
+            if (!p.WeaponCardEnabled(chanceStat))
+                return false;
+            if (!p.Has(chanceStat))
+                return false;
+            // ANCHORED (2026-08-29): the base stat is the T11 anchor and "<stat>_t25" the T25 anchor;
+            // tiers between roll the chance on the line. No _t25 = the old flat behaviour exactly.
+            var chance = Math.Clamp(p.GetT(chanceStat, 0.0, tier), 0.0, 1.0);
+            return chance > 0 && ThreadSafeRandom.Next(0.0f, 1.0f) < chance;
+        }
+
+        /// <summary>
+        /// The MODIFIER BOUNDS pass - the CAP trim (owner 2026-08-30, "the full combo must be
+        /// impossible at T11") followed by the FLOOR top-up (owner 2026-08-30 late, "need a hard
+        /// min floor and max"). Callers roll every card/line first (phase 1), hand the winner and
+        /// eligibility flags here, and stamp only what survives.
+        ///
+        /// CAP rules, all owner-ruled 2026-08-30:
+        ///   - capStat unset = UNCAPPED, the pre-cap behaviour exactly (Has() test, like Won's).
+        ///   - The cap is anchored (base = T11, _t25 twin = T25) and derived tiers ROUND the lerp.
+        ///   - PINNED winners - effective chance >= 100 pct at this tier - are "always included":
+        ///     they never trim, but they SPEND their cap slots FIRST (the cap is the player-legible
+        ///     total on the item, and a guarantee spends budget rather than adding to it). Rend at
+        ///     its authored 1.0 is the design case; there is no separate "always" flag on purpose.
+        ///   - The rest trim at RANDOM until the remaining slots fit - so junk cards genuinely
+        ///     dilute god-rolls (intended: more rarity, more variance).
+        ///   - More pinned winners than cap = all of them still stamp (the cap floors at the pinned
+        ///     count); only rolled cards are ever trimmed.
+        ///
+        /// FLOOR rules (why a floor when pins exist: a pin guarantees a NAMED modifier, the floor
+        /// guarantees a NUMBER of them with identity left random - "5 to 8 of the 10" is not
+        /// expressible with pins):
+        ///   - minStat unset = NO FLOOR, the pre-floor behaviour exactly. Anchored + rounded like
+        ///     the cap.
+        ///   - When fewer winners survive than the floor demands, the drop TOPS UP from the lines
+        ///     that were ELIGIBLE but lost their chance roll AND could have won it - enabled,
+        ///     chance authored, chance above zero (CouldWinT). A disabled or unauthored line can
+        ///     never be forced on, and an OFF toggle keeps meaning off.
+        ///   - The top-up pick is WEIGHTED BY EACH LINE'S OWN AUTHORED CHANCE (2026-08-31), not
+        ///     uniform. The COUNT is still guaranteed and the identity is still random, but a rare
+        ///     line stays rare in the pool. See WeightedPick for why - a uniform draw inflated the
+        ///     armour chase lines 2500x on the live shard.
+        ///   - The cap stays HARD: a floor above the cap clamps down to it.
+        ///   - Pool smaller than the deficit = stamp everything poolable and stop; no error.
+        ///   - Trim and top-up are mutually exclusive on one drop (with floor &lt;= cap, too many
+        ///     winners can't also be too few), so order is moot - trim runs first regardless.
+        /// </summary>
+        private static void ApplyModifierBounds(EvaluatedProfile p, string minStat, string capStat, int tier,
+            bool[] won, bool[] eligible, string[] chanceStats)
+        {
+            var cap = int.MaxValue;
+            if (p.Has(capStat))
+            {
+                // AwayFromZero so the half-steps climb early (3->6 anchors: 4 at T14, 5 at T18, 6 at
+                // T23) instead of banker's rounding pushing them a tier later.
+                cap = Math.Max(0, (int)Math.Round(p.GetT(capStat, 0.0, tier), MidpointRounding.AwayFromZero));
+                var rolled = new List<int>();
+                var pinned = 0;
+                for (int i = 0; i < won.Length; i++)
+                {
+                    if (!won[i])
+                        continue;
+                    if (PinnedT(p, chanceStats[i], tier))
+                        pinned++;
+                    else
+                        rolled.Add(i);
+                }
+                var slots = Math.Max(0, cap - pinned);
+                while (rolled.Count > slots)
+                {
+                    var k = ThreadSafeRandom.Next(0, rolled.Count - 1);
+                    won[rolled[k]] = false;
+                    rolled.RemoveAt(k);
+                }
+            }
+
+            if (!p.Has(minStat))
+                return;                                                   // unset = no floor
+            var min = Math.Max(0, (int)Math.Round(p.GetT(minStat, 0.0, tier), MidpointRounding.AwayFromZero));
+            if (min > cap)
+                min = cap;                                                // the cap is hard
+            var winners = 0;
+            for (int i = 0; i < won.Length; i++)
+                if (won[i]) winners++;
+            if (winners >= min)
+                return;
+            var pool = new List<int>();
+            var poolWeights = new List<double>();
+            for (int i = 0; i < won.Length; i++)
+                if (eligible[i] && !won[i] && CouldWinT(p, chanceStats[i], tier))
+                {
+                    pool.Add(i);
+                    poolWeights.Add(Math.Clamp(p.GetT(chanceStats[i], 0.0, tier), 0.0, 1.0));
+                }
+            while (winners < min && pool.Count > 0)
+            {
+                var k = WeightedPick(poolWeights);
+                won[pool[k]] = true;
+                pool.RemoveAt(k);
+                poolWeights.RemoveAt(k);
+                winners++;
+            }
+        }
+
+        /// <summary>
+        /// An index into <paramref name="weights"/>, drawn in proportion to the weights - the
+        /// floor's top-up pick (2026-08-31).
+        ///
+        /// 🔴 WHY THIS IS NOT A UNIFORM DRAW. Do not "simplify" it back to one. The pool holds every
+        /// eligible line that lost its roll, and those lines are NOT equally rare: the armour CHASE
+        /// lines sit at 0.0000228 while the FILLER lines sit at 0.3 - four orders of magnitude apart.
+        /// A uniform pick treats them as equals, so every short piece the floor fills becomes a
+        /// roughly 1-in-5 chance to mint a chase line. MEASURED on the live shard 2026-08-31 with
+        /// armor_modifier_min 2: chase lines went from their authored 1-in-21,930 to 15.8 pct of
+        /// armour pieces and 33.3 pct of jewellery (6/38 and 9/27) - a 2500x / 4000x inflation, in a
+        /// single loot run. Weighting by each line's own authored chance keeps the floor's COUNT
+        /// guarantee exactly (the line-count distribution is bit-identical) while leaving relative
+        /// rarity intact - measured 1.3x / 1.7x, i.e. noise.
+        ///
+        /// The plugin's Preview mirrors this draw; if you change one, change the other or the GUI
+        /// starts lying about what a drop looks like.
+        ///
+        /// All-zero weights cannot happen today - CouldWinT already requires chance &gt; 0 - but a
+        /// caller that ever loosens that gate gets a uniform fallback rather than a divide by zero.
+        /// </summary>
+        private static int WeightedPick(List<double> weights)
+        {
+            var total = 0.0;
+            for (int i = 0; i < weights.Count; i++)
+                total += weights[i];
+            if (total <= 0.0)
+                return ThreadSafeRandom.Next(0, weights.Count - 1);
+
+            var roll = ThreadSafeRandom.Next(0.0f, 1.0f) * total;
+            for (int i = 0; i < weights.Count; i++)
+            {
+                roll -= weights[i];
+                if (roll < 0.0)
+                    return i;
+            }
+            return weights.Count - 1;                                 // floating-point tail guard
+        }
+
+        /// <summary>The floor's top-up gate: every WonT condition EXCEPT the random roll - the
+        /// card is enabled, its chance is authored, and the effective chance at this tier is above
+        /// zero. Forcing on a line that could never have won on its own would turn the floor into
+        /// a silent enable switch.</summary>
+        private static bool CouldWinT(EvaluatedProfile p, string chanceStat, int tier)
+            => p.WeaponCardEnabled(chanceStat) && p.Has(chanceStat)
+                && Math.Clamp(p.GetT(chanceStat, 0.0, tier), 0.0, 1.0) > 0;
+
+        /// <summary>True when the stat's effective chance at this tier is >= 100 pct - the "always
+        /// included" test. Only ever called on a winner, so the enabled/off checks already passed
+        /// in WonT and are not repeated here.</summary>
+        private static bool PinnedT(EvaluatedProfile p, string chanceStat, int tier)
+            => p.Has(chanceStat) && p.GetT(chanceStat, 0.0, tier) >= 1.0;
+
+        /// <summary>Weighted 1-based index roll over a weight table summing to 100.</summary>
+        private static int RollWeighted(int[] weights)
+        {
+            var roll = ThreadSafeRandom.Next(1, 100);
+            var sum = 0;
+            for (int i = 0; i < weights.Length; i++)
+            {
+                sum += weights[i];
+                if (roll <= sum)
+                    return i + 1;
+            }
+            return weights.Length;
+        }
+
+        // MutateCreateListItem / MutateWeaponStats / ScaleBonusFraction / ScaleStack removed 2026-08-23
+        // together with coin_mult and weapon_stat_mult (createlist items are no longer mutated at all).
+    }
+}

--- a/Source/ACE.Server/Managers/ZoneControl/ZoneModifiers.cs
+++ b/Source/ACE.Server/Managers/ZoneControl/ZoneModifiers.cs
@@ -1,0 +1,709 @@
+using System;
+using System.Collections.Generic;
+using ACE.Common;
+
+using ACE.Entity.Enum;
+using ACE.Entity.Enum.Properties;
+using ACE.Server.WorldObjects;
+
+namespace ACE.Server.Managers.ZoneControl
+{
+    /// <summary>
+    /// Zone Control unique loot cantrips — a PROP-BASED system, deliberately OUTSIDE the spell/enchantment
+    /// machinery: no dat entries, no SpellId, no SpellCategory stacking rules. Each cantrip stamps int props
+    /// (custom block 50200-50399 in the shard's private prop space, plus the retail Gear* rating props) onto
+    /// the dropped item; read hooks sum them across EQUIPPED items, so the bonuses always stack on top of
+    /// every spell, gem and aug — and across multiple cantripped pieces worn at once.
+    /// Consumers: CreatureAttribute.GetCurrent, CreatureSkill.GetAugBonus_Current, CreatureVital.GearBonus,
+    /// Creature_Vitals.VitalHeartBeat (regen augMod), EnchantmentManager/AddEnchantmentResult (spell duration).
+    /// </summary>
+    public static class ZoneModifiers
+    {
+        // ── custom PropertyInt ids (ZC cantrip block) ────────────────────────
+        public const int PropMin = 50200;
+        public const int PropMax = 50399;
+
+        public const int AttrBonusBase = 50200;       // + (int)PropertyAttribute (1..6) => 50201..50206
+        public const int SpellDurationLevels = 50212; // each level = +20 pct spell duration (aug formula)
+        public const int FortifyVitalsPct = 50226;    // additive percentage POINTS across pieces - all three vitals (key 41)
+        public const int BattleMendChancePct = 50227; // per-PIECE proc chance in % (key 42)
+        public const int BattleMendHealAmount = 50228;// per-PIECE heal amount on proc (key 42) - LEGACY, no longer stamped
+        // Armor v2 slot specials (2026-08-21): MAX-wins across worn pieces (Creature.GetZoneModifierMax), never summed
+        public const int PctHpDamagePct = 50229;      // Gauntlets (key 44): pct of target max HP per hit, in TENTHS of a pct (45 = 4.5 pct)
+        public const int CheatDeathFlag = 50230;      // Boots (key 45): stamp 1 - lethal hit -> 1 HP + immunity window
+        public const int RegenSpecialMult = 50231;    // Bracers (key 46): FLAT pct of max vital added per natural regen tick (was a multiplier until 2026-08-23)
+        // 2026-08-22 additions (owner cantrip walkthrough)
+        public const int PctMaxHealthPct = 50232;     // key 47 Pct Max Health: percentage POINTS of max HP, SUMMED across worn pieces
+        public const int LifeOnHitPct = 50233;        // key 48 Life on Hit: pct of the wielder's MAX HP healed per landed hit, SUMMED, worn cap lifeonhit_cap (25)
+        public const int ReinforcedRank = 50234;      // key 49 Reinforced: the protection rank stamped on the piece (1 Superior / 2 Excellent / 3 Unparalleled) - display/bookkeeping only
+        public const int SkillBonusBase = 50300;      // + (int)Skill => 50300+.. (flat skill, post-vitae)
+
+        /// <summary>
+        /// Per-line slot rule (owner 2026-08-22, "a way to specify live in game which slots the cantrip
+        /// can drop in"). Bit flags; 0 = Any. The catalog's ArmorOnly / JewelryOnly flags are the
+        /// DEFAULT (DefaultSlotMask); a zone / Default-layer override (ZoneVariantProfile.CustomModifierSlots,
+        /// `cantrip <scope> slots <key> ...`) replaces it per key. The mutator and the premade forge both ask
+        /// EffectiveSlotMask, so what drops and what /asforge mints agree.
+        /// </summary>
+        [Flags]
+        public enum SlotMask
+        {
+            Any = 0,
+            Armor = 1,
+            Shield = 2,
+            Jewelry = 4,
+            Clothing = 8,
+            Cloak = 16,
+        }
+
+        public static SlotMask DefaultSlotMask(Def def)
+            => def == null ? SlotMask.Any : def.ArmorOnly ? SlotMask.Armor | SlotMask.Shield : def.JewelryOnly ? SlotMask.Jewelry : SlotMask.Any;
+
+        /// <summary>The mask the roll should use: the profile's per-key override when authored, else the catalog default.</summary>
+        public static SlotMask EffectiveSlotMask(Def def, IReadOnlyDictionary<int, int> overrides)
+            => def != null && overrides != null && overrides.TryGetValue(def.Key, out var m) ? (SlotMask)m : DefaultSlotMask(def);
+
+        /// <summary>What kind of piece this is, for the slot rule. Armor = has an armor level and is not a shield;
+        /// Shield = IsShield; Jewelry = ItemType Jewelry; Clothing = ItemType Clothing without an AL (undies);
+        /// Cloak = ItemType Clothing covering the cloak slot. Weapons return 0 (they never roll lines here anyway).</summary>
+        public static SlotMask PieceMask(WorldObject wo)
+        {
+            if (wo == null) return SlotMask.Any;
+            if (wo.IsShield) return SlotMask.Shield;
+            if (wo.ArmorLevel.HasValue && wo.ArmorLevel.Value > 0 && wo.ItemType != ItemType.Jewelry) return SlotMask.Armor;
+            if (wo.ItemType == ItemType.Jewelry) return SlotMask.Jewelry;
+            if (wo.ItemType == ItemType.Clothing)
+                return (wo.ValidLocations ?? 0).HasFlag(EquipMask.Cloak) ? SlotMask.Cloak : SlotMask.Clothing;
+            return SlotMask.Any;
+        }
+
+        public static bool SlotAllowed(SlotMask rule, SlotMask piece) => rule == SlotMask.Any || (rule & piece) != 0;
+
+        /// <summary>"armor,shield" / "jewelry" / "any" / "clear" -> mask; null on a bad token. -1 = clear.</summary>
+        public static bool TryParseSlotSpec(string spec, out int mask)
+        {
+            mask = 0;
+            if (string.IsNullOrWhiteSpace(spec)) return false;
+            if (spec.Trim().Equals("clear", StringComparison.OrdinalIgnoreCase)) { mask = -1; return true; }
+            if (int.TryParse(spec.Trim(), out var raw) && raw >= 0 && raw <= 31) { mask = raw; return true; }
+            foreach (var tok in spec.Split(new[] { ',', '+', ' ' }, StringSplitOptions.RemoveEmptyEntries))
+            {
+                switch (tok.Trim().ToLowerInvariant())
+                {
+                    case "any": break;
+                    case "armor": mask |= (int)SlotMask.Armor; break;
+                    case "shield": mask |= (int)SlotMask.Shield; break;
+                    case "jewelry": case "jewellery": mask |= (int)SlotMask.Jewelry; break;
+                    case "clothing": case "undies": mask |= (int)SlotMask.Clothing; break;
+                    case "cloak": mask |= (int)SlotMask.Cloak; break;
+                    default: return false;
+                }
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Where a SLOT SPECIAL lands (owner 2026-08-22: "drop down here, just with single slot"). One id per
+        /// drop slot of the T11+ set. The catalog's SpecialSlot (CoverageMask) is the default; a zone / Default
+        /// override in CustomModifierSlots (same dict as the line slot rules - for a special the value is a
+        /// SpecialSlotId, not a mask) replaces it. Creature_Death matches and spawns by this id.
+        /// </summary>
+        public enum SpecialSlotId
+        {
+            Helm = 1, Chest, Shoulders, Bracers, Gauntlets, Girth, Tassets, Greaves, Boots,
+            Shield = 10, Neck = 11, Trinket = 12, Ring = 13, Bracelet = 14, Cloak = 15,
+        }
+
+        public static SpecialSlotId DefaultSpecialSlot(Def def) => def?.SpecialSlot switch
+        {
+            CoverageMask.Head => SpecialSlotId.Helm,
+            CoverageMask.OuterwearChest => SpecialSlotId.Chest,
+            CoverageMask.OuterwearUpperArms => SpecialSlotId.Shoulders,
+            CoverageMask.OuterwearLowerArms => SpecialSlotId.Bracers,
+            CoverageMask.Hands => SpecialSlotId.Gauntlets,
+            CoverageMask.OuterwearAbdomen => SpecialSlotId.Girth,
+            CoverageMask.OuterwearUpperLegs => SpecialSlotId.Tassets,
+            CoverageMask.OuterwearLowerLegs => SpecialSlotId.Greaves,
+            CoverageMask.Feet => SpecialSlotId.Boots,
+            _ => SpecialSlotId.Chest,
+        };
+
+        public static SpecialSlotId EffectiveSpecialSlot(Def def, IReadOnlyDictionary<int, int> overrides)
+            => def != null && overrides != null && overrides.TryGetValue(def.Key, out var v) && Enum.IsDefined(typeof(SpecialSlotId), v)
+                ? (SpecialSlotId)v : DefaultSpecialSlot(def);
+
+        public static bool TryParseSpecialSlot(string spec, out int id)
+        {
+            id = 0;
+            if (string.IsNullOrWhiteSpace(spec)) return false;
+            var t = spec.Trim();
+            if (t.Equals("clear", StringComparison.OrdinalIgnoreCase)) { id = -1; return true; }
+            if (int.TryParse(t, out var raw) && Enum.IsDefined(typeof(SpecialSlotId), raw)) { id = raw; return true; }
+            switch (t.ToLowerInvariant())
+            {
+                case "helm": case "head": id = (int)SpecialSlotId.Helm; return true;
+                case "chest": id = (int)SpecialSlotId.Chest; return true;
+                case "shoulders": case "shoulder": case "pauldrons": id = (int)SpecialSlotId.Shoulders; return true;
+                case "bracers": case "bracer": id = (int)SpecialSlotId.Bracers; return true;
+                case "gauntlets": case "gloves": case "glove": case "hands": id = (int)SpecialSlotId.Gauntlets; return true;
+                case "girth": id = (int)SpecialSlotId.Girth; return true;
+                case "tassets": case "upperleg": id = (int)SpecialSlotId.Tassets; return true;
+                case "greaves": case "lowerleg": id = (int)SpecialSlotId.Greaves; return true;
+                case "boots": case "boot": case "feet": id = (int)SpecialSlotId.Boots; return true;
+                case "shield": id = (int)SpecialSlotId.Shield; return true;
+                case "neck": case "amulet": case "necklace": id = (int)SpecialSlotId.Neck; return true;
+                case "trinket": id = (int)SpecialSlotId.Trinket; return true;
+                case "ring": id = (int)SpecialSlotId.Ring; return true;
+                case "bracelet": case "wrist": id = (int)SpecialSlotId.Bracelet; return true;
+                case "cloak": id = (int)SpecialSlotId.Cloak; return true;
+            }
+            return false;
+        }
+
+        public static string SpecialSlotName(int id) => Enum.IsDefined(typeof(SpecialSlotId), id) ? ((SpecialSlotId)id).ToString() : "slot " + id;
+
+        private static CoverageMask SpecialCoverage(SpecialSlotId id) => id switch
+        {
+            SpecialSlotId.Helm => CoverageMask.Head,
+            SpecialSlotId.Chest => CoverageMask.OuterwearChest,
+            SpecialSlotId.Shoulders => CoverageMask.OuterwearUpperArms,
+            SpecialSlotId.Bracers => CoverageMask.OuterwearLowerArms,
+            SpecialSlotId.Gauntlets => CoverageMask.Hands,
+            SpecialSlotId.Girth => CoverageMask.OuterwearAbdomen,
+            SpecialSlotId.Tassets => CoverageMask.OuterwearUpperLegs,
+            SpecialSlotId.Greaves => CoverageMask.OuterwearLowerLegs,
+            SpecialSlotId.Boots => CoverageMask.Feet,
+            _ => 0,
+        };
+
+        /// <summary>Does this dropped piece sit in the special's slot?</summary>
+        public static bool SpecialPieceMatches(WorldObject wo, SpecialSlotId id)
+        {
+            if (wo == null) return false;
+            switch (id)
+            {
+                case SpecialSlotId.Shield: return wo.IsShield;
+                case SpecialSlotId.Cloak: return wo.ItemType == ItemType.Clothing && (wo.ValidLocations ?? 0).HasFlag(EquipMask.Cloak);
+                case SpecialSlotId.Neck: return wo.ItemType == ItemType.Jewelry && (wo.ValidLocations ?? 0).HasFlag(EquipMask.NeckWear);
+                case SpecialSlotId.Trinket: return wo.ItemType == ItemType.Jewelry && (wo.ValidLocations ?? 0).HasFlag(EquipMask.TrinketOne);
+                case SpecialSlotId.Ring: return wo.ItemType == ItemType.Jewelry && ((wo.ValidLocations ?? 0) & (EquipMask.FingerWearLeft | EquipMask.FingerWearRight)) != 0;
+                case SpecialSlotId.Bracelet: return wo.ItemType == ItemType.Jewelry && ((wo.ValidLocations ?? 0) & (EquipMask.WristWearLeft | EquipMask.WristWearRight)) != 0;
+                default:
+                    var cov = SpecialCoverage(id);
+                    return cov != 0 && !wo.IsShield && wo.ClothingPriority.HasValue && (wo.ClothingPriority.Value & cov) != 0 && (wo.ArmorLevel ?? 0) > 0;
+            }
+        }
+
+        public static string SlotMaskName(int mask)
+        {
+            if (mask <= 0) return "Any";
+            var parts = new List<string>();
+            if ((mask & 1) != 0) parts.Add("Armor");
+            if ((mask & 2) != 0) parts.Add("Shield");
+            if ((mask & 4) != 0) parts.Add("Jewelry");
+            if ((mask & 8) != 0) parts.Add("Clothing");
+            if ((mask & 16) != 0) parts.Add("Cloak");
+            return string.Join("+", parts);
+        }
+
+        public class Def
+        {
+            public int Key;
+            public string Name;                            // codename ("Empyrean Might")
+            public string Effect;                          // legacy fixed-value text, kept for old callers/help
+            public string ValFmt;                          // rolled-value format: "+{0}", "x{0}", "+{0} lvl", "+{0}% vitals", "heal {0}"
+            public int Min, Max;                           // roll band, INCLUSIVE both bounds
+            public bool ArmorOnly;                         // keys 25 / 49 - needs an ArmorLevel piece
+            public bool JewelryOnly;                       // key 48 Life on Hit - rolls only on jewelry (no AL, ItemType Jewelry)
+            public bool TierScaled;                        // the 1250-class lines + Armor Level: catalog band x (1 + (t-11)/14) when no Default is authored (owner 2026-08-23)
+            public int Min25, Max25;                       // optional explicit T25 anchor: band lerps linearly T11 (Min/Max) -> T25 (Min25/Max25); 0 = unused
+            public bool SetsProtection;                    // key 49 Reinforced - the rolled value is a RANK that SETS every ArmorModVs* on the piece
+            public (int PropId, int Value)[] Ints;         // int props stamped on the item; PropId also = banded stamp target
+            public ModifierClass Class;                     // Armor v2 pick weight class (Trash/Mid/Chase); None = never in the line pool
+            public bool SlotSpecial;                       // Armor v2 slot special: rolls once per KILL outside the line count, MAX-wins when worn
+            public CoverageMask SpecialSlot;               // the armor slot a SlotSpecial stamps onto (Head/OuterwearChest/Hands/Feet/OuterwearLowerArms)
+        }
+
+        /// <summary>Armor v2 random-pool weight class (Cantrip_Band_Ladder v2 section 2). The per-class
+        /// weights are zone stats cantrip_weight_trash/mid/chase.</summary>
+        public enum ModifierClass
+        {
+            None = 0,   // retired / specials - never drawn as a line
+            Trash,      // 32 Spell Duration, 25 Armor Level
+            Mid,        // 28 Damage Rating, 29 Crit Damage Rating, 19 Max Health, 31 Healing Boost, 49 Reinforced
+            Chase,      // 33 Crit Chance, 43 All Attributes, 47 Pct Max Health, 48 Life on Hit
+        }
+
+        private static (int, int)[] P(int propId, int v) => new[] { (propId, v) };
+
+        /// <summary>The unique zone cantrip catalog. Keys are stable — they live in saved zone pools.
+        /// Bands (Min/Max/ValFmt) mirror the plugin ModifierCatalog, the band authority.</summary>
+        public static readonly SortedDictionary<int, Def> Catalog = new()
+        {
+            // vitals
+            { 19, new Def { Key = 19, TierScaled = true, Class = ModifierClass.Mid, Name = "Max Health", Effect = "+14-69 Max Health", ValFmt = "+{0}", Min = 14, Max = 69, Ints = P((int)PropertyInt.GearMaxHealth, 300) } },
+            // bulwark (Aegis is the ONLY line that modifies the item, not the player - armor/shield pieces only)
+            { 25, new Def { Key = 25, TierScaled = true, Class = ModifierClass.Trash, ArmorOnly = true, Name = "Armor Level", Effect = "+300 Armor Level on this piece", ValFmt = "+{0}", Min = 50, Max = 250 } },
+            // slaughter
+            { 28, new Def { Key = 28, TierScaled = true, Class = ModifierClass.Mid, Name = "Damage Rating", Effect = "+14-69 Damage Rating", ValFmt = "+{0}", Min = 14, Max = 69, Ints = P((int)PropertyInt.GearDamage, 25) } },
+            { 29, new Def { Key = 29, TierScaled = true, Class = ModifierClass.Mid, Name = "Crit Damage Rating", Effect = "+14-69 Critical Damage Rating", ValFmt = "+{0}", Min = 14, Max = 69, Ints = P((int)PropertyInt.GearCritDamage, 40) } },
+            // whimsy
+            { 31, new Def { Key = 31, TierScaled = true, Class = ModifierClass.Mid, Name = "Healing Boost", Effect = "+14-69 Healing Boost Rating", ValFmt = "+{0}", Min = 14, Max = 69, Ints = P((int)PropertyInt.GearHealingBoost, 40) } },
+            { 32, new Def { Key = 32, Class = ModifierClass.Trash, Name = "Spell Duration", Effect = "+100 pct spell duration", ValFmt = "+{0} lvl", Min = 1, Max = 3, Ints = P(SpellDurationLevels, 5) } },
+            // ratings (banded-only lines - legacy fixed Value is 0, they never ship via the legacy overload)
+            { 33, new Def { Key = 33, Class = ModifierClass.Chase, Name = "Crit Chance", Effect = "+1-3 Crit Rating", ValFmt = "+{0}", Min = 1, Max = 3, Ints = P((int)PropertyInt.GearCrit, 0) } },
+            // 37-40 RETIRED 2026-08-22 (owner): four class-split copies of what Damage Rating (28) already does
+            // for every class. They forced a melee/caster premade split and made 3 of 4 dead for any given
+            // player. Keys kept (saved pools, old items still read), props 50222-50225 still summed on equip.
+            // ── Armor v2 SLOT SPECIALS (2026-08-21) ─────────────────────────────────────────────
+            // Roll ONCE per KILL outside the line count (Creature_Death), stamp the dropped piece of
+            // their slot, MAX-wins across worn pieces. Never drawn as a pool line (SlotSpecial).
+            // Helm - fortify vitals, percentage POINTS, highest single value wins, all three pools
+            { 41, new Def { Key = 41, SlotSpecial = true, SpecialSlot = CoverageMask.Head, Name = "Fortify Vitals", Effect = "+5-25 pct max vitals (Helm special)", ValFmt = "+{0}% vitals", Min = 5, Max = 25, Ints = P(FortifyVitalsPct, 0) } },
+            // Chest - Battle Mending death save: after damage, HP > 0 and < 25 pct -> heal to max, 60 s CD; no magnitude.
+            // The old proc PAIR is gone: only 50227 is stamped (= 1, presence flag); the combat side reads it MAX-wins.
+            { 42, new Def { Key = 42, SlotSpecial = true, SpecialSlot = CoverageMask.OuterwearChest, Name = "Battle Mending", Effect = "death save: below 25 pct HP heal to full, 60 s cooldown (Chest special)", ValFmt = "", Min = 1, Max = 1, Ints = P(BattleMendChancePct, 0) } },
+            // Gauntlets - flat pct of target max HP per hit, no crit/mults; value in TENTHS of a pct (40-60 = 4-6 pct at T11); 2 s CD; no-kill rule
+            { 44, new Def { Key = 44, SlotSpecial = true, SpecialSlot = CoverageMask.Hands, Name = "Pct HP Damage", Effect = "4-6 pct of target max HP per hit (Gauntlets special)", ValFmt = "{0} ({1:0.#} pct of max HP per hit)", Min = 40, Max = 60, Ints = P(PctHpDamagePct, 0) } },
+            // Boots - Cheat Death: lethal hit -> 1 HP + 5 s immunity, 10 min CD per character; no magnitude
+            { 45, new Def { Key = 45, SlotSpecial = true, SpecialSlot = CoverageMask.Feet, Name = "Cheat Death", Effect = "lethal hit leaves 1 HP + 5 s immunity, 10 min cooldown (Boots special)", ValFmt = "", Min = 1, Max = 1, Ints = P(CheatDeathFlag, 0) } },
+            // Bracers - natural regen multiplier (x3 default), Prodigal stays suppressed
+            { 46, new Def { Key = 46, SlotSpecial = true, SpecialSlot = CoverageMask.OuterwearLowerArms, Name = "Regeneration", Effect = "+1-2 pct (T11) to +3-5 pct (T25) of max vitals on every natural regen tick (Bracers special; FLAT, never multiplies the buff stack - owner 2026-08-23)", ValFmt = "+{0}% per tick", Min = 1, Max = 2, Min25 = 3, Max25 = 5, Ints = P(RegenSpecialMult, 0) } },
+            // ── 2026-08-22 pool additions (owner cantrip walkthrough; design in Cantrip_Pool_Decisions_2026-08-22.md) ──
+            // Pct Max Health - chase, pinned 1-3 like Crit Chance, SUMMED across pieces (18 x 3 = 54 pct at BiS),
+            // stacks on top of the Helm special Fortify Vitals (max-wins). Read in CreatureVital (MaxHealth only).
+            { 47, new Def { Key = 47, Class = ModifierClass.Chase, Name = "Max Health Pct", Effect = "+1-3 pct max health", ValFmt = "+{0}%", Min = 1, Max = 3, Ints = P(PctMaxHealthPct, 0) } },
+            // Life on Hit - chase, JEWELRY ONLY (6 slots), 1-3 pct of the wielder's max HP per landed hit, summed,
+            // worn cap lifeonhit_cap (25 pct), lifeonhit_cooldown (3 s). Read in Player.ZcTryLifeOnHit from both hit paths.
+            { 48, new Def { Key = 48, Class = ModifierClass.Chase, JewelryOnly = true, Name = "Life on Hit", Effect = "heal 1-3 pct max HP per hit", ValFmt = "{0}% HP per hit", Min = 1, Max = 3, Ints = P(LifeOnHitPct, 0) } },
+            // Reinforced - mid, ARMOR ONLY, the value is a protection RANK: +1 Superior 1.40 / +2 Excellent 1.60 /
+            // +3 Unparalleled 1.80. Stamp SETS every ArmorModVs* on the piece (after EqualizeT11ArmorResists), so it
+            // is item data, not an enchantment - hollow mobs cannot strip it. Tier-weighted toward +3 via TierThirds.
+            { 49, new Def { Key = 49, Class = ModifierClass.Mid, ArmorOnly = true, SetsProtection = true, Name = "Reinforced", Effect = "+1-3 protection rank (Superior / Excellent / Unparalleled)", ValFmt = "+{0}", Min = 1, Max = 3, Ints = P(ReinforcedRank, 0) } },
+            // ── Armor v2 pool additions ─────────────────────────────────────────────────────────
+            // All Attributes - six attrs behind ONE line (keys 1-6 retired); anchor 2500 at T25 = the Dmg/HP per-piece table. AVERAGE class since 2026-08-23 (owner)
+            { 43, new Def { Key = 43, TierScaled = true, Class = ModifierClass.Mid, Name = "All Attributes", Effect = "+14-69 to ALL six attributes", ValFmt = "+{0}", Min = 14, Max = 69,
+                Ints = new[] { (AttrBonusBase + (int)PropertyAttribute.Strength, 0), (AttrBonusBase + (int)PropertyAttribute.Endurance, 0), (AttrBonusBase + (int)PropertyAttribute.Coordination, 0),
+                               (AttrBonusBase + (int)PropertyAttribute.Quickness, 0), (AttrBonusBase + (int)PropertyAttribute.Focus, 0), (AttrBonusBase + (int)PropertyAttribute.Self, 0) } } },
+        };
+
+        public static bool TryGet(int key, out Def def) => Catalog.TryGetValue(key, out def);
+
+        /// <summary>Every catalog def, for the per-line roll sweep (owner 2026-08-29: each LINE rolls
+        /// its own anchored chance; the pool / count / weight machinery is retired).</summary>
+        public static IEnumerable<Def> AllDefs => Catalog.Values;
+
+        /// <summary>The per-line chance stat for a catalog key ("modifier_chance_43"); its "_t25"
+        /// twin is the T25 anchor. Registered explicitly in ZoneStat.All - a NEW catalog line needs
+        /// its pair added there too, or the wire will not carry it.</summary>
+        public static string LineChanceStat(int key) => "modifier_chance_" + key;
+
+        /// <summary>Tier scale of the anchored linear ladder: 1.0 at T11, 2.0 at T25 (same f as the core anchors).</summary>
+        public static double TierScale(int tier) => 1.0 + (Math.Clamp(tier, 11, 25) - 11) / 14.0;
+
+        // LinesFallback REMOVED 2026-08-29 with the line-count ladder (one-row-per-Modifier design):
+        // every line rolls its own anchored modifier_chance_<key> now, so there is no per-piece
+        // count to fall back to.
+
+        /// <summary>
+        /// The HARDCODED band at a tier - what every fallback uses when no Default / zone band is authored
+        /// (owner 2026-08-23: the catalog stays the reset target, but it must be tier-aware or T12+ rolls
+        /// T11 numbers). TierScaled lines (the 1250-class ones + Armor Level) scale min and max by
+        /// <see cref="TierScale"/>; pinned lines (1-3) and specials return the catalog band unchanged.
+        /// </summary>
+        public static (int Min, int Max) CatalogBandAt(Def def, int tier)
+        {
+            if (def == null) return (0, 0);
+            var (min, max) = def.Min <= def.Max ? (def.Min, def.Max) : (def.Max, def.Min);
+            if (def.Max25 > 0 && tier > 11)
+            {
+                // explicit T11 -> T25 anchors (owner 2026-08-23: Regeneration 1-2 at T11 -> 3-5 at T25)
+                var t = (Math.Clamp(tier, 11, 25) - 11) / 14.0;
+                return ((int)Math.Round(min + (def.Min25 - min) * t), (int)Math.Round(max + (def.Max25 - max) * t));
+            }
+            if (!def.TierScaled || tier <= 11) return (min, max);
+            var f = TierScale(tier);
+            return ((int)Math.Round(min * f), (int)Math.Round(max * f));
+        }
+
+        // ---- WEAPON card bands (2026-08-25) -----------------------------------------------------
+        //
+        // WHY THIS IS A SEPARATE TABLE AND NOT SIX MORE Catalog ROWS
+        //
+        // The six continuous weapon specials (Biting Strike, Crushing Blow, Armor Rend, Shield
+        // Cleaving, Slayer, Rend Power) are DOUBLES whose second decimal matters: 0.58 crit chance,
+        // 1.85x crush, 2.10 slayer. Def.Min/Max are ints, and CatalogBandAt returns (int, int).
+        // Widening those would drag ValueFor/GradeFor, StampGraded, Stamp, the "[min-max]" LongDesc
+        // text (which ZoneControlCommands.TryParseZcLine PARSES BACK for legacy-item migration),
+        // ModifierBand (which is BOTH the [[ZC]]/[[ZCD]] wire shape AND the on-disk store JSON), and
+        // the plugin's int.Parse of the cantrips= tag - a synchronised server+plugin deploy for six
+        // values that never travel the wire in the first place. So: a separate table, double bounds,
+        // keyed by the STAT NAME PAIR that already exists.
+        //
+        // Keying by stat name rather than by a new integer Catalog key is deliberate. Catalog keys
+        // are load-bearing forever (see the comment at Catalog and at the retired 37-40 block): they
+        // live in saved zone pools (ZoneVariantProfile.CustomModifiers) and on already-dropped items.
+        // Minting six of them for weapons would leak weapon keys into the armour line pool and into
+        // the "cantrip <scope> band <key>" command surface, where they mean nothing. This table
+        // mints none, changes no existing type, and needs ZERO wire or store work.
+        //
+        // WHAT THIS TABLE IS: the FALLBACK a weapon card rolls from when the zone authors NEITHER
+        // weapon_<card>_min NOR weapon_<card>_max - exactly the role CatalogBandAt plays for armour
+        // lines. An authored min/max still wins outright and behaves exactly as it did before this
+        // table existed, including the "one box = exact value, not a band" rule in RollRange.
+        //
+        // UNITS: every number below is in WIRE space, i.e. the units the weapon_*_min/max stats
+        // already carry and the units the roll site writes onto the item. The plugin's Weapons-tab
+        // boxes are NOT all in wire space, so each row states its own conversion. Getting this wrong
+        // is silent: a 100x error in Biting Strike just clamps to 1.0 and every weapon crits always.
+        //
+        // KEEP IN STEP WITH THE PLUGIN. The same six anchors are mirrored in the ZoneControl plugin
+        // at ZoneControlHud.cs "WpnBands" (BOX space there, wire space here). The plugin table is
+        // what the owner reads while authoring; this one is what actually rolls. If one moves and
+        // the other does not, the tooltip lies about what drops. There is no wire tag that syncs
+        // them - that is the price of option (C), and it is cheaper than the alternative.
+        //
+        // Lo/Hi on each row are NOT design numbers - they are copied verbatim from that card's
+        // existing RollRange(..., lo, hi) arguments in ZoneLootMutator.TrySpecialRolls, so the
+        // banded path can never produce a value the authored path could not. If a clamp moves there,
+        // move it here in the same edit.
+        /// <summary>
+        /// A T11 -> T25 magnitude ladder for ONE continuous weapon special, in wire units.
+        /// Deliberately NOT <see cref="Def"/>: doubles, no catalog key, never in the armour line pool.
+        /// </summary>
+        public sealed class WeaponBand
+        {
+            public string Name;              // card name as the plugin's Weapons tab shows it
+            public string MinStat, MaxStat;  // the authored zone stats that OVERRIDE this ladder entirely
+            public double Min, Max;          // T11 anchor, WIRE units
+            public double Min25, Max25;      // T25 anchor, WIRE units
+            public double Lo, Hi;            // hard clamp - mirrors the card's RollRange(lo, hi) at its roll site
+        }
+
+        // Biting Strike -> CriticalFrequency. Plugin box is PERCENT 0..100; wire is a 0..1 fraction.
+        // Conversion: wire = box / 100. Box 58-65 -> 0.58-0.65 at T11; box 78-88 -> 0.78-0.88 at T25.
+        public static readonly WeaponBand WeaponBite = new WeaponBand
+        {
+            Name = "Biting Strike", MinStat = ZoneScaling.ZoneStat.WeaponBiteMin, MaxStat = ZoneScaling.ZoneStat.WeaponBiteMax,
+            // T11 floor RE-ANCHORED 2026-08-25 (owner): exactly 0.33, which is what every
+            // general crit-chance craft SetValues - Bag of Abyssal-Touched Gems (527870098/100/113),
+            // Salvaged Yellow Garnet (527870006/010), Admin Only Yellow Garnet. So a T11 drop at its
+            // floor exactly TIES the best craftable weapon, and every roll above it beats one.
+            // The old 0.58 was chosen to clear the Critical Strike imbue's flat 0.50 - that imbue is
+            // suppressed for players now, so it is no longer the thing to beat.
+            // DECIDED 2026-08-29 (owner, power-level session): the whole weapon ladder is budgeted
+            // at +20% player power per tier (BiS-over-craft ~13x at T25, split evenly across the
+            // three multiplying cards). Bite's share is shaped so crits stay an EVENT: 0.60 at the
+            // T25 chase, deliberately NOT the old imbue-era 0.88 near-every-hit zone. T11 max 0.40
+            // gives an S-grade roll a visible edge over the 0.33 craft tie.
+            Min = 0.33, Max = 0.40, Min25 = 0.50, Max25 = 0.60, Lo = 0.0, Hi = 1.0,
+        };
+
+        // Armor Rend -> prop 9057, the fraction of the target's armour ignored. Plugin box is
+        // PERCENT 0..100; wire is a 0..1 fraction. Conversion: wire = box / 100.
+        // Box 62-68 -> 0.62-0.68 at T11; box 74-80 -> 0.74-0.80 at T25.
+        public static readonly WeaponBand WeaponArmorRend = new WeaponBand
+        {
+            Name = "Armor Rend", MinStat = ZoneScaling.ZoneStat.WeaponArmorRendMin, MaxStat = ZoneScaling.ZoneStat.WeaponArmorRendMax,
+            Min = 0.62, Max = 0.68, Min25 = 0.74, Max25 = 0.80, Lo = 0.0, Hi = 1.0,
+        };
+
+        // Rend Power -> prop 9056, a vuln FRACTION (the engine computes rendingMod = 1 + this, so
+        // wire 1.60 means the target takes 2.60x from that element - NOT 1.60x; that off-by-one bit
+        // once already, 2026-08-24). Plugin box is PERCENT 0..1000, i.e. box 160 = wire 1.60.
+        // Conversion: wire = box / 100. Box 150-213 -> 1.50-2.13 at T11; box 275-400 -> 2.75-4.00 at T25.
+        //
+        // RE-ANCHORED 2026-08-26 (owner set all four numbers plus the clamp). The old 1.60/1.85 ->
+        // 2.20/2.70 was imbue-era: 1.60 was picked to CLEAR the vanilla rend's 2.5x cap by a margin.
+        // The doctrine the other cards were re-anchored to on 08-25 is TIE THE BEST CRAFT, and here
+        // the best craft IS that ceiling - every elemental salvage SetValues 1.50 stored = 2.50x, on
+        // 280 weapon targets per element. So the floor moves DOWN to 1.50 to tie it exactly, and the
+        // spread above it is what carries the card.
+        // Hi LOWERED 10.0 -> 5.0 in the same edit. Rend Power substitutes into vulnMod AFTER the v11
+        // vulnerability compression (Creature_Properties.cs:130-146 then :168-169), so it is the one
+        // channel that BYPASSES v11_vuln_cap entirely - at 10.0 the engine computes rendingMod = 11.0,
+        // an 11x multiplier on the whole damage line before prots. 5.0 is still a 6x ceiling.
+        public static readonly WeaponBand WeaponRendPower = new WeaponBand
+        {
+            Name = "Rend Power", MinStat = ZoneScaling.ZoneStat.WeaponRendPowerMin, MaxStat = ZoneScaling.ZoneStat.WeaponRendPowerMax,
+            // T25 RAISED 2026-08-29 (owner, power-level session, +20%/tier budget): T25 3.75-5.00.
+            // In damage terms: wire 5.00 -> rendingMod 6.0 = 2.4x the craft's 2.5x contribution,
+            // sitting exactly AT the Hi clamp - rend's even third of the ~13x BiS-over-craft budget.
+            // Rides the Rending merge: every card-stamped rend rolls this band at the imbue chance.
+            Min = 1.50, Max = 2.13, Min25 = 3.75, Max25 = 5.00, Lo = 1.5, Hi = 5.0,
+        };
+
+        // Slayer -> SlayerDamageBonus, a RAW damage multiplier vs the killed creature type. The
+        // plugin box is raw too (weapon_slayer_* is NOT in the plugin's PercentStats set), so there
+        // is NO conversion: box 1.80 = wire 1.80. Box 1.80-2.10 at T11; box 2.40-3.00 at T25.
+        // Cast on Strike damage (added 2026-08-27, owner). B = the spell base the proc rolls, and it
+        // REPLACES the rolled base plus the flat War/Void aug term rather than multiplying it.
+        //
+        // WHY 440: collapsing everything a proc shares with a melee swing, landed proc damage is B x K
+        // with K ~= 3.20 against a T11 minion at the reference build, and measured melee lands ~1,413
+        // per hit there - so B ~= 440 is EXACTLY ONE MELEE HIT. That is the yardstick the owner chose
+        // over "tie the best craft" (~150), because 0.34 of a swing is not something a player notices.
+        // The ratio is rend-proof: a proc and a swing pass through the SAME weaponResistanceMod term
+        // with the same weapon, so a matched rend cancels out of it and 440 holds whatever the vuln
+        // cap becomes (see the vuln/rend MAX ruling, Creature_Properties.cs:167).
+        //
+        // RE-RULED 2026-08-30 (owner): base B is a token "one damage to two damage" - flat 1-2 at
+        // EVERY tier, no T25 growth. The proc's real damage comes from the WIELDER's War/Void augs,
+        // which the engine adds flat on top of B, so tier scaling rides the aug ladder, not this
+        // band. This supersedes the 440-660 provisional and the "440 + X pct" form entirely.
+        public static readonly WeaponBand WeaponProcArcDamage = new WeaponBand
+        {
+            Name = "Cast on Strike (Arc)", MinStat = ZoneScaling.ZoneStat.WeaponProcArcDmgMin, MaxStat = ZoneScaling.ZoneStat.WeaponProcArcDmgMax,
+            Min = 1, Max = 2, Min25 = 1, Max25 = 2, Lo = 1, Hi = 100000,
+        };
+
+        /// <summary>The ring's own band. Seeded identical to the arc's so the two start level and the
+        /// owner can tune them apart from a known baseline - NOT because they are expected to stay
+        /// equal. A ring is 9 projectiles centred on the wielder; an arc is one at the target.</summary>
+        public static readonly WeaponBand WeaponProcRingDamage = new WeaponBand
+        {
+            Name = "Cast on Strike (Ring)", MinStat = ZoneScaling.ZoneStat.WeaponProcRingDmgMin, MaxStat = ZoneScaling.ZoneStat.WeaponProcRingDmgMax,
+            Min = 1, Max = 2, Min25 = 1, Max25 = 2, Lo = 1, Hi = 100000,
+        };
+
+        public static readonly WeaponBand WeaponSlayer = new WeaponBand
+        {
+            Name = "Slayer", MinStat = ZoneScaling.ZoneStat.WeaponSlayerMin, MaxStat = ZoneScaling.ZoneStat.WeaponSlayerMax,
+            // T11 floor RE-ANCHORED 2026-08-25 (owner): exactly 1.75, the highest value a player can
+            // APPLY to a weapon. Fifteen separate stones and gems all SetValue exactly 1.75 and each
+            // reaches 508-535 real weapon WCIDs, so it is not a rarity - it is the baseline any drop has
+            // to at least match. Retail Isparian weapons reach 4.0 and the Weeping Axe 3.4, but those are
+            // fixed weapons you WIELD rather than something you apply to a drop, so they are not the bar.
+            // NOTE Lo below is 1.5, which sits BENEATH the free craftable value - it was never a
+            // meaningful floor. The engine's own no-match fallback is 1.0, not 1.5.
+            // DECIDED 2026-08-29 (owner, +20%/tier budget): T11 max 2.10 = +20% over the craft tie
+            // for an S-grade; T25 3.00-4.10 carries slayer's even third of the ~13x BiS budget.
+            Min = 1.75, Max = 2.10, Min25 = 3.00, Max25 = 4.10, Lo = 1.5, Hi = 10.0,
+        };
+
+        // Shield Cleaving -> IgnoreShield, the fraction of the defender's shield AL ignored. Plugin
+        // box is PERCENT 0..100; wire is a 0..1 fraction. Conversion: wire = box / 100.
+        // Box 60-75 -> 0.60-0.75 at T11; box 90-100 -> 0.90-1.00 at T25 (1.00 = shield fully ignored).
+        public static readonly WeaponBand WeaponShieldCleave = new WeaponBand
+        {
+            Name = "Shield Cleaving", MinStat = ZoneScaling.ZoneStat.WeaponShieldCleaveMin, MaxStat = ZoneScaling.ZoneStat.WeaponShieldCleaveMax,
+            // Floor re-ruled 2026-08-30 (owner: "fifty at T11 and a hundred percent at T25") -
+            // 0.60 was the tie-the-vanilla-imbue floor; 50 now sits UNDER the best craftable
+            // armor-rend-style value on purpose. T25 max 1.00 = total shield bypass, unchanged.
+            Min = 0.50, Max = 0.75, Min25 = 0.90, Max25 = 1.00, Lo = 0.0, Hi = 1.0,
+        };
+
+        // Crushing Blow -> PropertyFloat.CriticalMultiplier. The band is in DISPLAY space, i.e. the
+        // final crit damage multiplier the card advertises (7.50 = 7.5x), which is also what the
+        // plugin box holds - weapon_crush_* is NOT a PercentStat, so there is NO conversion here.
+        // The "- 1.0" that turns a display multiplier into the stored CriticalMultiplier does NOT live
+        // in this table and must never be baked into it, or the two spaces get mixed and every
+        // comparison is off by exactly one. Since 2026-08-25 it lives in exactly one method,
+        // ZoneStatResolver.EngineValue, which both the drop-time write site and the equip-time
+        // re-resolve call - the card's value is produced from a recorded grade now, so a second
+        // subtraction anywhere would walk a 7.5x weapon down by 1.0 on every single login.
+        public static readonly WeaponBand WeaponCrush = new WeaponBand
+        {
+            Name = "Crushing Blow", MinStat = ZoneScaling.ZoneStat.WeaponCrushMin, MaxStat = ZoneScaling.ZoneStat.WeaponCrushMax,
+            // T11 floor RE-ANCHORED 2026-08-25 (owner): exactly the best general craft. These numbers
+            // are in DISPLAY space (EngineValue subtracts the 1.0 at the single write site), and the
+            // craft SetValues the STORED property, so the two spaces have to be lined up carefully:
+            //   Bag of Abyssal-Touched Gems / Salvaged Turquoise store 2.25 -> 3.25x in combat
+            //   Salvaged Turquoise (527870007)          stores 2.45 -> 3.45x in combat
+            // 3.25 display here == the bag exactly. NOTE 3.45 is the true general ceiling, so a
+            // floor-rolled T11 card ties the bag but is still beaten by that one turquoise recipe.
+            // (Crimson Night Gem Setting reaches 3.0 stored / 4.0x, but it is retail quest content
+            // that applies ONLY to a Silifi of Crimson Stars - not a general competitor.)
+            // The old 7.50 cleared the Crippling Blow imbue's 7.0x; that imbue is suppressed for
+            // players now.
+            // DECIDED 2026-08-29 (owner, +20%/tier budget): T11 3.25-4.00 (S-grade beats the bag),
+            // T25 5.50-6.80 - paired with Bite's 0.50-0.60 the crit pair carries its even third of
+            // the ~13x BiS budget without the 9.5-10x every-hit-crits meta. Under the unified crit
+            // model (same night) this band IS the crit ratio's bound on all three schools - the old
+            // player_crit_damage_cap clamp was deleted with it.
+            Min = 3.25, Max = 4.00, Min25 = 5.50, Max25 = 6.80, Lo = 2.0, Hi = 10.0,
+        };
+
+        /// <summary>Every weapon band, for help text / catalog printouts. Order is display order.</summary>
+        public static readonly WeaponBand[] WeaponBands =
+        {
+            WeaponBite, WeaponArmorRend, WeaponRendPower, WeaponSlayer, WeaponShieldCleave, WeaponCrush,
+            WeaponProcArcDamage, WeaponProcRingDamage,
+        };
+
+        /// <summary>
+        /// The weapon band at a tier: linear on (tier - 11) / 14, clamped to [11, 25] - the SAME
+        /// anchoring shape <see cref="CatalogBandAt"/> uses for a Min25/Max25 armour row, so a weapon
+        /// band and a cantrip band read the same way and a reader only has to learn the rule once.
+        /// The only difference is that nothing is rounded: these are doubles all the way through.
+        ///
+        /// The tier passed in MUST be the loot tier (the lootTier PARAMETER of TrySpecialRolls), not a
+        /// property read off the weapon. At roll time the weapon carries NO tier property at all -
+        /// ZcTier is never stamped on weapons, and WeaponAugScaleTier is stamped in Creature_Death
+        /// AFTER MutateLootItem has already run. Asking the item (ZoneStatResolver.TierOf or
+        /// ZoneCraftGate.TierOf) therefore returns 0 at THIS instant and every band would collapse to
+        /// its T11 rung with no error anywhere. Both of those helpers are fine LATER in the same sweep -
+        /// the drop-path self-check and the equip-time re-resolve both use them - just not here.
+        /// </summary>
+        public static (double Min, double Max) WeaponBandAt(WeaponBand b, int tier)
+        {
+            if (b == null) return (0.0, 0.0);
+            var (min, max) = b.Min <= b.Max ? (b.Min, b.Max) : (b.Max, b.Min);
+            var (min25, max25) = b.Min25 <= b.Max25 ? (b.Min25, b.Max25) : (b.Max25, b.Min25);
+            var t = (Math.Clamp(tier, 11, 25) - 11) / 14.0;   // 0 at T11 and below .. 1 at T25 and above
+            var lo = min + (min25 - min) * t;
+            var hi = max + (max25 - max) * t;
+            if (lo > hi) (lo, hi) = (hi, lo);                 // insurance against a hand-edited crossing ladder
+            return (Math.Clamp(lo, b.Lo, b.Hi), Math.Clamp(hi, b.Lo, b.Hi));
+        }
+
+        /// <summary>
+        /// Tier-weighted roll position (owner 2026-08-22, Option A): the carrot for pushing tiers is
+        /// "better gear AND better-rolled gear". Every band splits into thirds (low / mid / high); the
+        /// third is picked by these weights, then the value rolls uniform inside it. T11 = 33/33/34
+        /// (today's uniform roll - T11 is deliberately UNCHANGED for ship), T25 = 10/30/60, linear
+        /// between, clamped outside. Three-outcome lines (Reinforced +1/+2/+3, Life on Hit 1/2/3 pct)
+        /// use the thirds directly. One curve for everything; Tempered's per-tier odds will ride it too.
+        /// </summary>
+        public static (int Lo, int Mid, int Hi) TierThirds(int tier)
+        {
+            var f = Math.Clamp((tier - 11) / 14.0, 0.0, 1.0);
+            var lo = (int)Math.Round(33 + (10 - 33) * f);
+            var mid = (int)Math.Round(33 + (30 - 33) * f);
+            return (lo, mid, Math.Max(0, 100 - lo - mid));
+        }
+
+        /// <summary>Reinforced rank -> the ArmorModVs* value it sets (client label thresholds: Superior 1.40,
+        /// Excellent 1.60, Unparalleled 1.80).</summary>
+        public static double ReinforcedMod(int rank) => rank >= 3 ? 1.80 : rank == 2 ? 1.60 : 1.40;
+
+        private static readonly PropertyFloat[] ReinforcedMods =
+        {
+            PropertyFloat.ArmorModVsSlash, PropertyFloat.ArmorModVsPierce, PropertyFloat.ArmorModVsBludgeon, PropertyFloat.ArmorModVsFire,
+            PropertyFloat.ArmorModVsCold, PropertyFloat.ArmorModVsAcid, PropertyFloat.ArmorModVsElectric, PropertyFloat.ArmorModVsNether,
+        };
+
+        /// <summary>The slot specials (Armor v2) — the per-kill special roll picks one of these at random.</summary>
+        public static List<Def> SlotSpecials()
+        {
+            var list = new List<Def>();
+            foreach (var def in Catalog.Values)
+                if (def.SlotSpecial)
+                    list.Add(def);
+            return list;
+        }
+
+        private static void AddInt(WorldObject wo, int propId, int value)
+        {
+            var cur = wo.GetProperty((PropertyInt)propId) ?? 0;
+            wo.SetProperty((PropertyInt)propId, cur + value);
+        }
+
+        /// <summary>
+        /// GRADED stamp (live stat resolution, 2026-08-22): records (key, grade) in the piece's ZcModifiers
+        /// record, SETS the line's props to the value the grade resolves to inside the EFFECTIVE band
+        /// (what a later ladder apply will recompute against the live band), and writes the same drop line
+        /// text as <see cref="Stamp"/>. SET, not additive - one line per key per piece, the record is the
+        /// truth and the props are its cache. Reinforced (SetsProtection) is NOT graded - it is earned and
+        /// frozen (owner ruling) - so callers route key 49 through the plain Stamp. Returns the value.
+        /// Callers must also <see cref="ZoneStatResolver.StampIdentity"/> the piece once (tier + version).
+        /// </summary>
+        public static int StampGraded(WorldObject wo, Def def, int grade, (int Min, int Max) band)
+        {
+            if (wo == null || def == null)
+                return 0;
+            if (def.SetsProtection)
+            {
+                var rank = ZoneStatResolver.ValueFor(band.Min, band.Max, grade);
+                Stamp(wo, def, rank, (band.Min, band.Max));
+                return rank;
+            }
+
+            var value = ZoneStatResolver.ValueFor(band.Min, band.Max, grade);
+            ZoneStatResolver.AddLine(wo, def.Key, grade);
+
+            if (def.ArmorOnly && def.Ints == null)
+            {
+                // key 25 Armor Level: the piece's AL = tier base + the line; SET through the base so a
+                // re-roll of the same key never stacks
+                var tier = ZoneStatResolver.TierOf(wo);
+                if (wo.ArmorLevel.HasValue)
+                    wo.ArmorLevel = (tier > 0 ? ZoneStatResolver.BaseArmorLevel(tier) : wo.ArmorLevel.Value) + value;
+            }
+            else if (def.Ints != null)
+            {
+                foreach (var (propId, _) in def.Ints)
+                    wo.SetProperty((PropertyInt)propId, value);
+            }
+
+            string line;
+            if (def.SlotSpecial)
+                line = string.IsNullOrEmpty(def.ValFmt) ? $"Zone Cantrip: {def.Name}" : $"Zone Cantrip: {def.Name} {string.Format(def.ValFmt, value, value / 10.0)}";
+            else
+                line = $"Zone Cantrip: {def.Name} {string.Format(def.ValFmt ?? "+{0}", value, value / 10.0)} [{band.Min}-{band.Max}]";
+            wo.LongDesc = string.IsNullOrEmpty(wo.LongDesc) ? line : wo.LongDesc + "\n\n" + line;
+            return value;
+        }
+
+        // The pre-band fixed-value Stamp(wo, def) overload was DELETED 2026-08-21: it had zero
+        // callers left, and for the banded-only keys 33-42 (Ints Value = 0 / no Ints at all) it
+        // would stamp nothing while still marking the item. Roll a value and use the overload below.
+
+        /// <summary>Banded stamp: writes the ROLLED value additively into each Ints PropId (the legacy fixed
+        /// Value is ignored), handles the ArmorOnly item-AL mechanism, and marks the item with the
+        /// plugin-format drop line ("Name +73 [25-100]"). The optional band is the
+        /// EFFECTIVE band the value was rolled from (zone override) — omitted, the catalog band is printed.</summary>
+        public static void Stamp(WorldObject wo, Def def, int value, (int Min, int Max)? band = null)
+        {
+            if (wo == null || def == null)
+                return;
+
+            if (def.SlotSpecial)
+            {
+                // Armor v2 slot special: the value is written to every Ints prop (magnitude-less keys
+                // stamp 1 = "present"); the combat side reads it MAX-wins across worn pieces. The drop
+                // line MUST start with "Zone Cantrip:" or FinalizeT11LongDesc deletes it; magnitude-less
+                // keys (42/45) print bare, 41/44/46 print the rolled value.
+                if (def.Ints != null)
+                    foreach (var (propId, _) in def.Ints)
+                        AddInt(wo, propId, value);
+
+                var specialLine = string.IsNullOrEmpty(def.ValFmt)
+                    ? $"Zone Cantrip: {def.Name}"
+                    : $"Zone Cantrip: {def.Name} {string.Format(def.ValFmt, value, value / 10.0)}";
+                wo.LongDesc = string.IsNullOrEmpty(wo.LongDesc) ? specialLine : wo.LongDesc + "\n\n" + specialLine;
+                return;
+            }
+
+            if (def.SetsProtection)
+            {
+                // key 49 Reinforced: the value is a RANK. SET every elemental armor mod on the piece to the
+                // rank's value (this runs after ApplyT11GearStats equalized them at ~1.30). Base mods are
+                // item data, so hollow mobs (IgnoreMagicArmor) cannot strip this the way they strip Banes.
+                var mod = ReinforcedMod(value);
+                if (wo.ArmorLevel.HasValue)
+                    foreach (var prop in ReinforcedMods)
+                        wo.SetProperty(prop, mod);
+                if (def.Ints != null)
+                    foreach (var (propId, _) in def.Ints)
+                        wo.SetProperty((PropertyInt)propId, value);     // bookkeeping, not summed-on-equip semantics
+            }
+            else if (def.ArmorOnly)
+            {
+                // key 25: modifies the item itself, no Ints — the rolled value, NOT the legacy 300
+                if (wo.ArmorLevel.HasValue)
+                    wo.ArmorLevel = wo.ArmorLevel.Value + value;
+            }
+            else if (def.Ints != null)
+            {
+                foreach (var (propId, _) in def.Ints)
+                    AddInt(wo, propId, value);
+            }
+
+            var (min, max) = band ?? (def.Min, def.Max);
+            var rolled = string.Format(def.ValFmt ?? "+{0}", value, value / 10.0);
+            var line = $"Zone Cantrip: {def.Name} {rolled} [{min}-{max}]";
+            wo.LongDesc = string.IsNullOrEmpty(wo.LongDesc) ? line : wo.LongDesc + "\n\n" + line;
+        }
+    }
+}

--- a/Source/ACE.Server/Managers/ZoneControl/ZoneSpawnScaler.cs
+++ b/Source/ACE.Server/Managers/ZoneControl/ZoneSpawnScaler.cs
@@ -1,0 +1,283 @@
+using System;
+using System.Linq;
+
+using ACE.Entity.Enum.Properties;
+using ACE.Entity.Models;
+using ACE.Server.Managers.ZoneScaling;
+using ACE.Server.WorldObjects;
+
+namespace ACE.Server.Managers.ZoneControl
+{
+    /// <summary>
+    /// Zone Control's spawn-time stat application — standalone (consults only <see cref="ZoneControlManager"/>).
+    /// Called wherever a creature enters the world, right after any other spawn scaling, so an authored zone
+    /// stat is authoritative: attributes and Stamina/Mana/Health maxes are set ABSOLUTELY on the live spawn
+    /// (per-instance only — weenies are never touched; despawn/respawn naturally reverts), then the profile's
+    /// generic prop overrides are stamped. A creature with no governing zone is untouched.
+    /// </summary>
+    public static class ZoneSpawnScaler
+    {
+        private static readonly log4net.ILog log =
+            log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
+        /// <summary>
+        /// Applies the governing zone's spawn snapshot to a freshly-spawned creature: attributes first
+        /// (Endurance/Self feed the vital formulas), then Stamina/Mana, then Health — each preserving the
+        /// current % across the max change (no free heal/refill). No-op when no enabled zone governs the
+        /// creature at its effective variation.
+        /// </summary>
+        public static void ApplyToSpawn(Creature creature)
+        {
+            if (creature == null)
+                return;
+
+            // ORDERING GUARD (2026-07-30): every resolve below keys on Location (landblock + variation).
+            // A caller that applies the snapshot BEFORE assigning a Location silently gets nothing —
+            // no attributes, no vitals, no prop stamps, no appearance — with no error anywhere. That is
+            // exactly how GeneratorProfile.Spawn skipped the snapshot for every generator-spawned mob
+            // until it was found by hand. Fail LOUD instead of silently, so the next such call site is
+            // caught in the log rather than months later in an appraisal window.
+            if (creature.Location == null)
+            {
+                log.Error($"ZoneSpawnScaler.ApplyToSpawn({creature.Name} 0x{creature.Guid}:{creature.WeenieClassId}) " +
+                          "called with a NULL Location - zone resolution needs one, so NOTHING was applied " +
+                          "(no attributes/vitals/props/appearance). Assign Location before calling this.");
+                return;
+            }
+
+            // Cosmetic appearance is resolved and stamped SEPARATELY from stats (its own zone lookup), so a
+            // per-WCID appearance override never creates a stat bucket and can't detach the mob from scaling.
+            ApplyAppearance(creature);
+
+            var profile = ZoneControlManager.ResolveForCreature(creature);
+            if (profile == null)
+                return;
+
+            // VITAL FILL RATIOS ARE CAPTURED HERE, BEFORE ANY ATTRIBUTE MOVES (owner 2026-09-01).
+            // Endurance feeds MaxHealth (and Self feeds Mana), so raising an attribute lifts MaxValue
+            // instantly while Current stays where the weenie left it. Reading the ratio AFTER that -
+            // which is what ApplyVital and the MaxHealth block below used to do - reads an already
+            // collapsed number and then faithfully preserves the wrong thing.
+            // Retail wcid 4124 in a T11 zone: Endurance 178 -> 1100 lifted MaxHealth ~89 -> ~550 while
+            // Current stayed 89, so the "preserved" ratio was 16 pct and the monster spawned at
+            // 161,819 / 1,000,000. Custom T11 monsters hid it because their attributes are already
+            // near 1100, so scaling barely moves their max - it only bites the arbitrary retail mob,
+            // i.e. exactly the drop-in case the whole Bestiary lane exists to serve.
+            var fillHealth = FillRatio(creature.Health);
+            var fillStamina = FillRatio(creature.Stamina);
+            var fillMana = FillRatio(creature.Mana);
+
+            ApplyAttribute(creature, profile, ZoneStat.Strength, PropertyAttribute.Strength);
+            ApplyAttribute(creature, profile, ZoneStat.Endurance, PropertyAttribute.Endurance);
+            ApplyAttribute(creature, profile, ZoneStat.Coordination, PropertyAttribute.Coordination);
+            ApplyAttribute(creature, profile, ZoneStat.Quickness, PropertyAttribute.Quickness);
+            ApplyAttribute(creature, profile, ZoneStat.Focus, PropertyAttribute.Focus);
+            ApplyAttribute(creature, profile, ZoneStat.Self, PropertyAttribute.Self);
+
+            // Level (2026-08-31): zone-wide, so an arbitrary retail weenie stops advertising its
+            // shipped level in a T11 zone. Stamped, not read live - Level is plain item data that
+            // Monster_Awareness target weighting and the appraisal panel read straight off the
+            // creature. Floored at 1; level 0 reads as "unset" to several consumers.
+            if (profile.Has(ZoneStat.MonsterLevel))
+                creature.SetProperty(PropertyInt.Level,
+                    (int)Math.Max(1.0, Math.Round(profile.Get(ZoneStat.MonsterLevel))));
+
+            // Creature type (2026-08-31): FALLBACK ONLY. Applied when the weenie has no species, or
+            // Invalid - never over a real one, so a Drudge stays a Drudge. Without a species the mob
+            // silently suppresses every slayer roll in its own loot (ZoneLootMutator eligibility).
+            if (profile.Has(ZoneStat.MonsterCreatureType)
+                && (creature.CreatureType == null || creature.CreatureType == ACE.Entity.Enum.CreatureType.Invalid))
+            {
+                var ct = (int)Math.Round(profile.Get(ZoneStat.MonsterCreatureType));
+                // CreatureType is `: uint` - IsDefined THROWS on a type mismatch rather than
+                // returning false, so the boxed value must be uint. This is the SPAWN path: an int
+                // here would have thrown on every governed spawn the moment the stat was authored.
+                if (ct > 0 && System.Enum.IsDefined(typeof(ACE.Entity.Enum.CreatureType), (uint)ct))
+                    creature.SetProperty(PropertyInt.CreatureType, ct);
+            }
+
+            ApplyVital(creature, profile, ZoneStat.MaxStamina, creature.Stamina);
+            ApplyVital(creature, profile, ZoneStat.MaxMana, creature.Mana);
+
+            if (profile.Has(ZoneStat.MaxHealth))
+            {
+                var maxBefore = creature.Health.MaxValue;
+                var target = (long)Math.Round(profile.Get(ZoneStat.MaxHealth));
+                // subtract the non-starting contributions (endurance formula, ranks) so MaxValue lands on target
+                var nonStarting = (long)maxBefore - creature.Health.StartingValue;
+                creature.Health.StartingValue = (uint)Math.Clamp(target - nonStarting, 1L, uint.MaxValue);
+            }
+
+            // Refill to the ratios captured above, AFTER every max has settled - attributes, the
+            // authored vitals, and max_health all move MaxValue, so this has to be the last word.
+            // A fresh spawn was at 100 pct, so it comes up full; a live re-apply onto a damaged
+            // monster keeps it damaged, which is the behaviour the ratio existed for.
+            RefillVital(creature.Health, fillHealth);
+            RefillVital(creature.Stamina, fillStamina);
+            RefillVital(creature.Mana, fillMana);
+
+            // Incoming crit protection: REPLACE the base rating props on the live spawn (engine reads
+            // them generically - Creature_Rating). The OUTGOING pair (crit_rating/crit_damage_rating)
+            // is NOT a prop stamp: those are read live at the combat choke points as absolute
+            // replacements (crit chance in percent / final crit multiplier) - WorldObject_Weapon.
+            ApplyRatingProp(creature, profile, ZoneStat.CritResistRating, PropertyInt.CritResistRating);
+            ApplyRatingProp(creature, profile, ZoneStat.CritDamageResistRating, PropertyInt.CritDamageResistRating);
+
+            // Generic prop overrides applied to this instance at (re)spawn. Int/Float/Bool/Int64 biota
+            // collections are per-instance clones (WeenieConverter), so this never touches the shared
+            // weenie; despawn/respawn naturally reverts. Guarded by ZonePropGuard.
+            ApplyProps(creature, profile);
+        }
+
+        /// <summary>Set a rating int prop absolutely on the live spawn when the zone authors its stat.</summary>
+        private static void ApplyRatingProp(Creature creature, EvaluatedProfile profile, string statKey, PropertyInt prop)
+        {
+            if (!profile.Has(statKey))
+                return;
+            creature.SetProperty(prop, (int)Math.Round(profile.Get(statKey)));
+        }
+
+        /// <summary>Set an attribute's StartingValue absolutely (mobs carry 0 XP/ranks, so this IS the Base).</summary>
+        private static void ApplyAttribute(Creature creature, EvaluatedProfile profile, string statKey, PropertyAttribute attr)
+        {
+            if (!profile.Has(statKey))
+                return;
+
+            var target = (long)Math.Round(profile.Get(statKey));
+            creature.Attributes[attr].StartingValue = (uint)Math.Clamp(target, 1L, uint.MaxValue);
+        }
+
+        /// <summary>Set a vital's (Stamina/Mana) max absolutely, as a spawn snapshot preserving current %
+        /// (same pattern as the MaxHealth block above; Health is handled separately in ApplyToSpawn).</summary>
+        /// <summary>How full a vital is, sampled BEFORE anything moves its maximum. See the block comment
+        /// at the top of ApplyToSpawn for why the timing is the whole point.</summary>
+        private static float FillRatio(WorldObjects.Entity.CreatureVital vital)
+            => vital != null && vital.MaxValue > 0 ? (float)vital.Current / vital.MaxValue : 1f;
+
+        /// <summary>Restore a vital to a ratio captured earlier, clamped to its CURRENT maximum.</summary>
+        private static void RefillVital(WorldObjects.Entity.CreatureVital vital, float fill)
+        {
+            if (vital == null)
+                return;
+            var max = vital.MaxValue;
+            vital.Current = (uint)Math.Clamp((uint)Math.Round(Math.Clamp(fill, 0f, 1f) * max), 0u, max);
+        }
+
+        /// <summary>Set a vital's authored maximum. The fill ratio is NOT applied here - RefillVital runs
+        /// once at the end of ApplyToSpawn, after every contributor to MaxValue has settled.</summary>
+        private static void ApplyVital(Creature creature, EvaluatedProfile profile, string statKey, WorldObjects.Entity.CreatureVital vital)
+        {
+            if (profile == null || !profile.Has(statKey))
+                return;
+
+            var maxBefore = vital.MaxValue;
+            var target = (long)Math.Round(profile.Get(statKey));
+            var nonStarting = (long)maxBefore - vital.StartingValue;
+            vital.StartingValue = (uint)Math.Clamp(target - nonStarting, 1L, uint.MaxValue);
+        }
+
+        /// <summary>Stamp a zone profile's generic prop overrides onto a freshly-spawned governed monster.</summary>
+        private static void ApplyProps(Creature creature, EvaluatedProfile profile)
+        {
+            if (profile.PropInts != null)
+                foreach (var kv in profile.PropInts)
+                    if (!ZonePropGuard.IsBlockedInt(kv.Key))
+                        creature.SetProperty((PropertyInt)kv.Key, (int)kv.Value);
+
+            if (profile.PropInt64s != null)
+                foreach (var kv in profile.PropInt64s)
+                    if (!ZonePropGuard.IsBlockedInt64(kv.Key))
+                        creature.SetProperty((PropertyInt64)kv.Key, kv.Value);
+
+            if (profile.PropFloats != null)
+                foreach (var kv in profile.PropFloats)
+                    if (!ZonePropGuard.IsBlockedFloat(kv.Key))
+                        creature.SetProperty((PropertyFloat)kv.Key, kv.Value);
+
+            if (profile.PropBools != null)
+                foreach (var kv in profile.PropBools)
+                    if (!ZonePropGuard.IsBlockedBool(kv.Key))
+                        creature.SetProperty((PropertyBool)kv.Key, kv.Value);
+        }
+
+        /// <summary>Stamp the governing zone's COSMETIC appearance onto a freshly-spawned monster, resolved from
+        /// the dedicated appearance layer (zone default overlaid by per-WCID). Per-instance property writes at
+        /// (re)spawn (revert on respawn), independent of the stat profile. Phase 1 levers: PaletteTemplate/Shade
+        /// (recolor), DefaultScale (size), Translucency (ghost), CreatureVariant (shiny texture swap).</summary>
+        private static void ApplyAppearance(Creature creature)
+        {
+            var ap = ZoneControlManager.ResolveAppearanceForCreature(creature);
+            if (ap == null)
+                return;
+
+            // ── Display name override (owner 2026-08-09; per-WCID only, enforced at the command) ──
+            if (!string.IsNullOrEmpty(ap.Name))
+            {
+                creature.Name = ap.Name;
+                creature.SetProperty(PropertyString.Name, ap.Name);
+            }
+
+            // ── Model / data swaps (DataId; guarded by class byte so a wrong id can't garble the client) ──
+            // A Setup swap replaces the body: clear the base weenie's own overlay + saved ObjDesc FIRST so its
+            // appearance doesn't bleed onto the new model (mirrors PetDevice.SummonCreature's capture apply),
+            // then set the new setup plus its matching motion/sound tables.
+            if (ap.SetupTableId.HasValue && IsDataId(ap.SetupTableId.Value, 0x02))
+            {
+                creature.RemoveProperty(PropertyDataId.ClothingBase);
+                creature.RemoveProperty(PropertyDataId.PaletteBase);
+                creature.RemoveProperty(PropertyInt.PaletteTemplate);
+                creature.RemoveProperty(PropertyFloat.Shade);
+                creature.Biota.PropertiesAnimPart?.Clear();
+                creature.Biota.PropertiesPalette?.Clear();
+                creature.Biota.PropertiesTextureMap?.Clear();
+
+                creature.SetupTableId = ap.SetupTableId.Value;
+            }
+
+            if (ap.MotionTable.HasValue && IsDataId(ap.MotionTable.Value, 0x09))
+                creature.MotionTableId = ap.MotionTable.Value;
+            if (ap.SoundTable.HasValue && IsDataId(ap.SoundTable.Value, 0x20))
+                creature.SoundTableId = ap.SoundTable.Value;
+
+            // ── Overlay / recolor (applied AFTER any model-swap clear so the intended overrides win) ──
+            if (ap.PaletteBase.HasValue && IsDataId(ap.PaletteBase.Value, 0x04))
+                creature.PaletteBaseId = ap.PaletteBase.Value;
+            if (ap.ClothingBase.HasValue && IsDataId(ap.ClothingBase.Value, 0x10))
+                creature.ClothingBase = ap.ClothingBase.Value;
+            if (ap.Icon.HasValue && IsDataId(ap.Icon.Value, 0x06))
+                creature.IconId = ap.Icon.Value;
+
+            if (ap.PaletteTemplate.HasValue)
+                creature.SetProperty(PropertyInt.PaletteTemplate, ap.PaletteTemplate.Value);
+            if (ap.Shade.HasValue)
+                creature.SetProperty(PropertyFloat.Shade, ap.Shade.Value);
+            if (ap.Scale.HasValue)
+                creature.SetProperty(PropertyFloat.DefaultScale, ap.Scale.Value);
+            if (ap.Translucency.HasValue)
+                creature.SetProperty(PropertyFloat.Translucency, ap.Translucency.Value);
+            if (ap.Shiny.HasValue)
+            {
+                if (ap.Shiny.Value)
+                    creature.SetProperty(PropertyInt.CreatureVariant, 1);
+                else
+                    creature.RemoveProperty(PropertyInt.CreatureVariant);
+            }
+
+            // ── Per-part body swaps (copied from a donor via copylook). Applied LAST so they survive the
+            // Setup-swap clear above; a non-null override REPLACES the creature's parts wholesale. Creatures
+            // with no equipped items render these biota rows directly (Creature.CalculateObjDesc). Spawn-time,
+            // pre-EnterWorld, single-threaded for this creature -> wholesale list assignment is safe (mirrors
+            // the unlocked biota Clear above). Reverts on respawn since the weenie is never touched.
+            if (ap.AnimParts != null)
+                creature.Biota.PropertiesAnimPart = ap.AnimParts
+                    .Select(p => new PropertiesAnimPart { Index = p.Index, AnimationId = p.GfxObj }).ToList();
+            if (ap.TextureMaps != null)
+                creature.Biota.PropertiesTextureMap = ap.TextureMaps
+                    .Select(t => new PropertiesTextureMap { PartIndex = t.Index, OldTexture = t.OldTex, NewTexture = t.NewTex }).ToList();
+        }
+
+        /// <summary>True if the DataId's class byte (top 8 bits) matches — a cheap guard against a wildly wrong id
+        /// (e.g. a "Setup" that isn't 0x02) that could break the client render. 0 is never valid.</summary>
+        private static bool IsDataId(uint id, byte classByte) => id != 0 && (id >> 24) == classByte;
+    }
+}

--- a/Source/ACE.Server/Managers/ZoneControl/ZoneStatResolver.cs
+++ b/Source/ACE.Server/Managers/ZoneControl/ZoneStatResolver.cs
@@ -539,10 +539,8 @@ namespace ACE.Server.Managers.ZoneControl
         {
             if (wo == null)
                 return 0;
-            var zc = wo.GetProperty(PropertyInt.ZcTier) ?? 0;
-            if (zc > 0)
-                return zc;
-            return wo.GetProperty(PropertyInt.WeaponAugScaleTier) ?? 0;
+            // the MAX of both stamps, exactly as ZoneCraftGate.TierOf - a weapon carries both
+            return Math.Max(wo.GetProperty(PropertyInt.ZcTier) ?? 0, wo.GetProperty(PropertyInt.WeaponAugScaleTier) ?? 0);
         }
 
         /// <summary>

--- a/Source/ACE.Server/Managers/ZoneControl/ZoneStatResolver.cs
+++ b/Source/ACE.Server/Managers/ZoneControl/ZoneStatResolver.cs
@@ -1,0 +1,966 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using ACE.Common;
+using ACE.Entity.Enum;
+using ACE.Entity.Enum.Properties;
+using ACE.Server.Managers.ZoneScaling;
+using ACE.Server.WorldObjects;
+
+namespace ACE.Server.Managers.ZoneControl
+{
+    /// <summary>
+    /// Live stat resolution (owner 2026-08-22, Plan_LiveStatResolution_2026-08-22.md): a T11+ piece carries
+    /// a GRADE per Zone Control line (0-1000 = where in the band it rolled) plus the loot tier; the numbers
+    /// retail code reads (Gear* ratings, Armor Level, the 502xx cantrip props) are a CACHE resolved from the
+    /// grades against the LIVE ladder. Weapon scaling already works this way (quality 0-1000); this is the
+    /// same model for armor / jewelry lines, the core four, Armor Level and the slot specials.
+    ///
+    /// Record format, PropertyString.ZcModifiers: "28:490;19:1000;c1:900;c2:850;c3:900;c4:880;25:500;41:650"
+    ///   - positive key  = ZoneModifiers catalog key (lines AND specials), value = grade 0-1000
+    ///   - c1..c4        = the core four (DamageResist / CritDamageResist / CritResist / NetherResist)
+    ///   - -11..-30      = the reserved WEAPON block (2026-08-25): the six continuous weapon cards,
+    ///                     which are PropertyFloats and resolve through ZoneModifiers.WeaponBand rather
+    ///                     than the armour catalog. See the block comment at WeaponBiteKey.
+    ///   - Reinforced (49) is NOT recorded: an earned, frozen armor mod (owner ruling 2026-08-22 §8.3)
+    /// PropertyInt.ZcTier = the ladder row; PropertyInt.ZcResolvedVersion = the per-tier ladder version the
+    /// cache was last written against (ZoneControlManager.GetLadderVersion).
+    ///
+    /// Three entry points:
+    ///   <see cref="Compute"/>      - PURE: grades -> resolved values. Appraisal uses this (read-only rule §3b).
+    ///   <see cref="ApplyIfStale"/> - EQUIP ONLY: re-stamp the cache when the tier's ladder version moved.
+    ///   <see cref="Apply"/>        - the unconditional stamp used at DROP time by the producers.
+    /// Nothing here walks biotas; items catch up lazily when worn (plan §8.2: lazy only).
+    /// </summary>
+    public static class ZoneStatResolver
+    {
+        public const int GradeMax = 1000;
+
+        /// <summary>Core-four pseudo keys inside the record (negative so they never collide with catalog keys).</summary>
+        public const int CoreDamageResist = -1;
+        public const int CoreCritDamageResist = -2;
+        public const int CoreCritResist = -3;
+        public const int CoreNetherResist = -4;
+
+        public static readonly int[] CoreKeys = { CoreDamageResist, CoreCritDamageResist, CoreCritResist, CoreNetherResist };
+
+        public static PropertyInt CoreProp(int coreKey) => coreKey switch
+        {
+            CoreDamageResist => PropertyInt.GearDamageResist,
+            CoreCritDamageResist => PropertyInt.GearCritDamageResist,
+            CoreCritResist => PropertyInt.GearCritResist,
+            _ => PropertyInt.GearNetherResist,
+        };
+
+        public static string CoreName(int coreKey) => coreKey switch
+        {
+            CoreDamageResist => "Damage Resist",
+            CoreCritDamageResist => "Crit Damage Resist",
+            CoreCritResist => "Crit Resist",
+            _ => "Nether Resist",
+        };
+
+        public static bool IsCoreKey(int key) => key <= CoreDamageResist && key >= CoreNetherResist;
+
+        // ── weapon-special pseudo keys (2026-08-25, weapon/armour parity) ────────
+        //
+        // WHY A RESERVED NEGATIVE BLOCK AND NOT SIX MORE ZoneModifiers.Catalog ROWS
+        //
+        // Catalog keys are load-bearing forever: they live in saved zone pools
+        // (ZoneVariantProfile.CustomModifiers), in the `cantrip <scope> band <key>` command surface,
+        // and in the plugin's mirrored ModifierCatalog. Minting six of them for weapons would leak
+        // weapon keys into the ARMOUR line pool (TryExtraModifier walks the catalog), into the plugin's
+        // Cantrips tab, and into the [[ZC]] wire - for six values that never travel the wire at all.
+        // That crossing is the thing this design deliberately avoided when the WeaponBand table was
+        // added (see the long comment above ZoneModifiers.WeaponBand). So: a reserved key block that
+        // lives ONLY in the item's own ZcModifiers record, exactly the way the core four do.
+        //
+        // WHY NEGATIVE. The record's key token is parsed by Read(): 'cN' is a core key, anything else
+        // goes through int.TryParse with NumberStyles.Integer, which accepts a leading '-'. So "-16:640"
+        // round-trips through Read/Format with ZERO format work, and a negative key can never collide
+        // with a catalog key (all positive) or with a core key (-1..-4, and those are written as 'cN'
+        // by Format, so they never appear as a bare negative token in a well-formed record).
+        //
+        // -5..-10 IS A DELIBERATE GAP so the core block can grow (a fifth core rating) without
+        // renumbering weapons. -11..-30 is the WEAPON block; only -11..-16 are defined today.
+        // NOTE for anyone touching the record format: a bare '-' in a ZcModifiers string means
+        // "this record contains a weapon key" and NOTHING else - grades are 0..1000 and never
+        // signed. HasWeaponKey below depends on that; keep it true.
+        public const int WeaponBiteKey = -11;
+        public const int WeaponArmorRendKey = -12;
+        public const int WeaponRendPowerKey = -13;
+        public const int WeaponSlayerKey = -14;
+        public const int WeaponShieldCleaveKey = -15;
+        public const int WeaponCrushKey = -16;
+        /// <summary>Cast on Strike damage B, one key per slot (added 2026-08-27).</summary>
+        public const int WeaponProcArcDamageKey = -17;
+        public const int WeaponProcRingDamageKey = -18;
+
+        /// <summary>The reserved weapon block, -11..-30. Membership of the block, NOT "is defined":
+        /// an unknown key inside the block is skipped by Compute exactly like an unknown catalog key,
+        /// so an item stamped by a newer build never throws on an older one.</summary>
+        public static bool IsWeaponKey(int key) => key <= -11 && key >= -30;
+
+        /// <summary>
+        /// One continuous weapon card as the RECORD sees it: the ladder row it resolves against
+        /// (<see cref="ZoneModifiers.WeaponBand"/>, which owns the T11-&gt;T25 anchors, the authored
+        /// stat names and the hard clamp) plus the PropertyFloat the engine actually reads.
+        ///
+        /// <see cref="DisplayIsMultiplier"/> is the Crushing Blow trap, isolated to one bool: the
+        /// band and the plugin box are in DISPLAY space (7.50 = "crits hit for 7.5x") but the engine
+        /// computes <c>1 + CriticalMultiplier</c>, so the stored number is display - 1. See
+        /// <see cref="EngineValue"/> - that method is the ONLY place in the server that subtracts it.
+        /// </summary>
+        public sealed class WeaponSpecial
+        {
+            public int Key;
+            public ZoneModifiers.WeaponBand Band;
+            public PropertyFloat Prop;
+            public bool DisplayIsMultiplier;
+            public string Name => Band?.Name ?? "?";
+        }
+
+        // The six rows. NAMED, and the drop-time write sites reference them BY NAME - never by an index
+        // into the array below. An index would silently re-point a card at the wrong property the day
+        // someone reorders the table, and the only symptom would be Slayer weapons that ignore shields.
+        public static readonly WeaponSpecial SpecBite = new WeaponSpecial
+        { Key = WeaponBiteKey, Band = ZoneModifiers.WeaponBite, Prop = PropertyFloat.CriticalFrequency };
+
+        public static readonly WeaponSpecial SpecArmorRend = new WeaponSpecial
+        { Key = WeaponArmorRendKey, Band = ZoneModifiers.WeaponArmorRend, Prop = (PropertyFloat)ZoneLootMutator.ArmorRendOverridePropId };
+
+        public static readonly WeaponSpecial SpecRendPower = new WeaponSpecial
+        { Key = WeaponRendPowerKey, Band = ZoneModifiers.WeaponRendPower, Prop = (PropertyFloat)ZoneLootMutator.RendingModOverridePropId };
+
+        public static readonly WeaponSpecial SpecSlayer = new WeaponSpecial
+        { Key = WeaponSlayerKey, Band = ZoneModifiers.WeaponSlayer, Prop = PropertyFloat.SlayerDamageBonus };
+
+        public static readonly WeaponSpecial SpecShieldCleave = new WeaponSpecial
+        { Key = WeaponShieldCleaveKey, Band = ZoneModifiers.WeaponShieldCleave, Prop = PropertyFloat.IgnoreShield };
+
+        /// <summary>The ONLY row with DisplayIsMultiplier - see <see cref="EngineValue"/>.</summary>
+        public static readonly WeaponSpecial SpecCrush = new WeaponSpecial
+        { Key = WeaponCrushKey, Band = ZoneModifiers.WeaponCrush, Prop = PropertyFloat.CriticalMultiplier, DisplayIsMultiplier = true };
+
+        /// <summary>The weapon block, in record-key order - for lookup and for the stable fold order
+        /// <see cref="WeaponPinFingerprint"/> depends on.</summary>
+        /// <summary>Cast on Strike. Unlike the other six this property is not read by the melee damage
+        /// pipeline at all - SpellProjectile.CalculateDamage substitutes it for the rolled spell base.</summary>
+        public static readonly WeaponSpecial SpecProcArcDamage = new WeaponSpecial
+        { Key = WeaponProcArcDamageKey, Band = ZoneModifiers.WeaponProcArcDamage, Prop = (PropertyFloat)ZoneLootMutator.ProcArcDamagePropId };
+
+        public static readonly WeaponSpecial SpecProcRingDamage = new WeaponSpecial
+        { Key = WeaponProcRingDamageKey, Band = ZoneModifiers.WeaponProcRingDamage, Prop = (PropertyFloat)ZoneLootMutator.ProcRingDamagePropId };
+
+        public static readonly WeaponSpecial[] WeaponSpecials =
+        {
+            SpecBite, SpecArmorRend, SpecRendPower, SpecSlayer, SpecShieldCleave, SpecCrush,
+            SpecProcArcDamage, SpecProcRingDamage,
+        };
+
+        public static bool TryGetWeapon(int key, out WeaponSpecial ws)
+        {
+            foreach (var w in WeaponSpecials)
+                if (w.Key == key) { ws = w; return true; }
+            ws = null;
+            return false;
+        }
+
+        /// <summary>
+        /// 🔴 THE ONLY "- 1.0" IN THE WEAPON PATH. Display space -&gt; the number the engine stores.
+        ///
+        /// Crushing Blow's card value IS the final crit damage multiplier (7.50 = crits deal 7.5x).
+        /// WorldObject_Weapon.GetWeaponCritDamageMod reads PropertyFloat.CriticalMultiplier and the
+        /// damage pipeline computes 1 + that, so the stored number must be display - 1. Retail's
+        /// absent-property default is 1.0, i.e. the familiar 2x crit - which is why 0 is NOT the
+        /// inert value for this property and why a naive "zero it out" is wrong (see WeaponResolveBand).
+        ///
+        /// WHY IT LIVES HERE AND NOWHERE ELSE. Before this pass the subtraction sat inline at the one
+        /// drop-time write site in ZoneLootMutator. Now the number is produced from a recorded grade,
+        /// and produced AGAIN on every equip re-stamp (ApplyIfStale -&gt; Compute -&gt; Apply). If the
+        /// subtraction were duplicated at the drop site as well, a 7.5x weapon would be stamped 6.5 at
+        /// drop, then re-resolved to 5.5 on the first login, 4.5 on the next ladder apply, and so on -
+        /// walking silently down forever with nothing in any log. So: DROP and RESOLVE both call this
+        /// method, this method is the only subtraction, and neither caller may pre-convert.
+        /// If you add a second display-space card, add a row with DisplayIsMultiplier - do not inline.
+        /// </summary>
+        public static double EngineValue(WeaponSpecial ws, double display)
+            => ws != null && ws.DisplayIsMultiplier ? display - 1.0 : display;
+
+        // ── grade math ──────────────────────────────────────────────────────────
+
+        /// <summary>Grade -> value inside an inclusive band. Linear, rounded once.</summary>
+        public static int ValueFor(int min, int max, int grade)
+        {
+            if (min > max) (min, max) = (max, min);
+            grade = Math.Clamp(grade, 0, GradeMax);
+            return min + (int)Math.Round((max - min) * (grade / (double)GradeMax));
+        }
+
+        /// <summary>
+        /// Grade -> value inside an inclusive DOUBLE band - the weapon-card sibling of
+        /// <see cref="ValueFor"/>. Deliberately NOT "call ValueFor and divide": every weapon card is a
+        /// PropertyFloat whose second decimal is the whole design (0.62 armour rend, 1.85x crush,
+        /// 0.58 crit chance). Routing those through the int overload rounds 0.62 to 1 and every
+        /// Biting Strike weapon on the shard crits on every swing, with nothing in any log to say why.
+        /// </summary>
+        public static double ValueForD(double min, double max, int grade)
+        {
+            if (min > max) (min, max) = (max, min);
+            grade = Math.Clamp(grade, 0, GradeMax);
+            return min + (max - min) * (grade / (double)GradeMax);
+        }
+
+        /// <summary>Value -> grade (migration of pre-grade items). Flat band = 1000.</summary>
+        public static int GradeFor(int min, int max, int value)
+        {
+            if (min > max) (min, max) = (max, min);
+            if (max == min) return GradeMax;
+            return Math.Clamp((int)Math.Round((value - min) * (double)GradeMax / (max - min)), 0, GradeMax);
+        }
+
+        /// <summary>
+        /// Roll a grade 0-1000 with the tier-weighted third (ZoneModifiers.TierThirds, Option A: T11 uniform,
+        /// T25 10/30/60). forceMax = 1000. The producers roll THIS and derive the value with
+        /// <see cref="ValueFor"/>, so the grade is the truth and the value its projection.
+        /// </summary>
+        public static int RollGrade(int tier, bool forceMax = false)
+        {
+            if (forceMax) return GradeMax;
+            var (wLo, wMid, wHi) = ZoneModifiers.TierThirds(tier);
+            var pick = ThreadSafeRandom.Next(0, wLo + wMid + wHi - 1);
+            if (pick < wLo) return ThreadSafeRandom.Next(0, 333);
+            if (pick < wLo + wMid) return ThreadSafeRandom.Next(334, 666);
+            return ThreadSafeRandom.Next(667, GradeMax);
+        }
+
+        // ── the live ladder ─────────────────────────────────────────────────────
+
+        /// <summary>
+        /// The band a catalog key resolves against at a tier: the tier's ANCHORED Default-layer override
+        /// (CustomModifierBands from GetAnchoredDefaultProfile - the v11 anchor board under the tier's own
+        /// Default, which is what real drops there roll from) when authored, else the catalog band scaled to
+        /// the tier (ZoneModifiers.CatalogBandAt). Reading the RAW Default here was the 2x-at-T25 bug: no
+        /// Default is authored above v11, so every tier 12-25 took the CatalogBandAt branch at resolve while
+        /// drops took the authored band. A ZONE's own band override is a drop-time concern only - the piece does not remember
+        /// its zone, and re-resolution only happens after an explicit ladder apply, when the tier's Default
+        /// IS the published truth.
+        /// </summary>
+        public static (int Min, int Max) EffectiveBand(int key, int tier)
+        {
+            if (!ZoneModifiers.TryGet(key, out var def))
+                return (0, 0);
+            // Zone Control off: the shrunk fallback band, and nothing authored is consulted (same rule
+            // as CoreWindow). owner 2026-08-23.
+            if (!ServerConfig.zonecontrol_enabled.Value)
+                return ZoneFallback.Band(def);
+            var anchored = ZoneControlManager.GetAnchoredDefaultProfile(tier);
+            if (anchored?.CustomModifierBands != null
+                && anchored.CustomModifierBands.TryGetValue(key, out var live)
+                && live != null && live.Max > 0)
+                return live.Min <= live.Max ? (live.Min, live.Max) : (live.Max, live.Min);
+            return ZoneModifiers.CatalogBandAt(def, tier);
+        }
+
+        /// <summary>
+        /// The band a WEAPON card resolves against at a tier - the exact twin of <see cref="EffectiveBand"/>,
+        /// and it must be read the same way:
+        ///
+        ///   1. Zone Control OFF -> the card's own T11 rung, TIER-BLIND, and nothing authored is consulted.
+        ///      Same rule as EffectiveBand / CoreWindow / BaseArmorLevel: off the switch nothing climbs
+        ///      with tier and no authored layer is read (owner 2026-08-23).
+        ///      🔴 NOTE this is deliberately NOT the armour SLOT-SPECIAL treatment (Compute zeroes those
+        ///      when the switch is off). Zeroing works for a slot special because its props are additive
+        ///      ZC-only ratings where 0 IS the inert value. Weapon cards write RETAIL properties where 0
+        ///      is not inert but CATASTROPHIC: SlayerDamageBonus 0 makes the weapon deal literally zero
+        ///      damage to its slayer type (WorldObject_Weapon.GetWeaponCreatureSlayerModifier returns the
+        ///      property verbatim once the creature type matches), and CriticalFrequency 0 means the
+        ///      weapon can never crit at all. The bottom rung of the card's own ladder is the honest
+        ///      "Zone Control is not tuning this" answer, and it is still inside the card's Lo/Hi clamp,
+        ///      so it can never produce a number the authored path could not.
+        ///   2. The TIER DEFAULT's authored weapon_&lt;card&gt;_min / _max -> that band, including the
+        ///      "one box = EXACT value, not a range" rule the drop path has always had.
+        ///   3. Otherwise the ladder: ZoneModifiers.WeaponBandAt(band, tier).
+        ///
+        /// Step 2 reads the TIER DEFAULT, never a zone, for the same reason EffectiveBand does: the piece
+        /// does not remember where it dropped, and a re-resolve only ever happens after an explicit ladder
+        /// apply, when the tier Default IS the published truth. A ZONE-level weapon pin therefore shapes
+        /// NEW DROPS IN THAT ZONE ONLY and existing weapons drift to the tier Default on their next equip -
+        /// which is precisely what a zone-level cantrip band already does to armour, and what the
+        /// `cantrip &lt;zone&gt; band` command already prints when you author one.
+        ///
+        /// <paramref name="stats"/> is the tier Default's Stats dictionary, passed in so a caller
+        /// resolving several cards on one weapon pays for ONE locked snapshot read instead of twelve.
+        /// Pass null to have it fetched here.
+        /// </summary>
+        public static (double Min, double Max) WeaponResolveBand(WeaponSpecial ws, int tier,
+            Dictionary<string, ZoneScaling.StatCurve> stats = null, bool statsFetched = false)
+        {
+            if (ws?.Band == null)
+                return (0.0, 0.0);
+            var b = ws.Band;
+            if (!ServerConfig.zonecontrol_enabled.Value)
+                return ZoneModifiers.WeaponBandAt(b, 11);
+            if (!statsFetched)
+                stats = ZoneControlManager.GetAnchoredDefaultProfile(tier)?.Stats;
+            var pin = PinBand(stats, b, tier);
+            if (pin.HasValue)
+                return Clamp(pin.Value.Min, pin.Value.Max, b);
+            return ZoneModifiers.WeaponBandAt(b, tier);
+        }
+
+        /// <summary>
+        /// The band a WEAPON card ROLLS from at drop time: the zone's evaluated profile (which already
+        /// has the tier Default merged into it at snapshot-build time) when it authors either box, else
+        /// the ladder. The twin of the (ModifierBands ?? CatalogBandAt) pair in
+        /// ZoneLootMutator.TryExtraModifier - drop reads the ZONE, resolve reads the tier DEFAULT.
+        /// Identical when the zone adds no pin of its own, which is the normal case.
+        /// </summary>
+        public static (double Min, double Max) WeaponDropBand(ZoneScaling.EvaluatedProfile p, WeaponSpecial ws, int tier)
+        {
+            if (ws?.Band == null)
+                return (0.0, 0.0);
+            var b = ws.Band;
+            if (p != null && (p.Has(b.MinStat) || p.Has(b.MaxStat)))
+            {
+                // The historical RollRange semantics, preserved EXACTLY per anchor: one box authored =
+                // that exact value (min == max), both authored = the range, reversed bounds swap.
+                // ANCHORED since 2026-08-29: the pair above is the T11 anchor; a "_t25" pair beside it
+                // is the T25 anchor and tiers between sit on the line. No _t25 pair = FLAT at every
+                // tier, which is byte-identical to the old pin behaviour.
+                var lo11 = p.Has(b.MinStat) ? p.Get(b.MinStat) : p.Get(b.MaxStat);
+                var hi11 = p.Has(b.MaxStat) ? p.Get(b.MaxStat) : lo11;
+                var (lo, hi) = AnchorLerp(lo11, hi11,
+                    p.Has(b.MinStat + "_t25") ? p.Get(b.MinStat + "_t25") : (double?)null,
+                    p.Has(b.MaxStat + "_t25") ? p.Get(b.MaxStat + "_t25") : (double?)null, tier);
+                return Clamp(lo, hi, b);
+            }
+            return ZoneModifiers.WeaponBandAt(b, tier);
+        }
+
+        /// <summary>Lerp an authored T11 pair toward its optional T25 anchor pair. One-box rule per
+        /// anchor: a lone _min_t25 or _max_t25 is an exact pair at T25. No T25 at all = flat.</summary>
+        private static (double Lo, double Hi) AnchorLerp(double lo11, double hi11, double? lo25, double? hi25, int tier)
+        {
+            if (lo25 == null && hi25 == null)
+                return (lo11, hi11);
+            var l25 = lo25 ?? hi25.Value;
+            var h25 = hi25 ?? l25;
+            var t = Math.Clamp((tier - 11) / 14.0, 0.0, 1.0);
+            return (lo11 + (l25 - lo11) * t, hi11 + (h25 - hi11) * t);
+        }
+
+        /// <summary>The authored pin on a Stats dictionary, or null when neither box is set. Same
+        /// one-box rule as <see cref="WeaponDropBand"/>, and since 2026-08-29 the same T11/T25
+        /// anchoring; StatCurve.Evaluate(1) is how every other Default-layer read in this file spells
+        /// "the authored number".</summary>
+        private static (double Min, double Max)? PinBand(Dictionary<string, ZoneScaling.StatCurve> stats, ZoneModifiers.WeaponBand b, int tier)
+        {
+            if (stats == null || stats.Count == 0)
+                return null;
+            double? Read(string key)
+                => stats.TryGetValue(key, out var c) && c != null ? c.Evaluate(1) : (double?)null;
+            var min11 = Read(b.MinStat);
+            var max11 = Read(b.MaxStat);
+            if (min11 == null && max11 == null)
+                return null;
+            var lo11 = min11 ?? max11.Value;
+            var hi11 = max11 ?? lo11;
+            return AnchorLerp(lo11, hi11, Read(b.MinStat + "_t25"), Read(b.MaxStat + "_t25"), tier);
+        }
+
+        /// <summary>Order + clamp a weapon band to the card's own Lo/Hi. Those bounds are copied from
+        /// the card's historical RollRange(lo, hi) arguments, so no path - authored, ladder or fallback -
+        /// can ever produce a value the old drop-time code could not.</summary>
+        private static (double Min, double Max) Clamp(double lo, double hi, ZoneModifiers.WeaponBand b)
+        {
+            if (lo > hi) (lo, hi) = (hi, lo);
+            return (Math.Clamp(lo, b.Lo, b.Hi), Math.Clamp(hi, b.Lo, b.Hi));
+        }
+
+        /// <summary>
+        /// A knob from the tier's DEFAULT layer, or null when the tier does not author it. Nullable so a
+        /// caller can tell "authored as 1100" from "not authored" - armor_base_level needs that distinction
+        /// (unset falls back to the historical formula, not to a constant).
+        /// One locked snapshot read (ZoneControlManager.GetVariationDefault); call it ONCE per operation.
+        /// </summary>
+        public static double? DefaultLayerValue(int tier, string stat)
+        {
+            var def = ZoneControlManager.GetAnchoredDefaultProfile(tier);
+            if (def?.Stats != null && def.Stats.TryGetValue(stat, out var curve) && curve != null)
+                return curve.Evaluate(1);
+            return null;
+        }
+
+        /// <summary>A core_anchor_* knob from the tier's Default layer, else the C# default.</summary>
+        private static double DefaultLayerStat(int tier, string stat, double fallback)
+            => DefaultLayerValue(tier, stat) ?? fallback;
+
+        /// <summary>
+        /// The core-four window at a tier - THE SAME formula as LootGenerationFactory.ApplyT11GearStats.RollCore
+        /// (cap = anchor/18 x (1+(t-11)/14), fixed T11 step = anchor/18/14, floor = cap - 1.5 step, T11 - 0.5 step,
+        /// rounded at the end). Anchors: the tier's Default-layer core_anchor_dr / core_anchor_cdr, else the LADDER
+        /// constants 1250 / 750. anchorOverride lets a drop-time caller pass the ZONE's evaluated anchors instead.
+        /// With zonecontrol_enabled OFF nothing authored is consulted at all - the T10 FALLBACK anchors win
+        /// outright, including over anchorOverride (owner 2026-08-23).
+        /// </summary>
+        public static (int Min, int Max) CoreWindow(int coreKey, int tier, double? anchorOverride = null)
+        {
+            var isDr = coreKey == CoreDamageResist;
+            var zcOn = ServerConfig.zonecontrol_enabled.Value;
+            var anchor = !zcOn
+                ? (isDr ? ZoneFallback.AnchorDr : ZoneFallback.AnchorCdr)
+                : anchorOverride ?? DefaultLayerStat(tier, isDr ? ZoneStat.CoreAnchorDr : ZoneStat.CoreAnchorCdr,
+                                                    isDr ? LadderAnchorDr : LadderAnchorCdr);
+            // The fallback is FLAT - nothing climbs with tier off the switch, matching the flat armour base
+            // and the tier-blind fallback line bands (owner 2026-08-23). Only the ladder scales.
+            var scale = zcOn ? 1.0 + (tier - 11) / 14.0 : 1.0;
+            var cap = anchor / 18.0 * scale;
+            var step = anchor / 18.0 / 14.0;
+            var lo = cap - (tier == 11 ? 0.5 : 1.5) * step;
+            var min = (int)Math.Round(lo);
+            var max = (int)Math.Round(cap);
+            if (min > max) min = max;
+            return (min, max);
+        }
+
+        /// <summary>The LADDER core anchors - the worn-set totals a maxed T25 suit lands on (18 pieces).</summary>
+        public const double LadderAnchorDr = 1250.0, LadderAnchorCdr = 750.0;
+
+        /// <summary>The per-tier armor base when nothing is authored: 1100 + 100/tier above 11 on the ladder.</summary>
+        public static int LadderArmorLevel(int tier) => 1100 + 100 * (tier - 11);
+
+        /// <summary>
+        /// The per-tier armor base (ApplyT11GearStats + Compute). Three-step chain, owner 2026-08-24
+        /// (Armor_Base_Values_Plan_2026-08-24.md section 2.1):
+        ///   zonecontrol_enabled OFF          -> the flat T10 fallback, and NOTHING authored is consulted
+        ///                                       (same rule as EffectiveBand / CoreWindow, owner 2026-08-23)
+        ///   Default[tier] armor_base_level   -> that value
+        ///   otherwise                        -> 1100 + 100 x (tier - 11), the historical formula
+        /// Unset therefore reproduces the pre-2026-08-24 numbers EXACTLY - nothing moves until authored.
+        ///
+        /// READ STAGE - this one is RESOLVE, not DROP. It is read inside <see cref="Compute"/>, so
+        /// authoring armor_base_level RE-PRICES EVERY EXISTING PIECE of that tier on its next equip or
+        /// login (or immediately via Apply Ladder). That is the opposite of armor_prot_base /
+        /// armor_prot_equalize, which are stamped once at drop time and never revisited.
+        ///
+        /// PERFORMANCE: Compute calls this exactly ONCE per resolve (after the line loop, not inside it),
+        /// so the Default-layer lookup is one locked snapshot read per resolve - no per-line cost, and no
+        /// signature change was needed to get there. Callers that already hold the Default's value can use
+        /// the overload below to skip the lookup entirely.
+        /// </summary>
+        public static int BaseArmorLevel(int tier)
+        {
+            if (!ServerConfig.zonecontrol_enabled.Value)
+                return ZoneFallback.ArmorLevel;
+            var authored = DefaultLayerValue(tier, ZoneStat.ArmorBaseLevel);
+            return authored.HasValue ? (int)Math.Round(authored.Value) : LadderArmorLevel(tier);
+        }
+
+        /// <summary>
+        /// Same chain as <see cref="BaseArmorLevel(int)"/> but fed an already-resolved authored value, for a
+        /// caller that has one in hand (a drop-time evaluated profile, or a loop over many pieces at one
+        /// tier). null = not authored -> the ladder formula.
+        /// </summary>
+        public static int BaseArmorLevel(int tier, double? authored)
+        {
+            if (!ServerConfig.zonecontrol_enabled.Value)
+                return ZoneFallback.ArmorLevel;
+            return authored.HasValue ? (int)Math.Round(authored.Value) : LadderArmorLevel(tier);
+        }
+
+        // ── armor protection (DROP-time only) ───────────────────────────────────
+        // Both of these are stamped when the piece is CREATED and never looked at again, unlike
+        // BaseArmorLevel above. Changing either affects NEW DROPS ONLY; existing gear keeps whatever it
+        // was stamped with, no matter how many times it is re-equipped or the ladder is applied.
+
+        /// <summary>The C# defaults, so every read site agrees: 1.0 protection, equalize ON.</summary>
+        public const double DefaultArmorProtBase = 1.0;
+        public const bool DefaultArmorProtEqualize = true;
+
+        /// <summary>
+        /// The value an ABSENT ArmorModVs* element is filled with at drop time (armor_prot_base). Same 0-2
+        /// scale the engine uses: 1.0 = Average, 1.4 = Superior, 0.6 = Below Average. ArmorModVs* defaults
+        /// to 0.0 and MULTIPLIES the piece AL, so an unfilled element is literally zero protection - this
+        /// is a floor, not a bonus. Zone layer wins when it defines the key, else the tier Default, else 1.0.
+        /// </summary>
+        public static double ArmorProtBase(int tier, ZoneScaling.EvaluatedProfile p = null)
+        {
+            if (p != null && p.Has(ZoneStat.ArmorProtBase))
+                return p.Get(ZoneStat.ArmorProtBase, DefaultArmorProtBase);
+            return DefaultLayerValue(tier, ZoneStat.ArmorProtBase) ?? DefaultArmorProtBase;
+        }
+
+        /// <summary>
+        /// Whether a fresh piece's present elements are averaged to their mean (armor_prot_equalize,
+        /// default ON). OFF re-admits the spread: a Poor roll stays Poor and an Unparalleled roll stays
+        /// Unparalleled instead of both collapsing toward the middle. Zone layer wins when it defines the
+        /// key, else the tier Default, else ON. tier &lt;= 0 = "no tier known" -> the C# default.
+        /// </summary>
+        public static bool ArmorProtEqualize(int tier, ZoneScaling.EvaluatedProfile p = null)
+        {
+            if (p != null && p.Has(ZoneStat.ArmorProtEqualize))
+                return p.Get(ZoneStat.ArmorProtEqualize, 1.0) != 0.0;
+            if (tier <= 0)
+                return DefaultArmorProtEqualize;
+            var authored = DefaultLayerValue(tier, ZoneStat.ArmorProtEqualize);
+            return authored.HasValue ? authored.Value != 0.0 : DefaultArmorProtEqualize;
+        }
+
+        // ── the record ──────────────────────────────────────────────────────────
+
+        public struct LineRecord
+        {
+            public int Key;      // catalog key, or a Core* pseudo key
+            public int Grade;    // 0-1000
+        }
+
+        public static bool HasRecord(WorldObject wo)
+            => wo != null && !string.IsNullOrEmpty(wo.GetProperty(PropertyString.ZcModifiers));
+
+        /// <summary>
+        /// The item's ladder row. ARMOUR, clothing and jewelry carry ZcTier; WEAPONS DO NOT -
+        /// LootGenerationFactory.ApplyT11GearStats returns at its `default:` case for weapons/casters
+        /// BEFORE <see cref="StampIdentity"/> ever runs, so a weapon's tier lives in
+        /// PropertyInt.WeaponAugScaleTier (stamped by ApplyWeaponAugScaleStamp later in the same
+        /// Creature_Death sweep). Reading only ZcTier - which is what this did before 2026-08-25 -
+        /// returned 0 for every weapon, which meant Compute silently resolved weapon lines at the T11
+        /// rung no matter what tier they dropped at, and ApplyIfStale bailed at its `tier &lt;= 0` guard
+        /// so a weapon NEVER re-resolved. Both were live bugs for the armour-style cantrip lines
+        /// weapons already carried; the weapon cards inherit the fix.
+        ///
+        /// Same shape as ZoneCraftGate.TierOf - if one of the two changes, change both.
+        /// ORDERING TRAP: at ZoneLootMutator time NEITHER property is set yet (the aug-scale stamp runs
+        /// after MutateLootItem), so every drop-time caller must pass the loot tier explicitly rather
+        /// than asking the item. VerifyLiveStatCache runs after both stamps, so it may ask.
+        /// </summary>
+        public static int TierOf(WorldObject wo)
+        {
+            if (wo == null)
+                return 0;
+            var zc = wo.GetProperty(PropertyInt.ZcTier) ?? 0;
+            if (zc > 0)
+                return zc;
+            return wo.GetProperty(PropertyInt.WeaponAugScaleTier) ?? 0;
+        }
+
+        /// <summary>
+        /// True when the record contains at least one reserved WEAPON key. Allocation-free and
+        /// deliberately a raw character scan, because it sits on the ApplyIfStale early-out - the
+        /// no-op path every login takes for every worn piece.
+        ///
+        /// It is exact, not a heuristic: Format writes core keys as 'cN', catalog keys as positive
+        /// integers and grades as 0..1000, so the ONLY '-' a well-formed record can contain is the
+        /// sign of a weapon key. Keep that true if you ever extend the format.
+        /// </summary>
+        public static bool HasWeaponKey(WorldObject wo)
+        {
+            var raw = wo?.GetProperty(PropertyString.ZcModifiers);
+            return !string.IsNullOrEmpty(raw) && raw.IndexOf('-') >= 0;
+        }
+
+        /// <summary>Parse the record. Unknown / malformed entries are skipped, never thrown on.</summary>
+        public static List<LineRecord> Read(WorldObject wo)
+        {
+            var list = new List<LineRecord>();
+            var raw = wo?.GetProperty(PropertyString.ZcModifiers);
+            if (string.IsNullOrEmpty(raw))
+                return list;
+            foreach (var part in raw.Split(';', StringSplitOptions.RemoveEmptyEntries))
+            {
+                var i = part.IndexOf(':');
+                if (i <= 0) continue;
+                var keyTok = part.Substring(0, i).Trim();
+                if (!int.TryParse(part.Substring(i + 1).Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var grade))
+                    continue;
+                int key;
+                if (keyTok.Length == 2 && (keyTok[0] == 'c' || keyTok[0] == 'C') && keyTok[1] >= '1' && keyTok[1] <= '4')
+                    key = -(keyTok[1] - '0');
+                else if (!int.TryParse(keyTok, NumberStyles.Integer, CultureInfo.InvariantCulture, out key))
+                    continue;
+                list.Add(new LineRecord { Key = key, Grade = Math.Clamp(grade, 0, GradeMax) });
+            }
+            return list;
+        }
+
+        public static string Format(IEnumerable<LineRecord> lines)
+        {
+            var sb = new StringBuilder();
+            foreach (var l in lines)
+            {
+                if (sb.Length > 0) sb.Append(';');
+                if (IsCoreKey(l.Key)) sb.Append('c').Append(-l.Key);
+                else sb.Append(l.Key.ToString(CultureInfo.InvariantCulture));
+                sb.Append(':').Append(Math.Clamp(l.Grade, 0, GradeMax).ToString(CultureInfo.InvariantCulture));
+            }
+            return sb.ToString();
+        }
+
+        public static void Write(WorldObject wo, List<LineRecord> lines)
+        {
+            if (wo == null) return;
+            if (lines == null || lines.Count == 0)
+                wo.RemoveProperty(PropertyString.ZcModifiers);
+            else
+                wo.SetProperty(PropertyString.ZcModifiers, Format(lines));
+        }
+
+        /// <summary>Append one grade to the record (a key already present is REPLACED - one line per key per piece).</summary>
+        public static void AddLine(WorldObject wo, int key, int grade)
+        {
+            if (wo == null) return;
+            var lines = Read(wo);
+            lines.RemoveAll(l => l.Key == key);
+            lines.Add(new LineRecord { Key = key, Grade = Math.Clamp(grade, 0, GradeMax) });
+            Write(wo, lines);
+        }
+
+        /// <summary>
+        /// The stamp that identifies a CURRENT resolve: the tier's ladder version, times two, plus a bit
+        /// for the Zone Control switch. The mode HAS to be part of the identity - zonecontrol_enabled
+        /// changes what a resolve produces, so without it flipping the switch would move the appraisal
+        /// (which computes live) while the item's stamped props never changed (owner 2026-08-23).
+        /// </summary>
+        public static int ResolveStamp(int tier) => ResolveStamp(tier, false);
+
+        /// <summary>
+        /// As above, plus the WEAPON PIN FINGERPRINT when <paramref name="withWeaponPins"/> is set.
+        ///
+        /// WHY THIS EXISTS (2026-08-25). `ladder apply` is the only thing that bumps
+        /// ZoneControlManager.GetLadderVersion, and the only Default-layer edits wired to auto-apply are
+        /// core_anchor_dr / core_anchor_cdr and the cantrip band editor (ZoneControlCommands
+        /// .AutoApplyForDefault). Authoring or clearing a weapon_&lt;card&gt;_min/max on a tier Default
+        /// changes what <see cref="WeaponResolveBand"/> returns, so without something in the identity
+        /// moving, every weapon already in the world would keep its old number FOREVER and the edit
+        /// would appear to do nothing except on new drops. Folding the authored pins into the stamp
+        /// makes the pin edit itself the invalidation - no command surface change, and it cannot be
+        /// forgotten the way "remember to run ladder apply" can.
+        ///
+        /// It is deliberately NOT folded into GetLadderVersion: that Version is displayed by
+        /// `/zonecontrol ladder show`, echoed by ladder apply and shipped to the plugin in the |ladder=
+        /// tag, where "v3" is a human-meaningful count of applies. A hashed number there would be a lie
+        /// in a GM surface. ResolveStamp, by contrast, is compared and never displayed as a quantity.
+        ///
+        /// ZERO WHEN NOTHING IS AUTHORED, and the shift keeps bit 0 (the Zone Control mode bit) intact:
+        /// a shard with no weapon pins produces byte-for-byte the pre-2026-08-25 stamp, so deploying
+        /// this does not spuriously re-resolve a single existing item.
+        ///
+        /// withWeaponPins is passed by the caller rather than derived here because the same item must
+        /// get the same answer at stamp time and at compare time; every internal caller derives it from
+        /// <see cref="HasWeaponKey"/> on the item itself. An armour piece never pays the lookup.
+        /// </summary>
+        public static int ResolveStamp(int tier, bool withWeaponPins)
+        {
+            var stamp = ZoneControlManager.GetLadderVersion(tier).Version * 2
+                      + (ServerConfig.zonecontrol_enabled.Value ? 0 : 1);
+            if (!withWeaponPins)
+                return stamp;
+            var fp = WeaponPinFingerprint(tier);
+            return fp == 0 ? stamp : unchecked(stamp ^ (fp << 1));
+        }
+
+        /// <summary>
+        /// A hash of the tier Default's authored weapon_*_min/max values, or 0 when the tier authors
+        /// none of them. Rows are folded in <see cref="WeaponSpecials"/> order so the result is stable
+        /// across runs; the value's exact bits are meaningless, only "did it change" matters.
+        /// With Zone Control OFF this returns 0 because <see cref="WeaponResolveBand"/> consults nothing
+        /// authored in that mode - a pin edit genuinely cannot change what a weapon resolves to, so it
+        /// must not invalidate anything either.
+        /// </summary>
+        private static int WeaponPinFingerprint(int tier)
+        {
+            if (!ServerConfig.zonecontrol_enabled.Value)
+                return 0;
+            var stats = ZoneControlManager.GetAnchoredDefaultProfile(tier)?.Stats;
+            if (stats == null || stats.Count == 0)
+                return 0;
+            var h = 0;
+            foreach (var ws in WeaponSpecials)
+            {
+                h = Fold(h, stats, ws.Band.MinStat);
+                h = Fold(h, stats, ws.Band.MaxStat);
+            }
+            return h;
+
+            static int Fold(int acc, Dictionary<string, ZoneScaling.StatCurve> s, string stat)
+            {
+                if (!s.TryGetValue(stat, out var curve) || curve == null)
+                    return acc;
+                // the VALUE, not the curve object: a re-author to the same number must not invalidate,
+                // and MutateVariationDefault replaces the StatCurve instance on every edit.
+                return unchecked(acc * 31 + curve.Evaluate(1).GetHashCode() + stat.Length);
+            }
+        }
+
+        /// <summary>Stamp the tier + the CURRENT resolve stamp (a fresh drop is resolved by definition).</summary>
+        public static void StampIdentity(WorldObject wo, int tier)
+        {
+            if (wo == null) return;
+            wo.SetProperty(PropertyInt.ZcTier, tier);
+            wo.SetProperty(PropertyInt.ZcResolvedVersion, ResolveStamp(tier, HasWeaponKey(wo)));
+        }
+
+        /// <summary>
+        /// The WEAPON half of <see cref="StampIdentity"/>: the resolve stamp WITHOUT ZcTier.
+        ///
+        /// CORRECTED 2026-08-25. This used to say "a weapon must not carry ZcTier", on the grounds
+        /// that TierOf and the crafting gate treat "has ZcTier" as "this is an armour-shaped piece".
+        /// They do not, and never did: both TierOf implementations take a plain max of ZcTier and
+        /// WeaponAugScaleTier and never branch on which is present, and the only code that decides
+        /// "is this armour" is <see cref="Compute"/>, which keys on ItemType + ArmorLevel. The rule
+        /// was a convention that had documented itself as a constraint.
+        /// Weapons now DO carry ZcTier (owner 2026-08-25, stamped in ApplyT11GearStats' default case)
+        /// so the crafting gate cannot be switched off by a single missing stamp.
+        /// This method still writes only the VERSION, because the version must be stamped after the
+        /// weapon's grades are recorded - which is here, not at gear-stat time.
+        ///
+        /// Call this AFTER the last grade has been recorded - HasWeaponKey reads the finished record.
+        /// </summary>
+        public static void StampWeaponResolve(WorldObject wo, int tier)
+        {
+            if (wo == null || tier <= 0) return;
+            wo.SetProperty(PropertyInt.ZcResolvedVersion, ResolveStamp(tier, HasWeaponKey(wo)));
+        }
+
+        // ── resolution ──────────────────────────────────────────────────────────
+
+        public class ResolvedLine
+        {
+            public LineRecord Record;
+            public ZoneModifiers.Def Def;     // null for a core key
+            public int Min, Max, Value;
+            public string Name => Def?.Name ?? CoreName(Record.Key);
+            /// <summary>The appraisal text for this line, in the stamp format ("Damage Rating +41 [14-69]").</summary>
+            public string Text
+            {
+                get
+                {
+                    if (Def == null)
+                        return $"{Name} +{Value} [{Min}-{Max}]";
+                    if (Def.SlotSpecial)
+                        return string.IsNullOrEmpty(Def.ValFmt) ? Name : $"{Name} {string.Format(Def.ValFmt, Value)}";
+                    return $"{Name} {string.Format(Def.ValFmt ?? "+{0}", Value)} [{Min}-{Max}]";
+                }
+            }
+        }
+
+        public class Resolved
+        {
+            public int Tier;
+            public List<ResolvedLine> Lines = new();
+            /// <summary>Every int prop the cache should hold, SET semantics (retail Gear* + 502xx block).</summary>
+            public Dictionary<PropertyInt, int> Ints = new();
+            /// <summary>
+            /// Every FLOAT prop the cache should hold, same SET semantics. This is the weapon half of the
+            /// cache: every continuous weapon card is a PropertyFloat (CriticalFrequency,
+            /// SlayerDamageBonus, IgnoreShield, CriticalMultiplier and the two override prop ids 9056 /
+            /// 9057), so none of them could ever live in <see cref="Ints"/>.
+            /// Values here are already in ENGINE space - <see cref="EngineValue"/> has run.
+            /// </summary>
+            public Dictionary<PropertyFloat, double> Floats = new();
+            /// <summary>Resolved Armor Level (base for tier + the key-25 line), null when the piece has no AL.</summary>
+            public int? ArmorLevel;
+        }
+
+        /// <summary>
+        /// PURE: grades -> resolved values against the live ladder. Never touches the item. Returns null when
+        /// the piece carries no record. Core keys resolve through <see cref="CoreWindow"/>; catalog keys
+        /// through <see cref="EffectiveBand"/>; key 25 adds to the tier's base AL; every Ints prop of a def
+        /// gets the value (All Attributes = six props, same number); Reinforced is skipped (frozen).
+        /// </summary>
+        public static Resolved Compute(WorldObject wo)
+        {
+            if (!HasRecord(wo))
+                return null;
+            var tier = TierOf(wo);
+            if (tier <= 0) tier = 11;
+            var r = new Resolved { Tier = tier };
+            var hasArmor = wo.ArmorLevel.HasValue && wo.ItemType == ItemType.Armor;
+            var alBonus = 0;
+
+            // The tier Default's Stats, fetched AT MOST ONCE per resolve and only when the record
+            // actually contains a weapon key. This used to matter for locking (GetVariationDefault takes
+            // the manager lock, and a fully carded weapon would have taken it twelve times - two stat
+            // names per card); since 2026-09-01 the anchored table is precomputed and read lock-free, so
+            // the caching is now just avoiding twelve dictionary probes.
+            Dictionary<string, ZoneScaling.StatCurve> defStats = null;
+            var defStatsFetched = false;
+
+            foreach (var rec in Read(wo))
+            {
+                if (IsWeaponKey(rec.Key))
+                {
+                    // An unknown key inside the reserved weapon block is skipped, not thrown on - an
+                    // item stamped by a newer build must stay loadable on an older one.
+                    if (!TryGetWeapon(rec.Key, out var ws))
+                        continue;
+                    if (!defStatsFetched)
+                    {
+                        defStats = ZoneControlManager.GetAnchoredDefaultProfile(tier)?.Stats;
+                        defStatsFetched = true;
+                    }
+                    var (wlo, whi) = WeaponResolveBand(ws, tier, defStats, statsFetched: true);
+                    var display = Math.Clamp(ValueForD(wlo, whi, rec.Grade), ws.Band.Lo, ws.Band.Hi);
+                    // EngineValue is the single display -> engine conversion (Crushing Blow's "- 1.0").
+                    // The drop site routes through the same method, so the subtraction happens exactly
+                    // once no matter how many times a weapon is re-equipped. See EngineValue.
+                    r.Floats[ws.Prop] = EngineValue(ws, display);
+                    // NOT added to r.Lines. r.Lines is the APPRAISAL projection (AppraiseInfo walks it),
+                    // and weapon cards have never had appraisal lines - adding them here would silently
+                    // change the examine panel of every Zone Control weapon on the shard, which is a
+                    // GUI change and needs its own plan + go. Floats alone is the mechanical parity.
+                    continue;
+                }
+                if (IsCoreKey(rec.Key))
+                {
+                    var (cmin, cmax) = CoreWindow(rec.Key, tier);
+                    var cval = ValueFor(cmin, cmax, rec.Grade);
+                    r.Lines.Add(new ResolvedLine { Record = rec, Def = null, Min = cmin, Max = cmax, Value = cval });
+                    r.Ints[CoreProp(rec.Key)] = cval;
+                    continue;
+                }
+                if (!ZoneModifiers.TryGet(rec.Key, out var def) || def.SetsProtection)
+                    continue;
+                // Zone Control off: slot SPECIALS are disabled outright (owner 2026-08-23). Zero their
+                // props so the effect is inert, and leave them out of r.Lines so the appraisal stops
+                // advertising them. The RECORD is untouched - switching back on restores the special at
+                // its recorded grade on the next equip / login.
+                if (def.SlotSpecial && !ServerConfig.zonecontrol_enabled.Value)
+                {
+                    if (def.Ints != null)
+                        foreach (var (propId, _) in def.Ints)
+                            r.Ints[(PropertyInt)propId] = 0;
+                    continue;
+                }
+                var (min, max) = EffectiveBand(rec.Key, tier);
+                var value = ValueFor(min, max, rec.Grade);
+                r.Lines.Add(new ResolvedLine { Record = rec, Def = def, Min = min, Max = max, Value = value });
+                if (def.ArmorOnly && def.Ints == null)
+                {
+                    alBonus += value;                       // key 25 Armor Level
+                }
+                else if (def.Ints != null)
+                    foreach (var (propId, _) in def.Ints)
+                        r.Ints[(PropertyInt)propId] = value;
+            }
+
+            // 🔴 PRE-APPLIED CRAFTS THAT LAND ON A CARD'S OWN PROPERTY.
+            // The Bandit Hilt is stamped LAST at drop time (owner rule: hilts go on after every other
+            // tuner so their bonuses ADD on top), and two of the things it adds to are the very
+            // properties Biting Strike and Crushing Blow own: +0.25 CriticalFrequency and +0.175
+            // CriticalMultiplier. Before the cards were graded that was harmless - nothing ever
+            // recomputed the property. Now r.Floats is written with SET semantics on every equip, so
+            // without this the hilt's contribution would be ERASED the first time a hilted weapon was
+            // re-resolved, and there would be nothing in any log to say where the crit went.
+            // Re-adding it here is also correct for a hilt a PLAYER applied with the real recipe after
+            // the drop - same marker, same delta, same erase avoided.
+            // Only props the RECORD actually produced are touched: a hilted weapon with no Biting
+            // Strike card has no -11 key, so CriticalFrequency is not in r.Floats and is left alone.
+            if (r.Floats.Count > 0 && ZoneLootMutator.HasBanditHilt(wo))
+            {
+                if (r.Floats.TryGetValue(PropertyFloat.CriticalFrequency, out var cf))
+                    r.Floats[PropertyFloat.CriticalFrequency] = cf + ZoneLootMutator.BanditHiltCritFrequencyBonus;
+                if (r.Floats.TryGetValue(PropertyFloat.CriticalMultiplier, out var cm))
+                    r.Floats[PropertyFloat.CriticalMultiplier] = cm + ZoneLootMutator.BanditHiltCritMultiplierBonus;
+            }
+
+            // EVERY recorded armour piece resolves its AL, line or no line: the tier base is no longer a
+            // constant (zonecontrol_enabled swaps the whole ladder for the T10 fallback, owner 2026-08-23),
+            // so a piece without an Armor Level line would otherwise keep a stamp from the other set forever.
+            // alBonus stays 0 without that line, so a lineless piece lands exactly on the tier base.
+            // ONE BaseArmorLevel call per Compute, deliberately outside the line loop: since 2026-08-24 it
+            // reads the tier Default (armor_base_level), and that is a locked snapshot read.
+            if (hasArmor)
+                r.ArmorLevel = BaseArmorLevel(tier) + alBonus;
+            return r;
+        }
+
+        /// <summary>
+        /// Write a Resolved set onto the item (SET semantics - ZC owns these props on a T11+ piece). With
+        /// allowNerf false a value that would DROP below what is stamped keeps the stamped number (owner
+        /// policy: an accidental apply fixes under-tuned gear, never silently cuts anyone). Stamps the
+        /// version. Returns the number of props that actually changed.
+        /// </summary>
+        public static int Apply(WorldObject wo, Resolved r, bool allowNerf = true)
+        {
+            if (wo == null || r == null) return 0;
+            var changed = 0;
+            foreach (var kv in r.Ints)
+            {
+                var cur = wo.GetProperty(kv.Key);
+                var next = kv.Value;
+                if (!allowNerf && cur.HasValue && next < cur.Value)
+                    next = cur.Value;
+                if (cur != next)
+                {
+                    wo.SetProperty(kv.Key, next);
+                    changed++;
+                }
+            }
+            // The weapon half, SAME semantics as the ints above: SET, nerf-guarded, counted only when
+            // the stored number actually moves. The comparison is exact rather than epsilon-based on
+            // purpose - both sides come from the same deterministic band math, so an unchanged ladder
+            // reproduces the identical double and this writes nothing. An epsilon here would let a
+            // genuine sub-epsilon retune go unstamped, and the stamp would then claim it had landed.
+            foreach (var kv in r.Floats)
+            {
+                var cur = wo.GetProperty(kv.Key);
+                var next = kv.Value;
+                if (!allowNerf && cur.HasValue && next < cur.Value)
+                    next = cur.Value;
+                if (cur != next)
+                {
+                    wo.SetProperty(kv.Key, next);
+                    changed++;
+                }
+            }
+            if (r.ArmorLevel.HasValue)
+            {
+                var cur = wo.ArmorLevel;
+                var next = r.ArmorLevel.Value;
+                if (!allowNerf && cur.HasValue && next < cur.Value)
+                    next = cur.Value;
+                if (cur != next)
+                {
+                    wo.ArmorLevel = next;
+                    changed++;
+                }
+            }
+            // wield gates follow the tier row live too (owner 2026-08-23: T16+ Item Augs + Triune on existing pieces)
+            changed += ACE.Server.Factories.LootGenerationFactory.RefreshWieldGate(wo, r.Tier);
+            // HasWeaponKey off the ITEM, not off r.Floats: the stamp written here has to be the same
+            // number ApplyIfStale computes on the next equip, and that one only has the item to go on.
+            wo.SetProperty(PropertyInt.ZcResolvedVersion, ResolveStamp(r.Tier, HasWeaponKey(wo)));
+            return changed;
+        }
+
+        /// <summary>
+        /// EQUIP hook: when the piece's stamp does not match the current one (tier ladder version + the
+        /// Zone Control switch), re-resolve and re-stamp, mark the biota dirty. Cheap no-op for every piece
+        /// without a record, and for a resolved one. Bounded by what a character can wear - never called
+        /// from appraisal (plan §3b). NOT-EQUAL rather than less-than: a mode flip must re-stamp in BOTH
+        /// directions, and going to the fallback is a nerf by definition, so the nerf guard is bypassed
+        /// while the switch is off (owner 2026-08-23 chose fallback numbers on existing items).
+        /// </summary>
+        public static bool ApplyIfStale(WorldObject wo)
+        {
+            if (!HasRecord(wo))
+                return false;
+            var tier = TierOf(wo);
+            if (tier <= 0) return false;
+            var ladder = ZoneControlManager.GetLadderVersion(tier);
+            var seen = wo.GetProperty(PropertyInt.ZcResolvedVersion) ?? 0;
+            if (seen == ResolveStamp(tier, HasWeaponKey(wo)))
+                return false;
+            var r = Compute(wo);
+            if (r == null) return false;
+            var allowNerf = ladder.AllowNerf || !ServerConfig.zonecontrol_enabled.Value;
+            var changed = Apply(wo, r, allowNerf);
+            wo.ChangesDetected = true;
+            if (changed > 0)
+                wo.SaveBiotaToDatabase();
+            return changed > 0;
+        }
+    }
+}

--- a/Source/ACE.Server/Managers/ZoneScaling/ZoneScalingModels.cs
+++ b/Source/ACE.Server/Managers/ZoneScaling/ZoneScalingModels.cs
@@ -809,6 +809,9 @@ namespace ACE.Server.Managers.ZoneScaling
         /// <summary>tier -&gt; pinned value; when present for a tier, replaces the curve for that tier only.</summary>
         public Dictionary<int, double> Overrides { get; set; }
 
+        /// <summary>Deep copy - Merge publishes results to lock-free readers, so it must not share the live admin-mutable object.</summary>
+        public StatCurve Clone() => new StatCurve { Base = Base, Growth = Growth, Additive = Additive, Overrides = Overrides == null ? null : new Dictionary<int, double>(Overrides) };
+
         public double Evaluate(int tier)
         {
             if (Overrides != null && Overrides.TryGetValue(tier, out var pinned))
@@ -967,7 +970,7 @@ namespace ACE.Server.Managers.ZoneScaling
                 if (layer.Stats != null)
                     foreach (var kv in layer.Stats)
                     {
-                        result.Stats[kv.Key] = kv.Value;
+                        result.Stats[kv.Key] = kv.Value?.Clone();
                         // THE SHADOW RULE (owner 2026-08-30, per-tier authoring): a layer that
                         // authors a BASE stat WITHOUT its "_t25" twin means "this value, FLAT" -
                         // an inherited twin from a lower layer must not keep bending it onto the
@@ -1140,7 +1143,7 @@ namespace ACE.Server.Managers.ZoneScaling
         /// Default -&gt; zone -&gt; wcid and happens in ZoneControlManager.</summary>
         public ZoneVariantProfile VariantForWcid(uint wcid, bool create = false)
         {
-            if (WcidOverrides.TryGetValue(wcid, out var v))
+            if (WcidOverrides.TryGetValue(wcid, out var v) && v != null)   // a null stored bucket (JSON) counts as absent
                 return v;
             if (!create)
                 return null;

--- a/Source/ACE.Server/Managers/ZoneScaling/ZoneScalingModels.cs
+++ b/Source/ACE.Server/Managers/ZoneScaling/ZoneScalingModels.cs
@@ -1,0 +1,1303 @@
+using System;
+using System.Collections.Generic;
+
+namespace ACE.Server.Managers.ZoneScaling
+{
+    /// <summary>
+    /// RESERVED — not read by anything. Left over from the pre-rewrite Zone Scaler design, which resolved
+    /// LandblockVariation &gt; Landblock &gt; Zone &gt; Global. The live model layers
+    /// <c>VariationDefault -&gt; zone -&gt; wcid</c> instead (see ZoneControlManager) and never consults this.
+    /// Kept deliberately (owner, 2026-07-30) in case scoped profiles come back; do NOT assume it works.
+    /// </summary>
+    public enum ZoneScopeType
+    {
+        Global = 0,
+        Zone = 1,
+        Landblock = 2,
+        LandblockVariation = 3,
+    }
+
+    /// <summary>Which stat variant a curve belongs to (bosses carry PropertyBool.IsEmpowerSource).</summary>
+    public enum ZoneVariant
+    {
+        Minion = 0,
+        Boss = 1,
+    }
+
+    /// <summary>
+    /// Canonical stat keys a zone profile can define. Kept as string constants (not an enum) so the JSON
+    /// store stays forward-compatible if new keys are added without a migration.
+    /// </summary>
+    public static class ZoneStat
+    {
+        // A. spawn-snapshot / attributes + vitals
+        public const string Strength = "strength";
+        public const string Endurance = "endurance";
+        public const string Coordination = "coordination";
+        public const string Quickness = "quickness";
+        public const string Focus = "focus";
+        public const string Self = "self";
+        public const string MaxHealth = "max_health";
+        public const string MaxStamina = "max_stamina";
+        public const string MaxMana = "max_mana";
+
+        // B. live per-hit
+        public const string AttackSkill = "attack_skill";
+        // min_attack_skill REMOVED 2026-08-02 (owner): redundant with attack_skill's absolute replace.
+        // The prestige-gated v11_min_attack_skill server config floor still exists independently.
+        /// <summary>
+        /// The monster's LEVEL (PropertyInt.Level, 25).
+        ///
+        /// Added 2026-08-31. Nothing scaled level before this - a retail weenie dropped into a T11
+        /// zone kept whatever level it shipped with. Stamped at spawn rather than read live because
+        /// Level is plain item data that other systems (target weighting in Monster_Awareness, the
+        /// appraisal panel) read directly off the creature.
+        /// </summary>
+        public const string MonsterLevel = "monster_level";
+
+        /// <summary>
+        /// FALLBACK creature type (PropertyInt.CreatureType, 2) - applied ONLY to a monster whose
+        /// weenie has none, or has Invalid. It never overwrites a real species.
+        ///
+        /// Added 2026-08-31. A null CreatureType means NO SLAYER WEAPON CAN EVER ROLL off that mob:
+        /// ZoneLootMutator gates slayer eligibility on `killed?.CreatureType != null &amp;&amp; != Invalid`
+        /// and then copies the value onto the drop. An arbitrary retail weenie dropped into a zone
+        /// therefore silently removed a whole weapon card from its loot table. Fallback rather than
+        /// override so retail identity survives wherever it exists - a Drudge stays a Drudge.
+        /// </summary>
+        public const string MonsterCreatureType = "monster_creature_type";
+
+        /// <summary>
+        /// The monster's OFFENSIVE magic skill - what its spells are resisted against
+        /// (WorldObject_Magic reads GetCreatureSkill(spell.School).Current).
+        ///
+        /// Added 2026-08-31. attack_skill, melee_defense, missile_defense and magic_defense were all
+        /// already zone stats; this was the missing member of that family. Without it a zone could
+        /// author beautiful spell_damage and still have every cast resisted, because the mob kept its
+        /// retail-level War/Life skill. Absolute replace, same shape as AttackSkill.
+        /// </summary>
+        public const string MagicSkill = "magic_skill";
+        public const string MeleeDefense = "melee_defense";
+        public const string MissileDefense = "missile_defense";
+        public const string MagicDefense = "magic_defense";
+        public const string DamageRating = "damage_rating";
+        public const string DamageResistRating = "damage_resist_rating";
+        // damage_resist_rating_leader / _boss (2026-09-02 morning) lived ONE day: superseded the same
+        // evening by RANK LAYERS - every stat now has Default / Regular / Leader / Boss rows via
+        // ZoneVariantProfile.Ranks, so per-stat rank twins are gone. Migration SQL moved the values.
+        public const string ArmorLevel = "armor_level";
+        // damage_taken_mult REMOVED 2026-08-03 (owner): redundant with damage_resist_rating's
+        // replace (and server-clamped to <= 1.0 anyway). The prestige-gated v11_mob_dmg_taken_*
+        // config path still exists independently.
+        public const string VulnCap = "vuln_cap";
+        public const string PercentHpBase = "percent_hp_base";
+
+        // B1b. crit ratings (REPLACE the creature's base rating props at spawn; engine reads them
+        // generically - 313/314 shape the mob's outgoing crits, 315/316 blunt incoming player crits.
+        // 313 also drives %HP-floor crit frequency since it feeds the IsCritical roll).
+        public const string CritRating = "crit_rating";
+        public const string CritDamageRating = "crit_damage_rating";
+        public const string CritResistRating = "crit_resist_rating";
+        public const string CritDamageResistRating = "crit_damage_resist_rating";
+
+        // B2. offense (REPLACE the weenie's body-part DVal/DVar/DType AND weapon damage — one number for
+        // "what this monster hits for"). attack_damage_type is a DamageType flag int (random pick per hit).
+        public const string AttackDamage = "attack_damage";
+        public const string AttackVariance = "attack_variance";
+        public const string AttackDamageType = "attack_damage_type";
+        // spell_damage is RETAIL-path (since 2026-08-02): the authored value is the base per-cast damage and
+        // runs the normal retail mitigation pipeline (resists/prots/ratings); crits multiply by
+        // crit_damage_rating, and the floor still enforces a minimum. spell_variance spreads each cast
+        // down from that value (0 = flat, like attack_variance); spell_damage_mult multiplies on top
+        // (kept in code but hidden from the plugin UI since 2026-07-26 - owner retired it).
+        public const string SpellDamage = "spell_damage";
+        public const string SpellVariance = "spell_variance";
+        public const string SpellDamageMult = "spell_damage_mult";
+
+        // B2b. v11+ relief-curve anchors (2026-07-27, owner design): per-zone player-progression
+        // damage reduction on AUTHORED damage (the %HP floor + WYSIWYG spell_damage). Each axis:
+        // 0% reduction at *_start, rising to *_cap (fraction 0-1) at *_max, clamped both ends.
+        // *_bend shapes the rise: relief = cap * t^bend where t = progress start->max; 1 = straight
+        // line, <1 = strong early relief that tapers off, >1 = slow start that ramps late. aug and
+        // dr axes MULTIPLY; critdr shrinks only the crit BONUS. Unset = server defaults
+        // (v11_relief_* config). aug = defender life augs; dr = defender aggregate Damage Resist
+        // rating; critdr = defender Crit Damage Resist rating.
+        public const string ReliefAugStart = "relief_aug_start";
+        public const string ReliefAugMax = "relief_aug_max";
+        public const string ReliefAugCap = "relief_aug_cap";
+        public const string ReliefAugBend = "relief_aug_bend";
+        public const string ReliefDrStart = "relief_dr_start";
+        public const string ReliefDrMax = "relief_dr_max";
+        public const string ReliefDrCap = "relief_dr_cap";
+        public const string ReliefDrBend = "relief_dr_bend";
+        public const string ReliefCritDrStart = "relief_critdr_start";
+        public const string ReliefCritDrMax = "relief_critdr_max";
+        public const string ReliefCritDrCap = "relief_critdr_cap";
+        public const string ReliefCritDrBend = "relief_critdr_bend";
+        // Optional relief mid-points (owner 2026-07-27: "multiple bends"): up to 4 per axis, each an
+        // (x = stat value, y = reduction fraction 0-1) pair. A point counts only when BOTH x and y
+        // are authored. Any defined points REPLACE the bend shape: the curve runs piecewise-linear
+        // through (start,0) -> sorted points -> (max,cap). Points outside (start,max) are ignored.
+        public const string ReliefAugX1 = "relief_aug_x1";
+        public const string ReliefAugY1 = "relief_aug_y1";
+        public const string ReliefAugX2 = "relief_aug_x2";
+        public const string ReliefAugY2 = "relief_aug_y2";
+        public const string ReliefAugX3 = "relief_aug_x3";
+        public const string ReliefAugY3 = "relief_aug_y3";
+        public const string ReliefAugX4 = "relief_aug_x4";
+        public const string ReliefAugY4 = "relief_aug_y4";
+        public const string ReliefDrX1 = "relief_dr_x1";
+        public const string ReliefDrY1 = "relief_dr_y1";
+        public const string ReliefDrX2 = "relief_dr_x2";
+        public const string ReliefDrY2 = "relief_dr_y2";
+        public const string ReliefDrX3 = "relief_dr_x3";
+        public const string ReliefDrY3 = "relief_dr_y3";
+        public const string ReliefDrX4 = "relief_dr_x4";
+        public const string ReliefDrY4 = "relief_dr_y4";
+        public const string ReliefCritDrX1 = "relief_critdr_x1";
+        public const string ReliefCritDrY1 = "relief_critdr_y1";
+        public const string ReliefCritDrX2 = "relief_critdr_x2";
+        public const string ReliefCritDrY2 = "relief_critdr_y2";
+        public const string ReliefCritDrX3 = "relief_critdr_x3";
+        public const string ReliefCritDrY3 = "relief_critdr_y3";
+        public const string ReliefCritDrX4 = "relief_critdr_x4";
+        public const string ReliefCritDrY4 = "relief_critdr_y4";
+
+        // B3. incoming resists (REPLACE the creature-level ResistX multiplier; 1.0 neutral, <1 resists, >1 vuln).
+        // Applies to melee AND magic damage of that element (same read point the weenie floats use).
+        public const string ResistSlash = "resist_slash";
+        public const string ResistPierce = "resist_pierce";
+        public const string ResistBludgeon = "resist_bludgeon";
+        public const string ResistFire = "resist_fire";
+        public const string ResistCold = "resist_cold";
+        public const string ResistAcid = "resist_acid";
+        public const string ResistElectric = "resist_electric";
+        public const string ResistNether = "resist_nether";
+
+        // B4. per-element armor multiplier (REPLACE the creature-level ArmorModVsX; scales base armor vs that element).
+        public const string ArmorVsSlash = "armor_vs_slash";
+        public const string ArmorVsPierce = "armor_vs_pierce";
+        public const string ArmorVsBludgeon = "armor_vs_bludgeon";
+        public const string ArmorVsFire = "armor_vs_fire";
+        public const string ArmorVsCold = "armor_vs_cold";
+        public const string ArmorVsAcid = "armor_vs_acid";
+        public const string ArmorVsElectric = "armor_vs_electric";
+        public const string ArmorVsNether = "armor_vs_nether";
+
+        // C. loot (rolled at corpse creation)
+        // (loot_tier_bonus / loot_quantity_mult / rare_chance_mult / loot_quality_mult removed 2026-08-23:
+        //  tier = zone floor, quantity = per-slot counts, quality = grade model)
+        public const string BonusCurrency = "bonus_currency";
+
+        // C2. loot post-roll mutations (applied per dropped item AFTER the factory rolls it — enhance, never replace)
+        // (weapon_stat_mult / weapon_damage_* / weapon_*_elem_* / weapon_workmanship_* / coin_mult / value_*
+        //  removed 2026-08-23: weapon damage is owned by the weapon aug-scaling system)
+        public const string WeaponAttuned = "weapon_attuned";        // nonzero = rolled weapons drop Attuned (can't be traded/dropped)
+        public const string WeaponBonded = "weapon_bonded";          // nonzero = rolled weapons drop Bonded (stay on death)
+        public const string WeaponUnenchantable = "weapon_unenchantable"; // nonzero = rolled weapons drop unenchantable (ResistMagic 9999)
+        // Armor-side drop rules (2026-08-28, owner: the Rules tab gets an armor twin so the two
+        // loot branches mirror). Same semantics as the weapon three; they cover every NON-weapon
+        // zone-set drop - armor, clothing, jewelry, cloaks - the population armor_modifier_chance
+        // already governs.
+        public const string ArmorAttuned = "armor_attuned";          // nonzero = rolled non-weapon drops are Attuned
+        public const string ArmorBonded = "armor_bonded";            // nonzero = rolled non-weapon drops are Bonded
+        public const string ArmorUnenchantable = "armor_unenchantable"; // nonzero = rolled non-weapon drops are unenchantable (ResistMagic 9999)
+
+        // C3. loot special-property rolls (independent 0..1 chance per eligible dropped item — "fun stuff")
+        // Cast on Strike, REWRITTEN 2026-08-27 (owner). The card is now TWO INDEPENDENT slots - an ARC
+        // and a RING - and both are picked from the weapon's OWN damage type, the same field the rend
+        // reads. The old weapon_proc_chance / _rate / _spell trio is GONE along with ProcSpellPool and
+        // its tier clamp; there is deliberately no back-compat shim (test shard, no migration).
+        //
+        // WHY MATCHED TO THE WEAPON: GetWeaponResistanceModifier resolves the rend off the SPELL's
+        // damage type (SpellProjectile.cs:752 -> WorldObject_Weapon.cs:641), so a proc only benefits
+        // from the weapon's rend when the two elements agree. Mismatched, the proc loses a 2.50-3.13x
+        // multiplier at T11 that the melee swing keeps. Matching is worth 4-5x and is not cosmetic.
+        public const string WeaponProcArcChance = "weapon_proc_arc_chance";   // per-drop odds the ARC slot is stamped
+        public const string WeaponProcArcRate = "weapon_proc_arc_rate";       // the arc's per-hit proc rate (engine ProcSpellRate)
+        public const string WeaponProcRingChance = "weapon_proc_ring_chance"; // per-drop odds the RING slot is stamped
+        public const string WeaponProcRingRate = "weapon_proc_ring_rate";     // the ring's per-hit proc rate (ProcRate2)
+        // The damage lever. B REPLACES the spell's rolled base AND the flat War/Void aug term at
+        // SpellProjectile.cs:704-722 - it must never multiply it: EffectiveWarAugCount is added 1:1 and
+        // the live shard ranges 0..10,000 War augs, a 60x spread coming from the WIELDER, not the weapon.
+        // A BAND PER SLOT, not one shared value (owner 2026-08-27, GUI layout B - two separate cards).
+        // Separate bands are what let the two be priced for what they actually are: the arc is one
+        // projectile at the target, the ring is 9 projectiles centred on the PLAYER (owner: rings keep
+        // the default behaviour and ring the caster, not the monster). At an identical B the ring would
+        // be strictly better on any melee weapon, since it hits everything around you for the same
+        // number. 440 = one melee hit is the anchor for BOTH; the ring's is expected to move first.
+        public const string WeaponProcArcDmgMin = "weapon_proc_arc_dmg_min";   // arc B floor (T11 anchor 440)
+        public const string WeaponProcArcDmgMax = "weapon_proc_arc_dmg_max";   // arc B ceiling (T11 660, PROVISIONAL)
+        public const string WeaponProcRingDmgMin = "weapon_proc_ring_dmg_min"; // ring B floor
+        public const string WeaponProcRingDmgMax = "weapon_proc_ring_dmg_max"; // ring B ceiling
+        // Without this the card is a LIE on a melee character: the proc's resist check falls back to the
+        // WIELDER's skill in the spell's school (TryResistSpell:140-161), and untrained War Magic ~600 vs
+        // a T11 mob's magic_defense 1100 is resisted ~100 pct of the time. Stamping ItemSpellcraft moves
+        // the check onto the WEAPON. This is the prerequisite for everything else on the card.
+        // Per-hit spread, PER SLOT (owner 2026-08-27). The damage band is rolled ONCE at drop, so
+        // without this every proc from a given weapon hits for the exact same number forever - nine
+        // ring hits at exactly 23,237 in the first live test.
+        //
+        // 🔴 SPREADS THE WHOLE BASE, B **AND** THE AUG TERM (owner: "whole base"). Varying B alone
+        // would be invisible: at 9,000 War augs B is 4.7 pct of the base, so a 50 pct spread on B
+        // moves the landed number by ~2 pct. Same shape as spell_variance - it spreads DOWN from the
+        // rolled value, so the band stays the ceiling.
+        public const string WeaponProcArcVariance = "weapon_proc_arc_variance";   // 0 = flat, 0.5 = 50-100 pct of base
+        public const string WeaponProcRingVariance = "weapon_proc_ring_variance";
+        // PER-SLOT since 2026-08-29 (owner: "each of those procs is its own thing") - the shared
+        // weapon_proc_spellcraft / weapon_proc_aug_cap stamps are RETIRED. A weapon carrying BOTH
+        // procs stamps ItemSpellcraft with the HIGHER of the two spellcrafts (one resist prop on the
+        // item; true per-slot resist is an adjust-after item).
+        public const string WeaponProcArcSpellcraft = "weapon_proc_arc_spellcraft";   // stamped ItemSpellcraft (arc)
+        // FLAT aug fold-in - WAR/VOID ONLY, picked by the proc spell's school (owner reversed the
+        // earlier melee/missile-matched build the same night, 2026-08-27: "The procs are spells").
+        // A melee character with no War/Void augs gets B and nothing more, which is intended.
+        // (An older version of this comment claimed all four counts were SUMMED - that build never
+        // shipped; the code below and both damage paths read the one school count.)
+        //
+        // THE CAP IS THE WHOLE SAFETY MECHANISM. War counts reach 10,000 and Void 17,150 on the
+        // live shard, so uncapped is up to a 0..17,150 flat addition on top of a 440 base - the
+        // same uncontrolled, wielder-driven spread that B was introduced to remove. UNSET =
+        // UNCAPPED; there is no defensible default to invent here, so it is a knob the owner must
+        // set. Read by BOTH damage paths since 2026-08-28 (the ring path missed it before).
+        public const string WeaponProcRingSpellcraft = "weapon_proc_ring_spellcraft"; // stamped ItemSpellcraft (ring)
+        public const string WeaponProcArcAugCap = "weapon_proc_arc_aug_cap";   // arc: max aug contribution (one school); unset/0 = uncapped
+        public const string WeaponProcRingAugCap = "weapon_proc_ring_aug_cap"; // ring: same, its OWN stamp (prop 9064)
+        public const string WeaponImbueChance = "weapon_imbue_chance";   // random imbue (rends / Critical Strike / Crippling Blow / Armor Rending)
+        public const string WeaponSlayerChance = "weapon_slayer_chance"; // slayer vs the killed monster's own creature type
+        public const string WeaponSlayerMin = "weapon_slayer_min";       // SlayerDamageBonus min (raw multiplier, floor 1.5, cap 10.0)
+        public const string WeaponSlayerMax = "weapon_slayer_max";       // SlayerDamageBonus max
+        // ── MODIFIERS (renamed from "cantrip" 2026-08-28, owner: the lines are flat stat bonuses,
+        // not cantrips - the retail word was a misnomer). The KEY STRINGS are the DB + wire + plugin
+        // contract; ZoneControlManager.UpgradeLegacyStoreKeys aliases the old cantrip_* keys on
+        // load, so any stored blob upgrades itself on its first save. ──
+        // ── RETIRED 2026-08-29 (owner, ModifiersBandsMerge_Plan REV 2): weapon_modifier_chance /
+        // armor_modifier_chance (the master line gates), modifier_lines_min/_max/_chance_1/2/3 (the
+        // line-count ladder) and modifier_weight_trash/mid/chase (the class-weight draw). Every
+        // catalog LINE now rolls its OWN anchored chance per eligible piece - see
+        // ZoneModifiers.LineChanceStat + ZoneLootMutator.TryExtraModifier. Weapons no longer roll
+        // armor-style lines at all. Zones that authored the old keys keep dead store rows until
+        // cleared with `/zonecontrol default <var> clearstat <key>`. ──
+        // Guaranteed core four anchors (SET totals at T25; per piece = anchor/18 x f(t)); see
+        // LootGenerationFactory.ApplyT11GearStats
+        public const string CoreAnchorDr = "core_anchor_dr";               // Damage Resist worn-set anchor (ladder 1250, authored on Default 11; ZoneFallback.AnchorDr 92 when off)
+        public const string CoreAnchorCdr = "core_anchor_cdr";             // CritDmgResist / CritResist / NetherResist worn-set anchor (ladder 750, authored on Default 11; ZoneFallback.AnchorCdr 73 when off)
+        // Slot specials: ONE roll per KILL (retail-rare model), 1-in-odds; boss/leader divide the odds
+        public const string SpecialOdds = "special_odds";                  // denominator (default 750000). Per rank via the Ranks rows (2026-09-02, owner D4: absolute per rank - special_boss_mult / special_leader_mult divisors RETIRED)
+        // Special behaviour knobs (read by the combat side)
+        public const string BattleMendThreshold = "battlemend_threshold";  // HP fraction below which Battle Mending fires (default .25)
+        public const string BattleMendCooldown = "battlemend_cooldown";    // seconds (default 60)
+        public const string PctHpCooldown = "pcthp_cooldown";              // pct-HP special cooldown, seconds (default 2)
+        public const string CheatDeathCooldown = "cheatdeath_cooldown";    // seconds per character (default 600)
+        public const string CheatDeathImmunity = "cheatdeath_immunity";    // immunity window, seconds (default 5)
+        public const string LifeOnHitCap = "lifeonhit_cap";                 // key 48: worn-total cap in pct of max HP per hit (default 25)
+        public const string LifeOnHitCooldown = "lifeonhit_cooldown";       // key 48: per-character seconds between heals (default 3)
+        // Worn-gear HARD caps (owner 2026-08-21: "everything we set at 2500 must cap at EXACTLY 2500, not
+        // around 2500"). The flat per-piece bands overshoot the anchor by rounding (18 x 139 = 2502 at T25),
+        // so the cap is enforced on the EQUIPPED SUM at read time - equipment term only, never enchantments /
+        // augs / enlightenment. Read for PLAYERS via the zone default the player stands in; no zone = the C#
+        // default, so the caps apply everywhere. Creature.GetGearCap / GetEquippedItemsRatingSumCapped /
+        // GetZoneModifierBonus are the read sites.
+        public const string GearCapDr = "gear_cap_dr";                     // worn Damage Resist sum (ladder ceiling 2500; ZoneFallback.CapDr 92 when zonecontrol_enabled is off)
+        public const string GearCapCdr = "gear_cap_cdr";                   // worn CritDmgResist / CritResist / NetherResist sums, EACH (ladder ceiling 1500; ZoneFallback.CapCdr 73 when off)
+        public const string GearCapLine = "gear_cap_line";                 // every anchored cantrip line: Dmg / CritDmg / MaxHP / MaxStam / MaxMana / HealBoost / each aug track / each attribute (ladder ceiling 2500; ZoneFallback.CapLine 211 when off)
+        public const string XpKill = "xp_kill";
+        public const string LumAward = "lum_award";
+
+        // PropertyBool ids the loot side reads by cast (the enum entries live with the combat work):
+        // 50048 IsZcBoss / 50049 IsZcLeader / 50050 IsZcMinion / 50051 ZcPctHpImmune (owner 50000+ block)
+        public const int BoolIsZcBoss = 50048;
+        public const int BoolIsZcLeader = 50049;
+        public const int BoolIsZcMinion = 50050;   // UI label "Regular" since 2026-09-02 (owner D1); the id and the JSON key "regular" are the same rank
+
+        public const int BoolZcPctHpImmune = 50051;
+        // Card amounts are min/max PAIRS: set one = exact value, set both = each drop rolls uniformly
+        // in the range, reversed bounds auto-swap.
+        public const string WeaponCleaveChance = "weapon_cleave_chance";   // melee: swing hits extra targets in an arc
+        public const string WeaponCleaveMin = "weapon_cleave_min";         //   extra targets, clamp 1..10 (default 1)
+        public const string WeaponCleaveMax = "weapon_cleave_max";
+        public const string WeaponSplitChance = "weapon_split_chance";     // bows: arrows split to hit extra targets
+        public const string WeaponSplitMin = "weapon_split_min";           //   splits, clamp 1..10 (default 1)
+        public const string WeaponSplitMax = "weapon_split_max";
+        public const string WeaponSplitRange = "weapon_split_range";       //   split seek range meters, clamp 0..50 (default 8; >=11 trips the bowstring already-strung guard)
+        public const string WeaponSplitDmg = "weapon_split_dmg";           //   damage fraction per split 0..1 (default 1)
+        public const string WeaponBiteChance = "weapon_bite_chance";       // Biting Strike: crit chance override
+        public const string WeaponBiteMin = "weapon_bite_min";             //   crit chance 0..1 (default 0.5; base is 0.1)
+        public const string WeaponBiteMax = "weapon_bite_max";
+        public const string WeaponCrushChance = "weapon_crush_chance";     // Crushing Blow: crit damage multiplier override
+        public const string WeaponCrushMin = "weapon_crush_min";           //   multiplier, clamp 1..10 (default 3)
+        public const string WeaponCrushMax = "weapon_crush_max";
+        public const string WeaponArmorRendChance = "weapon_armor_rend_chance"; // stamps the REAL ArmorRending imbue + tunable amount
+        public const string WeaponArmorRendMin = "weapon_armor_rend_min";  //   fraction of armor ignored 0..1 (default 0.5; skill imbue caps at 0.6)
+        public const string WeaponArmorRendMax = "weapon_armor_rend_max";
+        public const string WeaponShieldCleaveChance = "weapon_shield_cleave_chance"; // Shield Cleaving
+        public const string WeaponShieldCleaveMin = "weapon_shield_cleave_min"; //   fraction of shield ignored 0..1 (default 0.5)
+        public const string WeaponShieldCleaveMax = "weapon_shield_cleave_max";
+        // REMOVED 2026-08-25 (owner): weapon_phantom_chance, the Phantom (hollow) card's chance stat.
+        // The card is gone from ZoneLootMutator; the retail IgnoreMagicArmor / IgnoreMagicResist
+        // properties it used to stamp are untouched. Zones that authored the key keep a dead store row
+        // until it is cleared with `/zonecontrol default <var> clearstat weapon_phantom_chance`.
+        // Rend Power (2026-08-25): this card used to be the ONE special with no chance stat of its own -
+        // its gate was a PRESENCE test on the min/max pair below, which meant "authored = 100 pct". That
+        // made its T11 -> T25 ladder unreachable, because the presence test and WeaponDropBand's
+        // "is a pin authored?" test were the SAME condition: the gate only opened when a pin existed,
+        // and a pin always wins over the ladder. It now gates on this chance like the other five.
+        // Consequence, accepted by the owner: a zone that authors only min/max and no chance no longer
+        // rolls Rend Power at all, because Won() treats an UNDEFINED stat as NEVER (not as "0 pct").
+        // Re-author those zones with a chance; there is deliberately no back-compat shim.
+        // weapon_rend_power_chance RETIRED 2026-08-29 (owner: "Rending and Rend Power - it's 1").
+        // The Rending card (weapon_imbue_chance) is now the ONE gate: every rend the CARD stamps also
+        // rolls its power from the band below. Natural loot rends stay at the vanilla 150 (owner
+        // ruling, same day) - the old separate chance could boost those too, and no longer exists.
+        public const string WeaponRendPowerMin = "weapon_rend_power_min";  // rend strength as a DIRECT vuln bonus, rolled per drop; wire 1.5..10.0 = +150%..+1000% (rendingMod = 1 + this)
+        public const string WeaponRendPowerMax = "weapon_rend_power_max";
+
+        // C4. structured loot set + QB scaling (T11+ endgame loot; see ACE_Loot_Systems_DeepDive doc §12-13)
+        // PER-SLOT drop counts (owner 2026-07-20: no set enabler, each slot has its own count).
+        // Default = 1 each at tier 11+, 0 below; a zone stat overrides just that slot. Armor slots
+        // are coverage-aware: a multi-slot piece (coat) credits every slot it covers.
+        public const string LootSlotWeapons = "loot_slot_weapons";         // weapon drops PER FAMILY (9 families)
+        public const string LootSlotHelm = "loot_slot_helm";
+        public const string LootSlotChest = "loot_slot_chest";
+        public const string LootSlotShoulder = "loot_slot_shoulder";
+        public const string LootSlotBracer = "loot_slot_bracer";
+        public const string LootSlotGlove = "loot_slot_glove";
+        public const string LootSlotGirth = "loot_slot_girth";
+        public const string LootSlotUpperLeg = "loot_slot_upperleg";
+        public const string LootSlotLowerLeg = "loot_slot_lowerleg";
+        public const string LootSlotBoot = "loot_slot_boot";
+        public const string LootSlotShield = "loot_slot_shield";
+        public const string LootSlotAmulet = "loot_slot_amulet";
+        public const string LootSlotRing = "loot_slot_ring";
+        public const string LootSlotBracelet = "loot_slot_bracelet";
+        public const string LootSlotTrinket = "loot_slot_trinket";
+        public const string LootSlotCloak = "loot_slot_cloak";
+
+        // OPTIONAL per-slot RANGE (owner 2026-08-24): the base loot_slot_<slot> key above is the MIN
+        // and these are the MAX. When a max is defined AND above the min, the slot's count rolls
+        // uniform-inclusive per slot, per kill ("1-2 Weapons, 3-5 Chest"); each slot rolls
+        // INDEPENDENTLY. Max unset (the default) = an exact count, i.e. the pre-2026-08-24 behaviour.
+        // Reversed pairs are auto-swapped at read time, matching every other min/max pair here.
+        // Append-only: an older plugin ignores these, an older server never sends them.
+        public const string LootSlotWeaponsMax = "loot_slot_weapons_max";
+        public const string LootSlotHelmMax = "loot_slot_helm_max";
+        public const string LootSlotChestMax = "loot_slot_chest_max";
+        public const string LootSlotShoulderMax = "loot_slot_shoulder_max";
+        public const string LootSlotBracerMax = "loot_slot_bracer_max";
+        public const string LootSlotGloveMax = "loot_slot_glove_max";
+        public const string LootSlotGirthMax = "loot_slot_girth_max";
+        public const string LootSlotUpperLegMax = "loot_slot_upperleg_max";
+        public const string LootSlotLowerLegMax = "loot_slot_lowerleg_max";
+        public const string LootSlotBootMax = "loot_slot_boot_max";
+        public const string LootSlotShieldMax = "loot_slot_shield_max";
+        public const string LootSlotAmuletMax = "loot_slot_amulet_max";
+        public const string LootSlotRingMax = "loot_slot_ring_max";
+        public const string LootSlotBraceletMax = "loot_slot_bracelet_max";
+        public const string LootSlotTrinketMax = "loot_slot_trinket_max";
+        public const string LootSlotCloakMax = "loot_slot_cloak_max";
+
+        // BUDGET MODE (owner 2026-08-24). Defining loot_max_drops switches the structured set from
+        // "each slot drops its own count" to "roll this many ITEMS total, distributed by weight".
+        // In budget mode the loot_slot_<slot> values above are reinterpreted as WEIGHTS WITHIN THEIR
+        // CATEGORY (0 still = never); the _max range keys apply to LEGACY mode only, since the range
+        // now lives on the budget. Unset = legacy, i.e. the pre-2026-08-24 behaviour, unchanged.
+        // The budget is a CEILING, not a quota: armor coverage credit (one coat covering three slots)
+        // can land under it. Slot specials are deliberately OUTSIDE the budget.
+        // Renamed from loot_max_drops / loot_max_drops_max 2026-08-24: the first key is the LOWER
+        // bound, so calling it "max" was backwards and the UI inherited the error. Renamed while only
+        // a single test value existed - re-author it once.
+        public const string LootDropsMin = "loot_drops_min";   // floor; DEFINING THIS is what enables budget mode
+        public const string LootDropsMax = "loot_drops_max";   // optional ceiling; budget rolls uniform-inclusive between them
+        // Carried inventory on the corpse (owner 2026-09-01). Inside a governed v11+ zone a monster drops
+        // THAT VARIATION'S SET and nothing else, so create-list Contain items - which never pass through
+        // CreateRandomLootObjects and so survived the floor's zeroing of the three retail roll groups - are
+        // suppressed by DEFAULT. Set this above 0 to let one monster hand over what it carries anyway.
+        // That is the QUEST-ITEM channel: authored per-WCID, it is how a quest mob delivers its drop
+        // without re-opening the floodgate for every retail mob that happens to carry junk.
+        // Unset / 0 = suppressed. Only consulted when the zone loot floor is actually in force.
+        public const string DropCarriedInventory = "drop_carried_inventory";
+
+        public const string LootWeightWeapon = "loot_weight_weapon";       // relative category weights, normalized at roll time
+        public const string LootWeightArmor = "loot_weight_armor";         //   (shield rides armor)
+        public const string LootWeightJewelry = "loot_weight_jewelry";
+        public const string LootWeightCloak = "loot_weight_cloak";
+
+        // C5. ARMOR BASE VALUES (owner 2026-08-24, Armor_Base_Values_Plan_2026-08-24.md sections 2.1-2.3).
+        // The three numbers a T11+ armour piece was built on that had no authoring surface at all.
+        //
+        // READ STAGE MATTERS, and the three do NOT share one:
+        //   armor_base_level     -> RESOLVE. Read inside ZoneStatResolver.Compute, so authoring it
+        //                           RE-PRICES EXISTING GEAR on its next equip / login (or at once via
+        //                           Apply Ladder). Authored on the per-tier DEFAULT layer.
+        //   armor_prot_base      -> DROP. Stamped once when the piece is created; existing pieces
+        //                           never change. Zone layer wins, else the tier Default.
+        //   armor_prot_equalize  -> DROP. Same as above.
+        // If a change to one of the prot keys "does nothing", it is because the gear already dropped.
+        public const string ArmorBaseLevel = "armor_base_level";       // per-tier armour floor; UNSET = 1100 + 100 x (tier - 11), i.e. today's numbers exactly
+        public const string ArmorProtBase = "armor_prot_base";         // value written into every ArmorModVs* the weenie left absent (default 1.0 = the Average band)
+        public const string ArmorProtEqualize = "armor_prot_equalize"; // nonzero (default) = average the present elements and write the mean back; 0 = elements keep what they rolled, so Poor and Unparalleled both survive
+
+        // ── MODIFIER CAPS (owner 2026-08-30, "the full combo must be IMPOSSIBLE at T11"): max
+        // modifier CARDS per weapon drop / LINES per armor piece, anchored T11/_t25 like every
+        // other knob (derived tiers ROUND the lerp to an integer). UNSET = UNCAPPED - the pre-cap
+        // behaviour exactly. DROP stage only: cards are stamped at drop and never re-rolled, so a
+        // cap change binds new drops; Force Re-tune re-prices values but never adds/removes cards.
+        // ALWAYS-INCLUDED RULE: a winner whose effective chance at the drop tier is >= 100 pct is
+        // pinned - it skips the random trim but still SPENDS a cap slot first (Rend at its
+        // authored 1.0 is the design case; there is deliberately NO separate "always" flag - the
+        // chance box is the one source of truth). A pinned card that fails ELIGIBILITY (a plain
+        // bow's Rend) stamps nothing and frees its slot back to the rolled cards.
+        // /wsforge is untouched: the forge's cards clause stamps directly and never rolls chances.
+        public const string WeaponModifierCap = "weapon_modifier_cap";
+        public const string ArmorModifierCap = "armor_modifier_cap";
+
+        // ── MODIFIER FLOORS (owner 2026-08-30, "need a hard min floor and max"): the guaranteed
+        // MINIMUM modifier count per drop, the cap's twin. UNSET = NO FLOOR - the pre-floor
+        // behaviour exactly. When fewer winners survive the chance rolls than the floor demands,
+        // the drop is TOPPED UP at random from the lines that were ELIGIBLE but lost their roll
+        // (enabled, chance authored above zero, item can take them) - so identity stays random
+        // while the COUNT is guaranteed, which is the whole point: pins guarantee a NAMED
+        // modifier, the floor guarantees a NUMBER of them. Pinned winners count toward the
+        // floor like any other. The cap stays hard: a floor above the cap clamps to it.
+        public const string WeaponModifierMin = "weapon_modifier_min";
+        public const string ArmorModifierMin = "armor_modifier_min";
+
+        public static readonly string[] All =
+        {
+            Strength, Endurance, Coordination, Quickness, Focus, Self, MaxHealth, MaxStamina, MaxMana,
+            MonsterLevel, MonsterCreatureType, AttackSkill, MagicSkill, MeleeDefense, MissileDefense, MagicDefense, DamageRating,
+            DamageResistRating, ArmorLevel, VulnCap, PercentHpBase,
+            CritRating, CritDamageRating, CritResistRating, CritDamageResistRating,
+            AttackDamage, AttackVariance, AttackDamageType, SpellDamage, SpellVariance, SpellDamageMult,
+            ReliefAugStart, ReliefAugMax, ReliefAugCap, ReliefAugBend,
+            ReliefDrStart, ReliefDrMax, ReliefDrCap, ReliefDrBend,
+            ReliefCritDrStart, ReliefCritDrMax, ReliefCritDrCap, ReliefCritDrBend,
+            ReliefAugX1, ReliefAugY1, ReliefAugX2, ReliefAugY2, ReliefAugX3, ReliefAugY3, ReliefAugX4, ReliefAugY4,
+            ReliefDrX1, ReliefDrY1, ReliefDrX2, ReliefDrY2, ReliefDrX3, ReliefDrY3, ReliefDrX4, ReliefDrY4,
+            ReliefCritDrX1, ReliefCritDrY1, ReliefCritDrX2, ReliefCritDrY2, ReliefCritDrX3, ReliefCritDrY3, ReliefCritDrX4, ReliefCritDrY4,
+            ResistSlash, ResistPierce, ResistBludgeon, ResistFire, ResistCold, ResistAcid, ResistElectric, ResistNether,
+            ArmorVsSlash, ArmorVsPierce, ArmorVsBludgeon, ArmorVsFire, ArmorVsCold, ArmorVsAcid, ArmorVsElectric, ArmorVsNether,
+            BonusCurrency,
+            WeaponAttuned, WeaponBonded, WeaponUnenchantable,
+            ArmorAttuned, ArmorBonded, ArmorUnenchantable,
+            WeaponProcArcChance, WeaponProcArcRate, WeaponProcRingChance, WeaponProcRingRate,
+            WeaponProcArcDmgMin, WeaponProcArcDmgMax, WeaponProcRingDmgMin, WeaponProcRingDmgMax,
+            WeaponProcArcVariance, WeaponProcRingVariance,
+            WeaponProcArcSpellcraft, WeaponProcRingSpellcraft, WeaponProcArcAugCap, WeaponProcRingAugCap,
+            WeaponImbueChance,
+            WeaponSlayerChance, WeaponSlayerMin, WeaponSlayerMax,
+            WeaponCleaveChance, WeaponCleaveMin, WeaponCleaveMax,
+            WeaponSplitChance, WeaponSplitMin, WeaponSplitMax, WeaponSplitRange, WeaponSplitDmg,
+            WeaponBiteChance, WeaponBiteMin, WeaponBiteMax,
+            WeaponCrushChance, WeaponCrushMin, WeaponCrushMax,
+            WeaponArmorRendChance, WeaponArmorRendMin, WeaponArmorRendMax,
+            WeaponShieldCleaveChance, WeaponShieldCleaveMin, WeaponShieldCleaveMax,
+            WeaponRendPowerMin, WeaponRendPowerMax,
+            LootSlotWeapons,
+            LootSlotHelm, LootSlotChest, LootSlotShoulder, LootSlotBracer, LootSlotGlove,
+            LootSlotGirth, LootSlotUpperLeg, LootSlotLowerLeg, LootSlotBoot,
+            LootSlotShield, LootSlotAmulet, LootSlotRing, LootSlotBracelet, LootSlotTrinket, LootSlotCloak,
+            LootSlotWeaponsMax,
+            LootSlotHelmMax, LootSlotChestMax, LootSlotShoulderMax, LootSlotBracerMax, LootSlotGloveMax,
+            LootSlotGirthMax, LootSlotUpperLegMax, LootSlotLowerLegMax, LootSlotBootMax,
+            LootSlotShieldMax, LootSlotAmuletMax, LootSlotRingMax, LootSlotBraceletMax, LootSlotTrinketMax, LootSlotCloakMax,
+            LootDropsMin, LootDropsMax,
+            DropCarriedInventory,
+            LootWeightWeapon, LootWeightArmor, LootWeightJewelry, LootWeightCloak,
+            // Armor v2 (2026-08-21). Order here is cosmetic ONLY: every wire payload that carries these
+            // ([[ZC]] sync, [[ZCD]] Default reply) emits "<name>=<defined>,<value>" pairs, so the plugin
+            // matches by NAME - adding, reordering or REMOVING an entry mid-list is safe. (The genuinely
+            // positional lists are the bare comma payloads combatdefs= / diagdefs= in ZoneControlCommands.)
+            CoreAnchorDr, CoreAnchorCdr,
+            SpecialOdds,
+            BattleMendThreshold, BattleMendCooldown, PctHpCooldown, CheatDeathCooldown, CheatDeathImmunity,
+            LifeOnHitCap, LifeOnHitCooldown,
+            GearCapDr, GearCapCdr, GearCapLine,
+            // Kill rewards (2026-08-23): authored per zone, by rank - APPEND-ONLY
+            XpKill, LumAward,
+            // Armor base values (2026-08-24) - APPEND-ONLY, added at the END. The wire matches by NAME
+            // (see the note above), so appending is safe for an older plugin / older server.
+            ArmorBaseLevel, ArmorProtBase, ArmorProtEqualize,
+            // ── ANCHORED TIER MODEL (owner 2026-08-29, ModifiersBandsMerge_Plan REV 2) - APPEND-ONLY.
+            // Convention: every "<stat>_t25" is the T25 anchor for its base stat; the base stat is the
+            // T11 anchor. Both authored = tiers 12-24 sit on the straight line between them
+            // (EvaluatedProfile.GetT). _t25 absent = FLAT, the T11 value at every tier - exactly the
+            // pre-anchor behaviour, so nothing changes for a zone that never authors a _t25 key.
+            // A _t25 key with NO base key is ignored (the base is what turns a knob on). ──
+            "weapon_proc_arc_chance_t25", "weapon_proc_ring_chance_t25", "weapon_imbue_chance_t25",
+            "weapon_slayer_chance_t25", "weapon_armor_rend_chance_t25", "weapon_bite_chance_t25",
+            "weapon_crush_chance_t25", "weapon_shield_cleave_chance_t25",
+            "weapon_cleave_chance_t25", "weapon_split_chance_t25",
+            "weapon_proc_arc_rate_t25", "weapon_proc_ring_rate_t25",
+            "weapon_proc_arc_variance_t25", "weapon_proc_ring_variance_t25",
+            "weapon_proc_arc_spellcraft_t25", "weapon_proc_ring_spellcraft_t25",
+            "weapon_proc_arc_aug_cap_t25", "weapon_proc_ring_aug_cap_t25",
+            "weapon_split_range_t25", "weapon_split_dmg_t25",
+            "weapon_bite_min_t25", "weapon_bite_max_t25",
+            "weapon_crush_min_t25", "weapon_crush_max_t25",
+            "weapon_armor_rend_min_t25", "weapon_armor_rend_max_t25",
+            "weapon_rend_power_min_t25", "weapon_rend_power_max_t25",
+            "weapon_slayer_min_t25", "weapon_slayer_max_t25",
+            "weapon_shield_cleave_min_t25", "weapon_shield_cleave_max_t25",
+            "weapon_proc_arc_dmg_min_t25", "weapon_proc_arc_dmg_max_t25",
+            "weapon_proc_ring_dmg_min_t25", "weapon_proc_ring_dmg_max_t25",
+            "weapon_cleave_min_t25", "weapon_cleave_max_t25",
+            "weapon_split_min_t25", "weapon_split_max_t25",
+            // Armor per-LINE anchored chances (one per non-special ZoneModifiers catalog key - the
+            // catalog is the registry, keys are STABLE ints). Base = T11 anchor, _t25 = T25 anchor.
+            // Unset = the line NEVER rolls (Won semantics), which replaces pool membership.
+            "modifier_chance_19", "modifier_chance_19_t25",   // Max Health
+            "modifier_chance_25", "modifier_chance_25_t25",   // Armor Level
+            "modifier_chance_28", "modifier_chance_28_t25",   // Damage Rating
+            "modifier_chance_29", "modifier_chance_29_t25",   // Crit Damage Rating
+            "modifier_chance_31", "modifier_chance_31_t25",   // Healing Boost
+            "modifier_chance_32", "modifier_chance_32_t25",   // Spell Duration
+            "modifier_chance_33", "modifier_chance_33_t25",   // Crit Chance
+            "modifier_chance_43", "modifier_chance_43_t25",   // All Attributes
+            "modifier_chance_47", "modifier_chance_47_t25",   // Max Health Pct
+            "modifier_chance_48", "modifier_chance_48_t25",   // Life on Hit
+            "modifier_chance_49", "modifier_chance_49_t25",   // Reinforced
+            // Modifier caps (2026-08-30) - APPEND-ONLY, name-matched wire as above. Anchored pair;
+            // unset = uncapped. (Not weapon_*_chance shaped, so BuildWeaponCardChances skips them.)
+            WeaponModifierCap, "weapon_modifier_cap_t25",
+            ArmorModifierCap, "armor_modifier_cap_t25",
+            // Modifier floors (2026-08-30) - APPEND-ONLY, the caps' Min twins. Anchored pair;
+            // unset = no floor. (Not weapon_*_chance shaped, so BuildWeaponCardChances skips them.)
+            WeaponModifierMin, "weapon_modifier_min_t25",
+            ArmorModifierMin, "armor_modifier_min_t25",
+        };
+
+        /// <summary>
+        /// The weapon-card CHANCE stats, derived from <see cref="All"/> by shape (weapon_*_chance).
+        ///
+        /// WHY DERIVED AND NOT A HAND-WRITTEN LIST (2026-08-25). This is the identifier space of
+        /// `/zonecontrol weaponcard &lt;stat&gt; on|off` and the only key set
+        /// <see cref="ZoneVariantProfile.CustomWeaponCards"/> may ever hold. Armour's equivalent toggle
+        /// keys off a NUMERIC catalog key, which cannot go stale because the catalog is the registry.
+        /// A weapon card has no registry - its identity IS its chance stat - so the temptation is to
+        /// paste a fifteen-entry list here and let it rot the next time a card is added or renamed.
+        /// Deriving it means a new weapon_&lt;card&gt;_chance constant is toggleable the moment it lands
+        /// in All, with no second place to remember.
+        ///
+        /// THE TRAP: this matches weapon_cantrip_chance too, which is not one of the fourteen combat
+        /// cards but the "one EXTRA cantrip on a rolled weapon" roll. That is intentional and harmless -
+        /// it also passes through ZoneLootMutator.Won, so the toggle works on it exactly as it does on a
+        /// card. Its ARMOUR twin, armor_cantrip_chance, is deliberately NOT in this set (wrong prefix),
+        /// so armour drops can never be silenced by a weapon verb.
+        /// </summary>
+        public static readonly string[] WeaponCardChances = BuildWeaponCardChances();
+
+        private static readonly HashSet<string> WeaponCardChanceSet =
+            new HashSet<string>(WeaponCardChances, StringComparer.OrdinalIgnoreCase);
+
+        private static string[] BuildWeaponCardChances()
+        {
+            var list = new List<string>();
+            foreach (var s in All)
+                if (s.StartsWith("weapon_", StringComparison.Ordinal) && s.EndsWith("_chance", StringComparison.Ordinal))
+                    list.Add(s);
+            list.Sort(StringComparer.Ordinal);
+            return list.ToArray();
+        }
+
+        /// <summary>True when <paramref name="statKey"/> names a weapon card's chance stat, i.e. is a legal
+        /// identifier for the `weaponcard` verb and for the CustomWeaponCards map.</summary>
+        public static bool IsWeaponCardChance(string statKey)
+            => statKey != null && WeaponCardChanceSet.Contains(statKey);
+
+        private static readonly HashSet<string> AllSet = new HashSet<string>(All, StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>True when <paramref name="statKey"/> is a registered stat - the legal identifier
+        /// space of `/zonecontrol togglestat` and the StatToggles map (2026-08-29).</summary>
+        public static bool IsKnownStat(string statKey)
+            => statKey != null && AllSet.Contains(statKey);
+    }
+
+    /// <summary>
+    /// Per-body-part overrides for a zone variant. Body-part collections are SHARED between all live
+    /// instances and the weenie (WeenieConverter references them), so these are consumed by READ-TIME
+    /// hooks only — the weenie data is never mutated. All fields nullable = "not overridden".
+    /// Precedence at read time: per-part override &gt; all-parts scalar (armor_level / attack_*) &gt; weenie.
+    /// </summary>
+    public class ZoneBodyPart
+    {
+        public double? Armor { get; set; }        // per-part base armor (base_Armor)
+        public double? Damage { get; set; }       // DVal; 0 stops this part from attacking
+        public double? Variance { get; set; }     // DVar (0..1)
+        public int? DamageType { get; set; }      // DamageType flag int (random pick per hit if multi-flag)
+
+        public bool IsEmpty => Armor == null && Damage == null && Variance == null && DamageType == null;
+
+        public ZoneBodyPart Clone() => new ZoneBodyPart { Armor = Armor, Damage = Damage, Variance = Variance, DamageType = DamageType };
+
+        /// <summary>Per-FIELD layered merge: any non-null field on <paramref name="upper"/> wins, everything
+        /// else falls through to <paramref name="lower"/>. Returns a new instance; inputs are untouched.</summary>
+        public static ZoneBodyPart Merge(ZoneBodyPart lower, ZoneBodyPart upper)
+        {
+            if (lower == null) return upper?.Clone();
+            if (upper == null) return lower.Clone();
+            return new ZoneBodyPart
+            {
+                Armor = upper.Armor ?? lower.Armor,
+                Damage = upper.Damage ?? lower.Damage,
+                Variance = upper.Variance ?? lower.Variance,
+                DamageType = upper.DamageType ?? lower.DamageType,
+            };
+        }
+    }
+
+    /// <summary>
+    /// One entry in a zone's bonus-currency drop table: a stack of Wcid x Amount injected onto every governed
+    /// corpse with an independent per-kill Chance (0..1]. Entries are additive with each other and with the
+    /// legacy single-token bonus_currency stat. Loot-table independent — the weenie is never touched.
+    /// </summary>
+    public class ZoneCurrencyDrop
+    {
+        public uint Wcid { get; set; }
+        public int Amount { get; set; } = 1;
+        public double Chance { get; set; } = 1.0;
+
+        /// <summary>true = deliver straight into the killing player's inventory (with a chat message);
+        /// false (default) = drop onto the corpse. Direct delivery falls back to the corpse when the
+        /// killer isn't a player or their inventory is full.</summary>
+        public bool Direct { get; set; }
+
+        public ZoneCurrencyDrop Clone() => new ZoneCurrencyDrop { Wcid = Wcid, Amount = Amount, Chance = Chance, Direct = Direct };
+    }
+
+    /// <summary>
+    /// An authored roll-band override for one zone-cantrip catalog key: the value band (Min..Max, inclusive
+    /// both bounds) and, for proc lines, the proc-chance band in percent (0/0 = passive). A band is one
+    /// VALUE — layers overwrite it whole per key (like PropInts), never merge its fields.
+    /// </summary>
+    public class ModifierBand
+    {
+        public int Min { get; set; }
+        public int Max { get; set; }
+        public int ProcMin { get; set; }
+        public int ProcMax { get; set; }
+
+        public ModifierBand Clone() => new ModifierBand { Min = Min, Max = Max, ProcMin = ProcMin, ProcMax = ProcMax };
+    }
+
+    /// <summary>
+    /// One spell-book rule for a zone-governed monster: disable a known spell, override its cast chance,
+    /// or ADD a spell the weenie doesn't know. Consumed READ-TIME at the monster spell-selection choke
+    /// point (Monster_Magic.TryRollSpell) - spell books are weenie-shared, so they are never mutated,
+    /// and rule changes apply LIVE to already-spawned monsters.
+    /// </summary>
+    public class ZoneSpellRule
+    {
+        public int SpellId { get; set; }
+
+        /// <summary>true = the monster never casts this spell (book spells only - an added rule with
+        /// Disabled makes no sense but is harmlessly skipped).</summary>
+        public bool Disabled { get; set; }
+
+        /// <summary>Cast chance in PERCENT per cast opportunity (the book's 2.029 encodes 2.9). Null on a
+        /// book spell = keep the book's own chance; null on an ADDED spell = default 2.0.</summary>
+        public double? Chance { get; set; }
+
+        public ZoneSpellRule Clone() => new ZoneSpellRule { SpellId = SpellId, Disabled = Disabled, Chance = Chance };
+    }
+
+    /// <summary>
+    /// Guard rails for the generic prop-stamping system: property ids that must never be stamped onto a live
+    /// monster because they are structural/identity values (would corrupt resolution or object behavior) rather
+    /// than tuning knobs. Enforced both at command time and at stamp time.
+    /// </summary>
+    public static class ZonePropGuard
+    {
+        // PropertyInt ids
+        private static readonly HashSet<int> BlockedInts = new()
+        {
+            1,      // ItemType — object identity
+            9007,   // WeenieType (reserved id) — object identity
+            9043,   // PrestigeLevel — owned by PrestigeManager's scaling bookkeeping
+        };
+
+        // PropertyBool ids
+        private static readonly HashSet<int> BlockedBools = new()
+        {
+            50047,  // ExemptFromZoneScaling — stamping this from a zone profile is a resolve paradox
+        };
+
+        public static bool IsBlockedInt(int id) => BlockedInts.Contains(id);
+        public static bool IsBlockedInt64(int id) => false;
+        public static bool IsBlockedFloat(int id) => false;
+        public static bool IsBlockedBool(int id) => BlockedBools.Contains(id);
+    }
+
+    /// <summary>A monster's rank for stat resolution. None = unranked: reads the Default row only.</summary>
+    public enum ZcRank { None = 0, Regular = 1, Leader = 2, Boss = 3 }
+
+    /// <summary>Rank vocabulary shared by the resolver, the commands and the wire: store keys,
+    /// the marker bool ids, and the precedence when a monster somehow carries two marks.</summary>
+    public static class ZoneRank
+    {
+        public static readonly ZcRank[] All = { ZcRank.None, ZcRank.Regular, ZcRank.Leader, ZcRank.Boss };
+        public static readonly ZcRank[] Ranked = { ZcRank.Regular, ZcRank.Leader, ZcRank.Boss };
+
+        public static string Key(ZcRank r) => r switch
+        {
+            ZcRank.Regular => "regular",
+            ZcRank.Leader => "leader",
+            ZcRank.Boss => "boss",
+            _ => "default",
+        };
+
+        /// <summary>Owner-facing label (2026-09-02 D1: "Regular", never "Minion").</summary>
+        public static string Label(ZcRank r) => r switch
+        {
+            ZcRank.Regular => "Regular",
+            ZcRank.Leader => "Leader",
+            ZcRank.Boss => "Boss",
+            _ => "Default",
+        };
+
+        public static int BoolId(ZcRank r) => r switch
+        {
+            ZcRank.Regular => ZoneStat.BoolIsZcMinion,
+            ZcRank.Leader => ZoneStat.BoolIsZcLeader,
+            ZcRank.Boss => ZoneStat.BoolIsZcBoss,
+            _ => 0,
+        };
+
+        /// <summary>Parse a command / wire token: default|none, regular|minion, leader, boss.</summary>
+        public static bool TryParse(string s, out ZcRank rank)
+        {
+            rank = ZcRank.None;
+            if (string.IsNullOrWhiteSpace(s)) return false;
+            switch (s.Trim().ToLowerInvariant())
+            {
+                case "default": case "none": case "base": rank = ZcRank.None; return true;
+                case "regular": case "minion": rank = ZcRank.Regular; return true;
+                case "leader": rank = ZcRank.Leader; return true;
+                case "boss": rank = ZcRank.Boss; return true;
+                default: return false;
+            }
+        }
+
+        /// <summary>Rank from a set of authored bool props (a zone bucket's PropBools). Boss beats
+        /// Leader beats Regular when more than one is set - same order the old read sites used.</summary>
+        public static ZcRank FromPropBools(IReadOnlyDictionary<int, bool> bools)
+        {
+            if (bools == null || bools.Count == 0) return ZcRank.None;
+            if (bools.TryGetValue(ZoneStat.BoolIsZcBoss, out var b) && b) return ZcRank.Boss;
+            if (bools.TryGetValue(ZoneStat.BoolIsZcLeader, out var l) && l) return ZcRank.Leader;
+            if (bools.TryGetValue(ZoneStat.BoolIsZcMinion, out var m) && m) return ZcRank.Regular;
+            return ZcRank.None;
+        }
+    }
+
+    /// <summary>
+    /// One stat's value. Only <see cref="Base"/> is live: <c>EvaluateVariant</c> always calls
+    /// <c>Evaluate(1)</c>, so a stat is a flat number.
+    ///
+    /// <see cref="Growth"/> / <see cref="Additive"/> / <see cref="Overrides"/> are RESERVED and not wired up.
+    /// Reviving them would mean deriving a stat from the variation number, which is exactly the computed
+    /// scaling the owner ruled out on 2026-07-30 — progression is expressed as 15 explicitly AUTHORED
+    /// per-variation Defaults (v11-v25) instead, because those are visible and editable in a way a growth
+    /// exponent is not. The fields stay because the store already serializes them.
+    /// </summary>
+    public class StatCurve
+    {
+        public double Base { get; set; }
+        public double Growth { get; set; } = 1.0;
+        public bool Additive { get; set; }
+
+        /// <summary>tier -&gt; pinned value; when present for a tier, replaces the curve for that tier only.</summary>
+        public Dictionary<int, double> Overrides { get; set; }
+
+        public double Evaluate(int tier)
+        {
+            if (Overrides != null && Overrides.TryGetValue(tier, out var pinned))
+                return pinned;
+
+            var t = Math.Max(1, tier);
+            return Additive
+                ? Base + Growth * (t - 1)
+                : Base * Math.Pow(Growth, t - 1);
+        }
+    }
+
+    /// <summary>The set of stat curves for one variant (minion or boss) of a zone profile.</summary>
+    public class ZoneVariantProfile
+    {
+        public Dictionary<string, StatCurve> Stats { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>Per-body-part overrides, keyed by (int)CombatBodyPart. Missing on deserialize of older
+        /// profiles = empty dict (backward compatible). Consumed by read-time hooks.</summary>
+        public Dictionary<int, ZoneBodyPart> BodyParts { get; set; } = new();
+
+        /// <summary>Custom cantrip SpellIds this zone can roll as the EXTRA loot cantrip (alongside the
+        /// retail tables; see ZoneStat.CustomModifierWeight). Owner-authored spell ids — stamped as-is.
+        /// Missing on deserialize of older profiles = empty list (backward compatible).</summary>
+        public List<int> CustomModifiers { get; set; } = new();
+
+        /// <summary>Roll-band overrides for zone cantrip keys, keyed by catalog key. A key absent here rolls
+        /// the catalog's own band. Missing on deserialize of older profiles = empty dict (backward compatible).</summary>
+        public Dictionary<int, ModifierBand> CustomModifierBands { get; set; } = new();
+
+        /// <summary>Per-key SLOT RULE overrides (ZoneModifiers.SlotMask bits; 0 = Any), keyed by catalog key. A key
+        /// absent here uses the catalog's ArmorOnly / JewelryOnly default. Authored by `cantrip <scope> slots`,
+        /// merged OVERWRITE per key like the bands. Missing on deserialize of older profiles = empty dict.</summary>
+        public Dictionary<int, int> CustomModifierSlots { get; set; } = new();
+
+        /// <summary>Per-SPECIAL on/off (owner 2026-08-23): catalog key -> enabled. A key absent here is ON. Authored by
+        /// `cantrip <scope> special <key> on|off`, merged OVERWRITE per key (a zone can re-enable what the Default
+        /// turned off). Consulted by the per-kill special roll only. Missing on older profiles = empty dict.</summary>
+        public Dictionary<int, bool> CustomSpecials { get; set; } = new();
+
+        /// <summary>
+        /// Per-WEAPON-CARD on/off (owner 2026-08-25), keyed by the card's CHANCE STAT NAME
+        /// (weapon_bite_chance, weapon_rend_power_chance, ...) -> enabled. A key absent here is ON.
+        /// Authored by `/zonecontrol weaponcard`, merged OVERWRITE per key exactly like CustomSpecials.
+        ///
+        /// WHY THIS EXISTS AT ALL, since a card's odds already live in weapon_&lt;card&gt;_chance.
+        /// Before this map, "off" was the ABSENCE of the chance stat, which had two defects:
+        ///   1. turning a card off destroyed its tuned chance value - the number had to be retyped from
+        ///      memory to turn it back on;
+        ///   2. 🔴 at ZONE scope, clearing the key means INHERIT, not OFF. The zone layer is merged on
+        ///      top of the tier Default (ZoneVariantProfile.Merge), so a cleared zone key falls straight
+        ///      through to the Default's chance and the card keeps rolling while the UI shows it off.
+        ///      A zone simply could not switch off a card its tier Default enabled. Closing that is the
+        ///      entire point of this map.
+        /// It therefore stores an EXPLICIT true/false, never just an off-list: a zone must be able to
+        /// re-enable a card the Default turned off as well as disable one the Default turned on, and
+        /// only a three-state (true / false / absent) can express both against a merged parent.
+        ///
+        /// Consulted in exactly one place - ZoneLootMutator.Won - which is the single gate every
+        /// chance-gated weapon card already passes through. Missing on older profiles = empty dict.
+        /// </summary>
+        public Dictionary<string, bool> CustomWeaponCards { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Per-STAT on/off (2026-08-29, release audit blocker 3 - the CustomWeaponCards fix
+        /// generalized to every stat). Stat key -> enabled; a key absent here is ON. Authored by
+        /// `/zonecontrol togglestat`, merged OVERWRITE per key. An explicit FALSE at a nearer
+        /// scope makes the stat evaluate as ABSENT (never/unset semantics everywhere - Has()
+        /// misses, consumers fall back to the weenie), which is the only way a zone or a single
+        /// WCID can EXEMPT itself from a stat its tier Default authors: clearing the key merely
+        /// inherits. The authored value underneath is never touched, so off/on is lossless.
+        /// Missing on older profiles = empty dict.
+        /// </summary>
+        public Dictionary<string, bool> StatToggles { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>Bonus-currency drop table: each entry rolls independently on every governed kill and
+        /// injects a stack onto the corpse. Missing on deserialize of older profiles = empty list.</summary>
+        public List<ZoneCurrencyDrop> CurrencyDrops { get; set; } = new();
+
+        /// <summary>Spell-book rules (disable / reweight / add spells) consumed read-time at monster
+        /// spell selection. Missing on deserialize of older profiles = empty list.</summary>
+        public List<ZoneSpellRule> SpellRules { get; set; } = new();
+
+        /// <summary>Generic property overrides STAMPED onto each governed monster at (re)spawn
+        /// (ApplyZoneSnapshot). Int/Float/Bool/Int64 biota collections are per-instance clones, so
+        /// stamping is safe and reverts on respawn. Keyed by raw property id.</summary>
+        public Dictionary<int, long> PropInts { get; set; } = new();
+        public Dictionary<int, long> PropInt64s { get; set; } = new();
+        public Dictionary<int, double> PropFloats { get; set; } = new();
+        public Dictionary<int, bool> PropBools { get; set; } = new();
+
+        /// <summary>
+        /// RANK LAYERS (owner 2026-09-02, Plan_RankLayers): per-rank sub-profiles keyed "regular" /
+        /// "leader" / "boss", the same shape as this profile (a nested Ranks inside one is ignored).
+        /// Everything in the parent is the DEFAULT row - what every monster in scope gets; a rank
+        /// row overrides it for monsters of that rank only. Resolution flattens EACH layer for the
+        /// monster's rank (<see cref="ForRank"/>) and then merges the layers in scope order, so a
+        /// zone's Default row beats a tier's rank row (owner D2: local beats global). A per-WCID
+        /// bucket never carries Ranks - a monster type has exactly one rank - so <see cref="ForRank"/>
+        /// is the identity for it. Missing on deserialize of older stores = empty.
+        /// </summary>
+        public Dictionary<string, ZoneVariantProfile> Ranks { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+        /// <summary>Newtonsoft hook: an empty Ranks map is not written (it was "Ranks":{} on every layer, bucket and
+        /// rank row of a store that just overflowed 64 KB - review 2026-09-03).</summary>
+        public bool ShouldSerializeRanks() => Ranks != null && Ranks.Count > 0;
+
+        /// <summary>The rank sub-profile to EDIT (created on demand when <paramref name="create"/>), or
+        /// this profile itself for <see cref="ZcRank.None"/>. Null when absent and not creating.</summary>
+        public ZoneVariantProfile RankLayer(ZcRank rank, bool create = false)
+        {
+            if (rank == ZcRank.None) return this;
+            Ranks ??= new Dictionary<string, ZoneVariantProfile>(StringComparer.OrdinalIgnoreCase);
+            var key = ZoneRank.Key(rank);
+            if (Ranks.TryGetValue(key, out var v) && v != null) return v;
+            if (!create) return null;
+            Ranks[key] = v = new ZoneVariantProfile();
+            return v;
+        }
+
+        /// <summary>This layer flattened for one rank: the Default row with the rank row merged on top,
+        /// Ranks stripped. Always a fresh object (safe to hand to lock-free readers). For None, or a
+        /// rank this layer does not author, it is a plain clone of the Default row.</summary>
+        public ZoneVariantProfile ForRank(ZcRank rank)
+        {
+            var rankLayer = rank == ZcRank.None ? null : RankLayer(rank);
+            var flat = rankLayer == null ? Merge(this) : Merge(this, rankLayer);
+            flat.Ranks.Clear();
+            return flat;
+        }
+
+        public bool TryGet(string statKey, out StatCurve curve) => Stats.TryGetValue(statKey, out curve);
+
+        /// <summary>
+        /// Layered merge (2026-07-30 Default layer): later layers win, PER KEY — never wholesale. Feed it
+        /// <c>VariationDefault -&gt; zone -&gt; wcid</c>; a key absent from a layer falls through to the one
+        /// above it. Returns a NEW profile; every input is left untouched (they are the live admin-mutable
+        /// objects) and every nested value is cloned, so the result is safe to hand to a lock-free reader.
+        ///
+        /// Null layers are skipped, so a zone with no Default and no WCID bucket merges to just itself.
+        ///
+        /// List-valued fields UNION rather than replace (owner ruling): a zone can add one boss-specific
+        /// currency drop without restating the variation's standard drops. Collisions are keyed —
+        /// cantrip key / currency wcid / spell id — with the most specific layer winning.
+        /// </summary>
+        public static ZoneVariantProfile Merge(params ZoneVariantProfile[] layers)
+        {
+            var result = new ZoneVariantProfile();
+            if (layers == null)
+                return result;
+
+            foreach (var layer in layers)
+            {
+                if (layer == null)
+                    continue;
+
+                if (layer.Stats != null)
+                    foreach (var kv in layer.Stats)
+                    {
+                        result.Stats[kv.Key] = kv.Value;
+                        // THE SHADOW RULE (owner 2026-08-30, per-tier authoring): a layer that
+                        // authors a BASE stat WITHOUT its "_t25" twin means "this value, FLAT" -
+                        // an inherited twin from a lower layer must not keep bending it onto the
+                        // lower layer's ladder (a v14 Default's flat 40 would otherwise lerp
+                        // toward the v11 anchor board's T25 value). Drop the inherited twin.
+                        // A layer authoring both keeps both (guard below); order inside the layer
+                        // is irrelevant for the same reason. A twin alone still overlays - GetT
+                        // ignores a twin with no base, so it stays harmless until a base exists.
+                        if (!kv.Key.EndsWith("_t25", StringComparison.OrdinalIgnoreCase)
+                            && !layer.Stats.ContainsKey(kv.Key + "_t25"))
+                            result.Stats.Remove(kv.Key + "_t25");
+                    }
+
+                if (layer.BodyParts != null)
+                    foreach (var kv in layer.BodyParts)
+                    {
+                        result.BodyParts.TryGetValue(kv.Key, out var lower);
+                        var merged = ZoneBodyPart.Merge(lower, kv.Value);
+                        if (merged != null)
+                            result.BodyParts[kv.Key] = merged;
+                    }
+
+                if (layer.PropInts != null)
+                    foreach (var kv in layer.PropInts) result.PropInts[kv.Key] = kv.Value;
+                if (layer.PropInt64s != null)
+                    foreach (var kv in layer.PropInt64s) result.PropInt64s[kv.Key] = kv.Value;
+                if (layer.PropFloats != null)
+                    foreach (var kv in layer.PropFloats) result.PropFloats[kv.Key] = kv.Value;
+                if (layer.PropBools != null)
+                    foreach (var kv in layer.PropBools) result.PropBools[kv.Key] = kv.Value;
+
+                // union, deduped by key, most specific wins
+                if (layer.CustomModifiers != null)
+                    foreach (var key in layer.CustomModifiers)
+                        if (!result.CustomModifiers.Contains(key))
+                            result.CustomModifiers.Add(key);
+
+                // OVERWRITE per key like PropInts: a band is one value, the most specific layer wins it whole
+                if (layer.CustomModifierBands != null)
+                    foreach (var kv in layer.CustomModifierBands)
+                        if (kv.Value != null)
+                            result.CustomModifierBands[kv.Key] = kv.Value.Clone();
+
+                // slot rules: same OVERWRITE-per-key semantics
+                if (layer.CustomModifierSlots != null)
+                    foreach (var kv in layer.CustomModifierSlots)
+                        result.CustomModifierSlots[kv.Key] = kv.Value;
+
+                if (layer.CustomSpecials != null)
+                    foreach (var kv in layer.CustomSpecials)
+                        result.CustomSpecials[kv.Key] = kv.Value;
+
+                // weapon-card on/off: same OVERWRITE-per-key semantics as CustomSpecials. This is what
+                // lets a ZONE win against its tier Default in BOTH directions - an explicit false here
+                // beats an inherited true, which a merely-absent chance stat never could.
+                if (layer.CustomWeaponCards != null)
+                    foreach (var kv in layer.CustomWeaponCards)
+                        result.CustomWeaponCards[kv.Key] = kv.Value;
+
+                // stat on/off (2026-08-29): identical semantics, for every stat
+                if (layer.StatToggles != null)
+                    foreach (var kv in layer.StatToggles)
+                        result.StatToggles[kv.Key] = kv.Value;
+
+                if (layer.CurrencyDrops != null)
+                    foreach (var drop in layer.CurrencyDrops)
+                    {
+                        if (drop == null) continue;
+                        var at = result.CurrencyDrops.FindIndex(d => d.Wcid == drop.Wcid);
+                        if (at >= 0) result.CurrencyDrops[at] = drop.Clone();
+                        else result.CurrencyDrops.Add(drop.Clone());
+                    }
+
+                if (layer.SpellRules != null)
+                    foreach (var rule in layer.SpellRules)
+                    {
+                        if (rule == null) continue;
+                        var at = result.SpellRules.FindIndex(r => r.SpellId == rule.SpellId);
+                        if (at >= 0) result.SpellRules[at] = rule.Clone();
+                        else result.SpellRules.Add(rule.Clone());
+                    }
+
+                // Rank rows (2026-09-02): merged per rank key, recursively, so a deep copy
+                // (Merge(one)) carries them and a two-layer merge stacks leader-on-leader. This is
+                // the COPY semantics only - resolution never merges unflattened layers, it calls
+                // ForRank on each layer first (see the Ranks doc comment).
+                if (layer.Ranks is { Count: > 0 })
+                    foreach (var kv in layer.Ranks)
+                    {
+                        if (kv.Value == null) continue;
+                        result.Ranks.TryGetValue(kv.Key, out var lower);
+                        var mergedRank = Merge(lower, kv.Value);
+                        mergedRank.Ranks.Clear();
+                        result.Ranks[kv.Key] = mergedRank;
+                    }
+            }
+
+            return result;
+        }
+
+        /// <summary>True when this layer carries nothing at all (used to prune empty buckets).</summary>
+        public bool IsEmpty =>
+            (Stats == null || Stats.Count == 0)
+            && (BodyParts == null || BodyParts.Count == 0)
+            && (PropInts == null || PropInts.Count == 0)
+            && (PropInt64s == null || PropInt64s.Count == 0)
+            && (PropFloats == null || PropFloats.Count == 0)
+            && (PropBools == null || PropBools.Count == 0)
+            && (CustomModifiers == null || CustomModifiers.Count == 0)
+            && (CustomModifierBands == null || CustomModifierBands.Count == 0)
+            && (CustomModifierSlots == null || CustomModifierSlots.Count == 0)
+            && (CustomSpecials == null || CustomSpecials.Count == 0)
+            && (CustomWeaponCards == null || CustomWeaponCards.Count == 0)
+            && (StatToggles == null || StatToggles.Count == 0)
+            && (CurrencyDrops == null || CurrencyDrops.Count == 0)
+            && (SpellRules == null || SpellRules.Count == 0)
+            && RanksEmpty();
+
+        private bool RanksEmpty()
+        {
+            if (Ranks == null) return true;
+            foreach (var r in Ranks.Values)
+                if (r != null && !r.IsEmpty) return false;
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// A zone-scaling profile bound to a scope. Holds a minion + boss variant, each a bundle of stat curves.
+    /// Persisted as JSON in the shard config store; mutated live by /zonescale and the plugin.
+    /// </summary>
+    public class ZoneScalingProfile
+    {
+        public ZoneScopeType ScopeType { get; set; }
+        public int? Landblock { get; set; }        // ushort landblock id (e.g. 0xF559)
+        public int? Variation { get; set; }        // for LandblockVariation scope
+        public string ZoneName { get; set; }       // for Zone scope (e.g. "tou_tou")
+        public bool Enabled { get; set; } = true;
+        public string Notes { get; set; }
+
+        /// <summary>The ZONE-level layer: stats authored on this zone specifically. Sits between its
+        /// variation's Default and any per-WCID bucket. (JSON key stays "Minion" — the pre-2026-07-30 name
+        /// from when this was the minion slot of a minion/boss pair — so existing stores keep loading.)</summary>
+        [Newtonsoft.Json.JsonProperty("Minion")]
+        public ZoneVariantProfile Minion { get; set; } = new();
+
+        // Boss slot REMOVED 2026-07-30 (owner ruling): nothing read it post-decouple, and bosses are now
+        // ordinary mobs tuned ~2x their minions via per-WCID overrides, which are strictly more precise.
+        // Any "Boss" key still present in a stored profile simply deserializes to nothing.
+
+        /// <summary>Per-WCID overrides: a monster's own layer, merged ON TOP of its variation's Default and
+        /// the zone layer, PER STAT (2026-07-30 — it used to REPLACE the whole profile wholesale). A bucket
+        /// that sets one stat overrides one stat. Missing on deserialize of older profiles = empty dict.</summary>
+        public Dictionary<uint, ZoneVariantProfile> WcidOverrides { get; set; } = new();
+
+        /// <summary>MASTER SWITCH per monster (owner 2026-09-03: "master switch only, retire the per-stat
+        /// off"): WCIDs this zone leaves ALONE - the resolver returns null for them, so no stat, prop,
+        /// effect or hit gate applies and the weenie plays as authored. Zone-scoped on purpose: the
+        /// weenie bool ExemptFromZoneScaling is global and is refused as a zone stamp. Missing on
+        /// deserialize of older profiles = empty set.</summary>
+        public HashSet<uint> ExemptWcids { get; set; } = new();
+
+        /// <summary>MASTER SWITCH per GENERATOR (owner 2026-09-03: "same On / Off per generator", "exempt wins
+        /// from either side"): generator WCIDs whose spawns - through nested generators too - this zone
+        /// leaves alone. Keyed by generator WCID (every placement of it), matching the Generators tab.</summary>
+        public HashSet<uint> ExemptGenerators { get; set; } = new();
+
+        /// <summary>The per-WCID bucket to EDIT, or null when absent and <paramref name="create"/> is false.
+        /// Callers that want the RESOLVED stats for a monster must not use this — resolution layers
+        /// Default -&gt; zone -&gt; wcid and happens in ZoneControlManager.</summary>
+        public ZoneVariantProfile VariantForWcid(uint wcid, bool create = false)
+        {
+            if (WcidOverrides.TryGetValue(wcid, out var v))
+                return v;
+            if (!create)
+                return null;
+            v = new ZoneVariantProfile();
+            WcidOverrides[wcid] = v;
+            return v;
+        }
+
+        /// <summary>Canonical scope key used for the registry and memo cache.</summary>
+        public string ScopeKey() => MakeScopeKey(ScopeType, Landblock, Variation, ZoneName);
+
+        public static string MakeScopeKey(ZoneScopeType type, int? landblock, int? variation, string zoneName)
+        {
+            switch (type)
+            {
+                case ZoneScopeType.Global: return "global";
+                case ZoneScopeType.Zone: return "zone:" + (zoneName ?? "").ToLowerInvariant();
+                case ZoneScopeType.Landblock: return "lb:" + (landblock ?? 0).ToString("X4");
+                case ZoneScopeType.LandblockVariation:
+                    return "lbvar:" + (landblock ?? 0).ToString("X4") + ":v" + (variation ?? 0);
+                default: return "global";
+            }
+        }
+    }
+
+    /// <summary>
+    /// A profile resolved for a specific creature: the winning scope evaluated at the creature's tier and variant.
+    /// Consumers read stats from here. Null return from the manager means "not scaled" (leave weenie stats).
+    /// </summary>
+    public class EvaluatedProfile
+    {
+        public string ScopeKey { get; set; }
+        public int Tier { get; set; }
+        public ZoneVariant Variant { get; set; }
+        private readonly Dictionary<string, double> _values;
+        private readonly Dictionary<int, ZoneBodyPart> _bodyParts;
+
+        public EvaluatedProfile(string scopeKey, int tier, ZoneVariant variant, Dictionary<string, double> values,
+            Dictionary<int, ZoneBodyPart> bodyParts = null,
+            Dictionary<int, long> propInts = null, Dictionary<int, long> propInt64s = null,
+            Dictionary<int, double> propFloats = null, Dictionary<int, bool> propBools = null,
+            List<int> customModifiers = null, List<ZoneCurrencyDrop> currencyDrops = null,
+            List<ZoneSpellRule> spellRules = null, Dictionary<int, ModifierBand> modifierBands = null,
+            Dictionary<int, int> modifierSlots = null, Dictionary<int, bool> specialToggles = null,
+            Dictionary<string, bool> weaponCardToggles = null)
+        {
+            ModifierSlots = modifierSlots is { Count: > 0 } ? new Dictionary<int, int>(modifierSlots) : EmptyModifierSlots;
+            SpecialToggles = specialToggles is { Count: > 0 } ? new Dictionary<int, bool>(specialToggles) : EmptySpecialToggles;
+            WeaponCardToggles = weaponCardToggles is { Count: > 0 }
+                ? new Dictionary<string, bool>(weaponCardToggles, StringComparer.OrdinalIgnoreCase)
+                : EmptyWeaponCardToggles;
+            ScopeKey = scopeKey;
+            Tier = tier;
+            Variant = variant;
+            _values = values ?? new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase);
+            _bodyParts = bodyParts;
+            PropInts = propInts;
+            PropInt64s = propInt64s;
+            PropFloats = propFloats;
+            PropBools = propBools;
+            CustomModifiers = customModifiers;
+            CurrencyDrops = currencyDrops;
+            SpellRules = spellRules;
+
+            if (modifierBands is { Count: > 0 })
+            {
+                var bands = new Dictionary<int, (int Min, int Max, int ProcMin, int ProcMax)>(modifierBands.Count);
+                foreach (var kv in modifierBands)
+                    if (kv.Value != null)
+                        bands[kv.Key] = (kv.Value.Min, kv.Value.Max, kv.Value.ProcMin, kv.Value.ProcMax);
+                ModifierBands = bands;
+            }
+            else
+                ModifierBands = EmptyModifierBands;
+        }
+
+        private static readonly IReadOnlyDictionary<int, (int Min, int Max, int ProcMin, int ProcMax)> EmptyModifierBands
+            = new Dictionary<int, (int Min, int Max, int ProcMin, int ProcMax)>();
+        private static readonly IReadOnlyDictionary<int, int> EmptyModifierSlots = new Dictionary<int, int>();
+
+        /// <summary>Per-key slot rule overrides (ZoneModifiers.SlotMask bits), merged view. Empty = catalog defaults everywhere.</summary>
+        public IReadOnlyDictionary<int, int> ModifierSlots { get; }
+        private static readonly IReadOnlyDictionary<int, bool> EmptySpecialToggles = new Dictionary<int, bool>();
+        /// <summary>Per-special on/off (absent = on). See ZoneVariantProfile.CustomSpecials.</summary>
+        public IReadOnlyDictionary<int, bool> SpecialToggles { get; }
+        public bool SpecialEnabled(int key) => !SpecialToggles.TryGetValue(key, out var on) || on;
+
+        private static readonly IReadOnlyDictionary<string, bool> EmptyWeaponCardToggles
+            = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>Per-weapon-card on/off keyed by CHANCE STAT NAME (absent = on). Merged view, so this is
+        /// the tier Default's toggles with the zone's (and any per-WCID bucket's) laid over them per key.
+        /// See ZoneVariantProfile.CustomWeaponCards.</summary>
+        public IReadOnlyDictionary<string, bool> WeaponCardToggles { get; }
+
+        /// <summary>
+        /// May the card behind <paramref name="chanceStat"/> roll at this scope? Absent = YES (sparse, same
+        /// rule as SpecialEnabled), so a scope that authors no toggle behaves exactly as it did before the
+        /// map existed.
+        ///
+        /// Deliberately keyed by the raw stat name and NOT filtered to weapon cards here: the map can only
+        /// ever contain names ZoneStat.IsWeaponCardChance accepted at authoring time, so any other chance
+        /// stat asked about - armor_cantrip_chance above all - misses the lookup and comes back ON. That is
+        /// the scoping that keeps this weapon-only; do not "improve" it by adding a prefix test on the hot
+        /// path, and do not let anything write an unvalidated key into the map.
+        /// </summary>
+        public bool WeaponCardEnabled(string chanceStat)
+            => chanceStat == null || !WeaponCardToggles.TryGetValue(chanceStat, out var on) || on;
+
+        /// <summary>Custom cantrip SpellIds for the extra-loot-cantrip roll (may be null = none defined).</summary>
+        public IReadOnlyList<int> CustomModifiers { get; }
+
+        /// <summary>Authored roll-band overrides per zone-cantrip catalog key (never null; EMPTY when none
+        /// authored). A key absent here rolls the catalog's own Min/Max/ProcMin/ProcMax.</summary>
+        public IReadOnlyDictionary<int, (int Min, int Max, int ProcMin, int ProcMax)> ModifierBands { get; }
+
+        /// <summary>Bonus-currency drop table entries (may be null = none defined).</summary>
+        public IReadOnlyList<ZoneCurrencyDrop> CurrencyDrops { get; }
+
+        /// <summary>Spell-book rules (may be null = none defined). Read at monster spell selection.</summary>
+        public IReadOnlyList<ZoneSpellRule> SpellRules { get; }
+
+        /// <summary>Per-part override for a CombatBodyPart key, or null. Read-time hot path: one dict lookup.</summary>
+        public ZoneBodyPart GetBodyPart(int combatBodyPart)
+            => _bodyParts != null && _bodyParts.TryGetValue(combatBodyPart, out var p) ? p : null;
+
+        public bool HasBodyParts => _bodyParts != null && _bodyParts.Count > 0;
+        public IReadOnlyDictionary<int, ZoneBodyPart> BodyParts => _bodyParts;
+
+        /// <summary>Spawn-time prop stamps (may be null = none defined).</summary>
+        public IReadOnlyDictionary<int, long> PropInts { get; }
+        public IReadOnlyDictionary<int, long> PropInt64s { get; }
+        public IReadOnlyDictionary<int, double> PropFloats { get; }
+        public IReadOnlyDictionary<int, bool> PropBools { get; }
+
+        /// <summary>True if the winning profile actually defines this stat (otherwise the consumer keeps its own value).</summary>
+        public bool Has(string statKey) => _values.ContainsKey(statKey);
+
+        public double Get(string statKey, double fallback = 0.0)
+            => _values.TryGetValue(statKey, out var v) ? v : fallback;
+
+        /// <summary>
+        /// ANCHORED read (owner 2026-08-29): the base stat is the T11 anchor, "&lt;stat&gt;_t25" the
+        /// T25 anchor; tiers 12-24 sit on the straight line between them. _t25 absent = FLAT (the
+        /// base value at every tier - the pre-anchor behaviour). _t25 without the base is ignored:
+        /// the base stat is what turns a knob on, so fallback still rules when it is unset.
+        /// </summary>
+        public double GetT(string statKey, double fallback, int tier)
+        {
+            if (!_values.TryGetValue(statKey, out var t11))
+                return fallback;
+            if (!_values.TryGetValue(statKey + "_t25", out var t25))
+                return t11;
+            var t = Math.Clamp((tier - 11) / 14.0, 0.0, 1.0);
+            return t11 + (t25 - t11) * t;
+        }
+
+        public IReadOnlyDictionary<string, double> Values => _values;
+    }
+}

--- a/Source/ACE.Server/Managers/ZoneScaling/ZoneScalingModels.cs
+++ b/Source/ACE.Server/Managers/ZoneScaling/ZoneScalingModels.cs
@@ -1143,12 +1143,13 @@ namespace ACE.Server.Managers.ZoneScaling
         /// Default -&gt; zone -&gt; wcid and happens in ZoneControlManager.</summary>
         public ZoneVariantProfile VariantForWcid(uint wcid, bool create = false)
         {
-            if (WcidOverrides.TryGetValue(wcid, out var v) && v != null)   // a null stored bucket (JSON) counts as absent
+            var map = WcidOverrides ??= new Dictionary<uint, ZoneVariantProfile>();   // persisted JSON may carry an explicit null map
+            if (map.TryGetValue(wcid, out var v) && v != null)   // a null stored bucket (JSON) counts as absent
                 return v;
             if (!create)
                 return null;
             v = new ZoneVariantProfile();
-            WcidOverrides[wcid] = v;
+            map[wcid] = v;
             return v;
         }
 

--- a/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
+++ b/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
@@ -13,6 +13,7 @@ using ACE.Server.Managers;
 using ACE.Server.Network.Enum;
 using ACE.Server.WorldObjects;
 using ACE.Server.WorldObjects.Entity;
+using ZoneStatResolver = ACE.Server.Managers.ZoneControl.ZoneStatResolver;
 
 namespace ACE.Server.Network.Structure
 {
@@ -77,8 +78,15 @@ namespace ACE.Server.Network.Structure
             //Console.WriteLine("Appraise: " + wo.Guid);
             Success = success;
 
-            BuildProperties(wo);
+            BuildProperties(wo, examiner);
             BuildSpells(wo);
+
+            // Live Stat Resolution (owner 2026-08-22, plan 3b): a piece with a ZcModifiers record is
+            // resolved from its grades against the LIVE ladder for the RESPONSE COPY only - wo is
+            // never written, never marked dirty (equip is the only re-stamp site: ApplyIfStale).
+            var zcResolved = ZoneStatResolver.Compute(wo);
+            if (zcResolved != null)
+                SubstituteZoneResolvedInts(wo, zcResolved);
 
             // Help us make sure the item identify properly
             NPCLooksLikeObject = wo.GetProperty(PropertyBool.NpcLooksLikeObject) ?? false;
@@ -121,6 +129,11 @@ namespace ACE.Server.Network.Structure
 
             if (wo.Damage != null && !(wo is Clothing) || wo is MeleeWeapon || wo is Missile || wo is MissileLauncher || wo is Ammunition || wo is Caster)
                 BuildWeapon(wo, examiner);
+
+            // Owner 2026-08-22: Zone Cantrip lines belong in the Property Details section, not
+            // adrift in the description block. Runs here so downstream LongDesc edits see the same
+            // shape they always have (a block already pinned to the top).
+            PromoteZoneModifierLines(zcResolved, wo, examiner);
 
             // TODO: Resolve this issue a better way?
             // Because of the way ACE handles default base values in recipe system (or rather the lack thereof)
@@ -258,6 +271,45 @@ namespace ACE.Server.Network.Structure
                 }
 
                 PropertiesInt.Remove(PropertyInt.EncumbranceVal);
+            }
+
+            // Weapon aug-scaling: the EXAMINER-projected value, so a drop can be evaluated without
+            // equipping it (owner 2026-08-01). Computed from the VIEWER's current item augs — the
+            // same resolve combat uses — so re-examining after buying augs refreshes it. Appraisal
+            // output only, never persisted; only shows while the system is enabled and the item is
+            // stamped (GetFlatBonus returns 0 otherwise). While WIELDED the green damage line
+            // already includes the term (WeaponProfile), so the projection is for the unwielded case.
+            if (examiner != null && wo.Wielder == null)
+            {
+                var projected = ACE.Server.Managers.WeaponScaling.WeaponScalingCombat.GetFlatBonus(wo, examiner);
+                var floor = ACE.Server.Managers.WeaponScaling.WeaponScalingCombat.GetFloorBonus(wo);
+                if (projected > floor)
+                {
+                    // The unwielded damage line already shows the wield-FLOOR value (an honest
+                    // minimum for any hands), so this line is the examiner's bonus ABOVE that
+                    // floor — hidden entirely for a player sitting exactly at the wield req.
+                    var msg = $"Bonus Damage to weapon while equipped by you: +{(int)(projected - floor):N0}";
+
+                    // Provenance ("Dropped by:" / "Location:") stays the very last block (owner
+                    // 2026-08-01) - insert the per-viewer projection ABOVE it, not after. Legacy
+                    // single-line formats ("Dropped by X in...", "Dropped in the...") still match.
+                    if (PropertiesString.TryGetValue(PropertyString.LongDesc, out var ldCur) && !string.IsNullOrEmpty(ldCur))
+                    {
+                        var provIdx = ldCur.IndexOf("Dropped by", StringComparison.Ordinal);
+                        if (provIdx < 0)
+                            provIdx = ldCur.IndexOf("Dropped in ", StringComparison.Ordinal);
+                        if (provIdx < 0)
+                            provIdx = ldCur.IndexOf("Created by", StringComparison.Ordinal);   // forged test items
+                        if (provIdx < 0)
+                            provIdx = ldCur.IndexOf("Location:", StringComparison.Ordinal);
+                        if (provIdx >= 0)
+                            PropertiesString[PropertyString.LongDesc] = ldCur.Insert(provIdx, $"{msg}\n\n");
+                        else
+                            PropertiesString[PropertyString.LongDesc] = ldCur + $"\n\n{msg}";
+                    }
+                    else
+                        PropertiesString[PropertyString.LongDesc] = msg;
+                }
             }
 
             // Pet Bonding System - display bond info on PetDevice appraisal
@@ -562,27 +614,8 @@ namespace ACE.Server.Network.Structure
             {
                 if ((dec & 4) != 0) // AppraisalLongDescDecorations.AppendGemInfo
                 {
-                    if (wo.GemType.HasValue && wo.GemCount.HasValue)
-                    {
-                        var gemName = System.Text.RegularExpressions.Regex.Replace(wo.GemType.Value.ToString(), "(\\B[A-Z])", " $1");
-                        if (wo.GemCount > 1)
-                        {
-                            if (gemName.EndsWith("y"))
-                                gemName = gemName.Substring(0, gemName.Length - 1) + "ies";
-                            else if (gemName.EndsWith("x"))
-                                gemName += "es";
-                            else
-                                gemName += "s";
-                        }
-
-                        var gemString = $", set with {wo.GemCount} {gemName}";
-                        if (PropertiesString.ContainsKey(PropertyString.LongDesc))
-                            PropertiesString[PropertyString.LongDesc] += gemString;
-                        else
-                            PropertiesString[PropertyString.LongDesc] = gemString.TrimStart(',', ' ');
-                    }
-
-                    // Remove the AppendGemInfo flag so the client doesn't double-append
+                    // Gem-socket "set with N <gem>" label suppressed globally (owner 2026-07-14): don't
+                    // append it server-side, but still clear the flag so the client doesn't append it either.
                     dec &= ~4;
                     if (dec == 0)
                         PropertiesInt.Remove(PropertyInt.AppraisalLongDescDecoration);
@@ -614,7 +647,7 @@ namespace ACE.Server.Network.Structure
             BuildFlags();
         }
 
-        private void BuildProperties(WorldObject wo)
+        private void BuildProperties(WorldObject wo, Player examiner = null)
         {
             PropertiesInt = wo.GetAllPropertyInt().Where(x => AssessmentProperties.PropertiesInt.Contains(x.Key)).ToDictionary(x => x.Key, x => x.Value);
             PropertiesInt64 = wo.GetAllPropertyInt64().Where(x => AssessmentProperties.PropertiesInt64.Contains(x.Key)).ToDictionary(x => x.Key, x => x.Value);
@@ -623,6 +656,31 @@ namespace ACE.Server.Network.Structure
             PropertiesString = wo.GetAllPropertyString().Where(x => AssessmentProperties.PropertiesString.Contains(x.Key)).ToDictionary(x => x.Key, x => x.Value);
             PropertiesDID = wo.GetAllPropertyDataId().Where(x => AssessmentProperties.PropertiesDataId.Contains(x.Key)).ToDictionary(x => x.Key, x => x.Value);
             PropertiesIID = wo.GetAllPropertyInstanceId().Where(x => AssessmentProperties.PropertiesInstanceId.Contains(x.Key)).ToDictionary(x => x.Key, x => x.Value);
+
+            // Int64Stat is a server-side extension the client has no requirement text for — it
+            // renders the wield-requirement rows as a blank block (between the native Melee Defense
+            // and Mana Conversion sections on casters). Enforcement reads the biota, not appraisal;
+            // the authored "Wield requires: N Item Augmentations" line carries the requirement.
+            if (PropertiesInt.TryGetValue(PropertyInt.WieldRequirements, out var wieldReqType) &&
+                wieldReqType == (int)WieldRequirement.Int64Stat)
+            {
+                PropertiesInt.Remove(PropertyInt.WieldRequirements);
+                PropertiesInt.Remove(PropertyInt.WieldSkillType);
+                PropertiesInt.Remove(PropertyInt.WieldDifficulty);
+            }
+
+            // Paragon-stamped items (recipe + the ZoneLootMutator pre-Paragon card) carry
+            // ItemMaxLevel/ItemBaseXp/ItemTotalXp but no ItemXpStyle, and the client can't compose
+            // its item-level section without the style — it renders a blank block instead (between
+            // the native Melee Defense and Mana Conversion sections on casters). Real leveling
+            // items (cloaks, aetheria) always set ItemXpStyle and keep their display.
+            if (PropertiesInt.ContainsKey(PropertyInt.ItemMaxLevel) &&
+                !PropertiesInt.ContainsKey(PropertyInt.ItemXpStyle))
+            {
+                PropertiesInt.Remove(PropertyInt.ItemMaxLevel);
+                PropertiesInt64.Remove(PropertyInt64.ItemBaseXp);
+                PropertiesInt64.Remove(PropertyInt64.ItemTotalXp);
+            }
 
             if (wo is Player player)
             {
@@ -664,10 +722,10 @@ namespace ACE.Server.Network.Structure
                     PropertiesString[PropertyString.Fellowship] = player.Fellowship.FellowshipName;
             }
 
-            AddPropertyEnchantments(wo);
+            AddPropertyEnchantments(wo, examiner);
         }
 
-        private void AddPropertyEnchantments(WorldObject wo)
+        private void AddPropertyEnchantments(WorldObject wo, Player examiner = null)
         {
             if (wo == null) return;
 
@@ -710,6 +768,17 @@ namespace ACE.Server.Network.Structure
 
             if (PropertiesFloat.ContainsKey(PropertyFloat.ElementalDamageMod))
             {
+                // Weapon aug-scaling: show the RESOLVED elemental modifier, not the authored one —
+                // the same resolver combat uses, with the same replace semantics. WIELDED reads
+                // the wielder's augs; UNWIELDED reads the examiner's, so a drop in a pack reads as
+                // what it would do in YOUR hands. Without this the panel would show every tier of
+                // caster the same number, which is exactly the confusion the launcher lane hit on
+                // 2026-08-06 (two different-tier bows appraising identically, reasonably read as
+                // "these weapons are identical").
+                var casterHolder = (wo.Wielder as Player) ?? examiner;
+                if (ACE.Server.Managers.WeaponScaling.WeaponScalingCombat.TryGetCasterElementalMod(wo, casterHolder, out var gradedElemMod))
+                    PropertiesFloat[PropertyFloat.ElementalDamageMod] = gradedElemMod;
+
                 var enchantmentBonus = ResistMaskHelper.GetElementalDamageBonus(wo);
 
                 if (enchantmentBonus != 0)
@@ -746,7 +815,18 @@ namespace ACE.Server.Network.Structure
             if (wo.SpellDID.HasValue)
                 SpellBook.Add(wo.SpellDID.Value);
 
-            if (wo.ProcSpell.HasValue)
+            // Zone Control "Cast on Strike" withholds its spell id from the client (owner 2026-08-27).
+            // The client renders a SpellBook entry's name from its own DAT, so handing it the id would
+            // print "Nether Arc I" beside our own Property Details line that deliberately says "Nether
+            // Arc" - the level marker reads as a weak spell, which the card is not.
+            //
+            // GATED ON PROP 9058, NOT ON THE SPELL ID. A spell-id test would also swallow the ~11,700
+            // live items carrying player-crafted Ring Glyph procs of the very same spells, rewriting
+            // appraisal on gear we never touched. 9058 is stamped by this card and by nothing else.
+            var zcArcDmg = wo.GetProperty((PropertyFloat)ACE.Server.Managers.ZoneControl.ZoneLootMutator.ProcArcDamagePropId);
+            var zcHasProcCard = zcArcDmg.HasValue && zcArcDmg.Value > 0;
+
+            if (wo.ProcSpell.HasValue && !zcHasProcCard)
                 SpellBook.Add(wo.ProcSpell.Value);
 
             var woSpellDID = wo.SpellDID;   // prevent recursive lock
@@ -814,6 +894,169 @@ namespace ACE.Server.Network.Structure
                     }
                 }
             }
+        }
+
+        // The stored per-line marker. The VALUE is frozen plumbing - NEVER change the string: it is
+        // baked into live items' LongDesc and four readers key on the exact string (this promoter,
+        // the T11 whitelist, ladder diag/migrate). It is stripped before display, so players never
+        // see it. Only the const NAME followed the cantrip -> modifier rename (2026-08-28).
+        private const string LegacyModifierMarker = "Zone Cantrip:";
+        // The section header players DO see. "Cantrips:" -> "Modifiers:" (owner 2026-08-28: the
+        // lines are flat stat bonuses, not cantrips - the retail word was a misnomer).
+        private const string ModifierSectionHeader = "Modifiers:";
+        private const string WeaponDetailsHeader = "Property Details:";
+
+        /// <summary>
+        /// Cantrip lines are baked into wo.LongDesc at stamp time (ZoneModifiers.Stamp), so on
+        /// armor / clothing / shields / jewelry they render as raw description text - none of those
+        /// build a details section, only BuildWeapon does. Owner 2026-08-22: they get their own
+        /// "Cantrips:" section. Creature Augmentation used to be lifted in here as a special case
+        /// beside them; the fixed gear base that stamped that line was deleted the same day, so
+        /// Creature Augs arrives as an ordinary "Zone Cantrip:" line (key 35) like the other augs.
+        ///
+        /// Lifts them out of the APPRAISAL copy only - wo.LongDesc, the stamped source of truth,
+        /// is never touched, so nothing is re-rolled and existing drops re-render correctly on the
+        /// next appraise. Bullets stay in STAMP ORDER (owner: no sorting - two identical pieces
+        /// must read identically). The "Zone Cantrip:" prefix is a MARKER, not decoration -
+        /// FinalizeT11LongDesc's whitelist deletes any line that lacks it - so it stays in the
+        /// stored text and is dropped from the render only.
+        ///
+        /// Weapons carry their own "Property Details:" block pinned to the top; the cantrip group
+        /// becomes a SEPARATE section right after it, never folded in. Armor has no other details
+        /// entries, so it gets "Cantrips:" alone rather than an empty outer header (owner ruling).
+        /// </summary>
+        /// <summary>
+        /// Live Stat Resolution (plan 3b, READ-ONLY): swap the response copy's int props for the values
+        /// the record resolves to against the live ladder. Only keys the client is sent anyway
+        /// (AssessmentProperties - the retail Gear* ratings) are substituted; the 502xx custom block is
+        /// not an assessment property today and stays off the wire exactly as before. Armor Level is
+        /// carried to the client as PropertyInt.ArmorLevel (ArmorProfile holds only the per-damage-type
+        /// mods); BuildProperties already added the enchantment armor mod on top of the stamped base,
+        /// so the same mod goes on top of the resolved base. wo is never touched.
+        /// </summary>
+        private void SubstituteZoneResolvedInts(WorldObject wo, ZoneStatResolver.Resolved r)
+        {
+            // Core four -> Ratings (resolved). A Gear* prop that a CANTRIP LINE produced is REMOVED from the
+            // Ratings copy instead (owner 2026-08-23: it showed twice - once in the client's Ratings, once
+            // under Cantrips). Display only: the prop stays on the item, combat and character totals read it
+            // as before. Gated on the record, so pre-T11 gear never enters this path.
+            var lineProps = new HashSet<PropertyInt>();
+            foreach (var line in r.Lines)
+                if (line.Def?.Ints != null)
+                    foreach (var (propId, _) in line.Def.Ints)
+                        lineProps.Add((PropertyInt)propId);
+
+            foreach (var kv in r.Ints)
+            {
+                if (!AssessmentProperties.PropertiesInt.Contains(kv.Key))
+                    continue;
+                if (lineProps.Contains(kv.Key))
+                    PropertiesInt.Remove(kv.Key);
+                else
+                    PropertiesInt[kv.Key] = kv.Value;
+            }
+
+            if (r.ArmorLevel.HasValue && AssessmentProperties.PropertiesInt.Contains(PropertyInt.ArmorLevel))
+                PropertiesInt[PropertyInt.ArmorLevel] = r.ArmorLevel.Value + wo.EnchantmentManager.GetArmorMod();
+        }
+
+        private const string ReinforcedLineName = "Reinforced";
+
+        /// <param name="resolved">Live Stat Resolution record (null = legacy piece / weapon): when present
+        /// the bullets come from the record (record order, specials and Armor Level included, the core
+        /// four excluded - they are ratings, not cantrip lines) plus any baked Reinforced text line
+        /// (earned + frozen, never in the record). The baked "Zone Cantrip:" text is stripped either way.</param>
+        private void PromoteZoneModifierLines(ZoneStatResolver.Resolved resolved = null, WorldObject wo = null, Player examiner = null)
+        {
+            if (!PropertiesString.TryGetValue(PropertyString.LongDesc, out var ld) || string.IsNullOrEmpty(ld))
+                return;
+            if (ld.IndexOf(LegacyModifierMarker, StringComparison.Ordinal) < 0)
+                return;
+
+            var cantrips = new List<string>();
+            var reinforced = new List<string>();
+            var rest = new List<string>();
+            foreach (var raw in ld.Split('\n'))
+            {
+                var line = raw.Trim();
+                if (line.StartsWith(LegacyModifierMarker, StringComparison.Ordinal))
+                {
+                    var name = line.Substring(LegacyModifierMarker.Length).Trim();
+                    if (name.Length == 0)
+                        continue;
+                    if (resolved == null)
+                        cantrips.Add("- " + name);
+                    else if (name.StartsWith(ReinforcedLineName, StringComparison.Ordinal))
+                        reinforced.Add("- " + name);
+                }
+                else
+                    rest.Add(raw);
+            }
+
+            if (resolved != null)
+            {
+                foreach (var line in resolved.Lines)
+                {
+                    if (ZoneStatResolver.IsCoreKey(line.Record.Key))
+                        continue;
+                    cantrips.Add("- " + line.Text);
+                }
+                cantrips.AddRange(reinforced);
+            }
+
+            if (cantrips.Count == 0)
+                return;
+
+            // Armor zone lock (owner 2026-08-30, wording approved): same rule as the weapon
+            // panel - the lines keep showing full power (items are compared in town), and this
+            // pinned line reconciles that with the dormant contribution while the examiner
+            // stands outside every authored area.
+            if (ACE.Server.Managers.ZoneControl.ZoneControlManager.IsZcGear(wo)
+                && ACE.Server.Managers.ZoneControl.ZoneControlManager.WornPowerSuppressed(examiner))
+                cantrips.Insert(0, ACE.Server.Managers.ZoneControl.ZoneControlManager.ZoneLockedAppraisalLine);
+
+            // Collapse the blank runs the pulled lines leave behind: the slot-special stamp joins
+            // with a blank line, so removing one can leave three consecutive newlines.
+            var body = string.Join("\n", rest);
+            while (body.Contains("\n\n\n"))
+                body = body.Replace("\n\n\n", "\n\n");
+            body = body.Trim('\n');
+
+            var block = ModifierSectionHeader + "\n" + string.Join("\n", cantrips);
+
+            if (body.StartsWith(WeaponDetailsHeader, StringComparison.Ordinal))
+            {
+                var split = body.IndexOf("\n\n", StringComparison.Ordinal);
+                PropertiesString[PropertyString.LongDesc] = split >= 0
+                    ? body.Substring(0, split) + "\n\n" + block + body.Substring(split)
+                    : body + "\n\n" + block;
+                return;
+            }
+
+            // Non-weapon: the block goes in the USE string, not LongDesc. That is the position
+            // lever (owner 2026-08-22 - the section read too low): the client draws Use ABOVE its
+            // native sections and LongDesc BELOW them, which is why the original implementation
+            // (Ruggan, PR #327) used Use and why moving it to LongDesc pushed it under Spell
+            // Descriptions. The wand problem that forced that move does not apply here - armor,
+            // clothing, shields and jewelry have no native caster sections to sit on top of.
+            PropertiesString[PropertyString.LongDesc] = body;
+            if (string.IsNullOrEmpty(body))
+                PropertiesString.Remove(PropertyString.LongDesc);
+
+            var useParts = new List<string> { block };
+            if (PropertiesString.TryGetValue(PropertyString.Use, out var existingUse) && !string.IsNullOrWhiteSpace(existingUse))
+                useParts.Add(existingUse);
+
+            var use = string.Join("\n\n", useParts);
+
+            // Keep a break between the block and whatever the client draws next (same guard the
+            // original carried - without it the section runs straight into the following text).
+            if (PropertiesInt.ContainsKey(PropertyInt.ItemMaxLevel) ||
+                PropertiesInt.ContainsKey(PropertyInt.ItemSpellcraft) ||
+                PropertiesInt.ContainsKey(PropertyInt.WieldRequirements))
+                use += "\n";
+
+            PropertiesString[PropertyString.Use] = use;
         }
 
         private void BuildArmor(WorldObject wo)
@@ -930,7 +1173,7 @@ namespace ACE.Server.Network.Structure
             if (!Success)
                 return;
 
-            var weaponProfile = new WeaponProfile(weapon);
+            var weaponProfile = new WeaponProfile(weapon, examiner);
 
             //WeaponHighlight = WeaponMaskHelper.GetHighlightMask(weapon, wielder);
             //WeaponColor = WeaponMaskHelper.GetColorMask(weapon, wielder);
@@ -970,12 +1213,14 @@ namespace ACE.Server.Network.Structure
 
             CreatureSkill skill = examiner.GetCreatureSkill(checkSkill);
 
-            // Slayer
-            if (weapon.SlayerCreatureType.HasValue)
+            // Slayer. The forge-only all-creatures flag (PropertyBool 50052) has no species to name.
+            var slayerAll = weapon.GetProperty(PropertyBool.SlayerAllCreatures) == true;
+            if (weapon.SlayerCreatureType.HasValue || slayerAll)
             {
                 var bonus = weapon.SlayerDamageBonus ?? 1.0;
-                var rawName = weapon.SlayerCreatureType.ToString();
-                var niceName = CreatureNameRegex().Replace(rawName, " $1");
+                var niceName = slayerAll
+                    ? "All Creatures"
+                    : CreatureNameRegex().Replace(weapon.SlayerCreatureType.ToString(), " $1");
                 effectDescriptions.Add($"- {niceName} Slayer: {bonus:0.##}x Damage");
             }
 
@@ -985,6 +1230,11 @@ namespace ACE.Server.Network.Structure
                 var val = weapon.CriticalFrequency.Value;
                 effectDescriptions.Add($"- Biting Strike: +{val:P0} Crit Chance");
             }
+
+            // Cleaving (multi-target): the raw prop stores TOTAL targets (extra + 1), so raw-prop
+            // readouts look one higher than authored — this line shows the true extra-target count.
+            if (weapon.IsCleaving)
+                effectDescriptions.Add($"- Cleaving: +{weapon.CleaveTargets} Targets");
 
             // Resistance Cleaving (Fixed Resistance Modifier)
             if (weapon.ResistanceModifier.HasValue && weapon.ResistanceModifierType.HasValue)
@@ -1010,29 +1260,42 @@ namespace ACE.Server.Network.Structure
                 effectDescriptions.Add($"- Split Arrow: +{count} Targets, {val:P0} Dmg");
             }
 
-            // Crushing Blow
+            // Crushing Blow: engine crit damage = 1 + CriticalMultiplier, so the true multiplier the
+            // player actually deals is prop + 1 (a stored 1.0 = normal 2x crit).
             if (weapon.GetProperty(PropertyFloat.CriticalMultiplier) > 1.0f)
             {
-                var val = weapon.GetProperty(PropertyFloat.CriticalMultiplier);
+                var val = weapon.GetProperty(PropertyFloat.CriticalMultiplier).Value + 1.0;
                 effectDescriptions.Add($"- Crushing Blow: {val:0.##}x Crit Dmg");
             }
 
-            // Crippling Blow
-            if (weapon.HasImbuedEffect(ImbuedEffectType.CripplingBlow))
+            // Crippling Blow - hidden for players since 2026-08-25: WorldObject.CritImbuesSuppressed
+            // makes it inert on a player's weapon, and an item panel that advertises an effect doing
+            // exactly zero is worse for trust than an absent line. This panel is only ever built for
+            // a player examining something, so the const alone is the right test here.
+            if (weapon.HasImbuedEffect(ImbuedEffectType.CripplingBlow)
+                && !WorldObject.CritImbuesSuppressedForPlayers)
             {
                 var mod = WorldObject.GetCripplingBlowMod(skill);
                 effectDescriptions.Add($"- {ImbuedEffectType.CripplingBlow.DisplayName()}: {mod:0.##}x Crit Dmg");
             }
 
-            // Armor Rending
+            // Armor Rending: fraction of the target's armor IGNORED. Zone Control loot carries a
+            // per-weapon override (ArmorRendOverridePropId) = the configured fraction directly, which
+            // DamageEvent uses at hit time; retail weapons use the skill formula, which returns armor
+            // REMAINING, so the ignored fraction is 1 - that. (Old code showed the skill 'remaining'
+            // value mislabeled as "Ignored" and never reflected the Zone override.)
             if (weapon.HasImbuedEffect(ImbuedEffectType.ArmorRending))
             {
-                var mod = WorldObject.GetArmorRendingMod(skill);
-                effectDescriptions.Add($"- {ImbuedEffectType.ArmorRending.DisplayName()}: {mod:P1} Ignored");
+                var rendOverride = weapon.GetProperty((PropertyFloat)ACE.Server.Managers.ZoneControl.ZoneLootMutator.ArmorRendOverridePropId);
+                var ignored = rendOverride.HasValue
+                    ? Math.Clamp(rendOverride.Value, 0.0, 1.0)
+                    : 1.0 - WorldObject.GetArmorRendingMod(skill);
+                effectDescriptions.Add($"- {ImbuedEffectType.ArmorRending.DisplayName()}: {ignored:P1} Ignored");
             }
 
-            // Critical Strike
-            if (weapon.HasImbuedEffect(ImbuedEffectType.CriticalStrike))
+            // Critical Strike - hidden for players, same reason as Crippling Blow above.
+            if (weapon.HasImbuedEffect(ImbuedEffectType.CriticalStrike)
+                && !WorldObject.CritImbuesSuppressedForPlayers)
             {
                 var mod = WorldObject.GetCriticalStrikeMod(skill);
                 effectDescriptions.Add($"- {ImbuedEffectType.CriticalStrike.DisplayName()}: +{mod:P1} Crit Chance");
@@ -1056,10 +1319,34 @@ namespace ACE.Server.Network.Structure
                 if (weapon.HasImbuedEffect(type))
                 {
                     var mod = WorldObject.GetRendingMod(skill);
+
+                    // Zone Control loot: the rend power override substitutes for the skill formula
+                    // (rendingMod = 1 + override), mirroring GetWeaponResistanceModifier, so the tooltip
+                    // shows exactly the configured strength (e.g. wire 7.0 -> +700% Dmg).
+                    var rendOverride = weapon.GetProperty((PropertyFloat)ACE.Server.Managers.ZoneControl.ZoneLootMutator.RendingModOverridePropId);
+                    if (rendOverride.HasValue && rendOverride.Value > 0)
+                        mod = 1.0f + (float)rendOverride.Value;
+
+                    // NO "(vuln)" SUFFIX (owner 2026-08-27: "Rend is not a vuln, text should not be
+                    // there"). It shared a slot with the vuln multiplier internally - they are MAX'd,
+                    // never stacked - but that is an implementation detail of the resist chain and has
+                    // no business on a player-facing line. A rend is a rend.
                     var bonusPct = (mod - 1.0);
-                    effectDescriptions.Add($"- {type.DisplayName()}: +{bonusPct:P0} Dmg (vuln)");
+                    effectDescriptions.Add($"- {type.DisplayName()}: +{bonusPct:P0} Dmg");
                 }
             }
+
+            // Shield Cleaving: fraction of the target's shield AL the weapon ignores. Stored directly on
+            // the weapon (PropertyFloat.IgnoreShield); GetIgnoreShieldMod reads it at hit time.
+            if (weapon.IgnoreShield.HasValue && weapon.IgnoreShield.Value > 0)
+                effectDescriptions.Add($"- Shield Cleaving: {Math.Clamp(weapon.IgnoreShield.Value, 0.0, 1.0):P0} Shield Ignored");
+
+            // Phantom (hollow): the weapon bypasses the target's protective magic - Impen/Banes on armor
+            // and Life prots. RETAIL ONLY as of 2026-08-25: our loot card was deleted, so every weapon
+            // reaching this line is a retail hollow weapon (~830 of them) or one a GM made by hand. Some
+            // set only one of the two properties, but it is the same category, so one line covers both.
+            if (weapon.IgnoreMagicArmor || weapon.IgnoreMagicResist)
+                effectDescriptions.Add("- Phantom: Ignores Magic Protections");
 
             // Calculate Effective Melee Defense
             var meleeSkill = examiner.GetCreatureSkill(Skill.MeleeDefense).Current;
@@ -1079,26 +1366,104 @@ namespace ACE.Server.Network.Structure
             uint emdVal = (uint)Math.Round(meleeSkill * meleeMod * burdenMod * 1.0f + meleeImbues + meleeLum);
 
             effectDescriptions.Sort();
-            effectDescriptions.Add($"- Effective Melee Defense: {emdVal}");
 
-            var useParts = new List<string>();
-            useParts.Add($"Property Details:\n{string.Join("\n", effectDescriptions)}");
-
-            if (PropertiesString.TryGetValue(PropertyString.Use, out string existingUse) && !string.IsNullOrWhiteSpace(existingUse))
+            // Weapon Grade pinned ABOVE the sorted list; wield gate pinned to the very BOTTOM
+            // (owner 2026-08-01). Weapons carry these here instead of in the description block
+            // (armor/jewelry have no Property Details section and keep the LongDesc line).
+            var wsQuality = weapon.GetProperty(PropertyInt.WeaponAugScaleQuality);
+            if (wsQuality != null)
             {
-                useParts.Add(existingUse);
+                // Sub-grade label (owner 2026-08-03): k and variance both resolve per SUB-grade
+                // now, so the label has to carry the same granularity — "B+" is a different
+                // weapon from "B-", and showing both as "B" would hide a real damage step.
+                var wsGrade = ACE.Server.Managers.WeaponScaling.WeaponScalingManager.GetQualitySubGrade(wsQuality.Value);
+
+                // The percent is DAMAGE relative to a perfect roll, not the quality percentile
+                // (owner 2026-08-06). quality/10 was wrong twice over: an F- read "0 pct of max"
+                // while dealing 41.7 pct of an S weapon's damage, and two mechanically identical
+                // B+ weapons read 86 pct and 88 pct. Resolved off the SAME config the combat path
+                // reads, so the number cannot drift from what the weapon actually hits for.
+                var wsFamily = ACE.Server.Managers.WeaponScaling.WeaponScalingCombat.GetFamilyKey(weapon);
+                var wsCfg = ACE.Server.Managers.WeaponScaling.WeaponScalingManager.Current;
+                if (wsFamily != null && wsCfg.Scripts.TryGetValue(wsFamily, out var wsScript))
+                {
+                    var wsPct = ACE.Server.Managers.WeaponScaling.WeaponScalingManager
+                        .RelativeDamagePercent(wsScript, wsCfg.TightenStrength, wsQuality.Value);
+                    // "of max DAMAGE" (owner 2026-08-30): the percent measures dealt damage vs a
+                    // perfect roll, NOT the quality percentile, and family ladders have different
+                    // spreads - a bow F- honestly deals 72% of a perfect bow. Without the word
+                    // "damage" that read as a display bug ("how is the worst grade 72%?").
+                    effectDescriptions.Insert(0, $"- Weapon Grade: {wsGrade} ({wsPct}% of max damage)");
+                }
+                else
+                    effectDescriptions.Insert(0, $"- Weapon Grade: {wsGrade}");
             }
 
-            PropertiesString[PropertyString.Use] = string.Join("\n\n", useParts);
+            // Zone lock (owner 2026-08-30, "add the dormant line"): when the lock is ON and THIS
+            // examiner is standing outside every authored area, say so at the very top - the
+            // panel keeps showing the item's full power on purpose (players compare and trade in
+            // town, where gated numbers would make every drop read as junk), so this line is
+            // what reconciles the big numbers with the small hits. Absent when the lock is off,
+            // when the item is not ZC-stamped, or inside an authored area.
+            if (ACE.Server.Managers.ZoneControl.ZoneControlManager.WeaponPowerSuppressed(weapon, examiner))
+                effectDescriptions.Insert(0, ACE.Server.Managers.ZoneControl.ZoneControlManager.ZoneLockedAppraisalLine);
 
-            // Make sure there's a line break between the string and some of the other "details".
-            if (PropertiesInt.ContainsKey(PropertyInt.ItemMaxLevel) ||
-                PropertiesInt.ContainsKey(PropertyInt.ItemSpellcraft) ||
-                PropertiesInt.ContainsKey(PropertyInt.WieldRequirements))
-                PropertiesString[PropertyString.Use] += "\n";
+            // Cast on Strike (owner 2026-08-27: "Appraisal line should show Force Arc (13% proc chance)").
+            // One line PER SLOT - the arc and the ring are separate entities with separate rates, so a
+            // single merged line would hide which one a given rate belongs to. Names come from our own
+            // table, never from Spell.Name: the whole point is to drop the level marker.
+            var zcArcB = weapon.GetProperty((PropertyFloat)ACE.Server.Managers.ZoneControl.ZoneLootMutator.ProcArcDamagePropId);
+            var zcRingB = weapon.GetProperty((PropertyFloat)ACE.Server.Managers.ZoneControl.ZoneLootMutator.ProcRingDamagePropId);
+            if ((zcArcB ?? 0) > 0 || (zcRingB ?? 0) > 0)
+            {
+                if (weapon.ProcSpell.HasValue &&
+                    ACE.Server.Managers.ZoneControl.ZoneLootMutator.TryGetProcDisplayName(weapon.ProcSpell.Value, out var arcName))
+                    effectDescriptions.Add($"- Cast on Strike: {arcName} ({(weapon.ProcSpellRate ?? 0f) * 100f:0.#}% proc chance)");
+
+                if (weapon.ProcSpell2.HasValue &&
+                    ACE.Server.Managers.ZoneControl.ZoneLootMutator.TryGetProcDisplayName(weapon.ProcSpell2.Value, out var ringName))
+                    effectDescriptions.Add($"- Cast on Strike: {ringName} ({(weapon.ProcSpellRate2 ?? 0f) * 100f:0.#}% proc chance)");
+            }
+
+            effectDescriptions.Add($"- Effective Melee Defense: {emdVal}");
+
+            if (weapon.WieldRequirements == WieldRequirement.Int64Stat &&
+                weapon.WieldSkillType == (int)PropertyInt64.LumAugItemCount)
+                effectDescriptions.Add($"- Wield requires: {weapon.WieldDifficulty ?? 0:N0} Item Augmentations");
+
+            // T16+ charm wield gates in slots 3/4 (owner 2026-08-15)
+            if (weapon.WieldRequirements3 == WieldRequirement.Int64Stat && weapon.WieldSkillType3 != null)
+                effectDescriptions.Add($"- Wield requires: {weapon.WieldDifficulty3 ?? 0:N0} {CharmCounterName((PropertyInt64)weapon.WieldSkillType3.Value)}");
+            if (weapon.WieldRequirements4 == WieldRequirement.Int64Stat && weapon.WieldSkillType4 != null)
+                effectDescriptions.Add($"- Wield requires: {weapon.WieldDifficulty4 ?? 0:N0} {CharmCounterName((PropertyInt64)weapon.WieldSkillType4.Value)}");
+
+            // Property Details renders via the LONG DESCRIPTION, not the Use string (owner
+            // 2026-08-01): the client draws its native caster sections (Mana Conversion, "Damage
+            // bonus for X spells") AFTER the Use text, so a Use-carried block sat ABOVE them on
+            // wands. Prepending to LongDesc puts the block below every native section and above
+            // the per-viewer bonus line + provenance (which were inserted earlier in the build).
+            var detailsBlock = $"Property Details:\n{string.Join("\n", effectDescriptions)}";
+            if (PropertiesString.TryGetValue(PropertyString.LongDesc, out var ldExisting) && !string.IsNullOrEmpty(ldExisting))
+                PropertiesString[PropertyString.LongDesc] = $"{detailsBlock}\n\n{ldExisting}";
+            else
+                PropertiesString[PropertyString.LongDesc] = detailsBlock;
 
             // item enchantments can also be on wielder currently
             AddEnchantments(weapon);
+        }
+
+        /// <summary>Display name for a growth-charm counter used as a T16+ wield gate.</summary>
+        private static string CharmCounterName(PropertyInt64 prop)
+        {
+            switch (prop)
+            {
+                case PropertyInt64.TriuneWeaveCount: return "Triune Weave";
+                case PropertyInt64.BattlemagesWrathCharmCount: return "Battlemage's Wrath";
+                case PropertyInt64.NetherVeilCharmCount: return "Nether Veil";
+                case PropertyInt64.CrashingSteelCharmCount: return "Crashing Steel";
+                case PropertyInt64.TrueShotCharmCount: return "True Shot";
+                default: return prop.ToString();
+            }
         }
 
         private void BuildHookProfile(WorldObject hookedItem)

--- a/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
+++ b/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
@@ -776,14 +776,17 @@ namespace ACE.Server.Network.Structure
                 // 2026-08-06 (two different-tier bows appraising identically, reasonably read as
                 // "these weapons are identical").
                 var casterHolder = (wo.Wielder as Player) ?? examiner;
-                if (ACE.Server.Managers.WeaponScaling.WeaponScalingCombat.TryGetCasterElementalMod(wo, casterHolder, out var gradedElemMod))
-                    PropertiesFloat[PropertyFloat.ElementalDamageMod] = gradedElemMod;
-
                 var enchantmentBonus = ResistMaskHelper.GetElementalDamageBonus(wo);
+
+                if (ACE.Server.Managers.WeaponScaling.WeaponScalingCombat.TryGetCasterElementalMod(wo, casterHolder, out var gradedElemMod))
+                    // the same composition combat uses: the graded mod MULTIPLIES the aura, it does not add to it
+                    PropertiesFloat[PropertyFloat.ElementalDamageMod] = ACE.Server.Managers.WeaponScaling.WeaponScalingCombat.ComposeCasterModifier(
+                        gradedElemMod, enchantmentBonus, ACE.Server.Managers.WeaponScaling.WeaponScalingManager.Current.CasterAuraRescale);
+                else if (enchantmentBonus != 0)
+                    PropertiesFloat[PropertyFloat.ElementalDamageMod] += enchantmentBonus;
 
                 if (enchantmentBonus != 0)
                 {
-                    PropertiesFloat[PropertyFloat.ElementalDamageMod] += enchantmentBonus;
 
                     ResistHighlight = ResistMaskHelper.GetHighlightMask(wo);
                     ResistColor = ResistMaskHelper.GetColorMask(wo);

--- a/Source/ACE.Server/Network/Structure/WeaponProfile.cs
+++ b/Source/ACE.Server/Network/Structure/WeaponProfile.cs
@@ -35,7 +35,7 @@ namespace ACE.Server.Network.Structure
 
         public double Enchantment_WeaponDefense;    // gets sent elsewhere, calculating here for consistency
 
-        public WeaponProfile(WorldObject weapon)
+        public WeaponProfile(WorldObject weapon, Player examiner = null)
         {
             Weapon = weapon;
 
@@ -52,7 +52,39 @@ namespace ACE.Server.Network.Structure
             WeaponSkill = (Skill)(weapon.GetProperty(PropertyInt.WeaponSkill) ?? 0);
             Damage = GetDamage(weapon);
             DamageVariance = GetDamageVariance(weapon);
-            DamageMod = GetDamageMultiplier(weapon);
+
+            // Weapon aug-scaling: fold the scaling term into the displayed range. WIELDED = the
+            // wielder's live value; UNWIELDED = the EXAMINER's own value (owner 2026-08-03), so a
+            // drop in a corpse or pack reads as what it would do in YOUR hands — floored at the
+            // tier's wield-floor value, which no real wielder can be below. (Superseded: showing
+            // every examiner the tier floor, owner 2026-08-01 — honest, but it made two drops
+            // looted at different aug counts read identically and confused the owner repeatedly.)
+            // In combat the term is a flat post-roll add (variance never touches it), so the
+            // reported variance is re-derived to keep the displayed MIN true: min = staticMin +
+            // term, max = staticMax + term — without this the client applies the weapon's
+            // variance to the whole and understates min ~2x.
+            var augTerm = weapon.Wielder is Player wielderPlayer
+                ? (int)ACE.Server.Managers.WeaponScaling.WeaponScalingCombat.GetFlatBonus(weapon, wielderPlayer)
+                : (int)ACE.Server.Managers.WeaponScaling.WeaponScalingCombat.GetExamineBonus(weapon, examiner);
+            if (augTerm > 0)
+            {
+                if (ACE.Server.Managers.WeaponScaling.WeaponScalingCombat.TryGetEffectiveVariance(weapon, out var vEff))
+                {
+                    // Scheme C: combat rolls the WHOLE envelope down from max by the quality-
+                    // tightened family variance — display exactly that so examine = what you roll.
+                    Damage = (uint)(Damage + augTerm);
+                    Enchantment_Damage += augTerm;   // green "buffed" coloring client-side
+                    DamageVariance = vEff;
+                }
+                else
+                {
+                    var trueMin = Damage * (1.0 - DamageVariance) + augTerm;
+                    Damage = (uint)(Damage + augTerm);
+                    Enchantment_Damage += augTerm;   // green "buffed" coloring client-side
+                    DamageVariance = Damage > 0 ? Math.Max(0.0, 1.0 - trueMin / Damage) : 0.0;
+                }
+            }
+            DamageMod = GetDamageMultiplier(weapon, examiner);
             WeaponLength = weapon.GetProperty(PropertyFloat.WeaponLength) ?? 1.0f;
             MaxVelocity = weapon.MaximumVelocity ?? 1.0f;
             WeaponOffense = GetWeaponOffense(weapon);
@@ -68,6 +100,8 @@ namespace ACE.Server.Network.Structure
             var damageBonus = weapon.EnchantmentManager.GetDamageBonus();
             var auraDamageBonus = weapon.Wielder != null && (weapon.WeenieType != WeenieType.Ammunition || ServerConfig.show_ammo_buff.Value) ? weapon.Wielder.EnchantmentManager.GetDamageBonus() : 0;
             Enchantment_Damage = weapon.IsEnchantable ? damageBonus + auraDamageBonus : damageBonus;
+            // (the aug-scaling term is folded in by the ctor AFTER variance is known, so the
+            // displayed min can be corrected to the true post-roll value)
             return (uint)Math.Max(0, baseDamage + Enchantment_Damage);
         }
 
@@ -99,9 +133,18 @@ namespace ACE.Server.Network.Structure
         /// <summary>
         /// Returns the weapon damage multiplier, with enchantments factored in
         /// </summary>
-        public float GetDamageMultiplier(WorldObject weapon)
+        public float GetDamageMultiplier(WorldObject weapon, Player examiner = null)
         {
-            var baseMultiplier = weapon.GetProperty(PropertyFloat.DamageMod) ?? 1.0f;
+            // Weapon aug-scaling: stamped T11+ launchers display the quality-GRADED, TIER-SCALED
+            // damage modifier (same resolver combat uses — replace semantics, authored value
+            // fallback). WIELDED reads the wielder's augs; UNWIELDED reads the examiner's, which
+            // is what finally makes two different-tier bows appraise differently — on 2026-08-06
+            // the owner compared a T11 and a T13 bow, saw identical +300% panels, and reasonably
+            // concluded the weapons were identical.
+            var holder = (weapon.Wielder as Player) ?? examiner;
+            var baseMultiplier = ACE.Server.Managers.WeaponScaling.WeaponScalingCombat.TryGetLauncherDamageMod(weapon, holder, out var gradedMod)
+                ? gradedMod
+                : weapon.GetProperty(PropertyFloat.DamageMod) ?? 1.0f;
             var damageMod = weapon.EnchantmentManager.GetDamageMod();
             var auraDamageMod = weapon.Wielder != null ? weapon.Wielder.EnchantmentManager.GetDamageMod() : 0.0f;
             Enchantment_DamageMod = weapon.IsEnchantable ? damageMod + auraDamageMod : damageMod;

--- a/Source/ACE.Server/WorldObjects/Creature.cs
+++ b/Source/ACE.Server/WorldObjects/Creature.cs
@@ -22,6 +22,14 @@ namespace ACE.Server.WorldObjects
     {
         private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
+        /// <summary>Zone Control's cached read of this creature's own rank bools (50048-50050) and the
+        /// ExemptFromZoneScaling bool (50047): -1 = not read yet, else (int)ZcRank / 0-1. Filled by
+        /// ZoneControlManager in ONE biota read-lock pass; reset to -1 by SetProperty/RemoveProperty
+        /// (PropertyBool) for those ids, so the per-hit resolve path (ResolveForCreature, 29 call sites)
+        /// never takes the biota lock. Plain ints so a torn read is impossible.</summary>
+        public volatile int ZcRankCache = -1;
+        public volatile int ZcExemptCache = -1;
+
         public bool IsExhausted { get => Stamina.Current == 0; }
 
         protected QuestManager _questManager;

--- a/Source/ACE.Server/WorldObjects/Creature_Aura.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Aura.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using ACE.Entity.Enum.Properties;
+using ACE.Server.Entity;
+using ACE.Server.Network.GameMessages.Messages;
+
+namespace ACE.Server.WorldObjects
+{
+    public partial class Creature
+    {
+        private double lastAuraCheckTime = 0;
+
+        /// <summary>Empower aura radius, in meters: an IsEmpowerSource boss empowers matching group members within this range.</summary>
+        private const float EmpowerAuraRadius = 20.0f;
+
+        /// <summary>
+        /// Stores the original (non-prefixed) name so we can restore it cleanly.
+        /// </summary>
+        private string _originalName;
+
+        public void UpdateAuraBuffs(double currentUnixTime)
+        {
+            if (currentUnixTime - lastAuraCheckTime < 1.0)
+                return;
+
+            lastAuraCheckTime = currentUnixTime;
+
+            // Only process creatures flagged with CanBeEmpowered
+            if (GetProperty(PropertyBool.CanBeEmpowered) != true || IsDead)
+                return;
+
+            // Determine this creature's group identity:
+            // EmpowerGroup (explicit override) takes priority, else fall back to CreatureType
+            var myGroup = GetProperty(PropertyInt.EmpowerGroup);
+            var myCreatureType = CreatureType;
+
+            bool bossNearby = false;
+
+            if (CurrentLandblock != null && Location != null)
+            {
+                var nearbyObjects = CurrentLandblock.GetWorldObjectsForPhysicsHandling();
+                var myGlobalPos = Location.ToGlobal(false);
+
+                foreach (var obj in nearbyObjects)
+                {
+                    if (obj is Creature creature && creature.GetProperty(PropertyBool.IsEmpowerSource) == true)
+                    {
+                        if (!creature.IsAlive)
+                            continue;
+
+                        // Check group match:
+                        // If both have EmpowerGroup set, match on that
+                        // Otherwise fall back to CreatureType
+                        var bossGroup = creature.GetProperty(PropertyInt.EmpowerGroup);
+
+                        bool groupMatch;
+                        if (myGroup != null && bossGroup != null)
+                            groupMatch = myGroup == bossGroup;
+                        else
+                            groupMatch = myCreatureType != null && myCreatureType == creature.CreatureType;
+
+                        if (!groupMatch)
+                            continue;
+
+                        var dist = Vector3.Distance(myGlobalPos, creature.Location.ToGlobal(false));
+                        if (dist <= EmpowerAuraRadius)
+                        {
+                            bossNearby = true;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            bool currentlyEmpowered = GetProperty(PropertyBool.IsEmpowered) ?? false;
+
+            if (bossNearby && !currentlyEmpowered)
+            {
+                SetProperty(PropertyBool.IsEmpowered, true);
+
+                // Empower is a transient combat buff, but the name change below writes PropertyString.Name
+                // into the biota's dirty set. Suppress shard persistence so the "Empowered " prefix (and the
+                // runtime IsEmpowered flag) can never be saved and outlive the nearby boss. CanBeEmpowered
+                // creatures are generated combat mobs, so they carry no state worth persisting anyway.
+                SuppressShardPersistence = true;
+
+                // Save the original name on first empower
+                _originalName = Name;
+
+                var newName = "Empowered " + Name;
+                Name = newName;
+                SetProperty(PropertyString.Name, newName);
+
+                // Full object refresh - the client does not update its 3D name label from a bare
+                // property-string update, only from an object (re)create
+                EnqueueBroadcast(new GameMessageUpdateObject(this));
+
+                log.Debug($"[AURA STATE] Crew {Guid} became EMPOWERED -> {newName}");
+            }
+            else if (!bossNearby && currentlyEmpowered)
+            {
+                RemoveProperty(PropertyBool.IsEmpowered);
+
+                // Restore original name (fallback to string strip if _originalName is null)
+                var restoredName = _originalName;
+                if (restoredName == null)
+                    restoredName = Name.StartsWith("Empowered ") ? Name.Substring("Empowered ".Length) : Name;
+                _originalName = null;
+
+                Name = restoredName;
+                SetProperty(PropertyString.Name, restoredName);
+
+                EnqueueBroadcast(new GameMessageUpdateObject(this));
+
+                log.Debug($"[AURA STATE] Crew {Guid} lost EMPOWERED -> {restoredName}");
+            }
+        }
+    }
+}

--- a/Source/ACE.Server/WorldObjects/Creature_Aura.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Aura.cs
@@ -39,14 +39,15 @@ namespace ACE.Server.WorldObjects
 
             if (CurrentLandblock != null && Location != null)
             {
-                var nearbyObjects = CurrentLandblock.GetWorldObjectsForPhysicsHandling();
+                // one IsEmpowerSource scan per landblock per second, shared by every CanBeEmpowered creature here
+                var nearbyObjects = CurrentLandblock.GetEmpowerSources(currentUnixTime, 1.0);
                 var myGlobalPos = Location.ToGlobal(false);
 
                 foreach (var obj in nearbyObjects)
                 {
                     if (obj is Creature creature && creature.GetProperty(PropertyBool.IsEmpowerSource) == true)
                     {
-                        if (!creature.IsAlive)
+                        if (!creature.IsAlive || creature.Location == null)   // sources can be mid-removal
                             continue;
 
                         // Check group match:

--- a/Source/ACE.Server/WorldObjects/Creature_BodyPart.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_BodyPart.cs
@@ -48,8 +48,20 @@ namespace ACE.Server.WorldObjects
             var ignoreMagicArmor = (weapon?.IgnoreMagicArmor ?? false) || (attacker?.IgnoreMagicArmor ?? false);
             var ignoreMagicResist = (weapon?.IgnoreMagicResist ?? false) || (attacker?.IgnoreMagicResist ?? false);
 
-            // get base AL / RL
-            var armorVsType = Biota.Value.BaseArmor * (float)Creature.GetArmorVsType(damageType);
+            // get base AL / RL — Zone Control can set the monster's base armor absolutely (null profile -> weenie
+            // base_Armor). Precedence: armor_level (all parts) > per-part override > weenie (blanket beats
+            // per-part, owner ruling 2026-08-02) — the Defense-tab armor_level stays the live tuning lever;
+            // per-part armor (weak spots) only shows through on mobs with no blanket armor_level set.
+            var baseArmor = (float)Biota.Value.BaseArmor;
+            var zoneArm = ACE.Server.Managers.ZoneControl.ZoneControlManager.ResolveForCreature(Creature);
+            if (zoneArm != null)
+            {
+                if (zoneArm.Has(ACE.Server.Managers.ZoneScaling.ZoneStat.ArmorLevel))
+                    baseArmor = (float)zoneArm.Get(ACE.Server.Managers.ZoneScaling.ZoneStat.ArmorLevel);
+                else if (zoneArm.GetBodyPart((int)Biota.Key)?.Armor is double partArmor)
+                    baseArmor = (float)partArmor;
+            }
+            var armorVsType = baseArmor * (float)Creature.GetArmorVsType(damageType);
 
             // additive enchantments:
             // imperil / armor

--- a/Source/ACE.Server/WorldObjects/Creature_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Combat.cs
@@ -512,6 +512,13 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public virtual uint GetEffectiveAttackSkill()
         {
+            // Zone Scaler: an authored profile sets the monster's attack skill absolutely (null for players/exempt/
+            // non-endgame/no-match -> falls through to normal skill). The v11 attack-skill floor still applies on top.
+            var zoneAtk = ACE.Server.Managers.ZoneControl.ZoneControlManager.ResolveForCreature(this);
+            if (zoneAtk != null && zoneAtk.Has(ACE.Server.Managers.ZoneScaling.ZoneStat.AttackSkill))
+                // floor at 0: a negative authored value would wrap through the uint cast to ~4B
+                return (uint)Math.Round(Math.Max(0.0, zoneAtk.Get(ACE.Server.Managers.ZoneScaling.ZoneStat.AttackSkill)));
+
             var attackSkill = GetCreatureSkill(GetCurrentAttackSkill()).Current;
 
             // TODO: don't use for bow?
@@ -529,6 +536,19 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public virtual uint GetEffectiveDefenseSkill(CombatType combatType)
         {
+            // Zone Scaler: an authored profile sets the monster's melee/missile defense absolutely so hits land as
+            // designed (null for players/exempt/non-endgame/no-match -> normal calc). Exhaustion still zeroes it.
+            var zoneDef = ACE.Server.Managers.ZoneControl.ZoneControlManager.ResolveForCreature(this);
+            if (zoneDef != null)
+            {
+                var defStat = combatType == CombatType.Missile
+                    ? ACE.Server.Managers.ZoneScaling.ZoneStat.MissileDefense
+                    : ACE.Server.Managers.ZoneScaling.ZoneStat.MeleeDefense;
+                if (zoneDef.Has(defStat))
+                    // floor at 0: a negative authored value would wrap through the uint cast to ~4B
+                    return IsExhausted ? 0u : (uint)Math.Round(Math.Max(0.0, zoneDef.Get(defStat)));
+            }
+
             var defenseSkill = combatType == CombatType.Missile ? Skill.MissileDefense : Skill.MeleeDefense;
             var defenseMod = defenseSkill == Skill.MissileDefense ? GetWeaponMissileDefenseModifier(this) : GetWeaponMeleeDefenseModifier(this);
             var burdenMod = GetBurdenMod();

--- a/Source/ACE.Server/WorldObjects/Creature_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Death.cs
@@ -1024,6 +1024,19 @@ namespace ACE.Server.WorldObjects
                     slotCounts.Trinket = Slot(ACE.Server.Managers.ZoneScaling.ZoneStat.LootSlotTrinket, slotCounts.Trinket);
                     slotCounts.Cloak = Slot(ACE.Server.Managers.ZoneScaling.ZoneStat.LootSlotCloak, slotCounts.Cloak);
                 }
+                // LEGACY per-slot mode has no budget: its aggregate must respect the corpse cap too (the budget path
+                // clamps below). Weapons is a multiplier over the nine families.
+                if (zoneLoot != null && !zoneLoot.Has(ACE.Server.Managers.ZoneScaling.ZoneStat.LootDropsMin))
+                {
+                    var perSlotTotal = slotCounts.Weapons * 9 + slotCounts.Helm + slotCounts.Chest + slotCounts.Shoulder + slotCounts.Bracer
+                        + slotCounts.Glove + slotCounts.Girth + slotCounts.UpperLeg + slotCounts.LowerLeg + slotCounts.Boot + slotCounts.Shield
+                        + slotCounts.Amulet + slotCounts.Ring + slotCounts.Bracelet + slotCounts.Trinket + slotCounts.Cloak;
+                    if (perSlotTotal > ZoneCorpseItemCap)
+                    {
+                        log.Warn($"[ZoneLoot] {Name} (0x{Guid}): per-slot counts total {perSlotTotal}, above the corpse cap {ZoneCorpseItemCap}; rolling a capped budget instead.");
+                        slotCounts = LootGenerationFactory.RollBudgetedCounts(slotCounts, ZoneCorpseItemCap, 1.0, 1.0, 1.0, 1.0);
+                    }
+                }
 
                 // BUDGET MODE (owner 2026-08-24): defining loot_max_drops switches from "every slot
                 // drops its own count" to "roll this many ITEMS total, distributed by category weight".
@@ -1385,14 +1398,21 @@ namespace ACE.Server.WorldObjects
 
         private static void SpawnZoneCurrency(uint wcid, int amount, Corpse corpse, List<WorldObject> dropped)
         {
-            var token = CreateZoneCurrencyToken(wcid, amount);
-            if (token == null)
-                return;
-
-            if (corpse != null)
-                corpse.TryAddToInventory(token);
-            else
-                dropped.Add(token);
+            // an authored amount above the token's MaxStackSize spawns as several full stacks - never truncated silently
+            var remaining = Math.Max(amount, 0);
+            var guard = 0;
+            while (remaining > 0 && guard++ < 64)
+            {
+                var token = CreateZoneCurrencyToken(wcid, remaining);
+                if (token == null)
+                    return;
+                var stack = Math.Max(token.StackSize ?? 1, 1);
+                if (corpse != null)
+                    corpse.TryAddToInventory(token);
+                else
+                    dropped.Add(token);
+                remaining -= stack;
+            }
         }
 
         /// <summary>Direct-delivery currency drop: straight into the killing player's inventory with a chat

--- a/Source/ACE.Server/WorldObjects/Creature_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Death.cs
@@ -66,6 +66,10 @@ namespace ACE.Server.WorldObjects
 
             //QuestManager.OnDeath(lastDamager?.TryGetAttacker());
 
+            // Greater Rifts: progress + guardian-death detection. Fast-bails for the whole normal world
+            // (rift instances live exclusively at negative variations).
+            ACE.Server.Managers.Rifts.RiftManager.OnCreatureDeath(this, lastDamager);
+
             if (KillQuest != null)
                 OnDeath_HandleKillTask(KillQuest);
             if (KillQuest2 != null)
@@ -236,6 +240,24 @@ namespace ACE.Server.WorldObjects
             var monsterTier = PrestigeManager.GetKillScalingMonsterTier(this);
 
             var baseXp = (long)(XpOverride ?? 0);
+            long? luminanceAward = LuminanceAward;
+
+            // Owner ruling 2026-08-23: T11+ kill rewards are authored per zone by rank; weenie XpOverride/LuminanceAward are ignored when the zone sets them.
+            var killProfile = ACE.Server.Managers.ZoneControl.ZoneControlManager.ResolveForCreature(this);
+            if (killProfile != null)
+            {
+                // ONE key since 2026-09-02 (owner D3): xp_kill. The profile is already the mob's RANK
+                // chain, so a Leader reads the Leader row's xp_kill and an unranked mob the Default
+                // row's - the 08-29 / 08-31 branch logic (minion master key, unranked pays minion)
+                // now lives in the resolver's layer order instead of here.
+                if (killProfile.Has(ACE.Server.Managers.ZoneScaling.ZoneStat.XpKill))
+                    baseXp = (long)Math.Round(killProfile.Get(ACE.Server.Managers.ZoneScaling.ZoneStat.XpKill));
+                if (killProfile.Has(ACE.Server.Managers.ZoneScaling.ZoneStat.LumAward))
+                {
+                    var zoneLum = (long)Math.Round(killProfile.Get(ACE.Server.Managers.ZoneScaling.ZoneStat.LumAward));
+                    luminanceAward = zoneLum > 0 ? zoneLum : null;   // zone-provided 0 = grant nothing
+                }
+            }
 
             // One EarnXP / EarnLuminance per player: combine direct hits + all of that player's combat pets.
             // Avoids duplicate fellowship splits and matches "your kill bonuses apply to the full credit you earned on the mob."
@@ -277,10 +299,19 @@ namespace ACE.Server.WorldObjects
                     player.EarnXP((long)Math.Round(totalXP), XpType.Kill, ShareType.All, monsterTier);
                 }
 
-                if (LuminanceAward != null)
+                if (luminanceAward != null)
                 {
-                    var totalLuminance = LuminanceAward.Value * damagePercent;
+                    var totalLuminance = luminanceAward.Value * damagePercent;
                     player.EarnLuminance((long)Math.Round(totalLuminance), XpType.Kill, ShareType.All, monsterTier);
+                }
+
+                // Launch-day diagnostic (2026-08-23): the client filters XP/lum chat, so the log is the readout.
+                // One line per player per governed kill - switchable via zc_killxp_diag (review 2026-09-04).
+                if (killProfile != null && ServerConfig.zc_killxp_diag.Value)
+                {
+                    var (zcRank, rankSrc) = ACE.Server.Managers.ZoneControl.ZoneControlManager.ResolveRankForCreature(this);
+                    var rank = ACE.Server.Managers.ZoneScaling.ZoneRank.Key(zcRank) + "/" + rankSrc;
+                    log.Info($"[KILLXP] {Name} ({WeenieClassId}, {rank}) -> {player.Name}: share {damagePercent:P0}, xp {(long)Math.Round(baseXp * damagePercent):N0} of {baseXp:N0}, lum {(luminanceAward.HasValue ? ((long)Math.Round(luminanceAward.Value * damagePercent)).ToString("N0") : "none")}, zone-authored xp={killProfile.Has(ACE.Server.Managers.ZoneScaling.ZoneStat.XpKill)} lum={killProfile.Has(ACE.Server.Managers.ZoneScaling.ZoneStat.LumAward)}");
                 }
             }
 
@@ -690,7 +721,7 @@ namespace ACE.Server.WorldObjects
                     var dropped = player.CalculateDeathItems_Olthoi(corpse, hadVitae, killerIsOlthoiPlayer, killerIsPkPlayer);
 
                     foreach (var wo in dropped)
-                        DoCantripLogging(killer, wo);
+                        DoModifierLogging(killer, wo);
 
                     corpse.RecalculateDecayTime(player);
 
@@ -739,7 +770,7 @@ namespace ACE.Server.WorldObjects
                                         foreach (var item in lootItems)
                                         {
                                             corpse.TryAddToInventory(item);
-                                            DoCantripLogging(killer, item);
+                                            DoModifierLogging(killer, item);
                                         }
                                     }
                                 }
@@ -901,21 +932,281 @@ namespace ACE.Server.WorldObjects
             var droppedItems = new List<WorldObject>();
             var tier = PrestigeManager.GetKillScalingMonsterTier(this);
 
+            // Zone Scaler loot: an authored profile can bump the loot tier/quality/quantity and inject bonus
+            // currency for this mob (null for players/exempt/non-endgame/no-match -> normal loot).
+            var zoneLoot = ACE.Server.Managers.ZoneControl.ZoneControlManager.ResolveForCreature(this);
+
+            // Zone loot FLOOR (owner 2026-08-23): anything that dies inside a governed variant zone (v11+)
+            // drops that variation's set - a mis-tiered T8/T9/T10 WCID, a retail mob with its own table,
+            // or a retail mob with NO table (it gets the zone fallback profile). Exempt creatures never
+            // reach here (zoneLoot is null for them), T11+ profiles are untouched (max, not add).
+            var zoneFloorTier = zoneLoot != null ? (Location?.Variation ?? 0) : 0;
+            if (zoneFloorTier < ACE.Server.Managers.ZoneControl.ZoneControlManager.MinBoundedVariation) zoneFloorTier = 0;
+            var deathTreasure = DeathTreasure;
+            if (deathTreasure == null && zoneFloorTier > 0)
+                deathTreasure = DatabaseManager.World.GetCachedDeathTreasure(LootGenerationFactory.ZoneLootFallbackProfile);
+
             // create death treasure from loot generation factory
-            if (DeathTreasure != null)
+            if (deathTreasure != null)
             {
-                List<WorldObject> items = LootGenerationFactory.CreateRandomLootObjects(DeathTreasure);
+                // Zone Control loot tier = the zone floor: max(own tier, variation). (loot_tier_bonus,
+                // loot_quantity_mult, loot_quality_mult removed 2026-08-23.)
+                var effectiveTreasure = deathTreasure;
+                if (zoneFloorTier > 0 && effectiveTreasure.Tier < zoneFloorTier)
+                {
+                    effectiveTreasure = CloneTreasureDeath(effectiveTreasure);
+                    effectiveTreasure.Tier = zoneFloorTier;
+
+                    // ZONE SET ONLY (owner 2026-08-30). Raising the tier alone left the mob's OWN
+                    // retail chances intact, so a sub-tier-11 profile dying inside a v11+ zone rolled
+                    // its full retail payload AT THE RAISED TIER and then got the zone set on top -
+                    // e.g. tier-10 profile 3007 is 100/100/100 with 10 magic items, so ~11.5 extra
+                    // items per corpse. That is exactly the case this floor exists to serve (its own
+                    // comment names "a mis-tiered T8/T9/T10 WCID"), so it was a live double-drop on
+                    // the design's intended path - it just was not reachable yet, because no 3007 mob
+                    // is placed or generator-spawned in any authored zone landblock today.
+                    // The floor's contract is that such a mob drops THAT VARIATION'S SET, not its own
+                    // loot as well, so the three retail roll groups are zeroed here. Profiles already
+                    // at tier 11+ never enter this branch and are untouched; a mob with NO table of
+                    // its own already gets ZoneLootFallbackProfile (73001), which is all zeros too -
+                    // so after this every zone drop comes from one place.
+                    effectiveTreasure.ItemChance = 0;
+                    effectiveTreasure.MagicItemChance = 0;
+                    effectiveTreasure.MundaneItemChance = 0;
+                }
+
+                List<WorldObject> items = LootGenerationFactory.CreateRandomLootObjects(effectiveTreasure);
+
+                // Structured loot set: blank weapons + per-slot gear
+                // (items join the normal per-item mutation/corpse pipeline below).
+                //
+                // This is the DEFAULT for tier-11+ profiles and does not depend on Zone Control --
+                // those profiles carry zero item chances of their own, so without this they drop
+                // nothing. Every slot has its own count (default 1 at tier 11+, 0 below); a zone
+                // profile overrides individual slots via the loot_slot_* stats. There is no
+                // separate enable flag: a slot at 0 is off, and a zone can turn any slot on below
+                // tier 11 by giving it a count.
+                var slotCounts = LootGenerationFactory.ZoneLootSetCounts.TierDefault(effectiveTreasure.Tier);
+
+                if (zoneLoot != null)
+                {
+                    // Per-slot count. The loot_slot_<slot> stat is the MIN; the optional
+                    // loot_slot_<slot>_max turns it into a RANGE rolled uniform-inclusive, per slot,
+                    // per kill (owner 2026-08-24: "1-2 Weapons, 3-5 Chest", independent per slot).
+                    // Max undefined - the default and the pre-2026-08-24 behaviour - is an exact count.
+                    // Reversed pairs auto-swap, matching every other min/max pair in the profile.
+                    int Slot(string stat, int tierDefault)
+                    {
+                        var lo = (int)Math.Round(zoneLoot.Get(stat, tierDefault));
+                        var maxStat = stat + "_max";
+                        if (!zoneLoot.Has(maxStat))
+                            return lo;
+                        var hi = (int)Math.Round(zoneLoot.Get(maxStat, lo));
+                        if (hi < lo)
+                            (lo, hi) = (hi, lo);
+                        return hi > lo ? ACE.Common.ThreadSafeRandom.Next(lo, hi) : lo;   // inclusive both ends
+                    }
+
+                    slotCounts.Weapons = Slot(ACE.Server.Managers.ZoneScaling.ZoneStat.LootSlotWeapons, slotCounts.Weapons);
+                    slotCounts.Helm = Slot(ACE.Server.Managers.ZoneScaling.ZoneStat.LootSlotHelm, slotCounts.Helm);
+                    slotCounts.Chest = Slot(ACE.Server.Managers.ZoneScaling.ZoneStat.LootSlotChest, slotCounts.Chest);
+                    slotCounts.Shoulder = Slot(ACE.Server.Managers.ZoneScaling.ZoneStat.LootSlotShoulder, slotCounts.Shoulder);
+                    slotCounts.Bracer = Slot(ACE.Server.Managers.ZoneScaling.ZoneStat.LootSlotBracer, slotCounts.Bracer);
+                    slotCounts.Glove = Slot(ACE.Server.Managers.ZoneScaling.ZoneStat.LootSlotGlove, slotCounts.Glove);
+                    slotCounts.Girth = Slot(ACE.Server.Managers.ZoneScaling.ZoneStat.LootSlotGirth, slotCounts.Girth);
+                    slotCounts.UpperLeg = Slot(ACE.Server.Managers.ZoneScaling.ZoneStat.LootSlotUpperLeg, slotCounts.UpperLeg);
+                    slotCounts.LowerLeg = Slot(ACE.Server.Managers.ZoneScaling.ZoneStat.LootSlotLowerLeg, slotCounts.LowerLeg);
+                    slotCounts.Boot = Slot(ACE.Server.Managers.ZoneScaling.ZoneStat.LootSlotBoot, slotCounts.Boot);
+                    slotCounts.Shield = Slot(ACE.Server.Managers.ZoneScaling.ZoneStat.LootSlotShield, slotCounts.Shield);
+                    slotCounts.Amulet = Slot(ACE.Server.Managers.ZoneScaling.ZoneStat.LootSlotAmulet, slotCounts.Amulet);
+                    slotCounts.Ring = Slot(ACE.Server.Managers.ZoneScaling.ZoneStat.LootSlotRing, slotCounts.Ring);
+                    slotCounts.Bracelet = Slot(ACE.Server.Managers.ZoneScaling.ZoneStat.LootSlotBracelet, slotCounts.Bracelet);
+                    slotCounts.Trinket = Slot(ACE.Server.Managers.ZoneScaling.ZoneStat.LootSlotTrinket, slotCounts.Trinket);
+                    slotCounts.Cloak = Slot(ACE.Server.Managers.ZoneScaling.ZoneStat.LootSlotCloak, slotCounts.Cloak);
+                }
+
+                // BUDGET MODE (owner 2026-08-24): defining loot_max_drops switches from "every slot
+                // drops its own count" to "roll this many ITEMS total, distributed by category weight".
+                // The loot_slot_* values then mean WEIGHT WITHIN CATEGORY rather than count, and the
+                // budget is a CEILING - armor coverage credit can land the corpse under it. Slot
+                // specials below are deliberately OUTSIDE the budget. Unset = legacy, unchanged.
+                if (zoneLoot != null && zoneLoot.Has(ACE.Server.Managers.ZoneScaling.ZoneStat.LootDropsMin))
+                {
+                    var budgetLo = (int)Math.Round(zoneLoot.Get(ACE.Server.Managers.ZoneScaling.ZoneStat.LootDropsMin, 0.0));
+                    var budgetHi = budgetLo;
+                    if (zoneLoot.Has(ACE.Server.Managers.ZoneScaling.ZoneStat.LootDropsMax))
+                        budgetHi = (int)Math.Round(zoneLoot.Get(ACE.Server.Managers.ZoneScaling.ZoneStat.LootDropsMax, budgetLo));
+                    if (budgetHi < budgetLo)
+                        (budgetLo, budgetHi) = (budgetHi, budgetLo);
+                    var budget = budgetHi > budgetLo ? ACE.Common.ThreadSafeRandom.Next(budgetLo, budgetHi) : budgetLo;
+
+                    // A corpse holds 120 items (Corpse.cs:60-61) and TryAddToInventory's result is
+                    // DISCARDED at the fill sites below - so anything past 120 is silently destroyed,
+                    // not dropped to the ground and not logged. Clamp here rather than trust authoring.
+                    budget = Math.Min(budget, ZoneCorpseItemCap);
+
+                    slotCounts = LootGenerationFactory.RollBudgetedCounts(
+                        slotCounts, budget,
+                        zoneLoot.Get(ACE.Server.Managers.ZoneScaling.ZoneStat.LootWeightWeapon, 1.0),
+                        zoneLoot.Get(ACE.Server.Managers.ZoneScaling.ZoneStat.LootWeightArmor, 1.0),
+                        zoneLoot.Get(ACE.Server.Managers.ZoneScaling.ZoneStat.LootWeightJewelry, 1.0),
+                        zoneLoot.Get(ACE.Server.Managers.ZoneScaling.ZoneStat.LootWeightCloak, 1.0));
+                }
+
+                if (slotCounts.Any)
+                    items.AddRange(LootGenerationFactory.CreateZoneLootSet(effectiveTreasure, slotCounts));
+
+                // Armor v2 slot special (owner 2026-08-21): ONE roll per KILL, retail-rare model
+                // (1 in special_odds; IsZcBoss divides by special_boss_mult, IsZcLeader by
+                // special_leader_mult). On a hit pick one launch special at random and stamp the
+                // dropped piece of its slot (spawn one if the set has none). That piece becomes a
+                // PERFECT piece: core four + every line at band MAX (forceMax below). The flag is a
+                // LOCAL, never a prop - a 50200+ marker would be summed into the worn cache.
+                WorldObject specialPiece = null;
+                ACE.Server.Managers.ZoneControl.ZoneModifiers.Def specialDef = null;
+                // Zone Control off: no slot special is rolled at all (owner 2026-08-23) - the fallback
+                // is T10 max-rolled gear, which has no such thing.
+                if (zoneLoot != null && ServerConfig.zonecontrol_enabled.Value
+                    && effectiveTreasure.Tier >= LootGenerationFactory.ZoneLootSetMinTier)
+                {
+                    // special_odds is ABSOLUTE per rank since 2026-09-02 (owner D4): the profile is the
+                    // mob's rank chain, so a Boss reads the Boss row's own denominator. The old
+                    // special_boss_mult / special_leader_mult divisors were folded into those rows
+                    // by the migration SQL (151,200 / 3 and / 2 at T11).
+                    var odds = zoneLoot.Get(ACE.Server.Managers.ZoneScaling.ZoneStat.SpecialOdds, 750000.0);
+                    var denom = Math.Max(1, (int)Math.Round(odds));
+
+                    if (ACE.Common.ThreadSafeRandom.Next(1, denom) == 1)
+                    {
+                        var specials = ACE.Server.Managers.ZoneControl.ZoneModifiers.SlotSpecials();
+                        // per-special on/off (owner 2026-08-23): a special turned off at this scope never rolls;
+                        // the odds are unchanged, the remaining specials share the hit
+                        specials.RemoveAll(d => !zoneLoot.SpecialEnabled(d.Key));
+                        if (specials.Count > 0)
+                        {
+                            specialDef = specials[ACE.Common.ThreadSafeRandom.Next(0, specials.Count - 1)];
+                            // the special's home slot: the zone / Default override when authored (`cantrip <scope>
+                            // slots <key> helm|...|cloak`, owner 2026-08-22), else the catalog's SpecialSlot
+                            var slotId = ACE.Server.Managers.ZoneControl.ZoneModifiers.EffectiveSpecialSlot(specialDef, zoneLoot.ModifierSlots);
+                            specialPiece = items.FirstOrDefault(i => ACE.Server.Managers.ZoneControl.ZoneModifiers.SpecialPieceMatches(i, slotId));
+                            if (specialPiece == null)
+                            {
+                                // the set rolled no piece for that slot (zone turned it off) - spawn exactly one
+                                var one = new LootGenerationFactory.ZoneLootSetCounts();
+                                switch (slotId)
+                                {
+                                    case ACE.Server.Managers.ZoneControl.ZoneModifiers.SpecialSlotId.Helm: one.Helm = 1; break;
+                                    case ACE.Server.Managers.ZoneControl.ZoneModifiers.SpecialSlotId.Chest: one.Chest = 1; break;
+                                    case ACE.Server.Managers.ZoneControl.ZoneModifiers.SpecialSlotId.Shoulders: one.Shoulder = 1; break;
+                                    case ACE.Server.Managers.ZoneControl.ZoneModifiers.SpecialSlotId.Bracers: one.Bracer = 1; break;
+                                    case ACE.Server.Managers.ZoneControl.ZoneModifiers.SpecialSlotId.Gauntlets: one.Glove = 1; break;
+                                    case ACE.Server.Managers.ZoneControl.ZoneModifiers.SpecialSlotId.Girth: one.Girth = 1; break;
+                                    case ACE.Server.Managers.ZoneControl.ZoneModifiers.SpecialSlotId.Tassets: one.UpperLeg = 1; break;
+                                    case ACE.Server.Managers.ZoneControl.ZoneModifiers.SpecialSlotId.Greaves: one.LowerLeg = 1; break;
+                                    case ACE.Server.Managers.ZoneControl.ZoneModifiers.SpecialSlotId.Boots: one.Boot = 1; break;
+                                    case ACE.Server.Managers.ZoneControl.ZoneModifiers.SpecialSlotId.Shield: one.Shield = 1; break;
+                                    case ACE.Server.Managers.ZoneControl.ZoneModifiers.SpecialSlotId.Neck: one.Amulet = 1; break;
+                                    case ACE.Server.Managers.ZoneControl.ZoneModifiers.SpecialSlotId.Trinket: one.Trinket = 1; break;
+                                    case ACE.Server.Managers.ZoneControl.ZoneModifiers.SpecialSlotId.Ring: one.Ring = 1; break;
+                                    case ACE.Server.Managers.ZoneControl.ZoneModifiers.SpecialSlotId.Bracelet: one.Bracelet = 1; break;
+                                    case ACE.Server.Managers.ZoneControl.ZoneModifiers.SpecialSlotId.Cloak: one.Cloak = 1; break;
+                                    default: one.Chest = 1; break;
+                                }
+                                var spawned = LootGenerationFactory.CreateZoneLootSet(effectiveTreasure, one);
+                                specialPiece = spawned.FirstOrDefault(i => ACE.Server.Managers.ZoneControl.ZoneModifiers.SpecialPieceMatches(i, slotId));
+                                items.AddRange(spawned);
+                            }
+
+                            if (specialPiece != null)
+                                log.Info($"[ZONELOOT] SLOT SPECIAL: {killer?.Name ?? "(unknown)"} killed {Name} ({WeenieClassId}) -> {specialDef.Name} (key {specialDef.Key}, {slotId}) on {specialPiece.Name}, odds 1 in {denom}");
+                            else
+                            {
+                                log.Warn($"[ZONELOOT] SLOT SPECIAL won by {killer?.Name ?? "(unknown)"} on {Name} ({WeenieClassId}) but no {slotId} piece could be found or spawned");
+                                specialDef = null;
+                            }
+                        }
+                    }
+                }
+
+                // Corpse display order (owner 2026-07-20): casters, missiles, UA, sword, other
+                // melee, then armor/shields/jewelry/cloaks. The client's loot window shows items
+                // in REVERSE insertion order, so insert in exact reverse of the desired display
+                // (stable sort + Reverse keeps within-group generation order correct on screen).
+                // Quest/create-list items are added AFTER treasure (below) so they display first.
+                if (effectiveTreasure.Tier >= LootGenerationFactory.ZoneLootSetMinTier)
+                    items = items.OrderBy(LootGenerationFactory.GetZoneLootDisplayOrder).Reverse().ToList();
+
                 foreach (WorldObject wo in items)
                 {
                     if (tier > 0)
                         PrestigeManager.ApplyLootScaling(wo, tier);
+
+                    // T11+ deterministic per-slot gear budget (fixed base; cantrips carry the
+                    // variance). BEFORE MutateLootItem so the cantrip
+                    // stamps layer ON TOP of it rather than being clobbered.
+                    var isSpecial = specialPiece != null && ReferenceEquals(wo, specialPiece);
+                    if (effectiveTreasure.Tier >= LootGenerationFactory.ZoneLootSetMinTier)
+                        LootGenerationFactory.ApplyT11GearStats(wo, effectiveTreasure.Tier, forceMax: isSpecial, p: zoneLoot);
+
+                    // Zone Control loot: post-roll per-item mutations (weapon stats, AL, workmanship, coins,
+                    // value, and the low-chance special-property rolls)
+                    ACE.Server.Managers.ZoneControl.ZoneLootMutator.MutateLootItem(wo, zoneLoot, this, effectiveTreasure.Tier, forceMax: isSpecial);
+
+                    // the slot special itself (Armor v2): rolled in ITS band (zone override wins), stamped
+                    // after the lines so it reads last among the "Zone Cantrip:" lines
+                    if (isSpecial && specialDef != null)
+                    {
+                        var (sMin, sMax) = zoneLoot.ModifierBands.TryGetValue(specialDef.Key, out var sBand)
+                            ? (sBand.Min, sBand.Max) : ACE.Server.Managers.ZoneControl.ZoneModifiers.CatalogBandAt(specialDef, effectiveTreasure.Tier);
+                        if (sMin > sMax) (sMin, sMax) = (sMax, sMin);
+                        // specials join the grade model (owner 2026-08-22): graded roll, recorded in ZcModifiers
+                        var sGrade = ACE.Server.Managers.ZoneControl.ZoneStatResolver.RollGrade(effectiveTreasure.Tier, false);
+                        ACE.Server.Managers.ZoneControl.ZoneModifiers.StampGraded(wo, specialDef, sGrade, (sMin, sMax));
+                    }
+
+                    // Tier 11+ presentation sweep. Runs LAST so it also covers values that came
+                    // from the base weenie or any mutation above.
+                    if (effectiveTreasure.Tier >= LootGenerationFactory.ZoneLootSetMinTier)
+                    {
+                        // ALL inherited wield reqs removed, replaced by the per-tier item-aug gate
+                        LootGenerationFactory.StripWieldRequirements(wo);
+                        LootGenerationFactory.ApplyT11WieldRequirement(wo, effectiveTreasure.Tier);
+
+                        // Weapon aug-scaling identity: quality roll + tier (weapons/casters only)
+                        LootGenerationFactory.ApplyWeaponAugScaleStamp(wo, effectiveTreasure.Tier);
+
+                        // one uniform resist value across all eight elements. Pass the tier AND the
+                        // zone profile: without the profile the armor_prot_equalize switch resolves
+                        // from the tier Default only, so a ZONE-level override would be silently
+                        // ignored on this path while working everywhere else.
+                        LootGenerationFactory.EqualizeT11ArmorResists(wo, effectiveTreasure.Tier, zoneLoot);
+
+                        // description cleanup LAST: drop inherited weenie flavor text, keep our
+                        // lines in order, provenance ("Dropped by") to the very bottom
+                        LootGenerationFactory.FinalizeT11LongDesc(wo);
+
+                        // Live stat resolution self-check: the record must resolve to exactly what
+                        // was stamped (grades are the truth, props the cache). Cheap, once per piece.
+                        VerifyLiveStatCache(wo);
+
+                        // NOTE (owner 2026-07-21): the server-composed info block / full panel
+                        // takeover was REVERTED -- the client renders its stock examine panel.
+                        // A future pass will APPEND extra lines to the bottom (LongDesc renders
+                        // last) without touching the default layout.
+
+                        // "T11 - [base name]" (material cleared -- the client would prefix it)
+                        LootGenerationFactory.ApplyT11NamePrefix(wo);
+
+                        // name tinted by damage element (trial 2026-07-20, may revert)
+                        LootGenerationFactory.ApplyT11ElementTint(wo);
+                    }
 
                     if (corpse != null)
                         corpse.TryAddToInventory(wo);
                     else
                         droppedItems.Add(wo);
 
-                    DoCantripLogging(killer, wo);
+                    DoModifierLogging(killer, wo);
                 }
             }
 
@@ -954,8 +1245,32 @@ namespace ACE.Server.WorldObjects
                     droppedItems.Add(item);
             }
 
-            // contain and non-wielded treasure create
-            if (Biota.PropertiesCreateList != null)
+            // contain and non-wielded treasure create (create-list: quest drops etc.)
+            // Runs LAST: the client's loot window displays in reverse insertion order, so the
+            // last-inserted quest/special items show FIRST (owner loot-order decision 2026-07-20).
+            //
+            // ZONE LOOT FLOOR SUPPRESSES CARRIED INVENTORY, OPT-IN PER MONSTER (owner 2026-09-01).
+            // Inside a governed v11+ zone a monster drops THAT VARIATION'S SET and nothing else. The
+            // three retail roll groups are already zeroed where the floor is applied above, but that
+            // only covers ROLLED treasure - create-list Contain items never pass through
+            // CreateRandomLootObjects at all, so they kept landing on the corpse. Found on retail wcid
+            // 4124 (Lich Overseer), which carries three Focusing Stones and tipped all three into a T12
+            // corpse alongside the zone set.
+            //
+            // NOT a blanket rule, because quest mobs deliver their quest item through exactly this
+            // channel (owner: none do today, but they will). drop_carried_inventory authored above 0 -
+            // normally on that ONE monster's per-WCID bucket - lets it hand over what it carries. So the
+            // default is "drop the zone set only" and a quest drop is one authored stat away, instead of
+            // the quest silently delivering nothing on the day it is built.
+            //
+            // Scope is deliberately narrow. This block takes Contain, and Treasure-without-Wield; the
+            // WIELDED gear above is a separate path with its own creatures_drop_createlist_wield config
+            // and is untouched - which matters because every custom T11 monster authors its kit as
+            // DestinationType.Wield (its look), and NONE of them use Contain.
+            var carriedAllowed = zoneFloorTier <= 0
+                || (zoneLoot != null && zoneLoot.Get(ACE.Server.Managers.ZoneScaling.ZoneStat.DropCarriedInventory, 0.0) > 0.0);
+
+            if (Biota.PropertiesCreateList != null && carriedAllowed)
             {
                 var createList = Biota.PropertiesCreateList.Where(i => (i.DestinationType & DestinationType.Contain) != 0 ||
                                 (i.DestinationType & DestinationType.Treasure) != 0 && (i.DestinationType & DestinationType.Wield) == 0).ToList();
@@ -979,9 +1294,131 @@ namespace ACE.Server.WorldObjects
                 }
             }
 
-
+            // Zone Scaler: inject the custom bonus-currency token (independent of the loot table).
+            InjectZoneBonusCurrency(zoneLoot, killer, corpse, droppedItems);
 
             return droppedItems;
+        }
+
+        /// <summary>
+        /// Shallow field-copy of a TreasureDeath profile so per-kill scaling (zone / QB) can mutate a clone
+        /// without touching the shared cached row. Keep the field list in sync with TreasureDeath's columns.
+        /// </summary>
+        /// <summary>Hard ceiling on a budgeted drop set: a Corpse declares ItemCapacity 120
+        /// (Corpse.cs:61), and every corpse.TryAddToInventory call here ignores its return value, so
+        /// an item that will not fit is silently lost. Kept below the real cap so quest tokens,
+        /// currency and slot specials - all added OUTSIDE the budget - still have room.</summary>
+        private const int ZoneCorpseItemCap = 100;
+
+        private static ACE.Database.Models.World.TreasureDeath CloneTreasureDeath(ACE.Database.Models.World.TreasureDeath src)
+        {
+            return new ACE.Database.Models.World.TreasureDeath
+            {
+                Id = src.Id,
+                TreasureType = src.TreasureType,
+                Tier = src.Tier,
+                LootQualityMod = src.LootQualityMod,
+                UnknownChances = src.UnknownChances,
+                ItemChance = src.ItemChance,
+                ItemMinAmount = src.ItemMinAmount,
+                ItemMaxAmount = src.ItemMaxAmount,
+                ItemTreasureTypeSelectionChances = src.ItemTreasureTypeSelectionChances,
+                MagicItemChance = src.MagicItemChance,
+                MagicItemMinAmount = src.MagicItemMinAmount,
+                MagicItemMaxAmount = src.MagicItemMaxAmount,
+                MagicItemTreasureTypeSelectionChances = src.MagicItemTreasureTypeSelectionChances,
+                MundaneItemChance = src.MundaneItemChance,
+                MundaneItemMinAmount = src.MundaneItemMinAmount,
+                MundaneItemMaxAmount = src.MundaneItemMaxAmount,
+                MundaneItemTypeSelectionChances = src.MundaneItemTypeSelectionChances,
+                LastModified = src.LastModified,
+            };
+        }
+
+        /// <summary>
+        /// Zone Scaler: injects bonus currency onto the corpse/drop list. Two independent sources, both
+        /// loot-table independent: the legacy single-token bonus_currency stat (server-wide token wcid from
+        /// zonescale_bonus_currency_wcid) and the zone's per-entry currency drop table (each entry = its own
+        /// item wcid + stack amount + per-kill chance).
+        /// </summary>
+        private void InjectZoneBonusCurrency(ACE.Server.Managers.ZoneScaling.EvaluatedProfile profile, DamageHistoryInfo killer, Corpse corpse, List<WorldObject> dropped)
+        {
+            if (profile == null)
+                return;
+
+            if (profile.Has(ACE.Server.Managers.ZoneScaling.ZoneStat.BonusCurrency))
+            {
+                var amount = (int)Math.Round(profile.Get(ACE.Server.Managers.ZoneScaling.ZoneStat.BonusCurrency));
+                var wcid = (uint)ServerConfig.zonescale_bonus_currency_wcid.Value;
+                if (amount > 0 && wcid != 0)
+                    SpawnZoneCurrency(wcid, amount, corpse, dropped);
+            }
+
+            if (profile.CurrencyDrops != null)
+            {
+                foreach (var drop in profile.CurrencyDrops)
+                {
+                    if (drop == null || drop.Wcid == 0 || drop.Amount <= 0)
+                        continue;
+                    if (drop.Chance < 1.0 && ACE.Common.ThreadSafeRandom.Next(0.0f, 1.0f) >= drop.Chance)
+                        continue;
+
+                    if (drop.Direct && TryGiveZoneCurrencyToKiller(killer, drop.Wcid, drop.Amount))
+                        continue;
+
+                    SpawnZoneCurrency(drop.Wcid, drop.Amount, corpse, dropped);
+                }
+            }
+        }
+
+        private static WorldObject CreateZoneCurrencyToken(uint wcid, int amount)
+        {
+            var token = WorldObjectFactory.CreateNewWorldObject(wcid);
+            if (token == null)
+                return null;
+
+            if (token.MaxStackSize.HasValue && amount > 1)
+                token.SetStackSize(Math.Min(amount, token.MaxStackSize.Value));
+
+            return token;
+        }
+
+        private static void SpawnZoneCurrency(uint wcid, int amount, Corpse corpse, List<WorldObject> dropped)
+        {
+            var token = CreateZoneCurrencyToken(wcid, amount);
+            if (token == null)
+                return;
+
+            if (corpse != null)
+                corpse.TryAddToInventory(token);
+            else
+                dropped.Add(token);
+        }
+
+        /// <summary>Direct-delivery currency drop: straight into the killing player's inventory with a chat
+        /// message. Returns false (caller falls back to the corpse) when the killer isn't a player, the
+        /// token can't be created, or their inventory is full.</summary>
+        private static bool TryGiveZoneCurrencyToKiller(DamageHistoryInfo killer, uint wcid, int amount)
+        {
+            var player = killer?.TryGetPetOwnerOrAttacker() as Player;
+            if (player == null || player.Session == null)
+                return false;
+
+            var token = CreateZoneCurrencyToken(wcid, amount);
+            if (token == null)
+                return false;
+
+            if (!player.TryCreateInInventoryWithNetworking(token))
+            {
+                token.Destroy();
+                return false;
+            }
+
+            var qty = token.StackSize ?? 1;
+            var name = qty > 1 ? token.GetPluralName() : token.Name;
+            player.Session.Network.EnqueueSend(
+                new GameMessageSystemChat($"You receive {qty:N0} {name} from the kill!", ChatMessageType.Broadcast));
+            return true;
         }
 
         /// <summary>
@@ -999,7 +1436,55 @@ namespace ACE.Server.WorldObjects
             corpse.TryAddToInventory(slag);
         }
 
-        public void DoCantripLogging(DamageHistoryInfo killer, WorldObject wo)
+        /// <summary>
+        /// Debug assertion for live stat resolution (2026-08-22): ZoneStatResolver.Compute(wo) must equal the
+        /// props the producers stamped. Any difference means a producer bypassed the record, a zone override
+        /// (core anchor) diverged from the tier Default layer the resolver
+        /// reads, or a later mutation touched a ZC-owned prop. Warn only - never alters the drop.
+        /// </summary>
+        private static void VerifyLiveStatCache(WorldObject wo)
+        {
+            try
+            {
+                var r = ACE.Server.Managers.ZoneControl.ZoneStatResolver.Compute(wo);
+                if (r == null)
+                    return;
+                var diffs = new List<string>();
+                foreach (var kv in r.Ints)
+                {
+                    var cur = wo.GetProperty(kv.Key);
+                    if (cur != kv.Value)
+                        diffs.Add($"{kv.Key} item={(cur.HasValue ? cur.Value.ToString() : "null")} resolved={kv.Value}");
+                }
+                // WEAPON half (2026-08-25): every continuous weapon card is a PropertyFloat, so the
+                // same assertion has to walk r.Floats or the whole weapon lane would go unchecked.
+                //
+                // EPSILON, unlike the ints above: these are doubles produced by band interpolation, and
+                // the drop path and the resolve path reach the number by slightly different routes (the
+                // drop path clamps a freshly interpolated value; the resolve path re-interpolates from
+                // the stored grade). Bit-exact equality would make this warn on last-place noise and
+                // train everyone to ignore it. 1e-9 is far below the second decimal that any of these
+                // cards is designed in, so a REAL divergence - a producer bypassing the record, a
+                // Crushing Blow "- 1.0" applied twice, a zone band diverging from the tier Default the
+                // resolver reads - is still caught loudly.
+                foreach (var kv in r.Floats)
+                {
+                    var cur = wo.GetProperty(kv.Key);
+                    if (!cur.HasValue || Math.Abs(cur.Value - kv.Value) > 1e-9)
+                        diffs.Add($"{kv.Key} item={(cur.HasValue ? cur.Value.ToString(System.Globalization.CultureInfo.InvariantCulture) : "null")} resolved={kv.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)}");
+                }
+                if (r.ArmorLevel.HasValue && wo.ArmorLevel != r.ArmorLevel.Value)
+                    diffs.Add($"ArmorLevel item={(wo.ArmorLevel.HasValue ? wo.ArmorLevel.Value.ToString() : "null")} resolved={r.ArmorLevel.Value}");
+                if (diffs.Count > 0)
+                    log.Warn($"[ZONELOOT] LIVESTAT MISMATCH on {wo.Name} ({wo.WeenieClassId}, tier {r.Tier}, record \"{wo.GetProperty(PropertyString.ZcModifiers)}\"): {string.Join(", ", diffs)}");
+            }
+            catch (Exception ex)
+            {
+                log.Warn($"[ZONELOOT] LIVESTAT self-check threw on {wo?.Name}: {ex.Message}");
+            }
+        }
+
+        public void DoModifierLogging(DamageHistoryInfo killer, WorldObject wo)
         {
             var epicCantrips = wo.EpicCantrips;
             var legendaryCantrips = wo.LegendaryCantrips;

--- a/Source/ACE.Server/WorldObjects/Creature_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Death.cs
@@ -1413,6 +1413,8 @@ namespace ACE.Server.WorldObjects
                     dropped.Add(token);
                 remaining -= stack;
             }
+            if (remaining > 0)
+                log.Warn($"[ZoneLoot] currency {wcid}: {remaining} of {amount} could not be spawned within 64 stacks - the authored amount is too large.");
         }
 
         /// <summary>Direct-delivery currency drop: straight into the killing player's inventory with a chat

--- a/Source/ACE.Server/WorldObjects/Creature_Equipment.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Equipment.cs
@@ -37,7 +37,12 @@ namespace ACE.Server.WorldObjects
                 var worldObject = WorldObjectFactory.CreateWorldObject(biota);
                 EquippedObjects[worldObject.Guid] = worldObject;
 
+                // live stat resolution: a piece whose tier ladder moved since it was last resolved
+                // re-stamps its cache BEFORE the rating / cantrip caches read it (login path)
+                ACE.Server.Managers.ZoneControl.ZoneStatResolver.ApplyIfStale(worldObject);
+
                 AddItemToEquippedItemsRatingCache(worldObject);
+                UpdateZoneModifierCache(worldObject, +1);
 
                 EncumbranceVal += (worldObject.EncumbranceVal ?? 0);
             }
@@ -212,40 +217,64 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         private Dictionary<PropertyInt, int> equippedItemsRatingCache;
 
+        /// <summary>The ZC-ITEM PORTION of equippedItemsRatingCache (owner 2026-08-30, the armor
+        /// zone lock): every value a ZcTier 11+ item contributed, maintained by the same
+        /// add/remove pair so the two can never drift. When the lock suppresses this wearer,
+        /// reads return total minus this - retail cloaks/aetheria keep contributing, ZC lines go
+        /// dormant. Null until the first ZC rated item is worn.</summary>
+        private Dictionary<PropertyInt, int> equippedItemsZcRatingCache;
+
+        private static readonly PropertyInt[] RatingCacheProps =
+        {
+            PropertyInt.GearDamage, PropertyInt.GearDamageResist, PropertyInt.GearCritDamage,
+            PropertyInt.GearCritDamageResist, PropertyInt.GearHealingBoost, PropertyInt.GearMaxHealth,
+            PropertyInt.GearPKDamageRating, PropertyInt.GearPKDamageResistRating, PropertyInt.GearCrit,
+            PropertyInt.GearCritResist, PropertyInt.GearNetherResist,
+        };
+
+        private static int RatingOf(WorldObject wo, PropertyInt rating)
+            => rating switch
+            {
+                PropertyInt.GearDamage => wo.GearDamage ?? 0,
+                PropertyInt.GearDamageResist => wo.GearDamageResist ?? 0,
+                PropertyInt.GearCritDamage => wo.GearCritDamage ?? 0,
+                PropertyInt.GearCritDamageResist => wo.GearCritDamageResist ?? 0,
+                PropertyInt.GearHealingBoost => wo.GearHealingBoost ?? 0,
+                PropertyInt.GearMaxHealth => wo.GearMaxHealth ?? 0,
+                PropertyInt.GearPKDamageRating => wo.GearPKDamageRating ?? 0,
+                PropertyInt.GearPKDamageResistRating => wo.GearPKDamageResistRating ?? 0,
+                PropertyInt.GearCrit => wo.GearCrit ?? 0,
+                PropertyInt.GearCritResist => wo.GearCritResist ?? 0,
+                PropertyInt.GearNetherResist => wo.GearNetherResistRating ?? 0,
+                _ => 0,
+            };
+
+        private static Dictionary<PropertyInt, int> NewRatingCache()
+        {
+            var cache = new Dictionary<PropertyInt, int>();
+            foreach (var p in RatingCacheProps)
+                cache[p] = 0;
+            return cache;
+        }
+
         private void AddItemToEquippedItemsRatingCache(WorldObject wo)
         {
-            if ((wo.GearDamage ?? 0) == 0 && (wo.GearDamageResist ?? 0) == 0 && (wo.GearCritDamage ?? 0) == 0 && (wo.GearCritDamageResist ?? 0) == 0 && (wo.GearHealingBoost ?? 0) == 0 && (wo.GearMaxHealth ?? 0) == 0 && (wo.GearPKDamageRating ?? 0) == 0 && (wo.GearPKDamageResistRating ?? 0) == 0 && (wo.GearCrit ?? 0) == 0 && (wo.GearCritResist ?? 0) == 0 && (wo.GearNetherResistRating ?? 0) == 0)
+            var any = false;
+            foreach (var p in RatingCacheProps)
+                if (RatingOf(wo, p) != 0) { any = true; break; }
+            if (!any)
                 return;
 
-            if (equippedItemsRatingCache == null)
-            {
-                equippedItemsRatingCache = new Dictionary<PropertyInt, int>
-                {
-                    { PropertyInt.GearDamage, 0 },
-                    { PropertyInt.GearDamageResist, 0 },
-                    { PropertyInt.GearCritDamage, 0 },
-                    { PropertyInt.GearCritDamageResist, 0 },
-                    { PropertyInt.GearHealingBoost, 0 },
-                    { PropertyInt.GearMaxHealth, 0 },
-                    { PropertyInt.GearPKDamageRating, 0 },
-                    { PropertyInt.GearPKDamageResistRating, 0 },
-                    { PropertyInt.GearCrit, 0 },
-                    { PropertyInt.GearCritResist, 0 },
-                    { PropertyInt.GearNetherResist, 0 }
-                };
-            }
+            equippedItemsRatingCache ??= NewRatingCache();
+            foreach (var p in RatingCacheProps)
+                equippedItemsRatingCache[p] += RatingOf(wo, p);
 
-            equippedItemsRatingCache[PropertyInt.GearDamage] += (wo.GearDamage ?? 0);
-            equippedItemsRatingCache[PropertyInt.GearDamageResist] += (wo.GearDamageResist ?? 0);
-            equippedItemsRatingCache[PropertyInt.GearCritDamage] += (wo.GearCritDamage ?? 0);
-            equippedItemsRatingCache[PropertyInt.GearCritDamageResist] += (wo.GearCritDamageResist ?? 0);
-            equippedItemsRatingCache[PropertyInt.GearHealingBoost] += (wo.GearHealingBoost ?? 0);
-            equippedItemsRatingCache[PropertyInt.GearMaxHealth] += (wo.GearMaxHealth ?? 0);
-            equippedItemsRatingCache[PropertyInt.GearPKDamageRating] += (wo.GearPKDamageRating ?? 0);
-            equippedItemsRatingCache[PropertyInt.GearPKDamageResistRating] += (wo.GearPKDamageResistRating ?? 0);
-            equippedItemsRatingCache[PropertyInt.GearCrit] += (wo.GearCrit ?? 0);
-            equippedItemsRatingCache[PropertyInt.GearCritResist] += (wo.GearCritResist ?? 0);
-            equippedItemsRatingCache[PropertyInt.GearNetherResist] += (wo.GearNetherResistRating ?? 0);
+            if (ACE.Server.Managers.ZoneControl.ZoneControlManager.IsZcGear(wo))
+            {
+                equippedItemsZcRatingCache ??= NewRatingCache();
+                foreach (var p in RatingCacheProps)
+                    equippedItemsZcRatingCache[p] += RatingOf(wo, p);
+            }
         }
 
         private void RemoveItemFromEquippedItemsRatingCache(WorldObject wo)
@@ -253,17 +282,195 @@ namespace ACE.Server.WorldObjects
             if (equippedItemsRatingCache == null)
                 return;
 
-            equippedItemsRatingCache[PropertyInt.GearDamage] -= (wo.GearDamage ?? 0);
-            equippedItemsRatingCache[PropertyInt.GearDamageResist] -= (wo.GearDamageResist ?? 0);
-            equippedItemsRatingCache[PropertyInt.GearCritDamage] -= (wo.GearCritDamage ?? 0);
-            equippedItemsRatingCache[PropertyInt.GearCritDamageResist] -= (wo.GearCritDamageResist ?? 0);
-            equippedItemsRatingCache[PropertyInt.GearHealingBoost] -= (wo.GearHealingBoost ?? 0);
-            equippedItemsRatingCache[PropertyInt.GearMaxHealth] -= (wo.GearMaxHealth ?? 0);
-            equippedItemsRatingCache[PropertyInt.GearPKDamageRating] -= (wo.GearPKDamageRating ?? 0);
-            equippedItemsRatingCache[PropertyInt.GearPKDamageResistRating] -= (wo.GearPKDamageResistRating ?? 0);
-            equippedItemsRatingCache[PropertyInt.GearCrit] -= (wo.GearCrit ?? 0);
-            equippedItemsRatingCache[PropertyInt.GearCritResist] -= (wo.GearCritResist ?? 0);
-            equippedItemsRatingCache[PropertyInt.GearNetherResist] -= (wo.GearNetherResistRating ?? 0);
+            foreach (var p in RatingCacheProps)
+                equippedItemsRatingCache[p] -= RatingOf(wo, p);
+
+            if (equippedItemsZcRatingCache != null && ACE.Server.Managers.ZoneControl.ZoneControlManager.IsZcGear(wo))
+                foreach (var p in RatingCacheProps)
+                    equippedItemsZcRatingCache[p] -= RatingOf(wo, p);
+        }
+
+        /// <summary>
+        /// Zone Control cantrip gear: per-creature sums of the custom cantrip props (block 50200-50399,
+        /// see ZoneModifiers) across equipped items. Maintained on equip/dequip alongside the rating cache;
+        /// null until the first cantripped item is worn, so non-cantrip creatures pay nothing.
+        /// </summary>
+        private Dictionary<int, int> zoneModifierCache;
+
+        /// <summary>Per-prop MAX across worn pieces - the slot specials' combine rule - maintained beside the
+        /// sum cache (review 2026-09-04): GetZoneModifierMax used to scan every equipped item under its biota
+        /// lock on each read, and CreatureVital.GetMaxValue reads it (Fortify Vitals) many times per hit.
+        /// Add = Math.Max; remove = recompute the touched keys from what is still worn (dequip is rare).</summary>
+        private Dictionary<int, int> zoneModifierMaxCache;
+
+        /// <summary>
+        /// Live stat resolution, `ladder apply` online path (owner 2026-08-23): re-resolve every WORN piece
+        /// whose tier ladder moved, keeping the rating + cantrip caches exact (subtract the old numbers,
+        /// re-stamp, add the new). Bounded by what this creature wears. Returns the number of pieces whose
+        /// values actually changed. Call from the World Manager thread (an ActionChain on the creature).
+        /// </summary>
+        public int ReresolveWornZoneGear()
+        {
+            var changed = 0;
+            foreach (var wo in EquippedObjects.Values)
+            {
+                if (!ACE.Server.Managers.ZoneControl.ZoneStatResolver.HasRecord(wo))
+                    continue;
+                RemoveItemFromEquippedItemsRatingCache(wo);
+                UpdateZoneModifierCache(wo, -1);
+                if (ACE.Server.Managers.ZoneControl.ZoneStatResolver.ApplyIfStale(wo))
+                    changed++;
+                AddItemToEquippedItemsRatingCache(wo);
+                UpdateZoneModifierCache(wo, +1);
+            }
+            return changed;
+        }
+
+        private void UpdateZoneModifierCache(WorldObject wo, int sign)
+        {
+            List<int> removedKeys = null;
+            wo.BiotaDatabaseLock.EnterReadLock();
+            try
+            {
+                if (wo.Biota.PropertiesInt == null)
+                    return;
+
+                foreach (var kv in wo.Biota.PropertiesInt)
+                {
+                    var id = (int)kv.Key;
+                    if (id < ACE.Server.Managers.ZoneControl.ZoneModifiers.PropMin || id > ACE.Server.Managers.ZoneControl.ZoneModifiers.PropMax)
+                        continue;
+
+                    zoneModifierCache ??= new Dictionary<int, int>();
+                    zoneModifierCache.TryGetValue(id, out var cur);
+                    zoneModifierCache[id] = cur + sign * kv.Value;
+
+                    if (sign > 0)
+                    {
+                        zoneModifierMaxCache ??= new Dictionary<int, int>();
+                        zoneModifierMaxCache.TryGetValue(id, out var curMax);
+                        if (kv.Value > curMax)
+                            zoneModifierMaxCache[id] = kv.Value;
+                    }
+                    else
+                        (removedKeys ??= new List<int>()).Add(id);
+                }
+            }
+            finally
+            {
+                wo.BiotaDatabaseLock.ExitReadLock();
+            }
+
+            // the departing piece may have been the max for a key: recompute those keys from what is still
+            // worn, EXCLUDING the piece itself (TryDequipObject has already removed it; ReresolveWornZoneGear
+            // has not, and re-adds it with its re-resolved values right after)
+            if (removedKeys != null)
+                RecomputeZoneModifierMax(removedKeys, wo);
+        }
+
+        private void RecomputeZoneModifierMax(List<int> propIds, WorldObject except)
+        {
+            if (zoneModifierMaxCache == null)
+                return;
+            foreach (var id in propIds)
+            {
+                var max = 0;
+                foreach (var item in EquippedObjects.Values)
+                {
+                    if (ReferenceEquals(item, except))
+                        continue;
+                    var v = item.GetProperty((PropertyInt)id) ?? 0;
+                    if (v > max)
+                        max = v;
+                }
+                zoneModifierMaxCache[id] = max;
+            }
+        }
+
+        /// <summary>
+        /// Sum of a Zone Control cantrip prop across this creature's equipped items, HARD-CAPPED for the
+        /// anchored SET lines (gear_cap_line): the six attributes (key 43), Max Stamina 20, Max Mana 21
+        /// and every aug track 34-40. The cache keeps the TRUE sum so dequip arithmetic stays exact; the
+        /// cap is applied here at read time only. Everything else in the block (skills, spell duration,
+        /// specials) is uncapped. Creature_Rating clamps the retail-prop lines (Dmg / CritDmg / MaxHP /
+        /// HealBoost) the same way on the rating cache.
+        /// </summary>
+        public int GetZoneModifierBonus(int propId)
+        {
+            if (zoneModifierCache == null)
+                return 0;
+            // armor zone lock: the whole 50200 block is ZC-line-only (retail items never carry
+            // these props), so outside authored areas the worn lines contribute nothing at all
+            if (ACE.Server.Managers.ZoneControl.ZoneControlManager.WornPowerSuppressed(this))
+                return 0;
+            if (!zoneModifierCache.TryGetValue(propId, out var v))
+                return 0;
+            if (v > 0 && IsGearCapLineProp(propId))
+                v = Math.Min(v, GetGearCap(ACE.Server.Managers.ZoneScaling.ZoneStat.GearCapLine, 2500));
+            return v;
+        }
+
+        /// <summary>The 50200-block props that are anchored SET lines and read under gear_cap_line.</summary>
+        private static bool IsGearCapLineProp(int propId)
+        {
+            const int attrLo = ACE.Server.Managers.ZoneControl.ZoneModifiers.AttrBonusBase + 1;     // 50201 Strength
+            const int attrHi = ACE.Server.Managers.ZoneControl.ZoneModifiers.AttrBonusBase + 6;     // 50206 Self
+            return propId >= attrLo && propId <= attrHi;
+        }
+
+        /// <summary>
+        /// Worn-gear hard cap knob (gear_cap_dr / gear_cap_cdr / gear_cap_line). Players read the zone
+        /// DEFAULT they stand in; no governing zone (or a monster) = the C# default, so the cap holds
+        /// everywhere and a zone only re-tunes it. Never below 0.
+        /// </summary>
+        public int GetGearCap(string capStat, int ladderCap)
+        {
+            // Zone Control off: the T10 fallback cap wins outright - no zone is consulted (owner 2026-08-23).
+            if (!ServerConfig.zonecontrol_enabled.Value)
+                return ACE.Server.Managers.ZoneControl.ZoneFallback.GearCap(capStat);
+            if (this is not Player player)
+                return ladderCap;
+            var zone = ACE.Server.Managers.ZoneControl.ZoneControlManager.ResolveZoneDefaultForPlayer(player);
+            if (zone == null || !zone.Has(capStat))
+                return ladderCap;
+            return Math.Max(0, (int)Math.Round(zone.Get(capStat, ladderCap)));
+        }
+
+        /// <summary>
+        /// <see cref="GetEquippedItemsRatingSum"/> clamped to a worn-gear cap. Owner 2026-08-21: a set
+        /// anchored at 2500 reads EXACTLY 2500, not 2502 (18 x 139 flat bands). Equipment term only -
+        /// enchantments / augs / enlightenment stack on top untouched in the rating getters.
+        /// The cap arguments are the LADDER ceilings (gear_cap_dr 2500, gear_cap_cdr 1500,
+        /// gear_cap_line 2500) - calibrated so a maxed T25 set lands EXACTLY on them. A zone that
+        /// authors gear_cap_* tightens them for its own content; with zonecontrol_enabled OFF the
+        /// T10 fallback set replaces them entirely (ZoneFallback).
+        /// </summary>
+        public int GetEquippedItemsRatingSumCapped(PropertyInt rating, string capStat, int defaultCap)
+        {
+            var sum = GetEquippedItemsRatingSum(rating);
+            if (sum <= 0)
+                return sum;
+            return Math.Min(sum, GetGearCap(capStat, defaultCap));
+        }
+
+        /// <summary>
+        /// MAX (not sum) of a Zone Control cantrip prop across this creature's equipped items — the
+        /// combine rule for the slot SPECIALS (Fortify 41, Battle Mending 42, pct-HP 44, Cheat Death 45,
+        /// Regen 46): the highest single piece wins, two pieces never stack. Read from the max cache
+        /// maintained on equip/dequip (review 2026-09-04) - O(1), no biota lock - so creatures wearing
+        /// nothing cantripped pay nothing. 0 when no equipped item carries the prop.
+        /// </summary>
+        public int GetZoneModifierMax(int propId)
+        {
+            if (zoneModifierMaxCache == null || !zoneModifierMaxCache.TryGetValue(propId, out var max) || max <= 0)
+                return 0;
+
+            // armor zone lock: the slot specials (Cheat Death, Battle Mending, Fortify, pct-HP,
+            // Regen) go dormant with the rest of the lines
+            if (ACE.Server.Managers.ZoneControl.ZoneControlManager.WornPowerSuppressed(this))
+                return 0;
+
+            return max;
         }
 
         public int GetEquippedItemsRatingSum(PropertyInt rating)
@@ -272,7 +479,15 @@ namespace ACE.Server.WorldObjects
                 return 0;
 
             if (equippedItemsRatingCache.TryGetValue(rating, out var value))
+            {
+                // armor zone lock: subtract exactly what the worn ZC pieces contributed - retail
+                // cloaks / aetheria keep counting, the ZC lines go dormant outside authored areas
+                if (value != 0 && equippedItemsZcRatingCache != null
+                    && ACE.Server.Managers.ZoneControl.ZoneControlManager.WornPowerSuppressed(this)
+                    && equippedItemsZcRatingCache.TryGetValue(rating, out var zcPortion))
+                    value -= zcPortion;
                 return value;
+            }
 
             log.Error($"Creature_Equipment.GetEquippedItemsRatingsSum() does not support {rating}");
             return 0;
@@ -327,7 +542,11 @@ namespace ACE.Server.WorldObjects
 
             EquippedObjects[worldObject.Guid] = worldObject;
 
+            // live stat resolution (plan §3): resolve-on-EQUIP, the only place the cache is re-stamped
+            ACE.Server.Managers.ZoneControl.ZoneStatResolver.ApplyIfStale(worldObject);
+
             AddItemToEquippedItemsRatingCache(worldObject);
+            UpdateZoneModifierCache(worldObject, +1);
 
             EncumbranceVal += (worldObject.EncumbranceVal ?? 0);
             Value += (worldObject.Value ?? 0);
@@ -387,6 +606,7 @@ namespace ACE.Server.WorldObjects
             }
 
             RemoveItemFromEquippedItemsRatingCache(worldObject);
+            UpdateZoneModifierCache(worldObject, -1);
 
             wieldedLocation = worldObject.CurrentWieldedLocation ?? EquipMask.None;
 

--- a/Source/ACE.Server/WorldObjects/Creature_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Magic.cs
@@ -178,6 +178,13 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public uint GetEffectiveMagicDefense()
         {
+            // Zone Scaler: an authored profile sets the monster's magic defense absolutely (null for players/exempt/
+            // non-endgame/no-match -> normal calc below).
+            var zoneMd = ACE.Server.Managers.ZoneControl.ZoneControlManager.ResolveForCreature(this);
+            if (zoneMd != null && zoneMd.Has(ACE.Server.Managers.ZoneScaling.ZoneStat.MagicDefense))
+                // floor at 0: a negative authored value would wrap through the uint cast to ~4B
+                return (uint)Math.Round(Math.Max(0.0, zoneMd.Get(ACE.Server.Managers.ZoneScaling.ZoneStat.MagicDefense)));
+
             var current = GetCreatureSkill(Skill.MagicDefense).Current;
             var lumAug = this.LuminanceAugmentMagicDefenseCount ?? 0;
             var weaponDefenseMod = GetWeaponMagicDefenseModifier(this);

--- a/Source/ACE.Server/WorldObjects/Creature_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Melee.cs
@@ -96,6 +96,10 @@ namespace ACE.Server.WorldObjects
 
             if (!weapon.IsCleaving) return null;
 
+            // zone lock: outside authored areas a ZC weapon's Cleave stamp reads as absent
+            if (ACE.Server.Managers.ZoneControl.ZoneControlManager.WeaponPowerSuppressed(weapon, this))
+                return null;
+
             // sort visible objects by ascending distance
             var visible = PhysicsObj.ObjMaint.GetVisibleObjectsValuesWhere(o => o.WeenieObj.WorldObject != null);
             visible.Sort(DistanceComparator);

--- a/Source/ACE.Server/WorldObjects/Creature_Missile.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Missile.cs
@@ -146,7 +146,8 @@ namespace ACE.Server.WorldObjects
             proj.EnqueueBroadcast(new GameMessageScript(proj.Guid, PlayScript.Launch, 0f));
 
             // Create split arrows if weapon has split property
-            if (weapon != null)
+            // (zone lock: outside authored areas a ZC launcher's Split Arrows stamp reads as absent)
+            if (weapon != null && !ACE.Server.Managers.ZoneControl.ZoneControlManager.WeaponPowerSuppressed(weapon, this))
             {
                 var hasSplitArrows = weapon.GetProperty(PropertyBool.SplitArrows);
                 if (hasSplitArrows == true)

--- a/Source/ACE.Server/WorldObjects/Creature_PercentHpDamage.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_PercentHpDamage.cs
@@ -128,6 +128,10 @@ namespace ACE.Server.WorldObjects
         /// player (1.0 = no relief, floor at (1-augCap)*(1-drCap) = never immune).
         /// </summary>
         public static double GetV11ReliefMultiplier(Creature attacker, Player defender)
+            => GetV11ReliefMultiplier(attacker, defender, ACE.Server.Managers.ZoneControl.ZoneControlManager.ResolveForCreature(attacker));
+
+        /// <summary>Same, with the attacker's zone profile already resolved by the caller (one resolve per hit).</summary>
+        public static double GetV11ReliefMultiplier(Creature attacker, Player defender, ACE.Server.Managers.ZoneScaling.EvaluatedProfile zp)
         {
             if (attacker == null || defender == null)
                 return 1.0;
@@ -138,7 +142,6 @@ namespace ACE.Server.WorldObjects
             // mob inherits the zone's curves unless it authors its own, and authoring relief_* on a
             // --wcid bucket (a boss that respects player DR less, say) now actually works instead of
             // being silently ignored while the sim and the display both claimed it did.
-            var zp = ACE.Server.Managers.ZoneControl.ZoneControlManager.ResolveForCreature(attacker);
 
             var augRelief = GetAxisRelief(zp, AugPointKeys, defender.LuminanceAugmentLifeCount ?? 0,
                 ReliefAnchor(zp, ACE.Server.Managers.ZoneScaling.ZoneStat.ReliefAugStart, ServerConfig.v11_relief_aug_start.Value),
@@ -161,12 +164,15 @@ namespace ACE.Server.WorldObjects
         /// (1.0 = full bonus; at the cap a 2x crit lands as 1.5x).
         /// </summary>
         public static double GetV11CritBonusRelief(Creature attacker, Player defender)
+            => GetV11CritBonusRelief(attacker, defender, ACE.Server.Managers.ZoneControl.ZoneControlManager.ResolveForCreature(attacker));
+
+        /// <summary>Same, with the attacker's zone profile already resolved by the caller (one resolve per hit).</summary>
+        public static double GetV11CritBonusRelief(Creature attacker, Player defender, ACE.Server.Managers.ZoneScaling.EvaluatedProfile zp)
         {
             if (attacker == null || defender == null)
                 return 1.0;
 
             // per-creature merged profile — same 2026-08-29 fix as GetV11ReliefMultiplier
-            var zp = ACE.Server.Managers.ZoneControl.ZoneControlManager.ResolveForCreature(attacker);
 
             var relief = GetAxisRelief(zp, CritDrPointKeys, defender.GetCritDamageResistRating(),
                 ReliefAnchor(zp, ACE.Server.Managers.ZoneScaling.ZoneStat.ReliefCritDrStart, ServerConfig.v11_relief_critdr_start.Value),
@@ -229,7 +235,7 @@ namespace ACE.Server.WorldObjects
             // v11+ relief curves (2026-07-27): linear life-aug + gear Damage-Resist reduction replaces
             // the old exponential aug-only curve (v11_pcthp_aug_threshold/reduction_r/reduction_cap and
             // the per-weenie PercentHpReduction*Override props retired - no longer read here).
-            var floor = p * maxHealth * GetV11ReliefMultiplier(attacker, defender);
+            var floor = p * maxHealth * GetV11ReliefMultiplier(attacker, defender, zoneProfile);
 
             // Crit multiplies the floor too — otherwise it vanishes once the floor dominates
             // the (heavily mitigated) normal damage component. (The old Empower floor mult was
@@ -243,7 +249,7 @@ namespace ACE.Server.WorldObjects
                 var critMult = ServerConfig.v11_pcthp_crit_mult.Value;
                 if (zoneProfile != null && zoneProfile.Has(ACE.Server.Managers.ZoneScaling.ZoneStat.CritDamageRating))
                     critMult = zoneProfile.Get(ACE.Server.Managers.ZoneScaling.ZoneStat.CritDamageRating);
-                floor *= 1.0 + (critMult - 1.0) * GetV11CritBonusRelief(attacker, defender);
+                floor *= 1.0 + (critMult - 1.0) * GetV11CritBonusRelief(attacker, defender, zoneProfile);
             }
 
             // per-hit random spread so damage isn't identical every swing

--- a/Source/ACE.Server/WorldObjects/Creature_PercentHpDamage.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_PercentHpDamage.cs
@@ -1,0 +1,287 @@
+using System;
+
+using ACE.Common;
+using ACE.Entity.Enum.Properties;
+using ACE.Server.Managers;
+
+namespace ACE.Server.WorldObjects
+{
+    partial class Creature
+    {
+        /// <summary>
+        /// v11+ Percent-HP floor damage system.
+        /// Returns the minimum damage (a fraction of the defender's max health) that a high-variation
+        /// monster should deal to a player, bypassing the life-aug protection reduction that otherwise
+        /// pushes normal damage toward zero. Callers apply this as a floor: finalDamage = Max(normal, floor).
+        /// The floor itself is reduced by a separate, gentler life-aug curve (capped well below 100%).
+        /// Returns 0 when the system is disabled, the attacker is below the variation threshold, or inputs are invalid.
+        /// See T10/V11_PercentHP_Damage_Plan.md.
+        /// </summary>
+        // ────────────────────────────────────────────────────────────────────────────────────────
+        // v11+ relief curves (2026-07-27, owner design): player progression vs AUTHORED endgame
+        // damage. Each axis is a straight line: 0% reduction at start, rising to cap at max,
+        // clamped both ends. Anchors come from the attacker's zone profile (relief_* stats) else
+        // the v11_relief_* server defaults. Life augs + Damage Resist multiply into
+        // GetV11ReliefMultiplier (applied to the %HP floor AND WYSIWYG spell_damage);
+        // Crit Damage Resist shrinks only the crit BONUS via GetV11CritBonusRelief.
+
+        /// <summary>Relief curve: 0 at/below start, cap at/above max. Between them relief =
+        /// cap * t^bend (t = progress 0-1): bend 1 = straight line, &lt;1 = strong early relief
+        /// that tapers off, &gt;1 = slow start that ramps late.</summary>
+        public static double GetLinearRelief(double value, double start, double max, double cap, double bend = 1.0)
+        {
+            cap = Math.Clamp(cap, 0.0, 1.0);
+            if (cap <= 0.0 || value <= start)
+                return 0.0;
+            if (max <= start)
+                return cap;
+            var t = Math.Min(1.0, (value - start) / (max - start));
+            if (bend > 0.0 && Math.Abs(bend - 1.0) > 0.0001)
+                t = Math.Pow(t, bend);
+            return Math.Min(cap, cap * t);
+        }
+
+        private static double ReliefAnchor(ACE.Server.Managers.ZoneScaling.EvaluatedProfile zp, string stat, double dflt)
+            => zp != null && zp.Has(stat) ? zp.Get(stat) : dflt;
+
+        // Mid-point stat keys per axis, as (x,y) pairs in slot order. Precomputed so the per-hit
+        // path never builds key strings.
+        private static readonly string[] AugPointKeys =
+        {
+            ACE.Server.Managers.ZoneScaling.ZoneStat.ReliefAugX1, ACE.Server.Managers.ZoneScaling.ZoneStat.ReliefAugY1,
+            ACE.Server.Managers.ZoneScaling.ZoneStat.ReliefAugX2, ACE.Server.Managers.ZoneScaling.ZoneStat.ReliefAugY2,
+            ACE.Server.Managers.ZoneScaling.ZoneStat.ReliefAugX3, ACE.Server.Managers.ZoneScaling.ZoneStat.ReliefAugY3,
+            ACE.Server.Managers.ZoneScaling.ZoneStat.ReliefAugX4, ACE.Server.Managers.ZoneScaling.ZoneStat.ReliefAugY4,
+        };
+        private static readonly string[] DrPointKeys =
+        {
+            ACE.Server.Managers.ZoneScaling.ZoneStat.ReliefDrX1, ACE.Server.Managers.ZoneScaling.ZoneStat.ReliefDrY1,
+            ACE.Server.Managers.ZoneScaling.ZoneStat.ReliefDrX2, ACE.Server.Managers.ZoneScaling.ZoneStat.ReliefDrY2,
+            ACE.Server.Managers.ZoneScaling.ZoneStat.ReliefDrX3, ACE.Server.Managers.ZoneScaling.ZoneStat.ReliefDrY3,
+            ACE.Server.Managers.ZoneScaling.ZoneStat.ReliefDrX4, ACE.Server.Managers.ZoneScaling.ZoneStat.ReliefDrY4,
+        };
+        private static readonly string[] CritDrPointKeys =
+        {
+            ACE.Server.Managers.ZoneScaling.ZoneStat.ReliefCritDrX1, ACE.Server.Managers.ZoneScaling.ZoneStat.ReliefCritDrY1,
+            ACE.Server.Managers.ZoneScaling.ZoneStat.ReliefCritDrX2, ACE.Server.Managers.ZoneScaling.ZoneStat.ReliefCritDrY2,
+            ACE.Server.Managers.ZoneScaling.ZoneStat.ReliefCritDrX3, ACE.Server.Managers.ZoneScaling.ZoneStat.ReliefCritDrY3,
+            ACE.Server.Managers.ZoneScaling.ZoneStat.ReliefCritDrX4, ACE.Server.Managers.ZoneScaling.ZoneStat.ReliefCritDrY4,
+        };
+
+        /// <summary>
+        /// One relief axis with optional zone-authored mid-points ("multiple bends"): any defined
+        /// (x,y) pairs REPLACE the bend shape - the curve runs piecewise-linear through
+        /// (start,0) -> sorted points -> (max,cap). No points = the bend curve.
+        /// </summary>
+        private static double GetAxisRelief(ACE.Server.Managers.ZoneScaling.EvaluatedProfile zp, string[] ptKeys,
+            double value, double start, double max, double cap, double bend)
+        {
+            cap = Math.Clamp(cap, 0.0, 1.0);
+            if (cap <= 0.0 || value <= start)
+                return 0.0;
+            if (max <= start || value >= max)
+                return cap;
+
+            if (zp != null)
+            {
+                Span<double> px = stackalloc double[4];
+                Span<double> py = stackalloc double[4];
+                var n = 0;
+                for (int i = 0; i < ptKeys.Length; i += 2)
+                {
+                    if (!zp.Has(ptKeys[i]) || !zp.Has(ptKeys[i + 1]))
+                        continue;
+                    var x = zp.Get(ptKeys[i]);
+                    if (x <= start || x >= max)
+                        continue;   // out-of-range points are author errors - ignore
+                    px[n] = x;
+                    py[n] = Math.Clamp(zp.Get(ptKeys[i + 1]), 0.0, 1.0);
+                    n++;
+                }
+                if (n > 0)
+                {
+                    for (int i = 1; i < n; i++)              // insertion sort by x (n <= 4)
+                        for (int j = i; j > 0 && px[j] < px[j - 1]; j--)
+                        {
+                            (px[j], px[j - 1]) = (px[j - 1], px[j]);
+                            (py[j], py[j - 1]) = (py[j - 1], py[j]);
+                        }
+
+                    var ax = start;
+                    var ay = 0.0;
+                    for (int i = 0; i < n; i++)
+                    {
+                        if (value <= px[i])
+                            return ay + (py[i] - ay) * (value - ax) / Math.Max(1e-9, px[i] - ax);
+                        ax = px[i];
+                        ay = py[i];
+                    }
+                    return ay + (cap - ay) * (value - ax) / Math.Max(1e-9, max - ax);
+                }
+            }
+
+            return GetLinearRelief(value, start, max, cap, bend);
+        }
+
+        /// <summary>
+        /// Combined life-aug x Damage-Resist relief multiplier for authored v11 damage against this
+        /// player (1.0 = no relief, floor at (1-augCap)*(1-drCap) = never immune).
+        /// </summary>
+        public static double GetV11ReliefMultiplier(Creature attacker, Player defender)
+        {
+            if (attacker == null || defender == null)
+                return 1.0;
+
+            // PER-CREATURE merged profile since 2026-08-29 (release audit blocker 4). This read used
+            // the zone-Default resolve on the stale theory that "a per-WCID override REPLACES the
+            // whole default profile" - the merge has been PER-STAT since 2026-07-30, so an override
+            // mob inherits the zone's curves unless it authors its own, and authoring relief_* on a
+            // --wcid bucket (a boss that respects player DR less, say) now actually works instead of
+            // being silently ignored while the sim and the display both claimed it did.
+            var zp = ACE.Server.Managers.ZoneControl.ZoneControlManager.ResolveForCreature(attacker);
+
+            var augRelief = GetAxisRelief(zp, AugPointKeys, defender.LuminanceAugmentLifeCount ?? 0,
+                ReliefAnchor(zp, ACE.Server.Managers.ZoneScaling.ZoneStat.ReliefAugStart, ServerConfig.v11_relief_aug_start.Value),
+                ReliefAnchor(zp, ACE.Server.Managers.ZoneScaling.ZoneStat.ReliefAugMax, ServerConfig.v11_relief_aug_max.Value),
+                ReliefAnchor(zp, ACE.Server.Managers.ZoneScaling.ZoneStat.ReliefAugCap, ServerConfig.v11_relief_aug_cap.Value),
+                ReliefAnchor(zp, ACE.Server.Managers.ZoneScaling.ZoneStat.ReliefAugBend, ServerConfig.v11_relief_aug_bend.Value));
+
+            // aggregate rating (gear + enchantments + augs + lum augs) — the 400-750 scale the owner tunes by
+            var drRelief = GetAxisRelief(zp, DrPointKeys, defender.GetDamageResistRating(null),
+                ReliefAnchor(zp, ACE.Server.Managers.ZoneScaling.ZoneStat.ReliefDrStart, ServerConfig.v11_relief_dr_start.Value),
+                ReliefAnchor(zp, ACE.Server.Managers.ZoneScaling.ZoneStat.ReliefDrMax, ServerConfig.v11_relief_dr_max.Value),
+                ReliefAnchor(zp, ACE.Server.Managers.ZoneScaling.ZoneStat.ReliefDrCap, ServerConfig.v11_relief_dr_cap.Value),
+                ReliefAnchor(zp, ACE.Server.Managers.ZoneScaling.ZoneStat.ReliefDrBend, ServerConfig.v11_relief_dr_bend.Value));
+
+            return (1.0 - augRelief) * (1.0 - drRelief);
+        }
+
+        /// <summary>
+        /// Fraction of a crit's BONUS damage that remains against this player's Crit Damage Resist
+        /// (1.0 = full bonus; at the cap a 2x crit lands as 1.5x).
+        /// </summary>
+        public static double GetV11CritBonusRelief(Creature attacker, Player defender)
+        {
+            if (attacker == null || defender == null)
+                return 1.0;
+
+            // per-creature merged profile — same 2026-08-29 fix as GetV11ReliefMultiplier
+            var zp = ACE.Server.Managers.ZoneControl.ZoneControlManager.ResolveForCreature(attacker);
+
+            var relief = GetAxisRelief(zp, CritDrPointKeys, defender.GetCritDamageResistRating(),
+                ReliefAnchor(zp, ACE.Server.Managers.ZoneScaling.ZoneStat.ReliefCritDrStart, ServerConfig.v11_relief_critdr_start.Value),
+                ReliefAnchor(zp, ACE.Server.Managers.ZoneScaling.ZoneStat.ReliefCritDrMax, ServerConfig.v11_relief_critdr_max.Value),
+                ReliefAnchor(zp, ACE.Server.Managers.ZoneScaling.ZoneStat.ReliefCritDrCap, ServerConfig.v11_relief_critdr_cap.Value),
+                ReliefAnchor(zp, ACE.Server.Managers.ZoneScaling.ZoneStat.ReliefCritDrBend, ServerConfig.v11_relief_critdr_bend.Value));
+
+            return 1.0 - relief;
+        }
+
+        public static float GetPercentHpFloorDamage(Creature attacker, Player defender, bool isCrit = false)
+        {
+            if (attacker == null || defender == null)
+                return 0f;
+
+            if (!ServerConfig.v11_pcthp_enabled.Value)
+                return 0f;
+
+            var variation = VariationManager.GetEffectiveEndgameVariation(attacker);
+            var minVariation = ServerConfig.v11_pcthp_min_variation.Value;
+
+            // floor fraction P: per-weenie override wins; otherwise tier-scaled (+ boss multiplier)
+            double p;
+            var pOverride = attacker.GetProperty(PropertyFloat.PercentHpDamageOverride);
+            var zoneProfile = ACE.Server.Managers.ZoneControl.ZoneControlManager.ResolveForCreature(attacker);
+
+            // Gate: fire for prestige mobs (variation >= min, only while the prestige master switch is on)
+            // OR a controlled area that authored percent_hp_base (Zone Control path — never gated by prestige).
+            // Retail mobs with no such area keep the old behavior (no %HP floor).
+            var prestigeEligible = PrestigeManager.SystemsEnabled && variation >= minVariation;
+            if (!prestigeEligible
+                && !(zoneProfile != null && zoneProfile.Has(ACE.Server.Managers.ZoneScaling.ZoneStat.PercentHpBase)))
+                return 0f;
+            if (pOverride.HasValue)
+            {
+                p = pOverride.Value;
+            }
+            else if (zoneProfile != null && zoneProfile.Has(ACE.Server.Managers.ZoneScaling.ZoneStat.PercentHpBase))
+            {
+                // Zone profile value is per-variant (boss/minion) and per-tier already -> use directly, no boss mult.
+                p = zoneProfile.Get(ACE.Server.Managers.ZoneScaling.ZoneStat.PercentHpBase);
+            }
+            else
+            {
+                // geometric growth per tier so the base outpaces the (accelerating) life-aug reduction -> rising endgame
+                p = ServerConfig.v11_pcthp_base.Value
+                    * Math.Pow(ServerConfig.v11_pcthp_tier_growth.Value, variation - minVariation);
+
+                if (attacker.GetProperty(PropertyBool.IsEmpowerSource) == true)
+                    p *= ServerConfig.v11_pcthp_boss_mult.Value;
+            }
+
+            if (p <= 0.0)
+                return 0f;
+
+            var maxHealth = defender.Health?.MaxValue ?? 0;
+            if (maxHealth == 0)
+                return 0f;
+
+            // v11+ relief curves (2026-07-27): linear life-aug + gear Damage-Resist reduction replaces
+            // the old exponential aug-only curve (v11_pcthp_aug_threshold/reduction_r/reduction_cap and
+            // the per-weenie PercentHpReduction*Override props retired - no longer read here).
+            var floor = p * maxHealth * GetV11ReliefMultiplier(attacker, defender);
+
+            // Crit multiplies the floor too — otherwise it vanishes once the floor dominates
+            // the (heavily mitigated) normal damage component. (The old Empower floor mult was
+            // REMOVED 2026-08-02 with the rest of the empowered-boss damage bonuses - dead system.)
+
+            if (isCrit)
+            {
+                // zone-authored crit_damage_rating IS the final crit multiplier - it governs the floor's
+                // crit too, so "Crit Damage 4" means 4x floor crits, not just the normal path.
+                // The defender's Crit Damage Resist shrinks only the BONUS part (relief curve).
+                var critMult = ServerConfig.v11_pcthp_crit_mult.Value;
+                if (zoneProfile != null && zoneProfile.Has(ACE.Server.Managers.ZoneScaling.ZoneStat.CritDamageRating))
+                    critMult = zoneProfile.Get(ACE.Server.Managers.ZoneScaling.ZoneStat.CritDamageRating);
+                floor *= 1.0 + (critMult - 1.0) * GetV11CritBonusRelief(attacker, defender);
+            }
+
+            // per-hit random spread so damage isn't identical every swing
+            var variance = ServerConfig.v11_pcthp_variance.Value;
+            if (variance > 0.0)
+                floor *= 1.0 + ThreadSafeRandom.Next((float)-variance, (float)variance);
+            if (floor <= 0.0 || double.IsNaN(floor) || double.IsInfinity(floor))
+                return 0f;
+
+            return (float)floor;
+        }
+
+        /// <summary>
+        /// v11+ attack-skill floor: the minimum effective attack skill a monster uses against a PLAYER
+        /// defender, so endgame mobs can land hits against very high Effective Melee/Missile Defense.
+        /// Prestige-only: variation >= v11_pcthp_min_variation uses the v11_min_attack_skill config,
+        /// while prestige_systems_enabled is on. (The zone min_attack_skill stat was REMOVED 2026-08-02
+        /// — redundant with attack_skill's absolute replace; zones tune accuracy via attack_skill.)
+        /// Returns 0 when it doesn't apply, in which case callers keep the monster's normal attack skill.
+        /// </summary>
+        public static uint GetV11AttackSkillFloor(Creature attacker, Player defender)
+        {
+            if (attacker == null || defender == null)
+                return 0;
+
+            // Variation-triggered path — fully off with the prestige master switch.
+            if (!PrestigeManager.SystemsEnabled)
+                return 0;
+
+            var floor = ServerConfig.v11_min_attack_skill.Value;
+            if (floor <= 0)
+                return 0;
+
+            var variation = VariationManager.GetEffectiveEndgameVariation(attacker);
+            if (variation < ServerConfig.v11_pcthp_min_variation.Value)
+                return 0;
+
+            return (uint)floor;
+        }
+    }
+}

--- a/Source/ACE.Server/WorldObjects/Creature_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Properties.cs
@@ -117,6 +117,34 @@ namespace ACE.Server.WorldObjects
 
             var vulnMod = EnchantmentManager.GetVulnerabilityResistanceMod(damageType);
 
+            // Zone Scaler: resolve the winning zone profile for this monster once (null for players/exempt/non-endgame/
+            // no-match). Consumers below prefer a profile-defined stat over the global v11_* knob. Global profile is
+            // seeded DISABLED, so with no authored scope this is null and behavior is unchanged.
+            var zoneProfile = ACE.Server.Managers.ZoneControl.ZoneControlManager.ResolveForCreature(this as Creature);
+
+            // v11+ monster vuln-defense: compress the vuln (Imperil) multiplier so stacked vulns can't produce
+            // absurd damage against endgame mobs. Only the vuln enchantment bonus is touched here (before the
+            // weaponResistanceMod max below), so base damage, offensive augs, and weapon rending are unaffected.
+            // Player defenders never hit this: Player overrides GetResistanceMod. Gate is the monster's instance
+            // Variation (same convention as the v11+ percent-HP offense system) -> auto-applies to all v11+ mobs.
+            if (vulnMod > 1.0f && ServerConfig.v11_vuln_enabled.Value && !(this is Player)
+                && ((zoneProfile != null && zoneProfile.Has(ACE.Server.Managers.ZoneScaling.ZoneStat.VulnCap))
+                    || (ACE.Server.Managers.PrestigeManager.SystemsEnabled
+                        && ACE.Server.Managers.VariationManager.GetEffectiveEndgameVariation(this) >= ServerConfig.v11_vuln_min_variation.Value)))
+            {
+                var vulnEff = GetProperty(PropertyFloat.VulnEffectivenessOverride) ?? ServerConfig.v11_vuln_effectiveness.Value;
+                var vulnCap = GetProperty(PropertyFloat.VulnCapOverride) ?? ServerConfig.v11_vuln_cap.Value;
+                if (zoneProfile != null && zoneProfile.Has(ACE.Server.Managers.ZoneScaling.ZoneStat.VulnCap))
+                    vulnCap = zoneProfile.Get(ACE.Server.Managers.ZoneScaling.ZoneStat.VulnCap);
+
+                // diminishing curve: only a fraction of the vuln bonus lands, then clamp to the cap
+                vulnMod = 1.0f + (vulnMod - 1.0f) * (float)vulnEff;
+                if (vulnMod > vulnCap)
+                    vulnMod = (float)vulnCap;
+                if (vulnMod < 1.0f)
+                    vulnMod = 1.0f;
+            }
+
             var naturalResistMod = GetNaturalResistance(damageType);
 
             // protection mod becomes either life protection or natural resistance,
@@ -154,7 +182,43 @@ namespace ACE.Server.WorldObjects
                 vulnMod = GetPositiveRatingMod(addVuln);
             }
 
-            return protMod * vulnMod;
+            var resistMod = protMod * vulnMod;
+
+            // v11+ monster damage-taken mitigation: scale ALL incoming damage against endgame mobs by a flat factor so they are
+            // hard to kill via mitigation (not evasion). Applied after armor/resist, so it is rending-proof. Bosses (IsEmpowerSource)
+            // take even less. Player defenders never hit this (Player overrides GetResistanceMod). Prestige-gated -> dormant while
+            // prestige is off. The zone damage_taken_mult stat that used to override this was REMOVED 2026-08-03 (owner):
+            // redundant with damage_resist_rating.
+            if (ServerConfig.v11_mob_dmg_taken_enabled.Value && !(this is Player)
+                && ACE.Server.Managers.PrestigeManager.SystemsEnabled
+                && ACE.Server.Managers.VariationManager.GetEffectiveEndgameVariation(this) >= ServerConfig.v11_mob_dmg_taken_min_variation.Value)
+            {
+                var dmgMult = GetProperty(PropertyFloat.MobDmgTakenOverride) ?? ServerConfig.v11_mob_dmg_taken_mult.Value;
+
+                if (GetProperty(PropertyBool.IsEmpowerSource) == true)
+                    dmgMult *= ServerConfig.v11_mob_dmg_taken_boss_mult.Value;
+
+                dmgMult = Math.Clamp(dmgMult, ServerConfig.v11_mob_dmg_taken_floor.Value, 1.0);
+
+                resistMod *= (float)dmgMult;
+            }
+
+            // Per-monster ELEMENTAL WEAKNESS: if the incoming damage type is in the mob's weakness mask, multiply the
+            // (post-mitigation) resistance mod so the right element does proportionally more. Independent of zone
+            // scaling; a relative reward that stays meaningful even against heavily-mitigated endgame mobs. Unset
+            // mask => no-op, so this changes nothing for existing mobs. Players never carry it.
+            if (!(this is Player))
+            {
+                var weakMask = GetProperty(PropertyInt.ElementalWeaknessMask);
+                if (weakMask.HasValue && weakMask.Value != 0 && ((DamageType)weakMask.Value & damageType) != 0)
+                {
+                    var weakFactor = GetProperty(PropertyFloat.ElementalWeaknessFactor) ?? ServerConfig.elemental_weakness_default_factor.Value;
+                    if (weakFactor > 0)
+                        resistMod *= (float)weakFactor;
+                }
+            }
+
+            return resistMod;
         }
 
         public virtual float GetNaturalResistance(DamageType damageType)
@@ -163,26 +227,35 @@ namespace ACE.Server.WorldObjects
             return 1.0f;
         }
 
+        /// <summary>Zone Control: a governed monster's zone profile can REPLACE a creature-level multiplier
+        /// (resists / armor-vs-type). Returns the fallback when unprofiled — players and exempt mobs always
+        /// resolve null, so this is a no-op for them.</summary>
+        private double ZoneStatOr(string statKey, double fallback)
+        {
+            var zp = ACE.Server.Managers.ZoneControl.ZoneControlManager.ResolveForCreature(this as Creature);
+            return zp != null && zp.Has(statKey) ? zp.Get(statKey) : fallback;
+        }
+
         public double GetArmorVsType(DamageType damageType)
         {
             switch (damageType)
             {
                 case DamageType.Slash:
-                    return GetProperty(PropertyFloat.ArmorModVsSlash) ?? 1.0f;
+                    return ZoneStatOr(ACE.Server.Managers.ZoneScaling.ZoneStat.ArmorVsSlash, GetProperty(PropertyFloat.ArmorModVsSlash) ?? 1.0f);
                 case DamageType.Pierce:
-                    return GetProperty(PropertyFloat.ArmorModVsPierce) ?? 1.0f;
+                    return ZoneStatOr(ACE.Server.Managers.ZoneScaling.ZoneStat.ArmorVsPierce, GetProperty(PropertyFloat.ArmorModVsPierce) ?? 1.0f);
                 case DamageType.Bludgeon:
-                    return GetProperty(PropertyFloat.ArmorModVsBludgeon) ?? 1.0f;
+                    return ZoneStatOr(ACE.Server.Managers.ZoneScaling.ZoneStat.ArmorVsBludgeon, GetProperty(PropertyFloat.ArmorModVsBludgeon) ?? 1.0f);
                 case DamageType.Fire:
-                    return GetProperty(PropertyFloat.ArmorModVsFire) ?? 1.0f;
+                    return ZoneStatOr(ACE.Server.Managers.ZoneScaling.ZoneStat.ArmorVsFire, GetProperty(PropertyFloat.ArmorModVsFire) ?? 1.0f);
                 case DamageType.Cold:
-                    return GetProperty(PropertyFloat.ArmorModVsCold) ?? 1.0f;
+                    return ZoneStatOr(ACE.Server.Managers.ZoneScaling.ZoneStat.ArmorVsCold, GetProperty(PropertyFloat.ArmorModVsCold) ?? 1.0f);
                 case DamageType.Acid:
-                    return GetProperty(PropertyFloat.ArmorModVsAcid) ?? 1.0f;
+                    return ZoneStatOr(ACE.Server.Managers.ZoneScaling.ZoneStat.ArmorVsAcid, GetProperty(PropertyFloat.ArmorModVsAcid) ?? 1.0f);
                 case DamageType.Electric:
-                    return GetProperty(PropertyFloat.ArmorModVsElectric) ?? 1.0f;
+                    return ZoneStatOr(ACE.Server.Managers.ZoneScaling.ZoneStat.ArmorVsElectric, GetProperty(PropertyFloat.ArmorModVsElectric) ?? 1.0f);
                 case DamageType.Nether:
-                    return GetProperty(PropertyFloat.ArmorModVsNether) ?? 1.0f;
+                    return ZoneStatOr(ACE.Server.Managers.ZoneScaling.ZoneStat.ArmorVsNether, GetProperty(PropertyFloat.ArmorModVsNether) ?? 1.0f);
                 default:
                     return 1.0f;
             }
@@ -193,21 +266,21 @@ namespace ACE.Server.WorldObjects
             switch (resistance)
             {
                 case ResistanceType.Slash:
-                    return (ResistSlash ?? 1.0) * GetResistanceMod(DamageType.Slash, attacker, weapon, weaponResistanceMod);
+                    return ZoneStatOr(ACE.Server.Managers.ZoneScaling.ZoneStat.ResistSlash, ResistSlash ?? 1.0) * GetResistanceMod(DamageType.Slash, attacker, weapon, weaponResistanceMod);
                 case ResistanceType.Pierce:
-                    return (ResistPierce ?? 1.0) * GetResistanceMod(DamageType.Pierce, attacker, weapon, weaponResistanceMod);
+                    return ZoneStatOr(ACE.Server.Managers.ZoneScaling.ZoneStat.ResistPierce, ResistPierce ?? 1.0) * GetResistanceMod(DamageType.Pierce, attacker, weapon, weaponResistanceMod);
                 case ResistanceType.Bludgeon:
-                    return (ResistBludgeon ?? 1.0) * GetResistanceMod(DamageType.Bludgeon, attacker, weapon, weaponResistanceMod);
+                    return ZoneStatOr(ACE.Server.Managers.ZoneScaling.ZoneStat.ResistBludgeon, ResistBludgeon ?? 1.0) * GetResistanceMod(DamageType.Bludgeon, attacker, weapon, weaponResistanceMod);
                 case ResistanceType.Fire:
-                    return (ResistFire ?? 1.0) * GetResistanceMod(DamageType.Fire, attacker, weapon, weaponResistanceMod);
+                    return ZoneStatOr(ACE.Server.Managers.ZoneScaling.ZoneStat.ResistFire, ResistFire ?? 1.0) * GetResistanceMod(DamageType.Fire, attacker, weapon, weaponResistanceMod);
                 case ResistanceType.Cold:
-                    return (ResistCold ?? 1.0) * GetResistanceMod(DamageType.Cold, attacker, weapon, weaponResistanceMod);
+                    return ZoneStatOr(ACE.Server.Managers.ZoneScaling.ZoneStat.ResistCold, ResistCold ?? 1.0) * GetResistanceMod(DamageType.Cold, attacker, weapon, weaponResistanceMod);
                 case ResistanceType.Acid:
-                    return (ResistAcid ?? 1.0) * GetResistanceMod(DamageType.Acid, attacker, weapon, weaponResistanceMod);
+                    return ZoneStatOr(ACE.Server.Managers.ZoneScaling.ZoneStat.ResistAcid, ResistAcid ?? 1.0) * GetResistanceMod(DamageType.Acid, attacker, weapon, weaponResistanceMod);
                 case ResistanceType.Electric:
-                    return (ResistElectric ?? 1.0) * GetResistanceMod(DamageType.Electric, attacker, weapon, weaponResistanceMod);
+                    return ZoneStatOr(ACE.Server.Managers.ZoneScaling.ZoneStat.ResistElectric, ResistElectric ?? 1.0) * GetResistanceMod(DamageType.Electric, attacker, weapon, weaponResistanceMod);
                 case ResistanceType.Nether:
-                    return (ResistNether ?? 1.0) * GetResistanceMod(DamageType.Nether, attacker, weapon, weaponResistanceMod) * GetNetherResistRatingMod();
+                    return ZoneStatOr(ACE.Server.Managers.ZoneScaling.ZoneStat.ResistNether, ResistNether ?? 1.0) * GetResistanceMod(DamageType.Nether, attacker, weapon, weaponResistanceMod) * GetNetherResistRatingMod();
                 case ResistanceType.HealthBoost:
                     return (ResistHealthBoost ?? 1.0) * GetHealingRatingMod();
                 case ResistanceType.HealthDrain:

--- a/Source/ACE.Server/WorldObjects/Creature_Rating.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Rating.cs
@@ -206,11 +206,18 @@ namespace ACE.Server.WorldObjects
             // get from base properties (monsters)?
             var damageRating = DamageRating ?? 0;
 
+            // Zone Control: an authored profile REPLACES the monster's weenie-base DamageRating
+            // (null for players/exempt/non-endgame/no-match -> weenie base). Uniform with every other zone stat.
+            // Enchantment/equipment/aug bonuses below still stack (all 0 for monsters).
+            var zoneDr = ACE.Server.Managers.ZoneControl.ZoneControlManager.ResolveForCreature(this);
+            if (zoneDr != null && zoneDr.Has(ACE.Server.Managers.ZoneScaling.ZoneStat.DamageRating))
+                damageRating = (int)Math.Round(zoneDr.Get(ACE.Server.Managers.ZoneScaling.ZoneStat.DamageRating));
+
             // additive enchantments
             var enchantments = EnchantmentManager.GetRating(PropertyInt.DamageRating);
 
             // equipment ratings
-            var equipment = GetEquippedItemsRatingSum(PropertyInt.GearDamage);
+            var equipment = GetEquippedItemsRatingSumCapped(PropertyInt.GearDamage, ACE.Server.Managers.ZoneScaling.ZoneStat.GearCapLine, 2500);
 
             // weakness as negative damage rating?
             // TODO: this should be factored in as a separate weakness rating...
@@ -250,11 +257,24 @@ namespace ACE.Server.WorldObjects
             // get from base properties (monsters)?
             var damageResistRating = DamageResistRating ?? 0;
 
+            // Zone Control: an authored profile REPLACES the monster's weenie-base DRR
+            // (null for players/exempt/non-endgame/no-match -> weenie base). Uniform with every other zone stat.
+            // Enchantment/equipment bonuses below still stack (all 0 for monsters).
+            var zoneDrr = ACE.Server.Managers.ZoneControl.ZoneControlManager.ResolveForCreature(this);
+            // RANK LAYERS (2026-09-02 evening): the profile ResolveForCreature hands back is ALREADY the
+            // monster's rank chain (Default row with its Leader / Boss / Regular row merged on top), so
+            // one plain read replaces the day-old _leader/_boss twin branch that lived here.
+            if (zoneDrr != null && zoneDrr.Has(ACE.Server.Managers.ZoneScaling.ZoneStat.DamageResistRating))
+                damageResistRating = (int)Math.Round(zoneDrr.Get(ACE.Server.Managers.ZoneScaling.ZoneStat.DamageResistRating));
+
             // additive enchantments
             var enchantments = EnchantmentManager.GetRating(PropertyInt.DamageResistRating);
 
-            // equipment ratings
-            var equipment = GetEquippedItemsRatingSum(PropertyInt.GearDamageResist);
+            // equipment ratings - worn sum HARD-CAPPED at gear_cap_dr (owner 2026-08-21: the cap means EXACTLY the cap;
+            // the flat bands give 18 x 139 = 2502 at T25). Equipment term only; everything below stacks untouched.
+            // CritDmgResist / CritResist / NetherResist cap at gear_cap_cdr, the Dmg / CritDmg / MaxHP / HealBoost
+            // lines at gear_cap_line, all via GetEquippedItemsRatingSumCapped (Creature_Equipment).
+            var equipment = GetEquippedItemsRatingSumCapped(PropertyInt.GearDamageResist, ACE.Server.Managers.ZoneScaling.ZoneStat.GearCapDr, 2500);
 
             // nether DoTs as negative DRR?
             // TODO: this should be factored in as a separate nether damage rating...
@@ -276,6 +296,8 @@ namespace ACE.Server.WorldObjects
 
         public float GetDamageResistRatingMod(CombatType? combatType = null, bool directDamage = true)
         {
+            // Zone Control DRR override is applied inside GetDamageResistRating (weenie-base replacement),
+            // so appraisal and this mod both see the same zone value.
             var damageResistRating = GetDamageResistRating(combatType, directDamage);
 
             var allowBug = ServerConfig.allow_negative_rating_curve.Value;
@@ -341,7 +363,7 @@ namespace ACE.Server.WorldObjects
             var enchantments = EnchantmentManager.GetRating(PropertyInt.CritDamageRating);
 
             // equipment ratings
-            var equipment = GetEquippedItemsRatingSum(PropertyInt.GearCritDamage);
+            var equipment = GetEquippedItemsRatingSumCapped(PropertyInt.GearCritDamage, ACE.Server.Managers.ZoneScaling.ZoneStat.GearCapLine, 2500);
 
             // augmentations
             var augBonus = 0;
@@ -367,7 +389,7 @@ namespace ACE.Server.WorldObjects
             var enchantments = EnchantmentManager.GetRating(PropertyInt.CritResistRating);
 
             // equipment ratings
-            var equipment = GetEquippedItemsRatingSum(PropertyInt.GearCritResist);
+            var equipment = GetEquippedItemsRatingSumCapped(PropertyInt.GearCritResist, ACE.Server.Managers.ZoneScaling.ZoneStat.GearCapCdr, 1500);
 
             // no augs / lum augs?
             return critResistRating + enchantments + equipment;
@@ -382,7 +404,7 @@ namespace ACE.Server.WorldObjects
             var enchantments = EnchantmentManager.GetRating(PropertyInt.CritDamageResistRating);
 
             // equipment ratings
-            var equipment = GetEquippedItemsRatingSum(PropertyInt.GearCritDamageResist);
+            var equipment = GetEquippedItemsRatingSumCapped(PropertyInt.GearCritDamageResist, ACE.Server.Managers.ZoneScaling.ZoneStat.GearCapCdr, 1500);
 
             var lumAugBonus = 0;
             if (this is Player player)
@@ -400,7 +422,7 @@ namespace ACE.Server.WorldObjects
             var enchantments = EnchantmentManager.GetRating(PropertyInt.HealingBoostRating);
 
             // equipment ratings
-            var equipment = GetEquippedItemsRatingSum(PropertyInt.GearHealingBoost);
+            var equipment = GetEquippedItemsRatingSumCapped(PropertyInt.GearHealingBoost, ACE.Server.Managers.ZoneScaling.ZoneStat.GearCapLine, 2500);
 
             var lumAugBonus = 0;
             if (this is Player player)
@@ -467,7 +489,7 @@ namespace ACE.Server.WorldObjects
             var enchantments = EnchantmentManager.GetRating(PropertyInt.NetherResistRating);
 
             // equipment ratings
-            var equipment = GetEquippedItemsRatingSum(PropertyInt.GearNetherResist);
+            var equipment = GetEquippedItemsRatingSumCapped(PropertyInt.GearNetherResist, ACE.Server.Managers.ZoneScaling.ZoneStat.GearCapCdr, 1500);
 
             return netherResistRating + equipment + enchantments;
         }
@@ -483,7 +505,7 @@ namespace ACE.Server.WorldObjects
 
         public int GetGearMaxHealth()
         {
-            return GetEquippedItemsRatingSum(PropertyInt.GearMaxHealth);
+            return GetEquippedItemsRatingSumCapped(PropertyInt.GearMaxHealth, ACE.Server.Managers.ZoneScaling.ZoneStat.GearCapLine, 2500);
         }
 
         public int GetPKDamageRating()

--- a/Source/ACE.Server/WorldObjects/Creature_Vitals.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Vitals.cs
@@ -134,11 +134,58 @@ namespace ACE.Server.WorldObjects
             var enchantmentMod = EnchantmentManager.GetRegenerationMod(vital);
 
             var augMod = 1.0f;
-            if (this is Player player && player.AugmentationFasterRegen > 0)
-                augMod += player.AugmentationFasterRegen;
+            var zoneRegenMult = 1.0f;
+            var zoneProdigalBlocked = false;
+            var zcFlatRegenPct = 0;
+            if (this is Player player)
+            {
+                if (player.AugmentationFasterRegen > 0)
+                    augMod += player.AugmentationFasterRegen;
+
+                // Zone Control Regen slot special (key 46, bracers; prop 50231): FLAT pct of the vital's MAX
+                // added to every positive natural tick, MAX-wins across worn pieces (owner 2026-08-23: a
+                // multiplier compounded the shard's x900 buff stack into god-mode; flat reads as "+300 on a
+                // 1,700 tick" and can never compound). Applied after the tuner below (see zcFlatRegen).
+                zcFlatRegenPct = player.GetZoneModifierMax(50231);
+
+                // Zone Control Suppression: recompute the enchantment mod without the Prodigal regen line
+                // (uncached path — the cached mod can't know about zone borders), and pick up the regen tuner.
+                try
+                {
+                    var zfx = ACE.Server.Managers.ZoneControl.ZoneControlManager.ResolveEffectsForPlayer(player);
+                    if (zfx != null && zfx.EffectiveSuppressEnabled)
+                    {
+                        if (zfx.EffectiveSuppressProdigal)
+                        {
+                            enchantmentMod = EnchantmentManager.GetRegenerationMod(vital,
+                                ACE.Server.Managers.ZoneControl.ZoneEffectManager.ProdigalRegenSpells);
+                            zoneProdigalBlocked = true;
+                        }
+                        zoneRegenMult = (float)zfx.EffectiveSuppressRegenMult;
+                    }
+                }
+                catch
+                {
+                    // never let zone resolution break vital ticks
+                }
+            }
 
             // cap rate?
             var currentTick = vital.RegenRate * attributeMod * stanceMod * enchantmentMod * augMod;
+
+            // Suppression regen tuner: shrink POSITIVE regen only (a degen tick is never softened).
+            if (zoneRegenMult != 1.0f && currentTick > 0)
+                currentTick *= zoneRegenMult;
+
+            // Bracers Regeneration special: flat pct of max, only while the natural tick is regenerating
+            if (zcFlatRegenPct > 0 && currentTick >= 0)
+                currentTick += vitalMax * zcFlatRegenPct / 100.0f;
+
+            if (ACE.Server.Managers.ServerConfig.regen_diag_verbose.Value && this is Player)
+                log.Warn($"[RegenDiag] {Name} {vital.Vital}: {vitalCurrent}/{vitalMax} rate={vital.RegenRate} " +
+                         $"attr={attributeMod:F3} stance={stanceMod:F3} ench={enchantmentMod:F3}" +
+                         $"{(zoneProdigalBlocked ? " PRODIGAL-BLOCKED" : "")} aug={augMod:F3} bracersFlat={zcFlatRegenPct}pct " +
+                         $"zoneRegenMult={zoneRegenMult:F2} tick={currentTick:F3}");
 
             // add in partially accumulated / rounded vitals from previous tick(s)
             var totalTick = currentTick + vital.PartialRegen;

--- a/Source/ACE.Server/WorldObjects/Creature_Vitals.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Vitals.cs
@@ -146,7 +146,7 @@ namespace ACE.Server.WorldObjects
                 // added to every positive natural tick, MAX-wins across worn pieces (owner 2026-08-23: a
                 // multiplier compounded the shard's x900 buff stack into god-mode; flat reads as "+300 on a
                 // 1,700 tick" and can never compound). Applied after the tuner below (see zcFlatRegen).
-                zcFlatRegenPct = player.GetZoneModifierMax(50231);
+                zcFlatRegenPct = player.GetZoneModifierMax(ACE.Server.Managers.ZoneControl.ZoneModifiers.RegenSpecialMult);
 
                 // Zone Control Suppression: recompute the enchantment mod without the Prodigal regen line
                 // (uncached path — the cached mod can't know about zone borders), and pick up the regen tuner.
@@ -164,9 +164,11 @@ namespace ACE.Server.WorldObjects
                         zoneRegenMult = (float)zfx.EffectiveSuppressRegenMult;
                     }
                 }
-                catch
+                catch (Exception ex)
                 {
-                    // never let zone resolution break vital ticks
+                    // never let zone resolution break vital ticks - but do not lose the reason either
+                    if (log.IsDebugEnabled)
+                        log.Debug($"[ZoneControl] regen effect resolve failed for {player.Name}: {ex.Message}");
                 }
             }
 

--- a/Source/ACE.Server/WorldObjects/Entity/CreatureAttribute.cs
+++ b/Source/ACE.Server/WorldObjects/Entity/CreatureAttribute.cs
@@ -147,6 +147,10 @@ namespace ACE.Server.WorldObjects.Entity
 
             total = total.Round();
 
+            // Zone Control cantrip gear: flat bonus summed across equipped items, outside all
+            // enchantment stacking categories (always applies on top)
+            total += creature.GetZoneModifierBonus(ACE.Server.Managers.ZoneControl.ZoneModifiers.AttrBonusBase + (int)Attribute);
+
             // attributes cannot be debuffed below 10 normally,
             // or 1 for creatures with very low starting attributes
             var minimumAttribute = Base >= 10 ? 10 : 1;

--- a/Source/ACE.Server/WorldObjects/Entity/CreatureSkill.cs
+++ b/Source/ACE.Server/WorldObjects/Entity/CreatureSkill.cs
@@ -225,6 +225,12 @@ namespace ACE.Server.WorldObjects.Entity
             if (AdvancementClass == SkillAdvancementClass.Specialized && player.LumAugSkilledSpec != 0)
                 total += (uint)player.LumAugSkilledSpec * 2;
 
+            // Zone Control cantrip gear: flat per-skill bonus summed across equipped items,
+            // outside all enchantment stacking categories (always applies on top, not scaled by vitae)
+            var zoneModifier = player.GetZoneModifierBonus(ACE.Server.Managers.ZoneControl.ZoneModifiers.SkillBonusBase + (int)Skill);
+            if (zoneModifier > 0)
+                total += (uint)zoneModifier;
+
             return total;
         }
     }

--- a/Source/ACE.Server/WorldObjects/Entity/CreatureVital.cs
+++ b/Source/ACE.Server/WorldObjects/Entity/CreatureVital.cs
@@ -105,11 +105,42 @@ namespace ACE.Server.WorldObjects.Entity
         {
             get
             {
-                return StartingValue
+                var total = StartingValue
                     + AttributeFormula.GetFormula(creature, Vital, /*current*/false)
                     + EnlBonus
                     + Ranks
                     + GearBonus;
+
+                // Fortify Vitals deliberately NOT applied here: Base feeds raw-stat consumers
+                // (Innate reporting, RawSecondaryAttrib wield gates) that must not see gear
+                // multipliers. The player-facing max rides GetMaxValue below.
+                return (uint)total;
+            }
+        }
+
+        /// <summary>
+        /// Zone Control Fortify Vitals slot special (key 41, helm): pct points scaling the whole vital
+        /// total. MAX-wins across worn pieces (2026-08-21 armor v2) -- the highest single piece counts,
+        /// a second piece never stacks, so no clamp is needed (the band caps the roll). Applied in
+        /// GetMaxValue only (not the rating cache) so it covers all 3 vitals -- MaxHealth rides
+        /// GetGearMaxHealth and a rating-cache route would silently exclude it. Application point
+        /// (before vitae/additives) LEFT where it is -- owner ruling 08-21.
+        /// </summary>
+        private double FortifyVitalsMod
+        {
+            get
+            {
+                if (creature == null)
+                    return 1.0;
+
+                var pts = Math.Max(0, creature.GetZoneModifierMax(ACE.Server.Managers.ZoneControl.ZoneModifiers.FortifyVitalsPct));
+
+                // Pct Max Health (key 47, chase, 2026-08-22): percentage points SUMMED across worn pieces,
+                // MaxHealth only, additive with the Fortify Vitals points (owner: they stack).
+                if (Vital == PropertyAttribute2nd.MaxHealth)
+                    pts += Math.Max(0, creature.GetZoneModifierBonus(ACE.Server.Managers.ZoneControl.ZoneModifiers.PctMaxHealthPct));
+
+                return 1.0 + pts / 100.0;
             }
         }
 
@@ -126,9 +157,17 @@ namespace ACE.Server.WorldObjects.Entity
         {
             get
             {
-                if (creature is Player player && Vital == PropertyAttribute2nd.MaxHealth)
-                    return (uint)player.GetGearMaxHealth();
-                return 0;
+                if (creature is not Player player)
+                    return 0;
+
+                switch (Vital)
+                {
+                    case PropertyAttribute2nd.MaxHealth:
+                        // retail gear prop (also carries the Zone Control health cantrip)
+                        return (uint)player.GetGearMaxHealth();
+                    default:
+                        return 0;
+                }
             }
         }
 
@@ -152,6 +191,9 @@ namespace ACE.Server.WorldObjects.Entity
             // apply multiplicative enchantments first
             var multiplier = enchanted ? creature.EnchantmentManager.GetVitalMod_Multiplier(this) : 1.0f;
             var fTotal = total * multiplier;
+
+            // Zone Control Fortify Vitals cantrip (whole-total multiplier, all 3 vitals)
+            fTotal = (float)(fTotal * FortifyVitalsMod);
 
             var player = creature as Player;
             if (player != null)

--- a/Source/ACE.Server/WorldObjects/Hotspot.cs
+++ b/Source/ACE.Server/WorldObjects/Hotspot.cs
@@ -210,6 +210,7 @@ namespace ACE.Server.WorldObjects
                 default:
 
                     if (creature.Invincible) return;
+                    if (player != null && player.ZcDamageImmune) return;   // Zone Control Cheat Death window
 
                     amount *= creature.GetResistanceMod(DamageType, this, null);
 
@@ -255,12 +256,12 @@ namespace ACE.Server.WorldObjects
 
         private void Activate(Creature creature)
         {
-            ActivateCommon(creature, IsHot, (Creature c) => !c.Invincible && !c.IsDead);
+            ActivateCommon(creature, IsHot, (Creature c) => !c.Invincible && !c.IsDead && !(c is Player p && p.ZcDamageImmune));
         }
 
         private void ActivateEnragedHotspot(Creature creature)
         {
-            ActivateCommon(creature, EnragedHotspot, (Creature c) => !c.Invincible && !c.IsDead);
+            ActivateCommon(creature, EnragedHotspot, (Creature c) => !c.Invincible && !c.IsDead && !(c is Player p && p.ZcDamageImmune));
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Hotspot.cs
+++ b/Source/ACE.Server/WorldObjects/Hotspot.cs
@@ -199,6 +199,8 @@ namespace ACE.Server.WorldObjects
         private void ActivateCommon(Creature creature, bool isActive, Func<Creature, bool> isDamageable)
         {
             if (!isActive) return;
+            // one gate for every damage type: Invincible, dead, and the Zone Control Cheat Death window
+            if (isDamageable != null && !isDamageable(creature)) return;
 
             var amount = DamageNext;
             var iAmount = (int)Math.Round(amount);
@@ -208,9 +210,6 @@ namespace ACE.Server.WorldObjects
             switch (DamageType)
             {
                 default:
-
-                    if (creature.Invincible) return;
-                    if (player != null && player.ZcDamageImmune) return;   // Zone Control Cheat Death window
 
                     amount *= creature.GetResistanceMod(DamageType, this, null);
 

--- a/Source/ACE.Server/WorldObjects/Managers/EnchantmentManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EnchantmentManager.cs
@@ -185,9 +185,10 @@ namespace ACE.Server.WorldObjects.Managers
                 // should be update the StatModVal here?
 
                 var duration = spell.Duration;
-                if (caster is Player player && (player.AugmentationIncreasedSpellDuration > 0 || (player.LuminanceAugmentSpellDurationCount ?? 0) > 0) && spell.DotDuration == 0)
+                if (caster is Player player && (player.AugmentationIncreasedSpellDuration > 0 || (player.LuminanceAugmentSpellDurationCount ?? 0) > 0 || player.GetZoneModifierBonus(ACE.Server.Managers.ZoneControl.ZoneModifiers.SpellDurationLevels) > 0) && spell.DotDuration == 0)
                 {
-                    duration *= 1.0f + (player.AugmentationIncreasedSpellDuration * 0.2f) + ((player.LuminanceAugmentSpellDurationCount ?? 0) * 0.05f);
+                    duration *= 1.0f + (player.AugmentationIncreasedSpellDuration * 0.2f) + ((player.LuminanceAugmentSpellDurationCount ?? 0) * 0.05f)
+                        + (player.GetZoneModifierBonus(ACE.Server.Managers.ZoneControl.ZoneModifiers.SpellDurationLevels) * 0.2f);
                 }
 
                 var timeRemaining = refreshSpell.Duration + refreshSpell.StartTime;
@@ -231,14 +232,16 @@ namespace ACE.Server.WorldObjects.Managers
             {
                 entry.Duration = spell.Duration;
 
-                if (caster is Player player && !spell.IsFellowshipSpell && (player.AugmentationIncreasedSpellDuration > 0 || (player.LuminanceAugmentSpellDurationCount ?? 0) > 0) && spell.DotDuration == 0)
-                { 
-                    entry.Duration *= 1.0f + (player.AugmentationIncreasedSpellDuration * 0.2f) + ((player.LuminanceAugmentSpellDurationCount ?? 0) * 0.05f);
+                if (caster is Player player && !spell.IsFellowshipSpell && (player.AugmentationIncreasedSpellDuration > 0 || (player.LuminanceAugmentSpellDurationCount ?? 0) > 0 || player.GetZoneModifierBonus(ACE.Server.Managers.ZoneControl.ZoneModifiers.SpellDurationLevels) > 0) && spell.DotDuration == 0)
+                {
+                    entry.Duration *= 1.0f + (player.AugmentationIncreasedSpellDuration * 0.2f) + ((player.LuminanceAugmentSpellDurationCount ?? 0) * 0.05f)
+                        + (player.GetZoneModifierBonus(ACE.Server.Managers.ZoneControl.ZoneModifiers.SpellDurationLevels) * 0.2f);
                     //entry.Duration *= (caster as Player).LuminanceAugmentSpellDurationCount ?? 0 * 0.001f;
                 }
-                else if (caster is Player dotPlayer && (dotPlayer.AugmentationIncreasedSpellDuration > 0 || (dotPlayer.LuminanceAugmentSpellDurationCount ?? 0) > 0) && spell.DotDuration > 0)
+                else if (caster is Player dotPlayer && (dotPlayer.AugmentationIncreasedSpellDuration > 0 || (dotPlayer.LuminanceAugmentSpellDurationCount ?? 0) > 0 || dotPlayer.GetZoneModifierBonus(ACE.Server.Managers.ZoneControl.ZoneModifiers.SpellDurationLevels) > 0) && spell.DotDuration > 0)
                 {
-                    entry.Duration *= 1.0f + (dotPlayer.AugmentationIncreasedSpellDuration * 0.2f) + ((dotPlayer.LuminanceAugmentSpellDurationCount ?? 0) * ServerConfig.void_dot_duration_aug_effect.Value);
+                    entry.Duration *= 1.0f + (dotPlayer.AugmentationIncreasedSpellDuration * 0.2f) + ((dotPlayer.LuminanceAugmentSpellDurationCount ?? 0) * ServerConfig.void_dot_duration_aug_effect.Value)
+                        + (dotPlayer.GetZoneModifierBonus(ACE.Server.Managers.ZoneControl.ZoneModifiers.SpellDurationLevels) * 0.2f);
                 }
             }
             else
@@ -303,6 +306,17 @@ namespace ACE.Server.WorldObjects.Managers
                     {
                         entry.StatModValue += (player.EffectiveItemAugCount) * 0.01f;
                     }
+                    // 168 = Heart Seeker (WeaponAuraOffense), 169 = Defender.
+                    //
+                    // INTENTIONAL - DO NOT "FIX" THE PRECEDENCE (owner ruling 2026-08-21).
+                    // This parses as `168 || (169 && selfCastEligible)`: Heart Seeker gets the
+                    // item-aug bonus UNCONDITIONALLY. That is load-bearing: melee attack skill
+                    // ~= skill x (1.2 + 0.001 x itemAugs) ~= 44-64k at endgame, and 200+ custom
+                    // mobs carry MeleeDefense 3k-99k tuned against exactly that scale (60k
+                    // Thrungi, 65k Sagittarii, 99.5k Warren mobs...). Adding parentheses drops
+                    // melee attack ~4.5x and makes all of that content unhittable - it is
+                    // melee-only-hittable BY this mechanism (casters have no aura equivalent
+                    // and bounce off those mobs' 50-100k MagicDefense by design).
                     else if (spell.StatModKey == 168 || spell.StatModKey == 169 && selfCastEligible)
                     {
                         entry.StatModValue += GetItemAugPercentageRating(player.EffectiveItemAugCount); //(player.EffectiveItemAugCount) * 0.01f;
@@ -1313,6 +1327,26 @@ namespace ACE.Server.WorldObjects.Managers
             return modifier;
         }
 
+        /// <summary>
+        /// Regen mod with specific spell ids excluded BEFORE top-layer selection (a retail regen buff underneath
+        /// an excluded one still applies). Zone Control Suppression (Prodigal block) calls this per vital tick.
+        /// DELIBERATELY non-virtual and uncached: EnchantmentManagerWithCaching's regen cache only invalidates on
+        /// enchantment change, not movement, so a cached zone-dependent value would go stale at zone borders.
+        /// </summary>
+        public float GetRegenerationMod(CreatureVital vital, HashSet<int> excludeSpellIds)
+        {
+            var typeFlags = EnchantmentTypeFlags.Float | EnchantmentTypeFlags.SingleStat | EnchantmentTypeFlags.Multiplicative;
+            var vitalKey = GetVitalRateKey(vital);
+            var enchantments = WorldObject.Biota.PropertiesEnchantmentRegistry.GetEnchantmentsTopLayerByStatModType(
+                typeFlags, (uint)vitalKey, WorldObject.BiotaDatabaseLock, SpellSet.SetSpells, excludeSpellIds);
+
+            var modifier = 1.0f;
+            foreach (var enchantment in enchantments)
+                modifier *= enchantment.StatModValue;
+
+            return modifier;
+        }
+
 
         /// <summary>
         /// Returns the weapon damage bonus, ie. Blood Drinker
@@ -1654,7 +1688,8 @@ namespace ACE.Server.WorldObjects.Managers
             var healAmount = creature.UpdateVitalDelta(creature.Health, (int)Math.Round(tickAmountTotal));
             creature.DamageHistory.OnHeal((uint)healAmount);
 
-            if (creature is Player player)
+            // 0-point ticks (full HP) are pure spam - say nothing (owner 2026-08-23)
+            if (healAmount > 0 && creature is Player player)
                 player.SendMessage($"You receive {healAmount} points of periodic healing.", ServerConfig.aetheria_heal_color.Value ? ChatMessageType.Broadcast : ChatMessageType.Combat);
         }
 
@@ -1767,7 +1802,7 @@ namespace ACE.Server.WorldObjects.Managers
                 var damager = kvp.Key;
                 var amount = kvp.Value;
 
-                if (creature.Invincible)
+                if (creature.Invincible || creature is Player { ZcDamageImmune: true })   // incl. Zone Control Cheat Death window
                     amount = 0;
 
                 var damageSourcePlayer = damager as Player;

--- a/Source/ACE.Server/WorldObjects/Monster_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Combat.cs
@@ -303,6 +303,30 @@ namespace ACE.Server.WorldObjects
 
         public DamageType GetDamageType(PropertiesBodyPart attackPart, CombatType? combatType = null)
         {
+            // Zone Control offense element: attack_damage_type scalar > per-part DamageType override >
+            // OutgoingDamageTypeOverride prop > weapon/body-part (blanket beats per-part, owner ruling
+            // 2026-08-02). Random flag per hit when multi-flag.
+            var zoneProfile = ACE.Server.Managers.ZoneControl.ZoneControlManager.ResolveForCreature(this);
+            if (zoneProfile != null)
+            {
+                if (zoneProfile.Has(ACE.Server.Managers.ZoneScaling.ZoneStat.AttackDamageType))
+                {
+                    var mask = (int)zoneProfile.Get(ACE.Server.Managers.ZoneScaling.ZoneStat.AttackDamageType);
+                    if (mask != 0)
+                        return EnumFlagRandom.SelectRandomFlag((DamageType)mask, DamageType.Physical);
+                }
+
+                var zonePart = FindZoneBodyPart(zoneProfile, attackPart);
+                if (zonePart?.DamageType is int partMask && partMask != 0)
+                    return EnumFlagRandom.SelectRandomFlag((DamageType)partMask, DamageType.Physical);
+            }
+
+            // OFFENSE DAMAGE TYPE override: force this mob's physical/melee/missile attacks to a chosen element,
+            // regardless of weapon or body-part type. Picks one random flag from the mask per hit. 0/unset = no-op.
+            var outOverride = GetProperty(PropertyInt.OutgoingDamageTypeOverride);
+            if (outOverride.HasValue && outOverride.Value != 0)
+                return EnumFlagRandom.SelectRandomFlag((DamageType)outOverride.Value, DamageType.Physical);
+
             // If there is a weapon equipped, get the damage type from that weapon.
             var weapon = GetEquippedWeapon();
             if (weapon != null) return GetDamageType(false, combatType);

--- a/Source/ACE.Server/WorldObjects/Monster_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Magic.cs
@@ -47,9 +47,29 @@ namespace ACE.Server.WorldObjects
         }
 
         /// <summary>
-        /// Returns TRUE if monster has known spells
+        /// Returns TRUE if monster has known spells (or zone-ADDED spells - a zone can make a caster
+        /// out of a mob with an empty book).
+        ///
+        /// 2026-08-31: the old wording said "provided its combat style allows magic". That is NOT
+        /// true in this codebase and it sent a Bestiary audit chasing a gate that does not exist -
+        /// GetNextAttackType tests only `HasKnownSpells &amp;&amp; TryRollSpell()`, and nothing anywhere
+        /// reads AiAllowedCombatStyle for magic (it is used for DualWield and StubbornMissile only).
+        /// Zone-added spells fire regardless of combat style.
         /// </summary>
-        private bool HasKnownSpells => Biota.HasKnownSpell(BiotaDatabaseLock);
+        private bool HasKnownSpells => Biota.HasKnownSpell(BiotaDatabaseLock) || ZoneHasAddedSpells();
+
+        /// <summary>True when the governing zone's spell rules ADD at least one castable spell
+        /// this monster's own book doesn't contain.</summary>
+        private bool ZoneHasAddedSpells()
+        {
+            var rules = ACE.Server.Managers.ZoneControl.ZoneControlManager.ResolveForCreature(this)?.SpellRules;
+            if (rules == null)
+                return false;
+            foreach (var r in rules)
+                if (!r.Disabled && (Biota.PropertiesSpellBook == null || !Biota.PropertiesSpellBook.ContainsKey(r.SpellId)))
+                    return true;
+            return false;
+        }
 
         /// <summary>
         /// The next spell the monster will attempt to cast
@@ -69,30 +89,84 @@ namespace ACE.Server.WorldObjects
             // there were probably other criteria used to select these spells (emote responses, monster ai responses)
             // for now, 2.0 base just becomes a 2% chance
 
-            if (Biota.PropertiesSpellBook == null)
+            // Zone Control spell rules (disable / chance override / added spells) - read-time, so
+            // toggles apply LIVE to spawned monsters. Rules hold chance in PERCENT.
+            var zoneRules = ACE.Server.Managers.ZoneControl.ZoneControlManager.ResolveForCreature(this)?.SpellRules;
+
+            if (Biota.PropertiesSpellBook == null && zoneRules == null)
                 return false;
 
             // We don't use thread safety here. Monster spell books aren't mutated cross-threads.
             // This reduces memory consumption by not cloning the spell book every single TryRollSpell()
             //foreach (var spell in Biota.CloneSpells(BiotaDatabaseLock)) // Thread-safe
-            foreach (var spell in Biota.PropertiesSpellBook) // Not thread-safe
+            if (Biota.PropertiesSpellBook != null)
             {
-                var probability = spell.Value > 2.0f ? spell.Value - 2.0f : spell.Value / 100.0f;
-
-                var rng = ThreadSafeRandom.Next(0.0f, 1.0f);
-
-                if (rng < probability)
+                foreach (var spell in Biota.PropertiesSpellBook) // Not thread-safe
                 {
-                    CurrentSpell = new Spell(spell.Key);
-                    if (CurrentSpell.NotFound)
+                    var probability = spell.Value > 2.0f ? spell.Value - 2.0f : spell.Value / 100.0f;
+
+                    if (zoneRules != null)
                     {
-                        CurrentSpell = null;
-                        continue;
+                        var rule = FindSpellRule(zoneRules, spell.Key);
+                        if (rule != null)
+                        {
+                            if (rule.Disabled)
+                                continue;
+                            if (rule.Chance.HasValue)
+                                probability = (float)(rule.Chance.Value / 100.0);
+                        }
                     }
-                    return true;
+
+                    var rng = ThreadSafeRandom.Next(0.0f, 1.0f);
+
+                    if (rng < probability)
+                    {
+                        CurrentSpell = new Spell(spell.Key);
+                        if (CurrentSpell.NotFound)
+                        {
+                            CurrentSpell = null;
+                            continue;
+                        }
+                        return true;
+                    }
+                }
+            }
+
+            // zone-ADDED spells (not in the weenie book) roll after the book, same independent-chance model
+            if (zoneRules != null)
+            {
+                foreach (var rule in zoneRules)
+                {
+                    if (rule.Disabled)
+                        continue;
+                    if (Biota.PropertiesSpellBook != null && Biota.PropertiesSpellBook.ContainsKey(rule.SpellId))
+                        continue;
+
+                    var probability = (float)((rule.Chance ?? 2.0) / 100.0);
+                    var rng = ThreadSafeRandom.Next(0.0f, 1.0f);
+
+                    if (rng < probability)
+                    {
+                        CurrentSpell = new Spell(rule.SpellId);
+                        if (CurrentSpell.NotFound)
+                        {
+                            CurrentSpell = null;
+                            continue;
+                        }
+                        return true;
+                    }
                 }
             }
             return false;
+        }
+
+        private static ACE.Server.Managers.ZoneScaling.ZoneSpellRule FindSpellRule(
+            System.Collections.Generic.IReadOnlyList<ACE.Server.Managers.ZoneScaling.ZoneSpellRule> rules, int spellId)
+        {
+            for (int i = 0; i < rules.Count; i++)
+                if (rules[i].SpellId == spellId)
+                    return rules[i];
+            return null;
         }
 
         /// <summary>
@@ -102,11 +176,39 @@ namespace ACE.Server.WorldObjects
         {
             var probabilities = new List<float>();
 
-            foreach (var spell in Biota.GetKnownSpellsProbabilities(BiotaDatabaseLock))
-            {
-                var probability = spell > 2.0f ? spell - 2.0f : spell / 100.0f;
+            // mirror TryRollSpell: zone rules disable/override book chances and can add spells
+            var zoneRules = ACE.Server.Managers.ZoneControl.ZoneControlManager.ResolveForCreature(this)?.SpellRules;
 
-                probabilities.Add(probability);
+            if (Biota.PropertiesSpellBook != null)
+            {
+                foreach (var spell in Biota.PropertiesSpellBook)
+                {
+                    var probability = spell.Value > 2.0f ? spell.Value - 2.0f : spell.Value / 100.0f;
+                    if (zoneRules != null)
+                    {
+                        var rule = FindSpellRule(zoneRules, spell.Key);
+                        if (rule != null)
+                        {
+                            if (rule.Disabled)
+                                continue;
+                            if (rule.Chance.HasValue)
+                                probability = (float)(rule.Chance.Value / 100.0);
+                        }
+                    }
+                    probabilities.Add(probability);
+                }
+            }
+
+            if (zoneRules != null)
+            {
+                foreach (var rule in zoneRules)
+                {
+                    if (rule.Disabled)
+                        continue;
+                    if (Biota.PropertiesSpellBook != null && Biota.PropertiesSpellBook.ContainsKey(rule.SpellId))
+                        continue;
+                    probabilities.Add((float)((rule.Chance ?? 2.0) / 100.0));
+                }
             }
 
             return Probability.GetProbabilityAny(probabilities);

--- a/Source/ACE.Server/WorldObjects/Monster_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Melee.cs
@@ -447,8 +447,37 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public virtual BaseDamageMod GetBaseDamage(PropertiesBodyPart attackPart)
         {
+            // Zone Control offense: a governed monster's zone profile can REPLACE its attack damage.
+            // Precedence: attack_damage/attack_variance scalar > per-part override > weenie (weapon OR body part)
+            // — the blanket Offense-tab stats are the always-live tuning lever; per-part values are a refined
+            // baseline that only shows through where the blanket stat is unset (owner ruling 2026-08-02).
+            // This is the single choke point for melee, missile and weapon damage, so one number covers them all.
+            var zoneProfile = ACE.Server.Managers.ZoneControl.ZoneControlManager.ResolveForCreature(this);
+            double? zoneMax = null, zoneVar = null;
+            if (zoneProfile != null)
+            {
+                var zonePart = FindZoneBodyPart(zoneProfile, attackPart);
+                if (zoneProfile.Has(ACE.Server.Managers.ZoneScaling.ZoneStat.AttackDamage))
+                    zoneMax = zoneProfile.Get(ACE.Server.Managers.ZoneScaling.ZoneStat.AttackDamage);
+                else
+                    zoneMax = zonePart?.Damage;
+                if (zoneProfile.Has(ACE.Server.Managers.ZoneScaling.ZoneStat.AttackVariance))
+                    zoneVar = zoneProfile.Get(ACE.Server.Managers.ZoneScaling.ZoneStat.AttackVariance);
+                else
+                    zoneVar = zonePart?.Variance;
+
+                // variance is a fraction of the max hit (min = max * (1 - v)); out-of-range values
+                // produce negative rolls, so clamp 0..1 exactly like the spell_variance path does
+                if (zoneVar.HasValue)
+                    zoneVar = Math.Clamp(zoneVar.Value, 0.0, 1.0);
+
+                // a negative authored attack_damage would roll negative hits (heals) - floor at 0
+                if (zoneMax.HasValue)
+                    zoneMax = Math.Max(zoneMax.Value, 0.0);
+            }
+
             if (CurrentAttack == CombatType.Missile && GetMissileAmmo() != null)
-                return GetMissileDamage();
+                return ApplyZoneAttackDamage(GetMissileDamage(), zoneMax, zoneVar);
 
             // use weapon damage for every attack?
             var weapon = GetEquippedMeleeWeapon();
@@ -456,14 +485,44 @@ namespace ACE.Server.WorldObjects
             {
                 var weaponDamage = weapon.GetDamageMod(this);
                 //Console.WriteLine($"{Name} using weapon damage: {weaponDamage}");
-                return weaponDamage;
+                return ApplyZoneAttackDamage(weaponDamage, zoneMax, zoneVar);
             }
 
-            var maxDamage = attackPart.DVal;
-            var variance = attackPart.DVar;
+            var maxDamage = zoneMax.HasValue ? (int)Math.Round(zoneMax.Value) : attackPart.DVal;
+            var variance = zoneVar.HasValue ? (float)zoneVar.Value : attackPart.DVar;
 
             var baseDamage = new BaseDamage(maxDamage, variance);
-            return new BaseDamageMod(baseDamage);
+            var baseDamageMod = new BaseDamageMod(baseDamage);
+
+            return baseDamageMod;
+        }
+
+        /// <summary>Overwrites a weapon/missile BaseDamageMod's underlying max damage / variance with the zone
+        /// values (the BaseDamage instance is freshly created per call, so mutating it is safe). Enchantment /
+        /// launcher mods on the BaseDamageMod itself still apply on top.</summary>
+        private static BaseDamageMod ApplyZoneAttackDamage(BaseDamageMod mod, double? zoneMax, double? zoneVar)
+        {
+            if (mod?.BaseDamage != null)
+            {
+                if (zoneMax.HasValue) mod.BaseDamage.MaxDamage = (int)Math.Round(zoneMax.Value);
+                if (zoneVar.HasValue) mod.BaseDamage.Variance = (float)zoneVar.Value;
+            }
+            return mod;
+        }
+
+        /// <summary>Resolves the zone per-part override for a raw PropertiesBodyPart by reference (the callers
+        /// only have the value, not the CombatBodyPart key; collections are &lt;= ~10 entries so the scan is cheap).</summary>
+        private ACE.Server.Managers.ZoneScaling.ZoneBodyPart FindZoneBodyPart(
+            ACE.Server.Managers.ZoneScaling.EvaluatedProfile zoneProfile, PropertiesBodyPart attackPart)
+        {
+            if (zoneProfile == null || !zoneProfile.HasBodyParts || attackPart == null || Biota.PropertiesBodyPart == null)
+                return null;
+
+            foreach (var kv in Biota.PropertiesBodyPart)
+                if (ReferenceEquals(kv.Value, attackPart))
+                    return zoneProfile.GetBodyPart((int)kv.Key);
+
+            return null;
         }
 
         /// <summary>
@@ -638,10 +697,19 @@ namespace ACE.Server.WorldObjects
         {
             List<KeyValuePair<CombatBodyPart, PropertiesBodyPart>> parts = null;
 
+            // Zone Control: per-part damage overrides also gate WHICH parts attack — an override of 0 silences
+            // a part, an override > 0 lets a normally non-attacking part swing (weenie DVal used when unset).
+            var zoneProfile = ACE.Server.Managers.ZoneControl.ZoneControlManager.ResolveForCreature(this);
+            int EffectiveDVal(CombatBodyPart key, int baseDVal)
+            {
+                var ovr = zoneProfile?.GetBodyPart((int)key)?.Damage;
+                return ovr.HasValue ? (int)Math.Round(ovr.Value) : baseDVal;
+            }
+
             // todo: speed up key lookup?
             if (attackHook != null)
             {
-                parts = Biota.PropertiesBodyPart.Where(b => (uint)b.Key == attackHook.AttackCone.PartIndex && b.Value.DVal > 0).ToList();
+                parts = Biota.PropertiesBodyPart.Where(b => (uint)b.Key == attackHook.AttackCone.PartIndex && EffectiveDVal(b.Key, b.Value.DVal) > 0).ToList();
             }
             else if (motionCommand >= MotionCommand.SpecialAttack1 && motionCommand <= MotionCommand.SpecialAttack3)
             {
@@ -652,7 +720,7 @@ namespace ACE.Server.WorldObjects
             // added parts.Count check for monsters wielding weapons -- should we be getting a body part here?
             if (parts == null || parts.Count == 0)
                 //parts = Biota.BiotaPropertiesBodyPart.Where(b => b.DVal != 0 && b.BH != 0).ToList();
-                parts = Biota.PropertiesBodyPart.Where(b => b.Value.DVal != 0 && b.Key != CombatBodyPart.Breath).ToList();
+                parts = Biota.PropertiesBodyPart.Where(b => EffectiveDVal(b.Key, b.Value.DVal) != 0 && b.Key != CombatBodyPart.Breath).ToList();
 
             if (parts.Count == 0)
             {

--- a/Source/ACE.Server/WorldObjects/Monster_Tick.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Tick.cs
@@ -70,6 +70,8 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public void Monster_Tick(double currentUnixTime)
         {
+            UpdateAuraBuffs(currentUnixTime);
+
             if (IsChessPiece && this is GamePiece gamePiece)
             {
                 // faster than vtable?

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -267,6 +267,13 @@ namespace ACE.Server.WorldObjects
 
             ContainerCapacity = (byte)(7 + AugmentationExtraPackSlot);
 
+            // How many pack slots the CLIENT is actually showing. The client renders the slot count
+            // it read at login, so a PackSlot aug granted mid-session raises ContainerCapacity
+            // server-side while the extra slot stays invisible until relog - a pack placed there
+            // looks lost/buggy. Tooling that mints packs fills to THIS, never to live capacity
+            // (owner 2026-08-11: "dont want to get a buggy item").
+            ClientPackSlots = ContainerCapacity ?? 7;
+
             if (Session != null && AdvocateQuest && IsAdvocate) // Advocate permissions are per character regardless of override
             {
                 if (Session.AccessLevel == AccessLevel.Player)
@@ -1189,7 +1196,11 @@ namespace ACE.Server.WorldObjects
             return burdenMod;
         }
 
-        public bool Adminvision;
+        public bool Adminvision
+        {
+            get => GetProperty(PropertyBool.PersistentAdminvision) ?? false;
+            set { if (!value) RemoveProperty(PropertyBool.PersistentAdminvision); else SetProperty(PropertyBool.PersistentAdminvision, value); }
+        }
 
         public void HandleAdminvisionToggle(int choice)
         {

--- a/Source/ACE.Server/WorldObjects/Player_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Combat.cs
@@ -47,6 +47,244 @@ namespace ACE.Server.WorldObjects
             set { if (value == 0) RemoveProperty(PropertyFloat.PkTimestamp); else SetProperty(PropertyFloat.PkTimestamp, value); }
         }
 
+        #region Zone Control slot specials (armor v2, 2026-08-21)
+
+        // Cantrip props the specials are keyed on (ZoneModifiers block 50200-50399; literal ints here so
+        // this file does not chase the catalog's constant names): 50227/50228 = key 42 Battle Mending
+        // (chance / heal - either marks the piece; the magnitude is ignored, the save heals to full),
+        // 50229 = key 44 pct-HP damage in TENTHS of a pct, 50230 = key 45 Cheat Death flag (stamp 1),
+        // 50231 = key 46 Regen multiplier (read in Creature_Vitals).
+        private const int ZcBattleMendChanceProp = 50227;
+        private const int ZcBattleMendHealProp = 50228;
+        private const int ZcPctHpDamageProp = 50229;
+        private const int ZcCheatDeathProp = 50230;
+        private const int ZcLifeOnHitProp = 50233;      // key 48 Life on Hit: pct of max HP per landed hit, SUMMED across worn jewelry
+
+        // TRANSIENT per-session timers (unix seconds). Never persisted, never exposed as properties:
+        // a relog resets them, which is the accepted cost of keeping them out of the biota.
+        public double ZcBattleMendReadyAt;
+        public double ZcPctHpReadyAt;
+        public double ZcCheatDeathReadyAt;
+        public double ZcCheatDeathImmuneUntil;
+        public double ZcLifeOnHitReadyAt;
+
+        /// <summary>Cheat Death window: TRUE while the player is immune to ALL damage. OR'd into every
+        /// Invincible guard and unguarded HP writer (melee/missile/magic/DoT/zone tick/hotspot/falling/
+        /// boundary drain). Deliberately NOT PropertyBool.Invincible - that one is persisted and admin-owned.
+        /// Nothing the player does clears the window; it simply expires.</summary>
+        public bool ZcDamageImmune => Time.GetUnixTime() < ZcCheatDeathImmuneUntil;
+
+        /// <summary>
+        /// Per-zone tuning knob for the specials, read from the governing zone's DEFAULT profile
+        /// (ResolveZoneDefaultForCreature - the same layer the relief curves use, so a per-WCID stat
+        /// override never hides the knob). There is no player-side stat resolver, so the zone is found
+        /// through the OTHER creature in the exchange: the monster hitting us, or the monster we hit.
+        /// No creature (falling, zone DoT) or no zone -> the C# default.
+        /// </summary>
+        private static double ZcSpecialKnob(WorldObject other, string stat, double fallback)
+        {
+            try
+            {
+                if (other is Creature c && c is not Player)
+                {
+                    var profile = ACE.Server.Managers.ZoneControl.ZoneControlManager.ResolveZoneDefaultForCreature(c);
+                    if (profile != null)
+                        return profile.Get(stat, fallback);
+                }
+            }
+            catch
+            {
+                // never let zone resolution break a damage path
+            }
+            return fallback;
+        }
+
+        /// <summary>
+        /// Cheat Death (key 45, boots). Call with the FINAL incoming health amount, AFTER Mana Barrier and
+        /// BEFORE the health delta. If the wearer carries the flag, the cooldown is ready and the hit would
+        /// be lethal, the amount is clamped so Health lands on exactly 1, a full-damage immunity window
+        /// opens (cheatdeath_immunity, default 5 s) and the per-character cooldown starts
+        /// (cheatdeath_cooldown, default 600 s). Returns the amount to actually apply.
+        /// </summary>
+        private static string ZcFormatCooldown(double seconds)
+        {
+            if (seconds < 60) return $"{seconds:0}s";
+            var m = (int)(seconds / 60);
+            var sec = (int)(seconds % 60);
+            return sec > 0 ? $"{m}m {sec}s" : $"{m}m";
+        }
+
+        /// <summary>While the Cheat Death window is open, every absorbed hit is announced (owner 2026-08-23).</summary>
+        public void ZcAnnounceAbsorb(WorldObject source, string what)
+        {
+            if (!ZcDamageImmune || Invincible) return;
+            SendMessage($"Cheat Death absorbs {what}{(source != null ? " from " + source.Name : "")}.", ChatMessageType.Broadcast);
+        }
+
+        public uint ZcTryCheatDeath(WorldObject source, uint amount)
+        {
+            if (IsDead || Health.Current <= 0 || amount < Health.Current)
+                return amount;
+
+            if (GetZoneModifierMax(ZcCheatDeathProp) <= 0)
+                return amount;
+
+            var now = Time.GetUnixTime();
+            if (now < ZcCheatDeathReadyAt)
+                return amount;
+
+            var immunity = ZcSpecialKnob(source, "cheatdeath_immunity", 5.0);
+            var cooldown = ZcSpecialKnob(source, "cheatdeath_cooldown", 600.0);
+
+            ZcCheatDeathImmuneUntil = now + immunity;
+            ZcCheatDeathReadyAt = now + cooldown;
+
+            // announce one tick later so it reads AFTER the would-be killing blow's own damage line (owner 2026-08-23)
+            var announce = new ACE.Server.Entity.Actions.ActionChain();
+            announce.AddDelayForOneTick();
+            announce.AddAction(this, ACE.Server.Entity.Actions.ActionType.Player_ZcCheatDeathExpired, () =>
+                SendMessage($"Cheat Death! You are immune to all damage for {immunity:0} seconds.", ChatMessageType.Broadcast));
+            announce.EnqueueChain();
+            log.Info($"[ZCSPECIAL] Cheat Death: {Name} hit for {amount:N0} at {Health.Current:N0} HP by {source?.Name ?? "?"} -> 1 HP, immune {immunity:0}s, cooldown {cooldown:0}s");
+
+            // expiry notice (owner 2026-08-23): fires when the window closes, names the remaining cooldown
+            var expiry = new ACE.Server.Entity.Actions.ActionChain();
+            expiry.AddDelaySeconds(immunity);
+            expiry.AddAction(this, ACE.Server.Entity.Actions.ActionType.Player_ZcCheatDeathExpired, () =>
+            {
+                if (IsDead) return;
+                SendMessage($"Cheat Death has expired! Cooldown: {ZcFormatCooldown(cooldown - immunity)}.", ChatMessageType.Broadcast);
+            });
+            expiry.EnqueueChain();
+
+            // land on 1 HP, never below
+            return (uint)(Health.Current - 1);
+        }
+
+        /// <summary>
+        /// Battle Mending (key 42, chest) death save. Call AFTER a health delta has been applied and BEFORE
+        /// the death check: if the wearer is still alive but under battlemend_threshold (default 0.25) of
+        /// max health and the cooldown (battlemend_cooldown, default 60 s) is ready, heal to full. The
+        /// piece's rolled chance/heal magnitudes are ignored - the special has no magnitude.
+        /// </summary>
+        public void ZcTryBattleMend(WorldObject source)
+        {
+            if (IsDead || Health.Current <= 0)
+                return;
+
+            if (GetZoneModifierMax(ZcBattleMendHealProp) <= 0 && GetZoneModifierMax(ZcBattleMendChanceProp) <= 0)
+                return;
+
+            var now = Time.GetUnixTime();
+            if (now < ZcBattleMendReadyAt)
+                return;
+
+            var threshold = ZcSpecialKnob(source, "battlemend_threshold", 0.25);
+            if (Health.Current >= threshold * Health.MaxValue)
+                return;
+
+            var missing = (int)Math.Min(int.MaxValue, (long)Health.MaxValue - Health.Current);
+            if (missing <= 0)
+                return;
+
+            // UpdateVital sends the client vital update itself (Player_Vitals.UpdateVital)
+            var healed = UpdateVitalDelta(Health, missing);
+            if (healed > 0)
+                DamageHistory.OnHeal((uint)healed);
+
+            ZcBattleMendReadyAt = now + ZcSpecialKnob(source, "battlemend_cooldown", 60.0);
+
+            SendMessage("Battle Mending restores you to full health.", ChatMessageType.Broadcast);
+            log.Info($"[ZCSPECIAL] Battle Mending: {Name} healed {healed:N0} (was under {threshold:P0}) by {source?.Name ?? "?"}");
+        }
+
+        /// <summary>
+        /// pct-HP damage (key 44, gauntlets): the FLAT add (no crit, no mitigation) to put on a landed hit
+        /// against <paramref name="defender"/>, or 0. Fires only vs monsters carrying a Zone Control
+        /// variation profile (everything else immune by default), never vs a mob flagged
+        /// PropertyBool.ZcPctHpImmune (50051), on a per-character cooldown (pcthp_cooldown, default 2 s),
+        /// and under the NO-KILL rule: only while the mob's health fraction is above the rolled pct, so the
+        /// add can never be the killing blow. The cooldown starts only when it actually fires.
+        /// </summary>
+        public float ZcTryPctHpDamage(Creature defender)
+        {
+            if (defender == null || defender is Player || defender is CombatPet || defender.IsDead || defender.Health == null)
+                return 0.0f;
+
+            var tenths = GetZoneModifierMax(ZcPctHpDamageProp);
+            if (tenths <= 0)
+                return 0.0f;
+
+            var now = Time.GetUnixTime();
+            if (now < ZcPctHpReadyAt)
+                return 0.0f;
+
+            if (ACE.Server.Managers.ZoneControl.ZoneControlManager.ResolveForCreature(defender) == null)
+                return 0.0f;
+
+            if (defender.GetProperty(PropertyBool.ZcPctHpImmune) == true)
+                return 0.0f;
+
+            var max = defender.Health.MaxValue;
+            if (max == 0)
+                return 0.0f;
+
+            var frac = tenths / 1000.0;
+            if ((double)defender.Health.Current / max <= frac)
+                return 0.0f;
+
+            ZcPctHpReadyAt = now + ZcSpecialKnob(defender, "pcthp_cooldown", 2.0);
+
+            log.Info($"[ZCSPECIAL] Pct HP Damage: {Name} -> {defender.Name}: +{frac * max:N0} ({tenths / 10.0:0.#} pct of {max:N0})");
+            // visible to the wearer (owner 2026-08-23): one line per proc, after the hit's own damage line
+            var pctMsg = $"Pct HP Damage: +{frac * max:N0} ({tenths / 10.0:0.#} pct of {defender.Name}'s max health).";
+            var pctChain = new ACE.Server.Entity.Actions.ActionChain();
+            pctChain.AddDelayForOneTick();
+            pctChain.AddAction(this, ACE.Server.Entity.Actions.ActionType.Player_ZcCheatDeathExpired, () => SendMessage(pctMsg, ChatMessageType.Broadcast));
+            pctChain.EnqueueChain();
+            return (float)(frac * max);
+        }
+
+        /// <summary>
+        /// Life on Hit (key 48, jewelry-only chase line, owner 2026-08-22): after a landed damaging hit on a
+        /// monster, heal the attacker a pct of THEIR OWN max HP - the summed worn value, capped at
+        /// lifeonhit_cap (25 pct), on a per-character cooldown lifeonhit_cooldown (3 s) so multi-strike and
+        /// split arrows cannot pump it. Not a pct of damage dealt: "life on hit", not "lifesteal", on purpose.
+        /// Fires from both hit paths (DamageEvent melee/missile, SpellProjectile spells) when damage > 0.
+        /// Heals nothing at full HP and never starts the cooldown unless it actually healed.
+        /// </summary>
+        public void ZcTryLifeOnHit(Creature defender)
+        {
+            if (defender == null || defender is Player || IsDead || Health == null)
+                return;
+
+            var pct = GetZoneModifierBonus(ZcLifeOnHitProp);
+            if (pct <= 0)
+                return;
+
+            var now = Time.GetUnixTime();
+            if (now < ZcLifeOnHitReadyAt)
+                return;
+
+            var cap = (int)Math.Round(ZcSpecialKnob(defender, "lifeonhit_cap", 25.0));
+            pct = Math.Min(pct, Math.Max(0, cap));
+            if (pct <= 0)
+                return;
+
+            var max = Health.MaxValue;
+            var missing = (long)max - Health.Current;
+            if (missing <= 0)
+                return;
+
+            var heal = (uint)Math.Min(missing, Math.Max(1L, (long)Math.Round(max * pct / 100.0)));
+            UpdateVitalDelta(Health, (int)heal);
+            DamageHistory.OnHeal(heal);
+
+            ZcLifeOnHitReadyAt = now + ZcSpecialKnob(defender, "lifeonhit_cooldown", 3.0);
+        }
+
+        #endregion
+
         /// <summary>
         /// Returns the current attack skill for the player
         /// </summary>
@@ -453,13 +691,15 @@ namespace ACE.Server.WorldObjects
         {
             if (weapon == null || !weapon.IsRanged)
                 return PowerLevel + 0.5f;
+            else if (ServerConfig.missile_power_bar.Value)
+                return AccuracyLevel + 0.5f;
             else
                 return 1.0f;
         }
 
         public override float GetAccuracyMod(WorldObject weapon)
         {
-            if (weapon != null && weapon.IsRanged)
+            if (weapon != null && weapon.IsRanged && !ServerConfig.missile_power_bar.Value)
                 return AccuracyLevel + 0.6f;
             else
                 return 1.0f;
@@ -488,7 +728,8 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public override void TakeDamageOverTime(float _amount, DamageType damageType)
         {
-            if (Invincible || IsDead) return;
+            if (ZcDamageImmune && !Invincible && !IsDead) ZcAnnounceAbsorb(null, $"{Math.Round(_amount):N0} {damageType.ToString().ToLowerInvariant()} damage over time");
+            if (Invincible || ZcDamageImmune || IsDead) return;
 
             // check lifestone protection
             if (UnderLifestoneProtection)
@@ -512,7 +753,12 @@ namespace ACE.Server.WorldObjects
 
             // update health (skip if fully absorbed)
             if (!mbDotResult.FullyAbsorbed)
+            {
+                // Zone Control Cheat Death (key 45) / Battle Mending (key 42) - DoT ticks bypass TakeDamageInternal
+                amount = ZcTryCheatDeath(DamageHistory.LastDamager?.TryGetAttacker(), amount);
                 UpdateVitalDelta(Health, (int)-amount);
+                ZcTryBattleMend(DamageHistory.LastDamager?.TryGetAttacker());
+            }
 
             // update stamina
             //UpdateVitalDelta(Stamina, -1);
@@ -554,6 +800,82 @@ namespace ACE.Server.WorldObjects
                 EnqueueBroadcast(new GameMessageSound(Guid, Sound.Wound1, 1.0f));
         }
 
+        /// <summary>
+        /// Applies a single Zone Control effect "tick" to this player. Stamina/Mana drain their own pool;
+        /// every other damage type reduces Health. The periodic message names the element (fire/cold/lightning/
+        /// nether/…) and Health drains read as "drained". Kept separate from <see cref="TakeDamageOverTime"/> so
+        /// it can name the element + drain stamina/mana without changing retail DoT wording.
+        /// </summary>
+        public void TakeZoneEffectDamage(uint amount, DamageType damageType)
+        {
+            if (Invincible || ZcDamageImmune || IsDead || amount == 0)
+                return;
+
+            if (UnderLifestoneProtection)
+            {
+                HandleLifestoneProtection();
+                return;
+            }
+
+            switch (damageType)
+            {
+                case DamageType.Stamina:
+                {
+                    var drained = Math.Min(amount, (uint)Math.Max(0, Stamina.Current));
+                    if (drained > 0)
+                    {
+                        UpdateVitalDelta(Stamina, -(int)drained);
+                        SendMessage($"The zone drains {drained} points of your stamina.", ChatMessageType.Combat);
+                    }
+                    return;
+                }
+                case DamageType.Mana:
+                {
+                    var drained = Math.Min(amount, (uint)Math.Max(0, Mana.Current));
+                    if (drained > 0)
+                    {
+                        UpdateVitalDelta(Mana, -(int)drained);
+                        SendMessage($"The zone drains {drained} points of your mana.", ChatMessageType.Combat);
+                    }
+                    return;
+                }
+                default:
+                {
+                    // Zone Control Cheat Death (key 45) / Battle Mending (key 42) - zone ticks bypass TakeDamageInternal
+                    amount = ZcTryCheatDeath(null, amount);
+                    UpdateVitalDelta(Health, -(int)amount);
+                    ZcTryBattleMend(null);
+
+                    string text;
+                    ChatMessageType chan;
+                    if (damageType == DamageType.Health)
+                    {
+                        text = $"The zone drains {amount} points of your health.";
+                        chan = ChatMessageType.Combat;
+                    }
+                    else
+                    {
+                        var typeName = damageType == DamageType.Nether ? "nether"
+                                     : damageType == DamageType.Electric ? "lightning"
+                                     : damageType.ToString().ToLowerInvariant();
+                        text = $"You receive {amount} points of periodic {typeName} damage.";
+                        chan = damageType == DamageType.Nether ? ChatMessageType.Magic : ChatMessageType.Combat;
+                    }
+                    SendMessage(text, chan);
+
+                    var splatter = new GameMessageScript(Guid, damageType == DamageType.Nether ? PlayScript.HealthDownVoid : PlayScript.DirtyFightingDamageOverTime);
+                    EnqueueBroadcast(splatter);
+
+                    if (Health.Current <= 0)
+                    {
+                        OnDeath(DamageHistory.LastDamager, damageType, false);
+                        Die();
+                    }
+                    return;
+                }
+            }
+        }
+
         public int TakeDamage(WorldObject source, DamageEvent damageEvent)
         {
             var result = TakeDamageInternal(source, damageEvent.DamageType, damageEvent.Damage, damageEvent.BodyPart, out var absorbed, damageEvent.IsCritical, damageEvent.AttackConditions);
@@ -575,7 +897,8 @@ namespace ACE.Server.WorldObjects
         private int TakeDamageInternal(WorldObject source, DamageType damageType, float _amount, BodyPart bodyPart, out uint amountAbsorbed, bool crit, AttackConditions attackConditions)
         {
             amountAbsorbed = 0;
-            if (Invincible || IsDead) return 0;
+            if (ZcDamageImmune && !Invincible && !IsDead) ZcAnnounceAbsorb(source, $"{Math.Round(_amount):N0} {damageType.ToString().ToLowerInvariant()} damage");
+            if (Invincible || ZcDamageImmune || IsDead) return 0;
 
             if (source is Creature creatureAttacker)
                 SetCurrentAttacker(creatureAttacker);
@@ -629,8 +952,14 @@ namespace ACE.Server.WorldObjects
                 damageTaken = 0;
                 if (!mbResult.FullyAbsorbed)
                 {
+                    // Zone Control Cheat Death (key 45): lethal hit -> land on 1 HP + immunity window
+                    amount = ZcTryCheatDeath(source, amount);
+
                     damageTaken = (uint)-UpdateVitalDelta(Health, (int)-amount);
                     DamageHistory.Add(source, damageType, damageTaken);
+
+                    // Zone Control Battle Mending (key 42): survived, but under the threshold -> heal to full
+                    ZcTryBattleMend(source);
                 }
             }
 

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -2473,6 +2473,14 @@ namespace ACE.Server.WorldObjects
                         return WeenieError.SkillTooLow;
                     break;
 
+                case WieldRequirement.Int64Stat:    // server-side extension (T11 item-aug gate)
+
+                    // verify PropertyInt64 minimum
+                    var propInt64 = GetProperty((PropertyInt64)skillOrAttribute) ?? 0;
+                    if (propInt64 < difficulty)
+                        return WeenieError.SkillTooLow;
+                    break;
+
                 case WieldRequirement.CreatureType:
 
                     // verify creature type

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -18,6 +18,8 @@ namespace ACE.Server.WorldObjects
 {
     partial class Player
     {
+        private static readonly log4net.ILog zcLog = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
         // ── Charm redirect spell IDs ───────────────────────────────────────────
         private const uint SpellId_TectonicRiftsI  = 1789u;
         private const uint SpellId_TectonicRiftsII = 6196u;
@@ -1780,7 +1782,22 @@ namespace ACE.Server.WorldObjects
         /// derived from the drain rather than from the spell's Min/Max — see SpellProjectile.LifeProjectileDamage.
         /// </para>
         /// </summary>
-        internal void ApplyRingSpellAreaDamage(Spell spell, Position centerOverride = null, float radiusOverride = 0f, float heightOverride = 0f, float flatDamage = 0f, WorldObject scanOrigin = null, bool fromProc = false, float lifeProjectileDamage = 0f)
+        /// <summary>Element word for the Cast on Strike ring line. Mirrors SpellProjectile.ZcElementWord;
+        /// the two message sites must read identically.</summary>
+        private static string ZcElementWord(DamageType dt)
+        {
+            if (dt.HasFlag(DamageType.Slash)) return "slash";
+            if (dt.HasFlag(DamageType.Pierce)) return "pierce";
+            if (dt.HasFlag(DamageType.Bludgeon)) return "bludgeon";
+            if (dt.HasFlag(DamageType.Acid)) return "acid";
+            if (dt.HasFlag(DamageType.Cold)) return "cold";
+            if (dt.HasFlag(DamageType.Electric)) return "electric";
+            if (dt.HasFlag(DamageType.Fire)) return "fire";
+            if (dt.HasFlag(DamageType.Nether)) return "nether";
+            return "magic";
+        }
+
+        internal void ApplyRingSpellAreaDamage(Spell spell, Position centerOverride = null, float radiusOverride = 0f, float heightOverride = 0f, float flatDamage = 0f, WorldObject scanOrigin = null, bool fromProc = false, float lifeProjectileDamage = 0f, double procBaseDamage = 0, WorldObject procWeapon = null, double procVariance = 0)
         {
             var center = centerOverride ?? Location;
             if (center == null) return;
@@ -1830,7 +1847,14 @@ namespace ACE.Server.WorldObjects
             var attackSkill   = GetCreatureSkill(spell.School);
             var magicSkill    = attackSkill.Current;
             var resistanceType = Creature.GetResistanceType(spell.DamageType);
-            var weapon        = GetEquippedWand();
+            // PROC WEAPON WINS OVER THE EQUIPPED WAND. GetEquippedWand() is right for a hand-cast ring,
+            // but a ring fired as a weapon proc comes off a dagger/bow/wand that is NOT in the wand slot,
+            // so this returned NULL and every weapon-derived term silently vanished - above all the REND,
+            // since GetWeaponResistanceModifier bails on a null weapon. Measured in game 2026-08-27: the
+            // arc landed 56,378 and the ring 23,237 off the same Fire/Fire-Rending dagger, a 2.43x gap
+            // that is exactly the T11 rend band. Heritage bonus and the crit-damage mod were lost the
+            // same way.
+            var weapon        = procWeapon ?? GetEquippedWand();
 
             var isLifeProjectile = spell.MetaSpellType == ACE.Entity.Enum.SpellType.LifeProjectile;
 
@@ -1889,7 +1913,12 @@ namespace ACE.Server.WorldObjects
                     // Resist check — sends the resist message automatically.  A resisted spell still
                     // lands if the caster's Overpower procs, matching SpellProjectile.CalculateDamage,
                     // which only bails on `resisted && !overpower`.
-                    var resisted = TryResistSpell(creature, spell, null, true);
+                    // For a Cast on Strike proc the WEAPON is the itemCaster, so the resist rolls
+                    // against its ItemSpellcraft (the 9999 stamp) exactly as the arc path does via
+                    // resistSource - passing null here rolled the PLAYER's own War/Void skill, the
+                    // precise failure the spellcraft stamp exists to prevent (fixed 2026-08-28, the
+                    // sixth everything-must-be-done-TWICE bug). Hand-cast rings keep null = own skill.
+                    var resisted = TryResistSpell(creature, spell, fromProc && procBaseDamage > 0 ? weapon : null, true);
                     if (resisted && !(Overpower != null && Creature.GetOverpower(this, creature)))
                     {
                         dbgResist++;
@@ -1916,7 +1945,8 @@ namespace ACE.Server.WorldObjects
                     // on such spells.  Mirrors SpellProjectile.CalculateDamage's LifeProjectile branch.
                     var lifeMagicDamage = isLifeProjectile ? lifeProjectileDamage * spell.DamageRatio : 0.0f;
 
-                    // Crit chance — 5% base + player crit rating, mitigated by target resist rating.
+                    // Crit chance — 10% base since 2026-08-29 (unified with melee/missile) + player
+                    // crit rating, mitigated by target resist rating.
                     var critChance = GetWeaponMagicCritFrequency(weapon, this as Creature, attackSkill, creature);
                     if (ThreadSafeRandom.Next(0.0f, 1.0f) < critChance)
                     {
@@ -1932,12 +1962,18 @@ namespace ACE.Server.WorldObjects
                         if (!critDefended)
                         {
                             criticalHit = true;
-                            // Life: +50% of the drained damage (pre-aug, matching SpellProjectile).
-                            // War/Void — PvE: +50% of MaxDamage.  PvP: +50% of MinDamage.
-                            critDamageBonus  = isLifeProjectile
-                                ? lifeMagicDamage * 0.5f
-                                : (isPvP ? spell.MinDamage * 0.5f : spell.MaxDamage * 0.5f);
-                            critDamageBonus *= GetWeaponCritDamageMod(weapon, this as Creature, attackSkill, creature);
+                            // UNIFIED CRIT MODEL (owner 2026-08-29, matching SpellProjectile): PvE
+                            // crit = CritX x the fully composed base, computed AFTER the aug term
+                            // below. Life: CritX x the drained base (0.5 coefficient gone). PvP
+                            // keeps the retail halved-min rule.
+                            // only the life / PvP branches use the mod here; the war/void PvE crit reads it
+                            // once in the unified block below (review 2026-09-04: it was computed twice)
+                            var earlyMod = isLifeProjectile || isPvP
+                                ? GetWeaponCritDamageMod(weapon, this as Creature, attackSkill, creature)
+                                : 0f;
+                            critDamageBonus = isLifeProjectile
+                                ? lifeMagicDamage * earlyMod
+                                : (isPvP ? spell.MinDamage * 0.5f * earlyMod : 0f);
                         }
                     }
 
@@ -1966,23 +2002,45 @@ namespace ACE.Server.WorldObjects
                         if (magicSkill > spell.Power)
                             skillBonus = spell.MinDamage * (magicSkill - spell.Power) / 1000.0f;
 
-                        baseDamage = ThreadSafeRandom.Next(spell.MinDamage, spell.MaxDamage);
+                        // Zone Control "Cast on Strike" ring slot: the authored B replaces the rolled
+                        // spell base here exactly as it does on the projectile path. A ring's damage is
+                        // applied by THIS method and never reaches SpellProjectile.CalculateDamage, so
+                        // without this the ring fires on the spell's own base and the whole band is
+                        // ignored - which is what the first in-game test was actually measuring.
+                        baseDamage = procBaseDamage > 0
+                            ? (long)Math.Round(procBaseDamage)
+                            // unified crit: a PvE crit uses the MAX roll, matching SpellProjectile
+                            : (criticalHit && !isPvP
+                                ? spell.MaxDamage
+                                : ThreadSafeRandom.Next(spell.MinDamage, spell.MaxDamage));
 
                         // Luminance augment — the pool MUST match the spell's school.  This previously
                         // added the War count unconditionally, which fed a caster's War pool into Void
                         // rings (e.g. Clouded Soul) and dropped their Void pool entirely.
                         //
                         // Effective counts, matching SpellProjectile: gems plus the school's charm.
+                        long ringAugs = 0;
                         if (spell.School == MagicSchool.WarMagic)
-                        {
-                            if (EffectiveWarAugCount >= 1)
-                                baseDamage += EffectiveWarAugCount;
-                        }
+                            ringAugs = EffectiveWarAugCount;
                         else if (spell.School == MagicSchool.VoidMagic)
+                            ringAugs = EffectiveVoidAugCount;
+
+                        // The proc aug cap (prop 9061), mirroring SpellProjectile.CalculateDamage:
+                        // clamps the aug term for a Cast on Strike proc ONLY - a hand-cast ring is
+                        // deliberately untouched. The ring path never read the cap before 2026-08-28
+                        // (the fifth everything-must-be-done-TWICE bug on this card), so a capped
+                        // weapon still delivered the full 0..17,150 term on every ring hit.
+                        if (ringAugs > 0 && fromProc && procBaseDamage > 0)
                         {
-                            if (EffectiveVoidAugCount >= 1)
-                                baseDamage += EffectiveVoidAugCount;
+                            // PER-SLOT since 2026-08-29: the ring reads its OWN cap (prop 9064), falling
+                            // back to the old shared 9061 so pre-split test daggers keep theirs.
+                            var ringAugCap = weapon?.GetProperty((ACE.Entity.Enum.Properties.PropertyFloat)ACE.Server.Managers.ZoneControl.ZoneLootMutator.ProcRingAugCapPropId)
+                                ?? weapon?.GetProperty((ACE.Entity.Enum.Properties.PropertyFloat)ACE.Server.Managers.ZoneControl.ZoneLootMutator.ProcAugCapPropId);
+                            if (ringAugCap.HasValue && ringAugCap.Value > 0)
+                                ringAugs = Math.Min(ringAugs, (long)Math.Round(ringAugCap.Value));
                         }
+                        if (ringAugs > 0)
+                            baseDamage += ringAugs;
                     }
 
                     // Elemental modifier (wand element vs target).
@@ -2015,6 +2073,32 @@ namespace ACE.Server.WorldObjects
                     }
 
                     // Damage selection:
+                    // Per-hit variance on the WHOLE base - see SpellProjectile for the reasoning.
+                    // Passed in rather than read off the weapon here, because this method is also the
+                    // Explosive Arrow path and must not start reading Cast on Strike props for it.
+                    if (procBaseDamage > 0 && procVariance > 0)
+                    {
+                        var v = Math.Clamp(procVariance, 0.0, 1.0);
+                        baseDamage = (long)Math.Round(baseDamage * (1.0 - v * ThreadSafeRandom.Next(0.0f, 1.0f)));
+                    }
+
+                    // Cast on Strike: re-derive the crit bonus from the REPLACED base. Stock computes it
+                    // from spell.MaxDamage, which for Cassius' Ring of Fire is 84 - so a crit added ~42
+                    // to a ~9,440 base and a proc could not meaningfully crit at all. Crushing Blow was
+                    // dead for the same reason: it feeds weaponCritDamageMod, which multiplied that same
+                    // 84. Measured in game 2026-08-27: a CRIT ring hit landed 0.16 pct above a non-crit
+                    // arc. Mirrors what the zone monster path already does after replacing a base.
+                    //
+                    // Placed AFTER the aug term so the crit scales with the whole base the hit uses, and
+                    // BEFORE preModDamage, which is the only consumer.
+                    // ══ UNIFIED CRIT (owner 2026-08-29): PvE war/void crit = CritX x the fully
+                    // composed base (max roll or ring B, plus the aug term, post-variance/cap) -
+                    // one formula for hand-casts and ring procs alike, replacing the 0.5f
+                    // proc-only re-derive. mod = CritX - 1 (default 1.0 = retail's 2x).
+                    if (criticalHit && !isLifeProjectile && !isPvP)
+                        critDamageBonus = (baseDamage + skillBonus)
+                            * GetWeaponCritDamageMod(weapon, this as Creature, attackSkill, creature);
+
                     var preModDamage = isLifeProjectile
                         ? lifeMagicDamage + critDamageBonus
                         : baseDamage + critDamageBonus + skillBonus;
@@ -2078,6 +2162,14 @@ namespace ACE.Server.WorldObjects
                         percent = finalDamage / creature.Health.MaxValue;
                     }
 
+                    // [ZCPROC] diagnostic - see SpellProjectile for why. Fires only for our ring procs,
+                    // and only with the zc_proc_diag server property on (off by default since 2026-09-04).
+                    if (procBaseDamage > 0 && ServerConfig.zc_proc_diag.Value)
+                        zcLog.Info($"[ZCPROC] ring spell={spell.Name} ({spell.Id}) B={baseDamage} " +
+                                 $"weapon={(weapon?.Name ?? "NULL")} rendMod={weaponResistanceMod:F3} " +
+                                 $"resistMod={resistanceMod:F4} attrib={attribBonus:F2} crit={criticalHit} " +
+                                 $"final={finalDamage:F0} target={creature.Name}");
+
                     creature.TakeDamage(this, spell.DamageType, finalDamage, criticalHit);
 
                     // Only send "You hit X for Y" if the target survived
@@ -2089,7 +2181,19 @@ namespace ACE.Server.WorldObjects
                         string verb = null, plural = null;
                         Strings.GetAttackVerb(spell.DamageType, pct, ref verb, ref plural);
                         var critMsg     = criticalHit ? "Critical hit! " : "";
-                        var attackerMsg = $"{critMsg}You {verb} {creature.Name} for {amtStr} points with {spell.Name}.";
+
+                        // Zone Control "Cast on Strike" reads with its OWN name and sentence here too.
+                        // A ring proc never reaches SpellProjectile.DamageTarget - its damage is applied
+                        // by this method - so the message had to be matched in BOTH places or the arc
+                        // and the ring on the same weapon would print in two different formats, which is
+                        // exactly what the first in-game test showed.
+                        string zcRingName = null;
+                        if (fromProc)
+                            ACE.Server.Managers.ZoneControl.ZoneLootMutator.TryGetProcDisplayName(spell.Id, out zcRingName);
+
+                        var attackerMsg = zcRingName != null
+                            ? $"{critMsg}{zcRingName} hits {creature.Name} for {amtStr} {ZcElementWord(spell.DamageType)} damage."
+                            : $"{critMsg}You {verb} {creature.Name} for {amtStr} points with {spell.Name}.";
                         if (!SquelchManager.Squelches.Contains(creature, ACE.Entity.Enum.ChatMessageType.Magic))
                             Session?.Network.EnqueueSend(new GameMessageSystemChat(attackerMsg, ACE.Entity.Enum.ChatMessageType.Magic));
 

--- a/Source/ACE.Server/WorldObjects/Player_Move.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Move.cs
@@ -281,7 +281,7 @@ namespace ACE.Server.WorldObjects
 
         public void TakeDamage_Falling(float amount)
         {
-            if (IsDead || Invincible) return;
+            if (IsDead || Invincible || ZcDamageImmune) return;   // ZcDamageImmune = Zone Control Cheat Death window
 
             // handle lifestone protection?
             if (UnderLifestoneProtection)

--- a/Source/ACE.Server/WorldObjects/Player_Tick.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Tick.cs
@@ -33,6 +33,9 @@ namespace ACE.Server.WorldObjects
         private double houseRentWarnTimestamp;
         private const double houseRentWarnInterval = 3600;
 
+        /// <summary>Zone Control: unix time this player is next due for a zone-effect tick (see ZoneEffectManager).</summary>
+        public double ZoneEffectNextTick;
+
         public void Player_Tick(double currentUnixTime)
         {
             if (CharacterSaveFailed)
@@ -65,6 +68,10 @@ namespace ACE.Server.WorldObjects
 
             UCMChecker.Tick();
             TickJail();
+
+            // Zone Control: per-zone player effects (DoT, etc.), self-timed so ticks can be as fast as 1s
+            // regardless of the 5s heartbeat.
+            ACE.Server.Managers.ZoneControl.ZoneEffectManager.Tick(this, currentUnixTime);
 
             var recoverySecs = ServerConfig.PortalStuckRecoverySecondsEffective;
             if (Teleporting && PortalSpaceEnteredUtc.HasValue && recoverySecs > 0)
@@ -118,11 +125,25 @@ namespace ACE.Server.WorldObjects
             }
             
             
-            // Sync Location with Physics before boundary checks; skip prestige logic when physics has no cell (stale Location).
+            // Sync Location with Physics before boundary checks; skip boundary logic when physics has no cell (stale Location).
+            // The two boundary systems are independent: prestige enforces its tier table, Zone Control enforces
+            // its bounded-zone unions (Player_ZoneBoundary.cs). Each gates itself and no-ops when not applicable.
             if (PhysicsObj?.CurCell != null)
             {
-                SyncLocationWithPhysics();
+                // SyncLocationWithPhysics advances Location to the physics position AND reports whether
+                // that crossed into a different landblock. Discarding that flag (as this call used to)
+                // left Location in the NEW block while CurrentLandblock still pointed at the OLD one
+                // until the movedObjects queue relocated the player after the tick. During that window
+                // Landblock.GetObject resolves through the stale CurrentLandblock, so nearby creatures
+                // are untargetable and objects can be missed - and the [VoidHeal] guard below fires a
+                // WARN every time, which reads like a broken landblock but is only this ordering gap
+                // (chased for an evening on 2026-07-26 before the cause was found here).
+                // Relocating from heartbeat context is the same call ValidateCurrentLandblockTick makes.
+                if (SyncLocationWithPhysics())
+                    LandblockManager.RelocateObjectForPhysics(this, true);
+
                 CheckPrestigeBoundary();
+                CheckZoneBoundary();
             }
 
             // Staggered choreographed visual animation playout for Auto-Rebuff Charm
@@ -151,6 +172,8 @@ namespace ACE.Server.WorldObjects
         public override void Heartbeat(double currentUnixTime)
         {
             NotifyLandblocks();
+
+            ValidateCurrentLandblockTick();
 
             ManaConsumersTick();
 
@@ -525,6 +548,11 @@ namespace ACE.Server.WorldObjects
 
             _lastPrestigeBoundaryCheck = Time.GetUnixTime();
 
+            // Master kill-switch: with prestige systems off, the whole boundary loop is inert
+            // (GetTier=0 would make every landblock allowed anyway — this just skips the work).
+            if (!PrestigeManager.SystemsEnabled)
+                return;
+
             var variation = Location.Variation;
             var currentLBVal = (ushort)(Location.Cell >> 16);
 
@@ -574,11 +602,13 @@ namespace ACE.Server.WorldObjects
                     // 2. Text: Center Screen (Yellow) ONLY
                     Session.Network.EnqueueSend(new ACE.Server.Network.GameEvent.Events.GameEventCommunicationTransientString(
                         Session, 
-                        "!!! YOU ARE LEAVING THE PRESTIGE ZONE! RETURN IMMEDIATELY! !!!"));
+                        "!!! YOU ARE LEAVING THE ZONE! RETURN IMMEDIATELY! !!!"));
 
                     // 3. Damage: Force update vital (Direct HP reduction)
+                    // Zone Control Cheat Death window (ZcDamageImmune): warning + wisp still fire, no HP loss.
                     var dmg = (int)(Health.MaxValue * 0.05f);
                     if (dmg < 10) dmg = 10;
+                    if (ZcDamageImmune) dmg = 0;
                     
                     UpdateVitalDelta(Health, -dmg);
                     Session.Network.EnqueueSend(new ACE.Server.Network.GameMessages.Messages.GameMessagePrivateUpdateVital(this, Health));
@@ -604,7 +634,7 @@ namespace ACE.Server.WorldObjects
                 if (danger)
                 {
                     Session.Network.EnqueueSend(new ACE.Server.Network.GameEvent.Events.GameEventCommunicationTransientString(
-                        Session, "!!! PRESTIGE BOUNDARY NEARBY !!!"));
+                        Session, "!!! ZONE BOUNDARY NEARBY !!!"));
                 }
                 else
                 {
@@ -700,7 +730,8 @@ namespace ACE.Server.WorldObjects
                             var wisp = Factories.WorldObjectFactory.CreateNewWorldObject(weenie) as Creature;
                             if (wisp != null)
                             {
-                                wisp.Name = "Prestige Guide";
+                                wisp.Name = "Guide";
+                                wisp.SuppressShardPersistence = true; // ephemeral escort — never save to shard
                                 wisp.SetProperty(PropertyBool.Invincible, true);
                                 wisp.SetProperty(PropertyBool.IgnoreCollisions, true);
                                 wisp.SetProperty(PropertyBool.Attackable, false);
@@ -832,6 +863,53 @@ namespace ACE.Server.WorldObjects
             Location = new ACE.Entity.Position(blockcell, pos, rotate, variation);
 
             return landblockUpdate;
+        }
+
+        /// <summary>
+        /// Void-landblock self-heal (2026-07-18): a player's Location can cross into a landblock whose
+        /// (landblock, variation) instance never got created — observed walking into F658 v11 ~2 min
+        /// after its unload: server Location updated, no create fired, and the block stayed a void
+        /// (no statics/gens). With players present a void block never unloads, so on live it could
+        /// stay broken until restart. Whatever the upstream leak, the invariant is enforceable here:
+        /// CurrentLandblock must match Location's (landblock, variation). On mismatch, run the normal
+        /// relocation path — it creates and initializes the landblock if missing (same call
+        /// Monster_Navigation makes from tick context, so thread-deferral is already handled).
+        /// </summary>
+        private void ValidateCurrentLandblockTick()
+        {
+            if (Teleporting || Session == null || PhysicsObj == null || Location == null || IsInDeathProcess)
+                return;
+
+            var locLb = (ushort)(Location.Cell >> 16);
+            var curLb = CurrentLandblock;
+
+            if (curLb != null && curLb.Id.Landblock == locLb &&
+                VariationManager.SameVariationForVisibility(curLb.VariationId, Location.Variation))
+            {
+                // Liveness check (2026-08-10, F35A v11 void with THIS guard silent): the id+variation
+                // match above trusts CurrentLandblock, but says nothing about the MANAGER still
+                // holding that instance. A block unloaded (or replaced) out from under the player
+                // passes it while the world it represents is gone - an unhealable void until a manual
+                // /reload-landblock. Verify by reference against the manager's loaded instance; on
+                // mismatch, relocate (which creates/reattaches to the live instance).
+                var live = LandblockManager.GetLoadedLandblock(curLb.Id, curLb.VariationId);
+                if (ReferenceEquals(live, curLb))
+                    return;
+
+                log.Warn($"[VoidHeal] {Name} (0x{Guid}) CurrentLandblock {curLb.Id.Landblock:X4} v={curLb.VariationId?.ToString() ?? "null"} " +
+                         $"matches Location lb={locLb:X4} v={Location.Variation?.ToString() ?? "null"} but is " +
+                         $"{(live == null ? "NOT LOADED in the manager (unloaded out from under the player?)" : "a STALE instance (the manager holds a different one)")} - " +
+                         "forcing relocation (creates/reattaches the landblock).");
+
+                LandblockManager.RelocateObjectForPhysics(this, true);
+                return;
+            }
+
+            log.Warn($"[VoidHeal] {Name} (0x{Guid}) Location lb={locLb:X4} v={Location.Variation?.ToString() ?? "null"} " +
+                     $"but CurrentLandblock={(curLb == null ? "null" : $"{curLb.Id.Landblock:X4} v={curLb.VariationId?.ToString() ?? "null"}")} - " +
+                     $"forcing relocation (creates the landblock if missing).");
+
+            LandblockManager.RelocateObjectForPhysics(this, true);
         }
 
         private bool gagNoticeSent = false;

--- a/Source/ACE.Server/WorldObjects/Player_Use.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Use.cs
@@ -382,9 +382,9 @@ namespace ACE.Server.WorldObjects
 
             var og = new ObjectGuid(targetGuidFull);
             var rawOnActorLandblock = CurrentLandblock?.GetObject(og, true, true);
-            var effSelf = PrestigeManager.GetEffectiveVariationForVisibility(this);
-            var effOther = PrestigeManager.GetEffectiveVariationForVisibility(other);
-            var sameVar = PrestigeManager.SameVariationForVisibility(effSelf, effOther);
+            var effSelf = VariationManager.GetEffectiveVariationForVisibility(this);
+            var effOther = VariationManager.GetEffectiveVariationForVisibility(other);
+            var sameVar = VariationManager.SameVariationForVisibility(effSelf, effOther);
             var dist = (Location != null && other.Location != null) ? Location.DistanceTo(other.Location) : float.NaN;
 
             var actorMaint = ObjMaint;

--- a/Source/ACE.Server/WorldObjects/Player_ZoneBoundary.cs
+++ b/Source/ACE.Server/WorldObjects/Player_ZoneBoundary.cs
@@ -55,11 +55,12 @@ namespace ACE.Server.WorldObjects
             var currentLBVal = (ushort)(Location.Cell >> 16);
 
             // Gate purely on Zone Control state: no bounded zone at this variation = free roam, zero cost.
-            if (!ZoneControlManager.HasBoundedZonesAt(variation))
+            if (!ZoneControlManager.HasBoundedZonesAt(variation) || currentLBVal == 0)
+            {
+                if (_zoneGuideWisp != null)
+                    CleanupZoneBoundaryEffects();   // a boundary that just went inactive must not leave its wisp behind
                 return;
-
-            if (currentLBVal == 0)
-                return;
+            }
 
             if (!ZoneControlManager.IsLandblockAllowed(variation, currentLBVal))
             {
@@ -126,8 +127,9 @@ namespace ACE.Server.WorldObjects
 
                     if (Health.Current <= 0 && !IsInDeathProcess)
                     {
-                        OnDeath(new DamageHistoryInfo(this), DamageType.Nether, false);
-                        Die();
+                        var selfInfo = new DamageHistoryInfo(this);
+                        OnDeath(selfInfo, DamageType.Nether, false);
+                        Die(selfInfo, selfInfo);   // explicit attribution: the parameterless Die() would read an empty damage history
                         CleanupZoneBoundaryEffects();
                     }
                 }));

--- a/Source/ACE.Server/WorldObjects/Player_ZoneBoundary.cs
+++ b/Source/ACE.Server/WorldObjects/Player_ZoneBoundary.cs
@@ -1,0 +1,348 @@
+using System.Numerics;
+
+using ACE.Common;
+using ACE.Database;
+using ACE.Entity.Enum;
+using ACE.Server.Entity;
+using ACE.Server.Entity.Actions;
+using ACE.Server.Managers;
+using ACE.Server.Managers.ZoneControl;
+using ACE.Server.Network.Enum;
+using ACE.Server.Network.GameEvent.Events;
+using ACE.Server.Network.GameMessages.Messages;
+
+namespace ACE.Server.WorldObjects
+{
+    /// <summary>
+    /// Zone Control BOUNDARY enforcement — a fully standalone system owned by Zone Control.
+    /// When any BOUNDED zone exists at the player's variation — enabled or not (owner 2026-07-21:
+    /// the boundary is independent of the zone's stat controls) — the union of bounded-zone
+    /// landblocks there is the allowlist (<see cref="ZoneControlManager.IsLandblockAllowed"/>).
+    /// Stepping outside it: center-screen warning + void FX + 5%-max-HP drain per 2s + a "Guide"
+    /// wisp leading back to safety. Near an outside edge: proximity warning + wisp.
+    /// Independent of every other system — it consults only ZoneControlManager.
+    /// </summary>
+    partial class Player
+    {
+        private double _lastZoneBoundaryCheck;
+        private double _lastZoneForbiddenLog;
+        private double _lastZoneForbiddenPunishTime;
+        private double _zoneOutOfBoundsEntryTime;
+        private double _zoneLastDangerTime;
+        private Creature _zoneGuideWisp;
+
+        private void CheckZoneBoundary()
+        {
+            // Throttle to every 2 seconds
+            if (Time.GetUnixTime() - _lastZoneBoundaryCheck < 2.0)
+                return;
+
+            _lastZoneBoundaryCheck = Time.GetUnixTime();
+
+            // Dungeons are exempt (owner 2026-07-26): the dungeon IS the boundary. Indoor cells
+            // use dungeon-local coordinates (map-edge math is meaningless there) and have no
+            // walkable path onto neighboring landblocks. Stand down and clear any lingering wisp.
+            if (Location.Indoors)
+            {
+                _zoneOutOfBoundsEntryTime = 0;
+                _lastZoneForbiddenPunishTime = 0;
+                if (_zoneGuideWisp != null)
+                    CleanupZoneBoundaryEffects();
+                return;
+            }
+
+            var variation = Location.Variation;
+            var currentLBVal = (ushort)(Location.Cell >> 16);
+
+            // Gate purely on Zone Control state: no bounded zone at this variation = free roam, zero cost.
+            if (!ZoneControlManager.HasBoundedZonesAt(variation))
+                return;
+
+            if (currentLBVal == 0)
+                return;
+
+            if (!ZoneControlManager.IsLandblockAllowed(variation, currentLBVal))
+            {
+                // PUNISHMENT ZONE
+                var nowOob = Time.GetUnixTime();
+                if (_zoneOutOfBoundsEntryTime == 0) _zoneOutOfBoundsEntryTime = nowOob;
+                _zoneLastDangerTime = nowOob;
+
+                // Enqueue everything to ensure thread safety (AddWorldObjectInternal must be main thread)
+                WorldManager.ActionQueue.EnqueueAction(new ActionEventDelegate(ActionType.Landblock_CreateWorldObjects, () =>
+                {
+                    if (Session == null || Session.State != SessionState.WorldConnected || Health == null)
+                        return;
+                    var cell = Location?.Cell ?? 0;
+                    var lbVal = (ushort)(cell >> 16);
+                    if (lbVal != currentLBVal || Location?.Variation != variation)
+                        return;
+                    if (ZoneControlManager.IsLandblockAllowed(variation, lbVal))
+                        return;
+
+                    var nowExec = Time.GetUnixTime();
+                    const double forbiddenPunishCooldown = 2.0;
+                    if (nowExec - _zoneOutOfBoundsEntryTime <= forbiddenPunishCooldown)
+                        return;
+                    if (_lastZoneForbiddenPunishTime > 0 && nowExec - _lastZoneForbiddenPunishTime < forbiddenPunishCooldown)
+                        return;
+
+                    _lastZoneForbiddenPunishTime = nowExec;
+
+                    if (nowExec - _lastZoneForbiddenLog >= 10.0)
+                    {
+                        log.Info($"[ZoneControl] Player {Name} ({Guid}) is outside the zone boundary in landblock {currentLBVal:X4} (Var: {variation})");
+                        _lastZoneForbiddenLog = nowExec;
+                    }
+
+                    // 1. Visuals: Void Particles (no fog — avoids fog/teleport interaction with the boundary)
+                    Session.Network.EnqueueSend(new GameMessageScript(Guid, PlayScript.HealthDownVoid));
+
+                    // 2. Text: Center Screen (Yellow) ONLY
+                    Session.Network.EnqueueSend(new GameEventCommunicationTransientString(
+                        Session,
+                        "!!! YOU ARE LEAVING THE ZONE! RETURN IMMEDIATELY! !!!"));
+
+                    // Lifestone protection spares the boundary drain too (mirrors TakeZoneEffectDamage):
+                    // the player still saw the warning + gets the guide wisp above, but takes no HP loss
+                    // and cannot be killed by the boundary while protected.
+                    if (UnderLifestoneProtection)
+                    {
+                        HandleLifestoneProtection();
+                        UpdateZoneGuideWisp(true, variation);
+                        return;
+                    }
+
+                    // 3. Damage: Force update vital (Direct HP reduction)
+                    // Zone Control Cheat Death window (ZcDamageImmune): warning + wisp still fire, no HP loss.
+                    var dmg = (int)(Health.MaxValue * 0.05f);
+                    if (dmg < 10) dmg = 10;
+                    if (ZcDamageImmune) dmg = 0;
+
+                    UpdateVitalDelta(Health, -dmg);
+                    Session.Network.EnqueueSend(new GameMessagePrivateUpdateVital(this, Health));
+
+                    UpdateZoneGuideWisp(true, variation);
+
+                    if (Health.Current <= 0 && !IsInDeathProcess)
+                    {
+                        OnDeath(new DamageHistoryInfo(this), DamageType.Nether, false);
+                        Die();
+                        CleanupZoneBoundaryEffects();
+                    }
+                }));
+            }
+            else
+            {
+                _zoneOutOfBoundsEntryTime = 0;
+                _lastZoneForbiddenPunishTime = 0;
+
+                // Edge proximity and/or forbidden current landblock (re-checked live in wisp spawn lambda)
+                var danger = IsZoneBoundaryDangerState(variation);
+
+                if (danger)
+                {
+                    Session.Network.EnqueueSend(new GameEventCommunicationTransientString(
+                        Session, "!!! ZONE BOUNDARY NEARBY !!!"));
+
+                    // Track when we last had danger (for wisp persistence)
+                    _zoneLastDangerTime = Time.GetUnixTime();
+                }
+
+                // Wisp with 10s persistence after reaching safety — full danger (edge + forbidden re-checked in spawn lambda)
+                UpdateZoneGuideWisp(danger, variation);
+
+                // Note: Boundary perimeter lanterns are spawned by the Landblock at load time,
+                // so no per-player marker logic is needed here.
+            }
+        }
+
+        /// <summary>
+        /// True when in a landblock outside the Zone Control boundary or within 20m of a map edge that
+        /// borders an outside neighbor. Used for guide wisp spawn checks so proximity danger still spawns
+        /// when the current landblock is allowed.
+        /// </summary>
+        private bool IsZoneBoundaryDangerState(int? variation)
+        {
+            // Dungeon exemption (owner 2026-07-26) - also guards the wisp-spawn lambda's re-check
+            // when a player slips indoors between enqueue and execution.
+            if (Location.Indoors)
+                return false;
+
+            var lbId = new ACE.Entity.LandblockId(Location.Cell);
+            var pos = Location.Pos;
+
+            if (pos.X > 182.0f && lbId.LandblockX < 255 && !ZoneControlManager.IsLandblockAllowed(variation, lbId.East.Landblock))
+                return true;
+            if (pos.X < 10.0f && lbId.LandblockX > 0 && !ZoneControlManager.IsLandblockAllowed(variation, lbId.West.Landblock))
+                return true;
+            if (pos.Y > 182.0f && lbId.LandblockY < 255 && !ZoneControlManager.IsLandblockAllowed(variation, lbId.North.Landblock))
+                return true;
+            if (pos.Y < 10.0f && lbId.LandblockY > 0 && !ZoneControlManager.IsLandblockAllowed(variation, lbId.South.Landblock))
+                return true;
+
+            return !ZoneControlManager.IsLandblockAllowed(variation, lbId.Landblock);
+        }
+
+        /// <summary>
+        /// Cleans up player-specific Zone Control boundary effects (guide wisp).
+        /// Perimeter lanterns are landblock-owned and don't need per-player cleanup.
+        /// </summary>
+        public void CleanupZoneBoundaryEffects()
+        {
+            var capturedWisp = _zoneGuideWisp;
+            if (capturedWisp == null)
+                return;
+
+            WorldManager.ActionQueue.EnqueueAction(new ActionEventDelegate(ActionType.Landblock_CreateWorldObjects, () =>
+            {
+                capturedWisp.Destroy();
+                if (_zoneGuideWisp == capturedWisp)
+                    _zoneGuideWisp = null;
+            }));
+        }
+
+        private void UpdateZoneGuideWisp(bool danger, int? variation)
+        {
+            if (danger)
+            {
+                if (_zoneGuideWisp == null)
+                {
+                    // Spawn Wisp
+                    var weenie = DatabaseManager.World.GetCachedWeenie((uint)ACE.Entity.Enum.WeenieClassName.W_WISPETHEREAL_CLASS);
+                    if (weenie != null)
+                    {
+                        // Capture state for thread safety
+                        var playerPos = Location.Pos; // Exact player position
+                        var cell = Location.Cell;
+                        var lbId = new ACE.Entity.LandblockId(cell);
+
+                        WorldManager.ActionQueue.EnqueueAction(new ActionEventDelegate(ActionType.Landblock_CreateWorldObjects, () =>
+                        {
+                            if (Session == null || Session.State != SessionState.WorldConnected)
+                                return;
+
+                            // Double check inside queue
+                            if (_zoneGuideWisp != null)
+                                return;
+
+                            var liveCell = Location?.Cell ?? 0;
+                            if (liveCell != cell || Location?.Variation != variation)
+                                return;
+
+                            if (!IsZoneBoundaryDangerState(variation))
+                                return;
+
+                            var wisp = Factories.WorldObjectFactory.CreateNewWorldObject(weenie) as Creature;
+                            if (wisp != null)
+                            {
+                                wisp.Name = "Guide";
+                                wisp.SuppressShardPersistence = true; // ephemeral escort — never save to shard
+                                wisp.SetProperty(ACE.Entity.Enum.Properties.PropertyBool.Invincible, true);
+                                wisp.SetProperty(ACE.Entity.Enum.Properties.PropertyBool.IgnoreCollisions, true);
+                                wisp.SetProperty(ACE.Entity.Enum.Properties.PropertyBool.Attackable, false);
+                                wisp.SetProperty(ACE.Entity.Enum.Properties.PropertyBool.NeverAttack, true);
+
+                                var spawnPos = playerPos + (Vector3.UnitZ * 0.2f);
+                                wisp.Location = new ACE.Entity.Position(cell, spawnPos.X, spawnPos.Y, spawnPos.Z, 0, 0, 0, 0, false, variation);
+
+                                if (!wisp.EnterWorld() || wisp.CurrentLandblock == null)
+                                {
+                                    log.Warn($"[ZoneControl] Failed to enter world for zone boundary guide wisp (player {Name} 0x{Guid.Full:X8}).");
+                                    wisp.Destroy();
+                                    return;
+                                }
+
+                                _zoneGuideWisp = wisp;
+
+                                // Calculate "Smart" Safe Spot
+                                uint targetCell = cell;
+                                float targetX = 96.0f;
+                                float targetY = 96.0f;
+                                string safeDir = "None";
+
+                                // Check cardinal neighbors for safety
+                                bool eAllowed = lbId.LandblockX < 255 && ZoneControlManager.IsLandblockAllowed(variation, lbId.East.Landblock);
+                                bool wAllowed = lbId.LandblockX > 0 && ZoneControlManager.IsLandblockAllowed(variation, lbId.West.Landblock);
+                                bool nAllowed = lbId.LandblockY < 255 && ZoneControlManager.IsLandblockAllowed(variation, lbId.North.Landblock);
+                                bool sAllowed = lbId.LandblockY > 0 && ZoneControlManager.IsLandblockAllowed(variation, lbId.South.Landblock);
+
+                                if (eAllowed)
+                                {
+                                    targetCell = lbId.East.Raw;
+                                    targetX = 5.0f;
+                                    targetY = playerPos.Y;
+                                    safeDir = "East";
+                                }
+                                else if (wAllowed)
+                                {
+                                    targetCell = lbId.West.Raw;
+                                    targetX = 187.0f;
+                                    targetY = playerPos.Y;
+                                    safeDir = "West";
+                                }
+                                else if (nAllowed)
+                                {
+                                    targetCell = lbId.North.Raw;
+                                    targetX = playerPos.X;
+                                    targetY = 5.0f;
+                                    safeDir = "North";
+                                }
+                                else if (sAllowed)
+                                {
+                                    targetCell = lbId.South.Raw;
+                                    targetX = playerPos.X;
+                                    targetY = 187.0f;
+                                    safeDir = "South";
+                                }
+                                else
+                                {
+                                    safeDir = "Fallback(Center)";
+                                }
+
+                                var safePos = new ACE.Entity.Position(targetCell, targetX, targetY, spawnPos.Z, 0, 0, 0, 0, false, variation);
+
+                                log.Debug($"[ZoneControl] Wisp: Spawned at {lbId}. Safe direction: {safeDir}. Move to {safePos} (cell {targetCell:X8}).");
+
+                                wisp.MoveToPosition(safePos);
+
+                                Session.Network.EnqueueSend(new GameMessageSystemChat(
+                                    "Follow the Wisp to safety!", ChatMessageType.Broadcast));
+                            }
+                        }));
+                    }
+                }
+            }
+            else
+            {
+                // Only destroy wisp if we've been safe for 10+ seconds
+                if (_zoneGuideWisp != null)
+                {
+                    var timeSinceDanger = Time.GetUnixTime() - _zoneLastDangerTime;
+
+                    if (timeSinceDanger >= 10.0)
+                    {
+                        var wispAtEnqueue = _zoneGuideWisp;
+                        WorldManager.ActionQueue.EnqueueAction(new ActionEventDelegate(ActionType.Landblock_CreateWorldObjects, () =>
+                        {
+                            if (Session == null || Session.State != SessionState.WorldConnected)
+                                return;
+
+                            if (Time.GetUnixTime() - _zoneLastDangerTime < 10.0)
+                                return;
+
+                            if (wispAtEnqueue == null || _zoneGuideWisp != wispAtEnqueue)
+                                return;
+
+                            var msg = new GameMessageHearSpeech("Do try to stay on the path next time...", wispAtEnqueue.Name, wispAtEnqueue.Guid.Full, ChatMessageType.Speech);
+                            Session.Network.EnqueueSend(msg);
+
+                            wispAtEnqueue.Destroy();
+                            _zoneGuideWisp = null;
+                        }));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -625,13 +625,10 @@ namespace ACE.Server.WorldObjects
                 // UNIFIED CRIT MODEL (owner 2026-08-29, "all 3 schools get the same treatment"):
                 // a crit deals CritX x the base - the old 0.5 coefficient that quietly halved
                 // Crushing Blow on every magic path is gone. mod is (CritX - 1), default 1.0,
-                // so a cardless crit = 2x, the same retail rule the melee path now follows.
+                // so a cardless crit = 2x, the same retail rule the melee path now follows. The bonus itself is
+                // derived below, once the base is final (life aug term, zone replacement, variance).
                 if (criticalHit)
-                {
                     weaponCritDamageMod = GetWeaponCritDamageMod(weapon, sourceCreature, attackSkill, target);
-
-                    critDamageBonus = lifeMagicDamage * weaponCritDamageMod;
-                }
 
                 if (sourceCreature != null && sourceCreature.EffectiveLifeAugCount >= 1)
                 {
@@ -658,10 +655,6 @@ namespace ACE.Server.WorldObjects
                             var sv = Math.Clamp(zpFlat.Get(ACE.Server.Managers.ZoneScaling.ZoneStat.SpellVariance), 0.0, 1.0);
                             lifeMagicDamage *= (float)(1.0 - sv * ThreadSafeRandom.Next(0.0f, 1.0f));
                         }
-                        // crit bonus re-derived from the base the hit ACTUALLY uses - after a replacement and after the
-                        // variance roll alike (spell_variance may be authored on its own)
-                        if (criticalHit)
-                            critDamageBonus = lifeMagicDamage * weaponCritDamageMod;   // unified: CritX x base
                     }
                 }
 
@@ -671,6 +664,10 @@ namespace ACE.Server.WorldObjects
                 // only pass if SpellProjectile has it directly, such as 2637 - Invoking Aun Tanua
 
                 resistanceMod = (float)Math.Max(0.0f, target.GetResistanceMod(resistanceType, this, null, weaponResistanceMod));
+
+                // UNIFIED CRIT: CritX x the base the hit ACTUALLY uses - player and governed casters alike
+                if (criticalHit)
+                    critDamageBonus = lifeMagicDamage * weaponCritDamageMod;
 
                 finalDamage = (lifeMagicDamage + critDamageBonus) * elementalDamageMod * slayerMod * resistanceMod * absorbMod * attribBonus;
             }

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -520,8 +520,15 @@ namespace ACE.Server.WorldObjects
             var sourcePlayer = source as Player;
             var targetPlayer = target as Player;
 
-            if (source == null || !target.IsAlive || targetPlayer != null && (targetPlayer.Invincible || targetPlayer.ZcDamageImmune))
+            if (!target.IsAlive || targetPlayer != null && targetPlayer.Invincible)
                 return null;
+            if (targetPlayer != null && targetPlayer.ZcDamageImmune)
+            {
+                // Cheat Death window: the hit is absorbed here and never reaches DamageTarget, so the feedback the
+                // melee paths give from TakeDamage has to come from this bail-out
+                targetPlayer.ZcAnnounceAbsorb(ProjectileSource, $"{Spell.Name} ({Spell.DamageType.ToString().ToLowerInvariant()})");
+                return null;
+            }
 
             // check lifestone protection
             if (targetPlayer != null && targetPlayer.UnderLifestoneProtection)
@@ -641,20 +648,19 @@ namespace ACE.Server.WorldObjects
                     var zpFlat = ACE.Server.Managers.ZoneControl.ZoneControlManager.ResolveForCreature(sourceCreature);
                     if (zpFlat != null)
                     {
-                        var zoneReplaced = false;
                         if (zpFlat.Has(ACE.Server.Managers.ZoneScaling.ZoneStat.SpellDamage))
                         {
                             // negative authored spell_damage would heal - floor at 0
                             lifeMagicDamage = (float)Math.Max(zpFlat.Get(ACE.Server.Managers.ZoneScaling.ZoneStat.SpellDamage), 0.0);
-                            zoneReplaced = true;
                         }
                         if (zpFlat.Has(ACE.Server.Managers.ZoneScaling.ZoneStat.SpellVariance))
                         {
                             var sv = Math.Clamp(zpFlat.Get(ACE.Server.Managers.ZoneScaling.ZoneStat.SpellVariance), 0.0, 1.0);
                             lifeMagicDamage *= (float)(1.0 - sv * ThreadSafeRandom.Next(0.0f, 1.0f));
                         }
-                        // crit bonus re-derived from the replaced base (stock bonus above used the weenie base)
-                        if (zoneReplaced && criticalHit)
+                        // crit bonus re-derived from the base the hit ACTUALLY uses - after a replacement and after the
+                        // variance roll alike (spell_variance may be authored on its own)
+                        if (criticalHit)
                             critDamageBonus = lifeMagicDamage * weaponCritDamageMod;   // unified: CritX x base
                     }
                 }

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -19,6 +19,8 @@ namespace ACE.Server.WorldObjects
 {
     public class SpellProjectile : WorldObject
     {
+        private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
         public const float DefaultSpellAttributeMult = 0.25f;
         public Spell Spell;
         public ProjectileSpellType SpellType { get; set; }
@@ -381,6 +383,7 @@ namespace ACE.Server.WorldObjects
 
             var forkEligibleOnImpact = creatureTarget.IsAlive
                 && !(targetPlayer?.Invincible ?? false)
+                && !(targetPlayer?.ZcDamageImmune ?? false)
                 && !(targetPlayer?.UnderLifestoneProtection ?? false);
 
             var pkError = ProjectileSource?.CheckPKStatusVsTarget(creatureTarget, Spell);
@@ -494,6 +497,22 @@ namespace ACE.Server.WorldObjects
         /// Calculates the damage for a spell projectile
         /// Used by war magic, void magic, and life magic projectiles
         /// </summary>
+        /// <summary>Lower-case element word for the Cast on Strike combat line ("... for 1,408 pierce
+        /// damage"). Deliberately the SPELL's damage type, which for this card is always the weapon's
+        /// own element.</summary>
+        private static string ZcElementWord(DamageType dt)
+        {
+            if (dt.HasFlag(DamageType.Slash)) return "slash";
+            if (dt.HasFlag(DamageType.Pierce)) return "pierce";
+            if (dt.HasFlag(DamageType.Bludgeon)) return "bludgeon";
+            if (dt.HasFlag(DamageType.Acid)) return "acid";
+            if (dt.HasFlag(DamageType.Cold)) return "cold";
+            if (dt.HasFlag(DamageType.Electric)) return "electric";
+            if (dt.HasFlag(DamageType.Fire)) return "fire";
+            if (dt.HasFlag(DamageType.Nether)) return "nether";
+            return "magic";
+        }
+
         public float? CalculateDamage(WorldObject source, Creature target, ref bool criticalHit, ref bool critDefended, ref bool overpower)
         {
             if (source == null || target == null)
@@ -501,7 +520,7 @@ namespace ACE.Server.WorldObjects
             var sourcePlayer = source as Player;
             var targetPlayer = target as Player;
 
-            if (source == null || !target.IsAlive || targetPlayer != null && targetPlayer.Invincible)
+            if (source == null || !target.IsAlive || targetPlayer != null && (targetPlayer.Invincible || targetPlayer.ZcDamageImmune))
                 return null;
 
             // check lifestone protection
@@ -589,26 +608,55 @@ namespace ACE.Server.WorldObjects
                 attribBonus += SkillFormula.GetAttributeMod((int)sourcePlayer.Focus.Current) * DefaultSpellAttributeMult;
                 attribBonus += SkillFormula.GetAttributeMod((int)sourcePlayer.Self.Current) * DefaultSpellAttributeMult;
             }
-            
+
+
             // life magic projectiles: ie., martyr's hecatomb
             if (Spell.MetaSpellType == ACE.Entity.Enum.SpellType.LifeProjectile)
             {
                 lifeMagicDamage = LifeProjectileDamage * Spell.DamageRatio;
 
-                // could life magic projectiles crit?
-                // if so, did they use the same 1.5x formula as war magic, instead of 2.0x?
+                // UNIFIED CRIT MODEL (owner 2026-08-29, "all 3 schools get the same treatment"):
+                // a crit deals CritX x the base - the old 0.5 coefficient that quietly halved
+                // Crushing Blow on every magic path is gone. mod is (CritX - 1), default 1.0,
+                // so a cardless crit = 2x, the same retail rule the melee path now follows.
                 if (criticalHit)
                 {
-                    // verify: CriticalMultiplier only applied to the additional crit damage,
-                    // whereas CD/CDR applied to the total damage (base damage + additional crit damage)
                     weaponCritDamageMod = GetWeaponCritDamageMod(weapon, sourceCreature, attackSkill, target);
 
-                    critDamageBonus = lifeMagicDamage * 0.5f * weaponCritDamageMod;
+                    critDamageBonus = lifeMagicDamage * weaponCritDamageMod;
                 }
 
                 if (sourceCreature != null && sourceCreature.EffectiveLifeAugCount >= 1)
                 {
                     lifeMagicDamage += sourceCreature.EffectiveLifeAugCount;
+                }
+
+                // Zone Control (retail-semantics since 2026-08-02, owner ruling — the old WYSIWYG felt-damage
+                // bypass is GONE): authored spell_damage REPLACES the life-projectile base + augs PRE-mitigation,
+                // exactly like attack_damage replaces weapon/part damage. Every downstream mod still applies:
+                // elemental/slayer, the defender's resists + absorb, and the rating chain in DamageTarget.
+                // spell_variance spreads each cast down from the base (unset = stock behavior above).
+                if (sourceCreature != null && !(sourceCreature is Player))
+                {
+                    var zpFlat = ACE.Server.Managers.ZoneControl.ZoneControlManager.ResolveForCreature(sourceCreature);
+                    if (zpFlat != null)
+                    {
+                        var zoneReplaced = false;
+                        if (zpFlat.Has(ACE.Server.Managers.ZoneScaling.ZoneStat.SpellDamage))
+                        {
+                            // negative authored spell_damage would heal - floor at 0
+                            lifeMagicDamage = (float)Math.Max(zpFlat.Get(ACE.Server.Managers.ZoneScaling.ZoneStat.SpellDamage), 0.0);
+                            zoneReplaced = true;
+                        }
+                        if (zpFlat.Has(ACE.Server.Managers.ZoneScaling.ZoneStat.SpellVariance))
+                        {
+                            var sv = Math.Clamp(zpFlat.Get(ACE.Server.Managers.ZoneScaling.ZoneStat.SpellVariance), 0.0, 1.0);
+                            lifeMagicDamage *= (float)(1.0 - sv * ThreadSafeRandom.Next(0.0f, 1.0f));
+                        }
+                        // crit bonus re-derived from the replaced base (stock bonus above used the weenie base)
+                        if (zoneReplaced && criticalHit)
+                            critDamageBonus = lifeMagicDamage * weaponCritDamageMod;   // unified: CritX x base
+                    }
                 }
 
                 weaponResistanceMod = GetWeaponResistanceModifier(weapon, sourceCreature, attackSkill, Spell.DamageType);
@@ -641,16 +689,14 @@ namespace ACE.Server.WorldObjects
                     // Starting in July, War Magic critical hits will instead add a multiple of the maximum damage of the spell.
                     // No more crits that do less damage than non-crits!
 
-                    if (isPVP) // PvP: 50% of the MIN damage added to normal damage roll
-                        critDamageBonus = Spell.MinDamage * 0.5f;
-                    else   // PvE: 50% of the MAX damage added to normal damage roll
-                        critDamageBonus = Spell.MaxDamage * 0.5f;
-
-                    // verify: CriticalMultiplier only applied to the additional crit damage,
-                    // whereas CD/CDR applied to the total damage (base damage + additional crit damage)
+                    // UNIFIED CRIT MODEL (owner 2026-08-29): PvE crit = CritX x the FULL composed
+                    // base (max roll + aug term + skill bonus) - computed AFTER the base is built,
+                    // in the unified block below, so procs / zone bases / augs all crit in full.
+                    // PvP keeps the retail halved-min rule, deliberately out of scope.
                     weaponCritDamageMod = GetWeaponCritDamageMod(weapon, sourceCreature, attackSkill, target);
 
-                    critDamageBonus *= weaponCritDamageMod;
+                    if (isPVP) // PvP: 50% of the MIN damage added to normal damage roll
+                        critDamageBonus = Spell.MinDamage * 0.5f * weaponCritDamageMod;
                 }
 
                 /* War Magic skill-based damage bonus
@@ -667,25 +713,88 @@ namespace ACE.Server.WorldObjects
                         skillBonus = Spell.MinDamage * percentageBonus;
                     }
                 }
-                baseDamage = ThreadSafeRandom.Next(Spell.MinDamage, Spell.MaxDamage);
+                // unified crit: a PvE crit uses the MAX roll (retail melee's own rule), so the
+                // CritX multiple below lands on the spell's ceiling, not a random roll
+                baseDamage = criticalHit && !isPVP
+                    ? Spell.MaxDamage
+                    : ThreadSafeRandom.Next(Spell.MinDamage, Spell.MaxDamage);
+
+                // Zone Control "Cast on Strike": an authored B REPLACES THE ROLLED SPELL BASE, and
+                // nothing else. The War/Void aug term below still applies on top of it - owner
+                // 2026-08-27: "The procs will be based simply off war or void just like originally
+                // coded. The procs are spells." So the BASE is the weapon's (banded, tunable, 440 = one
+                // melee hit at T11) and the SCALING is the caster's, exactly as for a hand-cast spell.
+                //
+                // Consequence, chosen deliberately: a melee character with no War or Void augs gets B
+                // and nothing more. Melee and Missile aug counts are NOT read here - an earlier build
+                // did that and it was wrong; a proc is a spell and scales with spell investment.
+                //
+                // WHICH slot fired decides which band applies - the arc and the ring carry separate
+                // damage now. Matched on the spell id rather than on a flag, because the projectile is
+                // all we have here and the two slots can never hold the same spell.
+                double? procDmgOverride = null;
+                if (FromProc && weapon != null)
+                {
+                    if (weapon.ProcSpell.HasValue && weapon.ProcSpell.Value == Spell.Id)
+                        procDmgOverride = weapon.GetProperty((PropertyFloat)ACE.Server.Managers.ZoneControl.ZoneLootMutator.ProcArcDamagePropId);
+                    else if (weapon.ProcSpell2.HasValue && weapon.ProcSpell2.Value == Spell.Id)
+                        procDmgOverride = weapon.GetProperty((PropertyFloat)ACE.Server.Managers.ZoneControl.ZoneLootMutator.ProcRingDamagePropId);
+                }
+
+                var isZcProc = procDmgOverride.HasValue && procDmgOverride.Value > 0;
+
+                if (isZcProc)
+                    baseDamage = (long)Math.Round(procDmgOverride.Value);
 
                 if (sourceCreature != null)
                 {
                     // Effective counts: purchased gems plus the school's growth charm. Player_Magic's
                     // smart-ring path mirrors this method and must use the same counts.
+                    long augs = 0;
                     if (Spell.School == MagicSchool.WarMagic)
-                    {
-                        if (sourceCreature.EffectiveWarAugCount >= 1)
-                        {
-                            baseDamage += sourceCreature.EffectiveWarAugCount;
-                        }
-                    }
+                        augs = sourceCreature.EffectiveWarAugCount;
                     else if (Spell.School == MagicSchool.VoidMagic)
+                        augs = sourceCreature.EffectiveVoidAugCount;
+
+                    // The card's own ceiling on that term, stamped on the weapon at drop. Applies ONLY
+                    // to a Cast on Strike proc - a hand-cast spell is deliberately untouched, so this
+                    // cannot change what any existing spell does. Uncapped, the aug term is 0..10,000
+                    // flat on a 440 base, which is the wielder-driven spread the banded base exists to
+                    // contain re-entering through the aug door. Unset = uncapped.
+                    if (augs > 0 && isZcProc)
                     {
-                        if (sourceCreature.EffectiveVoidAugCount >= 1)
+                        var augCap = weapon?.GetProperty((PropertyFloat)ACE.Server.Managers.ZoneControl.ZoneLootMutator.ProcAugCapPropId);
+                        if (augCap.HasValue && augCap.Value > 0)
+                            augs = Math.Min(augs, (long)Math.Round(augCap.Value));
+                    }
+
+                    if (augs > 0)
+                        baseDamage += augs;
+                }
+
+                // Zone Control (retail-semantics since 2026-08-02, owner ruling — the old WYSIWYG felt-damage
+                // bypass is GONE): authored spell_damage REPLACES the rolled spell base + augs PRE-mitigation,
+                // the exact analogue of attack_damage. All downstream mods still apply (elemental/slayer,
+                // defender resists + absorb, rating chain in DamageTarget). spell_variance spreads each cast
+                // down from the base (0 = flat, 0.5 = casts land 50-100% of base). Unset = stock behavior above.
+                if (sourceCreature != null && !(sourceCreature is Player))
+                {
+                    var zpFlat = ACE.Server.Managers.ZoneControl.ZoneControlManager.ResolveForCreature(sourceCreature);
+                    if (zpFlat != null)
+                    {
+                        var zoneReplaced = false;
+                        if (zpFlat.Has(ACE.Server.Managers.ZoneScaling.ZoneStat.SpellDamage))
                         {
-                            baseDamage += sourceCreature.EffectiveVoidAugCount;
+                            // negative authored spell_damage would heal - floor at 0
+                            baseDamage = (long)Math.Round(Math.Max(zpFlat.Get(ACE.Server.Managers.ZoneScaling.ZoneStat.SpellDamage), 0.0));
+                            zoneReplaced = true;
                         }
+                        if (zpFlat.Has(ACE.Server.Managers.ZoneScaling.ZoneStat.SpellVariance))
+                        {
+                            var sv = Math.Clamp(zpFlat.Get(ACE.Server.Managers.ZoneScaling.ZoneStat.SpellVariance), 0.0, 1.0);
+                            baseDamage = (long)Math.Round(baseDamage * (1.0 - sv * ThreadSafeRandom.Next(0.0f, 1.0f)));
+                        }
+                        // (crit handled by the unified block below, which reads the replaced base)
                     }
                 }
 
@@ -705,13 +814,61 @@ namespace ACE.Server.WorldObjects
                     resistanceMod *= (float)ServerConfig.void_pvp_modifier.Value;
                 }
 
+                // Per-hit variance, applied to the WHOLE base - B AND the aug term (owner 2026-08-27:
+                // "whole base"). Varying B alone would be invisible: at 9,000 War augs B is 4.7 pct of
+                // the base. Spreads DOWN from the rolled value, same shape as zone spell_variance, so
+                // the band stays the ceiling. Before the crit re-derivation, so a crit scales off the
+                // number the hit actually uses.
+                if (isZcProc && weapon != null)
+                {
+                    var vProp = weapon.ProcSpell.HasValue && weapon.ProcSpell.Value == Spell.Id
+                        ? ACE.Server.Managers.ZoneControl.ZoneLootMutator.ProcArcVariancePropId
+                        : ACE.Server.Managers.ZoneControl.ZoneLootMutator.ProcRingVariancePropId;
+                    var variance = weapon.GetProperty((PropertyFloat)vProp) ?? 0.0;
+                    if (variance > 0)
+                    {
+                        variance = Math.Clamp(variance, 0.0, 1.0);
+                        baseDamage = (long)Math.Round(baseDamage * (1.0 - variance * ThreadSafeRandom.Next(0.0f, 1.0f)));
+                    }
+                }
+
+                // ══ UNIFIED CRIT (owner 2026-08-29, "all 3 schools get the same treatment"): the
+                // PvE crit bonus is computed HERE, after the base is fully composed (max roll or
+                // proc B or zone base, plus the aug term, post-variance), so the crit total is
+                // exactly CritX x the base the hit actually uses - on hand-casts, procs and mob
+                // casts alike. mod = CritX - 1 (default 1.0 = the retail 2x rule); the Crushing
+                // Blow band bounds it. This replaces the per-site 0.5f re-derives that quietly
+                // halved crush on every magic path. PvP keeps its retail bonus from above.
+                if (criticalHit && !isPVP)
+                    critDamageBonus = (float)((baseDamage + skillBonus) * weaponCritDamageMod);
+
                 finalDamage = baseDamage + critDamageBonus + skillBonus;
 
                 finalDamage *= elementalDamageMod * slayerMod * resistanceMod * absorbMod * attribBonus;
+
+                // [ZCPROC] diagnostic, added 2026-08-27 for the Cast on Strike bring-up. Combat chat
+                // never reaches ACE_Log.txt, so without this the only way to read a proc's terms is the
+                // owner pasting client text. Fires ONLY for our procs, so it cannot spam a live shard.
+                // REMOVE once the card is tuned.
+                if (isZcProc && ServerConfig.zc_proc_diag.Value)
+                    log.Info($"[ZCPROC] arc spell={Spell.Name} ({Spell.Id}) B={baseDamage} " +
+                             $"rendMod={weaponResistanceMod:F3} resistMod={resistanceMod:F4} " +
+                             $"attrib={attribBonus:F2} crit={criticalHit} preRating={finalDamage:F0} target={target.Name}");
             }
             // Fork Charm: reduce damage for fork projectiles based on tier multiplier.
             if (IsForkProjectile)
                 finalDamage *= ForkDamageMult;
+
+            // (The 2026-07-27 WYSIWYG felt-damage override that used to live here was REMOVED 2026-08-02:
+            // spell_damage is now a plain PRE-mitigation base replacement and rides the retail pipeline.)
+
+            // Zone Control: a governed monster's zone profile can scale its spell damage (players resolve null).
+            if (sourceCreature != null && !(sourceCreature is Player))
+            {
+                var zoneProfile = ACE.Server.Managers.ZoneControl.ZoneControlManager.ResolveForCreature(sourceCreature);
+                if (zoneProfile != null && zoneProfile.Has(ACE.Server.Managers.ZoneScaling.ZoneStat.SpellDamageMult))
+                    finalDamage *= (float)zoneProfile.Get(ACE.Server.Managers.ZoneScaling.ZoneStat.SpellDamageMult);
+            }
 
             // show debug info (after fork mult so displayed damage matches actual dealt damage)
             if (sourceCreature != null && sourceCreature.DebugDamage.HasFlag(Creature.DebugDamageType.Attacker))
@@ -730,6 +887,30 @@ namespace ACE.Server.WorldObjects
                 var m = combatPet.GetSpellProjectileDamageTakenMultiplier();
                 if (m < 1.0f)
                     finalDamage *= m;
+            }
+
+            // v11+ percent-HP floor: applied in DamageTarget, AFTER the attacker/defender rating mods,
+            // so the floor lands at the felt scale (mirrors the melee DamageEvent ordering — taking it
+            // here let a governed mob's damage_rating inflate the floor value itself).
+
+            // Extensive spell-damage server log - same flags and defender gate as the melee/missile
+            // DamageEvent block (damage_event_debug_server_log; incoming damage on Players/CombatPets only).
+            if (ServerConfig.damage_event_debug_server_log.Value
+                && (targetPlayer != null || target is CombatPet)
+                && (!ServerConfig.damage_event_debug_only_nonplayer_attackers.Value || sourceCreature is not Player))
+            {
+                var sb = new System.Text.StringBuilder(1024);
+                sb.AppendLine("=== SpellDamage.Debug ===");
+                sb.AppendLine($"Attacker: {sourceCreature?.Name ?? "<null>"} ({sourceCreature?.Guid.ToString() ?? "?"}) wcid={sourceCreature?.WeenieClassId ?? 0} level={sourceCreature?.Level ?? 0}");
+                sb.AppendLine($"Defender: {target.Name} ({target.Guid}) wcid={target.WeenieClassId} level={target.Level ?? 0}");
+                sb.AppendLine($"spell: {Spell.Name} ({Spell.Id}) school={Spell.School} damageType={Spell.DamageType} power={Spell.Power} weapon={weapon?.Name ?? "<none>"}");
+                sb.AppendLine($"crit={criticalHit} critDefended={critDefended} overpower={overpower} critChance={criticalChance:F4}");
+                sb.AppendLine($"components: base={baseDamage:F2} critBonus={critDamageBonus:F2} skillBonus={skillBonus:F2} lifeMagic={lifeMagicDamage:F2} critDmgMod={weaponCritDamageMod:F4}");
+                sb.AppendLine($"mods: elemental={elementalDamageMod:F4} slayer={slayerMod:F4} resist={resistanceMod:F4} weapResist={weaponResistanceMod:F4} absorb={absorbMod:F4} attrib={attribBonus:F4}");
+                sb.AppendLine("(rating mods + pcthp floor apply post-CalculateDamage in DamageTarget; floor win logs as [SpellFloor])");
+                sb.AppendLine($"final: Damage={finalDamage:F4} defenderHealth: current={target.Health.Current} max={target.Health.MaxValue}");
+                sb.Append("=== end SpellDamage.Debug ===");
+                log.Info(sb.ToString());
             }
 
             return finalDamage;
@@ -970,7 +1151,9 @@ namespace ACE.Server.WorldObjects
         {
             var targetPlayer = target as Player;
 
-            if (targetPlayer != null && targetPlayer.Invincible || target.IsDead)
+            if (targetPlayer != null && targetPlayer.ZcDamageImmune && !targetPlayer.Invincible && !target.IsDead)
+                targetPlayer.ZcAnnounceAbsorb(ProjectileSource, $"{Math.Round(damage):N0} {Spell.DamageType.ToString().ToLowerInvariant()} damage ({Spell.Name})");
+            if (targetPlayer != null && (targetPlayer.Invincible || targetPlayer.ZcDamageImmune) || target.IsDead)
                 return;
 
             var sourceCreature = ProjectileSource as Creature;
@@ -1056,6 +1239,9 @@ namespace ACE.Server.WorldObjects
                     damageResistRatingMod = Creature.AdditiveCombine(damageResistRatingMod, pkDamageResistRatingMod);
                 }
 
+                // Rating chain applies unconditionally (2026-08-02, owner ruling): authored spell_damage
+                // is a PRE-mitigation base replacement, so Damage Rating and the defender's Damage Resist
+                // Rating hit spells exactly like they hit melee. (Old WYSIWYG skip removed.)
                 damage *= damageRatingMod * damageResistRatingMod;
 
                 // Apply enrage damage reduction for the defender
@@ -1064,6 +1250,30 @@ namespace ACE.Server.WorldObjects
                     var enrageReduction = target.EnrageDamageReduction ?? 0.0f; // Default to 0% reduction
                     damage *= (1.0f - enrageReduction);
                     //Console.WriteLine($"[DEBUG] Enrage Damage Reduction Applied by Defender: {enrageReduction * 100}%, Final Damage: {damage}");
+                }
+
+                // v11+ percent-HP floor: a high-variation monster's harmful health-damage spell always
+                // deals at least a %HP chunk to a player, bypassing life-aug damage reduction. Taken here,
+                // after the rating mods, so the floor lands at the felt scale (mirrors the melee ordering).
+                if (damage > 0 && Spell.IsHarmful && targetPlayer != null && sourceCreature != null
+                    && Spell.DamageType != DamageType.Stamina && Spell.DamageType != DamageType.Mana)
+                {
+                    var pctHpFloor = Creature.GetPercentHpFloorDamage(sourceCreature, targetPlayer, critical);
+                    if (pctHpFloor > damage)
+                    {
+                        if (ServerConfig.damage_event_debug_server_log.Value)
+                            log.Info($"[SpellFloor] floor won: preFloor={damage:F2} floor={pctHpFloor:F2} attacker={sourceCreature.Name} ({sourceCreature.Guid}) defender={targetPlayer.Name} spell={Spell.Name} ({Spell.Id})");
+                        damage = pctHpFloor;
+                    }
+                }
+
+                // Zone Control pct-HP damage special (key 44): flat pct of the mob's max HP, added AFTER
+                // every rating/mitigation step so nothing scales it (mirrors DamageEvent.cs). Player
+                // caster vs a zone-profiled monster only; NO-KILL + cooldown inside.
+                if (damage > 0 && sourcePlayer != null && targetPlayer == null)
+                {
+                    damage += sourcePlayer.ZcTryPctHpDamage(target);
+                    sourcePlayer.ZcTryLifeOnHit(target);             // key 48 Life on Hit (heals the caster; cooldown inside)
                 }
 
                 percent = damage / target.Health.MaxValue;
@@ -1100,11 +1310,21 @@ namespace ACE.Server.WorldObjects
                 else
                 {
                     spellPreHitHealth = (uint)Math.Max(0, target.Health.Current);
-                    amount = (uint)-target.UpdateVitalDelta(target.Health, (int)-Math.Round(damage));
-                    spellRoundedDamage = (uint)Math.Round(damage);
+                    var roundedDamage = (uint)Math.Round(damage);
+
+                    // Zone Control Cheat Death (key 45): lethal hit -> land on 1 HP + immunity window
+                    if (targetPlayer != null)
+                        roundedDamage = targetPlayer.ZcTryCheatDeath(ProjectileSource, roundedDamage);
+
+                    amount = (uint)-target.UpdateVitalDelta(target.Health, (int)-roundedDamage);
+                    spellRoundedDamage = roundedDamage;
                 }
 
                 target.DamageHistory.Add(ProjectileSource, Spell.DamageType, amount);
+
+                // Zone Control Battle Mending (key 42): survived, but under the threshold -> heal to full
+                if (targetPlayer != null && !mbResult.FullyAbsorbed)
+                    targetPlayer.ZcTryBattleMend(ProjectileSource);
                 // ───────────────────────────────────────────────────────────────────
 
                 if (target is CombatPet spellPet)
@@ -1147,12 +1367,23 @@ namespace ACE.Server.WorldObjects
                 // Show actual damage landed (0 when fully absorbed); mbSuffix describes what the barrier blocked.
                 var displayAmount = amount;
 
+                // Zone Control "Cast on Strike" reads with its OWN name and its own sentence (owner
+                // 2026-08-27). Gated on FromProc AND on the spell being one of ours, so every retail
+                // proc - cloaks, aetheria, the player Ring Glyph crafts - keeps the stock message.
+                // The rename exists because the client would otherwise print the DAT name, and "Nether
+                // Arc I" reads as a weak spell when the card is anything but.
+                var zcProcName = (string)null;
+                if (FromProc)
+                    ACE.Server.Managers.ZoneControl.ZoneLootMutator.TryGetProcDisplayName(Spell.Id, out zcProcName);
+
                 if (sourcePlayer != null)
                 {
                     var critProt = critDefended ? " Your critical hit was avoided with their augmentation!" : "";
                     var amtStr = Creature.FormatDamage(displayAmount, sourcePlayer.DamageNumberFormat);
 
-                    var attackerMsg = $"{critMsg}{overpowerMsg}{sneakMsg}You {verb} {target.Name} for {amtStr} points with {Spell.Name}.{critProt}{mbSuffix}";
+                    var attackerMsg = zcProcName != null
+                        ? $"{critMsg}{overpowerMsg}{sneakMsg}{zcProcName} hits {target.Name} for {amtStr} {ZcElementWord(Spell.DamageType)} damage.{critProt}{mbSuffix}"
+                        : $"{critMsg}{overpowerMsg}{sneakMsg}You {verb} {target.Name} for {amtStr} points with {Spell.Name}.{critProt}{mbSuffix}";
 
                     // could these crit / sneak attack?
                     if (nonHealth)
@@ -1170,7 +1401,9 @@ namespace ACE.Server.WorldObjects
                     var critProt = critDefended ? " Your augmentation allows you to avoid a critical hit!" : "";
                     var amtStr = Creature.FormatDamage(displayAmount, targetPlayer.DamageNumberFormat);
 
-                    var defenderMsg = $"{critMsg}{overpowerMsg}{sneakMsg}{ProjectileSource.Name} {plural} you for {amtStr} points with {Spell.Name}.{critProt}{mbSuffix}";
+                    var defenderMsg = zcProcName != null
+                        ? $"{critMsg}{overpowerMsg}{sneakMsg}{ProjectileSource.Name}'s {zcProcName} hits you for {amtStr} {ZcElementWord(Spell.DamageType)} damage.{critProt}{mbSuffix}"
+                        : $"{critMsg}{overpowerMsg}{sneakMsg}{ProjectileSource.Name} {plural} you for {amtStr} points with {Spell.Name}.{critProt}{mbSuffix}";
 
                     if (nonHealth)
                     {

--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -187,6 +187,13 @@ namespace ACE.Server.WorldObjects
                 PhysicsObj.Velocity = new Vector3(0, 0, 0.5f);
         }
 
+        /// <summary>
+        /// Transient (never persisted): best-effort cosmetic spawns (e.g. Zone Control boundary lanterns at a
+        /// water edge) set this so a NoValidPosition placement failure is skipped quietly instead of emitting a
+        /// [SpawnDiag] WARN. Only silences the log — the object is still destroyed/skipped on failure as before.
+        /// </summary>
+        public bool SuppressSpawnPlacementDiag;
+
         public bool AddPhysicsObj(int? VariationId)
         {
             if (PhysicsObj.CurCell != null)
@@ -200,6 +207,9 @@ namespace ACE.Server.WorldObjects
             var cell = LScape.get_landcell(Location.Cell, VariationId);
             if (cell == null)
             {
+                if (ServerConfig.spawn_diag_verbose.Value)
+                    log.Warn($"[SpawnDiag] AddPhysicsObj: get_landcell returned NULL for 0x{Guid}:{Name} " +
+                         $"[{WeenieClassId}] cell={Location.Cell:X8} v={VariationId?.ToString() ?? "null"} locV={Location.Variation?.ToString() ?? "null"}");
                 PhysicsObj.DestroyObject();
                 PhysicsObj = null;
                 return false;
@@ -220,9 +230,13 @@ namespace ACE.Server.WorldObjects
 
             if (!success || PhysicsObj.CurCell == null)
             {
+                if (ServerConfig.spawn_diag_verbose.Value && !SuppressSpawnPlacementDiag)
+                    log.Warn($"[SpawnDiag] AddPhysicsObj: enter_world FAILED for 0x{Guid}:{Name} [{WeenieClassId}] " +
+                         $"@ cell {cell.ID:X8} pos {Location.Pos} rot {Location.Rotation} v={VariationId?.ToString() ?? "null"} " +
+                         $"locV={Location.Variation?.ToString() ?? "null"} cellLbVar={(cell.CurLandblock?.VariationId)?.ToString() ?? "null"} " +
+                         $"success={success} curCellNull={PhysicsObj.CurCell == null} sposErr={PhysicsObj.LastEnterWorldError} SetupID={SetupTableId:X8}");
                 PhysicsObj.DestroyObject();
                 PhysicsObj = null;
-                //Console.WriteLine($"AddPhysicsObj: failure: {Name} @ {cell.ID.ToString("X8")} - {Location.Pos} - {Location.Rotation} - lv: {Location.Variation}, v: {VariationId} - SetupID: {SetupTableId.ToString("X8")}, MTableID: {MotionTableId.ToString("X8")}");
                 return false;
             }
 

--- a/Source/ACE.Server/WorldObjects/WorldObject_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Combat.cs
@@ -52,7 +52,11 @@ namespace ACE.Server.WorldObjects
             // handle aetheria procs
             if (attacker is Creature wielder)
             {
-                var equippedAetheria = wielder.EquippedObjects.Values.Where(i => i.HasProc && i.ProcSpellSelfTargeted == selfTarget);
+                // BUGFIX 2026-08-27: this loop walks EVERY equipped item with a proc, and the wielded
+                // weapon (and `this`, e.g. equipped ammo) are IN EquippedObjects - so anything already
+                // rolled above was rolling a SECOND time here. A 5 pct weapon fired at 1-(0.95^2) = 9.75 pct.
+                // TryProcWeaponOnCleaveTarget already excluded the weapon this way; the primary path did not.
+                var equippedAetheria = wielder.EquippedObjects.Values.Where(i => i != weapon && i != this && i.HasProc && i.ProcSpellSelfTargeted == selfTarget);
 
                 // aetheria
                 foreach (var aetheria in equippedAetheria)
@@ -86,7 +90,11 @@ namespace ACE.Server.WorldObjects
             // handle aetheria procs
             if (attacker is Creature wielder)
             {
-                var equippedAetheria = wielder.EquippedObjects.Values.Where(i => i.HasProc && i.ProcSpellSelfTargeted == selfTarget && i.IsProcSafeForCleave());
+                // BUGFIX 2026-08-27: this loop walks EVERY equipped item with a proc, and the wielded
+                // weapon (and `this`, e.g. equipped ammo) are IN EquippedObjects - so anything already
+                // rolled above was rolling a SECOND time here. A 5 pct weapon fired at 1-(0.95^2) = 9.75 pct.
+                // TryProcWeaponOnCleaveTarget already excluded the weapon this way; the primary path did not.
+                var equippedAetheria = wielder.EquippedObjects.Values.Where(i => i != weapon && i != this && i.HasProc && i.ProcSpellSelfTargeted == selfTarget && i.IsProcSafeForCleave());
 
                 foreach (var aetheria in equippedAetheria)
                     aetheria.TryProcItem(attacker, target, selfTarget);
@@ -315,7 +323,11 @@ namespace ACE.Server.WorldObjects
             // handle aetheria procs
             if (attacker is Creature wielder)
             {
-                var equippedAetheria = wielder.EquippedObjects.Values.Where(i => i.HasProc && i.ProcSpellSelfTargeted == selfTarget);
+                // BUGFIX 2026-08-27: this loop walks EVERY equipped item with a proc, and the wielded
+                // weapon (and `this`, e.g. equipped ammo) are IN EquippedObjects - so anything already
+                // rolled above was rolling a SECOND time here. A 5 pct weapon fired at 1-(0.95^2) = 9.75 pct.
+                // TryProcWeaponOnCleaveTarget already excluded the weapon this way; the primary path did not.
+                var equippedAetheria = wielder.EquippedObjects.Values.Where(i => i != weapon && i != this && i.HasProc && i.ProcSpellSelfTargeted == selfTarget);
 
                 foreach (var aetheria in equippedAetheria)
                     aetheria.TryProcItemWithChanceMod(attacker, target, selfTarget, chanceMultiplier);

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -145,9 +145,19 @@ namespace ACE.Server.WorldObjects
 
             if (casterCreature != null)
             {
-                // Retrieve caster's skill level in the Magic School
-                magicSkill = casterCreature.GetCreatureSkill(spell.School).Current;
-
+                // Zone Scaler (2026-08-31): an authored profile sets the monster's OFFENSIVE magic
+                // skill absolutely, exactly like attack_skill does for melee/missile in
+                // Creature_Combat.GetEffectiveAttackSkill. ResolveForCreature returns null for
+                // players, exempt creatures and unauthored zones, so this falls through to the normal
+                // skill everywhere else. Without it, zone-authored spell damage lands on a mob's
+                // retail-level War Magic and players resist essentially every cast.
+                var zoneMagic = ACE.Server.Managers.ZoneControl.ZoneControlManager.ResolveForCreature(casterCreature);
+                if (zoneMagic != null && zoneMagic.Has(ACE.Server.Managers.ZoneScaling.ZoneStat.MagicSkill))
+                    // floor at 0: a negative authored value would wrap through the uint cast
+                    magicSkill = (uint)Math.Round(Math.Max(0.0, zoneMagic.Get(ACE.Server.Managers.ZoneScaling.ZoneStat.MagicSkill)));
+                else
+                    // Retrieve caster's skill level in the Magic School
+                    magicSkill = casterCreature.GetCreatureSkill(spell.School).Current;
             }
             else if (caster.ItemSpellcraft != null)
             {
@@ -171,6 +181,13 @@ namespace ACE.Server.WorldObjects
 
             //Console.WriteLine($"{target.Name}.ResistSpell({Name}, {spell.Name}): magicSkill: {magicSkill}, difficulty: {difficulty}");
             bool resisted = MagicDefenseCheck(magicSkill, difficulty, out float resistChance);
+
+            // T11+ HIT GATE (owner 2026-08-31): an under-augmented player's spells are resisted
+            // outright by a tier-11+ monster, whatever the skill check said. Same all-or-nothing
+            // rule as melee/missile in DamageEvent.
+            if (!resisted && this is Creature gateCaster
+                && !ACE.Server.Managers.ZoneControl.TierHitGate.CanHitOrTell(gateCaster, targetCreature))
+                resisted = true;
 
             var player = this as Player;
             var targetPlayer = target as Player;
@@ -222,6 +239,18 @@ namespace ACE.Server.WorldObjects
             if (targetCreature != null && targetCreature.DebugDamage.HasFlag(Creature.DebugDamageType.Defender))
             {
                 ShowResistInfo(targetCreature, this, target, spell, magicSkill, difficulty, resistChance, resisted);
+            }
+
+            // Server-log spell-resist visibility - same flags as damage_event_debug_server_log
+            // (incoming spells on Players/CombatPets; logs BOTH outcomes so resisted casts are visible).
+            if (ServerConfig.damage_event_debug_server_log.Value
+                && (target is Player || target is CombatPet)
+                && (!ServerConfig.damage_event_debug_only_nonplayer_attackers.Value || caster is not Player))
+            {
+                log.Info($"[SpellResist] attacker={Name} ({Guid}) wcid={WeenieClassId} spell={spell.Name} ({spell.Id}) " +
+                         $"school={spell.School} castSkill={magicSkill} vs magicDef={difficulty} chance={resistChance:F4} " +
+                         $"resisted={resisted} defender={targetCreature.Name} ({targetCreature.Guid}) " +
+                         $"hp={targetCreature.Health.Current}/{targetCreature.Health.MaxValue}");
             }
 
             return resisted;
@@ -1086,7 +1115,18 @@ namespace ACE.Server.WorldObjects
             if (SpellProjectile.GetProjectileSpellType(spell.Id) == ProjectileSpellType.Ring
                 && this is Player ringPlayer
                 && !(ringPlayer.GetProperty(PropertyBool.ClassicRingAoe) ?? false))
-                ringPlayer.ApplyRingSpellAreaDamage(spell, lifeProjectileDamage: damage);
+            {
+                // Carry the proc flag and the authored ring band through - a ring's damage AND its
+                // combat message are both produced inside that method, never on the projectile path.
+                var zcRingB = fromProc
+                    ? (weapon?.GetProperty((PropertyFloat)ACE.Server.Managers.ZoneControl.ZoneLootMutator.ProcRingDamagePropId) ?? 0)
+                    : 0;
+                ringPlayer.ApplyRingSpellAreaDamage(spell, lifeProjectileDamage: damage,
+                    fromProc: fromProc, procBaseDamage: zcRingB, procWeapon: fromProc ? weapon : null,
+                    procVariance: fromProc
+                        ? (weapon?.GetProperty((PropertyFloat)ACE.Server.Managers.ZoneControl.ZoneLootMutator.ProcRingVariancePropId) ?? 0)
+                        : 0);
+            }
 
             if (spell.School == MagicSchool.LifeMagic)
             {

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -105,6 +105,18 @@ namespace ACE.Server.WorldObjects
                 if (changed)
                     ChangesDetected = true;
             }
+            InvalidateZcBoolCache(property);
+        }
+
+        /// <summary>The Zone Control rank / exempt bools (50047-50050) are cached on the Creature so the
+        /// per-hit resolve never takes the biota lock; any write to one of them drops that cache.</summary>
+        private void InvalidateZcBoolCache(PropertyBool property)
+        {
+            if ((int)property >= (int)PropertyBool.ExemptFromZoneScaling && (int)property <= (int)PropertyBool.ExemptFromZoneScaling + 3 && this is Creature c)
+            {
+                c.ZcRankCache = -1;
+                c.ZcExemptCache = -1;
+            }
         }
         public void SetProperty(PropertyDataId property, uint value)
         {
@@ -229,6 +241,7 @@ namespace ACE.Server.WorldObjects
                 if (Biota.TryRemoveProperty(property, BiotaDatabaseLock))
                     ChangesDetected = true;
             }
+            InvalidateZcBoolCache(property);
         }
         public void RemoveProperty(PropertyDataId property)
         {

--- a/Source/ACE.Server/WorldObjects/WorldObject_Teleport.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Teleport.cs
@@ -22,11 +22,20 @@ namespace ACE.Server.WorldObjects
             var newPosition = new ACE.Entity.Position(_newPosition);
             newPosition.PositionZ += 0.005f * (ObjScale ?? 1.0f);
 
+            // Variation 0 == retail base. The landblock/physics caches key variation 0 and null as
+            // SEPARATE instances, but visibility and ZoneControl treat 0 as the base world — teleporting
+            // to an explicit 0 lands in an empty parallel landblock copy (invisible/unattackable mobs).
+            // Normalize at this single choke point so no teleport path (@tv, /tele, portals, recalls)
+            // can ever place an object in the explicit layer-0 instance.
+            if (newPosition.Variation == 0)
+                newPosition.Variation = null;
+
             if (player != null && player.HandleFogBeforeTeleport(_newPosition))
                 return;
 
             // After fog deferral path returns false: cleanup runs with the real teleport (not ~1s early on a no-op).
             player?.CleanupPrestigeEffects();
+            player?.CleanupZoneBoundaryEffects();
 
             Teleporting = true;
             var timestamp = Time.GetUnixTime();
@@ -36,6 +45,12 @@ namespace ACE.Server.WorldObjects
 
             if (player != null)
                 player.LastTeleportTime = DateTime.UtcNow;
+
+            // A teleport interrupts any in-progress attack loop. A stale live MeleeTarget/MissileTarget
+            // otherwise swallows every subsequent attack request silently (the "already in melee loop"
+            // early-out in HandleActionTargetedMeleeAttack), which presents as "cannot attack anything".
+            if (player != null && (player.MeleeTarget != null || player.MissileTarget != null || player.AttackTarget != null))
+                player.OnAttackDone();
 
             if (fromPortal)
                 SetProperty(PropertyFloat.LastPortalTeleportTimestamp, timestamp);
@@ -71,6 +86,59 @@ namespace ACE.Server.WorldObjects
             player?.HandlePreTeleportVisibility(newPosition);
 
             UpdatePosition(new ACE.Entity.Position(newPosition), true);
+
+            // The physics placement above runs cell-entry enumerations (handle_visible_cells etc.)
+            // while the player still carries the ORIGIN variation, which can re-track origin-variation
+            // objects right after the cleanup at the top of this method (ghost mobs after /tv).
+            // Sweep again now that Location holds the destination variation.
+            if (prevLoc.Variation != newPosition.Variation)
+            {
+                try
+                {
+                    HandleVariationChangeVisbilityCleanup(prevLoc.Variation, newPosition.Variation);
+                }
+                catch (Exception e)
+                {
+                    log.Warn(e);
+                }
+            }
+
+            // Post-teleport invariant: a player's CurrentLandblock must be the destination landblock
+            // INSTANCE (landblock id + variation). Any path that leaves it stale makes creatures in the
+            // destination instance untargetable — Landblock.GetObject resolves from CurrentLandblock and
+            // its same-variation adjacents, and the melee/missile handlers silently no-op on a miss.
+            if (player != null)
+            {
+                var lb = player.CurrentLandblock;
+                if (lb == null || lb.Id.Landblock != Location.LandblockId.Landblock || lb.VariationId != Location.Variation)
+                {
+                    log.Warn($"{Name}.Teleport() - stale CurrentLandblock after teleport: " +
+                             $"lb={(lb == null ? "null" : $"0x{lb.Id.Landblock:X4} v={lb.VariationId?.ToString() ?? "null"}")} " +
+                             $"vs Location 0x{Location.LandblockId.Landblock:X4} v={Location.Variation?.ToString() ?? "null"} - forcing relocation");
+                    LandblockManager.RelocateObjectForPhysics(this, true);
+                }
+            }
+
+            // Final authoritative variation reconcile (fixes v11-object leak after a same-cell /tv
+            // swap). set_request_pos only re-fetches CurCell when it is null, so a same-cell variation
+            // change can leave the physics Position.Variation stale at the ORIGIN; since
+            // GetEffectiveVariationForVisibility falls back to Position.Variation when Location.Variation
+            // is null/base, the player stays mis-classified and re-tracks origin-variation objects every
+            // tick, defeating the earlier sweeps. Pin the physics variation to the destination and do a
+            // last cleanup so no origin-variation object survives the transition.
+            if (player != null && prevLoc.Variation != newPosition.Variation)
+            {
+                if (PhysicsObj?.Position != null)
+                    PhysicsObj.Position.Variation = newPosition.Variation;
+                try
+                {
+                    HandleVariationChangeVisbilityCleanup(prevLoc.Variation, newPosition.Variation);
+                }
+                catch (Exception e)
+                {
+                    log.Warn(e);
+                }
+            }
         }
 
         /// <summary>
@@ -116,7 +184,9 @@ namespace ACE.Server.WorldObjects
             {
                 if (knownObj.PhysicsObj == null) continue;
                 if (knownObj.Location == null) continue;
-                if (knownObj.Location.Variation == destinationVariation) continue;
+                // Normalized compare (0 and null are both "base"); a raw == would wrongly drop an
+                // explicit-0 base object when destination is null, or vice versa.
+                if (VariationManager.SameVariationForVisibility(knownObj.Location.Variation, destinationVariation)) continue;
 
                 knownObj.PhysicsObj.ObjMaint?.RemoveObject(PhysicsObj);
                 PhysicsObj?.ObjMaint?.RemoveObject(knownObj.PhysicsObj);
@@ -222,6 +292,16 @@ namespace ACE.Server.WorldObjects
 
                         player?.CheckMonsters();
                     }
+                    else if (player != null &&
+                             ACE.Server.Diagnostics.LogRateLimiter.ShouldEmit($"updatepos_nullcell:{Guid.Full}", TimeSpan.FromSeconds(10), out _))
+                    {
+                        // Void-walk diagnostic (2026-07-18): the physics move used to be skipped here
+                        // with NO trace while Location still advanced below — a player could end up
+                        // "in" a landblock that was never created (F658 v11 void). The heartbeat
+                        // [VoidHeal] guard relocates them; this records the leak's moment.
+                        log.Warn($"[VoidHeal] {Name}.UpdatePosition: get_landcell NULL for cell {newPosition.Cell:X8} " +
+                                 $"v={newPosition.Variation?.ToString() ?? "null"} - physics move skipped, Location will still advance.");
+                    }
                 }
                 else
                     PhysicsObj.Position.Frame.Orientation = newPosition.Rotation;
@@ -229,7 +309,16 @@ namespace ACE.Server.WorldObjects
 
             if (Teleporting && !forceUpdate) return true;
 
-            if (!success) return false;
+            if (!success)
+            {
+                // During a forced teleport this leaves Location and CurrentLandblock at the ORIGIN while
+                // the client is already mid-teleport — log loudly so a variation/instance desync is traceable.
+                if (Teleporting && forceUpdate)
+                    log.Warn($"{Name}.UpdatePosition() - physics placement FAILED during teleport to {newPosition} " +
+                             $"(v={newPosition.Variation?.ToString() ?? "null"}); Location/CurrentLandblock left at origin " +
+                             $"(loc v={Location.Variation?.ToString() ?? "null"}, lb v={CurrentLandblock?.VariationId?.ToString() ?? "null"})");
+                return false;
+            }
 
             var landblockUpdate = (Location.Cell >> 16 != newPosition.Cell >> 16) || variationChange;
 

--- a/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
@@ -346,6 +346,48 @@ namespace ACE.Server.WorldObjects
             set { if (!value.HasValue) RemoveProperty(PropertyFloat.CriticalFrequency); else SetProperty(PropertyFloat.CriticalFrequency, value.Value); }
         }
 
+        /// <summary>
+        /// OWNER RULING 2026-08-25: Biting Strike and Crushing Blow - the Zone Control weapon cards -
+        /// are the ONLY sources of crit chance and crit damage on a PLAYER's weapon. The two vanilla
+        /// imbues that do the same job are suppressed for players:
+        ///   Critical Strike  - a FLAT 0.50 crit chance at capped skill (MaxCriticalStrikeMod)
+        ///   Crippling Blow   - 6.0 stored, which the engine turns into 7.0x in combat
+        /// Both meet our card through Math.Max, so an unsuppressed imbue is a free floor the card has
+        /// to clear before it means anything. Suppressing them makes the band the whole story.
+        ///
+        /// PLAYERS ONLY, deliberately (owner's word). A monster's own imbues are part of ITS balance
+        /// and keep working exactly as before - suppressing shard-wide would quietly re-tune every mob
+        /// carrying one, which nobody asked for.
+        ///
+        /// WHY A READ-SITE GUARD rather than blocking the crafts. Two reasons the craft gate cannot
+        /// cover, both measured 2026-08-25:
+        ///   - 125 weenies carry these imbues BAKED IN (55 of them casters). No crafting gate ever
+        ///     sees those; they arrive already imbued.
+        ///   - The gate's layer-2 rule is "a weaker imbue cannot go on, but NOT-imbued could", so a
+        ///     weapon with no card would accept Critical Strike for ever, by design.
+        /// Craft-gate denies are still worth having as a second line - they give the player a refusal
+        /// reason, which a silent read-site guard cannot - but only this expresses NEVER.
+        ///
+        /// NOTE this does not touch the OTHER crit contributors: the weapon aug-scaling crit term, the
+        /// luminance-aug crit term or gear crit rating. (A historical note here about the
+        /// player_crit_damage_cap clamp binding on melee is obsolete - that clamp was deleted
+        /// 2026-08-29 with the unified crit model; the Crushing Blow band bounds the ratio now.)
+        ///
+        /// Flip this const to restore retail behaviour; it is the single switch.
+        /// </summary>
+        public const bool CritImbuesSuppressedForPlayers = true;
+
+        /// <summary>True when Critical Strike / Crippling Blow must be ignored for this wielder.</summary>
+        public static bool CritImbuesSuppressed(Creature wielder)
+            => CritImbuesSuppressedForPlayers && wielder is Player;
+
+        /// <summary>The weapon zone lock (owner 2026-08-30): true when this ZC weapon's custom
+        /// power is suppressed for this swing - toggle on, player wielder, ZcTier 11+ item,
+        /// outside every enabled authored area. One name so the card read sites below stay
+        /// one-line gates; the rule itself lives in ZoneControlManager.WeaponPowerSuppressed.</summary>
+        public static bool ZcPowerSuppressed(WorldObject weapon, Creature wielder)
+            => ACE.Server.Managers.ZoneControl.ZoneControlManager.WeaponPowerSuppressed(weapon, wielder);
+
         private const float defaultPhysicalCritFrequency = 0.1f;    // 10% base chance
 
         /// <summary>
@@ -353,9 +395,13 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public static float GetWeaponCriticalChance(WorldObject weapon, Creature wielder, CreatureSkill skill, Creature target)
         {
-            var critRate = (float)(weapon?.CriticalFrequency ?? defaultPhysicalCritFrequency);
+            // zone lock: outside authored areas a ZC weapon's Biting Strike stamp reads as absent
+            var critRate = ZcPowerSuppressed(weapon, wielder)
+                ? defaultPhysicalCritFrequency
+                : (float)(weapon?.CriticalFrequency ?? defaultPhysicalCritFrequency);
 
-            if (weapon != null && weapon.HasImbuedEffect(ImbuedEffectType.CriticalStrike))
+            if (weapon != null && weapon.HasImbuedEffect(ImbuedEffectType.CriticalStrike)
+                && !CritImbuesSuppressed(wielder))   // owner 2026-08-25: Biting Strike is the only crit-chance source on a player weapon
             {
                 var criticalStrikeBonus = GetCriticalStrikeMod(skill);
 
@@ -365,11 +411,41 @@ namespace ACE.Server.WorldObjects
             if (wielder != null)
                 critRate += wielder.GetCritRating() * 0.01f;
 
+            // Zone Control: an authored crit_rating REPLACES the governed monster's crit chance outright
+            // (value in percent; the defender's crit-resist below still applies)
+            var zoneCrit = GetZoneCritChanceOverride(wielder);
+            if (zoneCrit.HasValue)
+                critRate = zoneCrit.Value;
+
             // mitigation
             var critResistRatingMod = Creature.GetNegativeRatingMod(target.GetCritResistRating());
             critRate *= critResistRatingMod;
 
             return critRate;
+        }
+
+        /// <summary>Zone Control: zone-authored crit_rating REPLACES a governed monster's crit chance
+        /// (stat value in percent, e.g. 25 = crits 25% of the time). Null for players/ungoverned mobs.</summary>
+        private static float? GetZoneCritChanceOverride(Creature wielder)
+        {
+            if (wielder == null || wielder is Player)
+                return null;
+            var zp = ACE.Server.Managers.ZoneControl.ZoneControlManager.ResolveForCreature(wielder);
+            if (zp == null || !zp.Has(ACE.Server.Managers.ZoneScaling.ZoneStat.CritRating))
+                return null;
+            return (float)(zp.Get(ACE.Server.Managers.ZoneScaling.ZoneStat.CritRating) / 100.0);
+        }
+
+        /// <summary>Zone Control: zone-authored crit_damage_rating IS a governed monster's final crit
+        /// multiplier (e.g. 4 = crits deal 4x). Null for players/ungoverned mobs.</summary>
+        private static float? GetZoneCritDamageOverride(Creature wielder)
+        {
+            if (wielder == null || wielder is Player)
+                return null;
+            var zp = ACE.Server.Managers.ZoneControl.ZoneControlManager.ResolveForCreature(wielder);
+            if (zp == null || !zp.Has(ACE.Server.Managers.ZoneScaling.ZoneStat.CritDamageRating))
+                return null;
+            return (float)zp.Get(ACE.Server.Managers.ZoneScaling.ZoneStat.CritDamageRating);
         }
 
         // http://acpedia.org/wiki/Announcements_-_2002/08_-_Atonement#Letter_to_the_Players - 2% originally
@@ -379,7 +455,11 @@ namespace ACE.Server.WorldObjects
         // what this was actually increased to for base, was never stated directly in the dev notes
         // speculation is that it was 5%, to align with the minimum that CS magic scales from
 
-        private const float defaultMagicCritFrequency = 0.05f;
+        // UNIFIED 2026-08-29 (owner, "all 3 should get the same crit treatment"): magic's base crit
+        // chance comes up from retail's speculative 0.05 to match melee/missile's 0.10, so Biting
+        // Strike means the same thing on every school. The retail note this shadowed was itself
+        // speculation ("what this was actually increased to ... was never stated").
+        private const float defaultMagicCritFrequency = 0.10f;
 
         /// <summary>
         /// Returns the critical chance for the caster weapon
@@ -389,11 +469,23 @@ namespace ACE.Server.WorldObjects
             // TODO : merge with above function
 
             if (weapon == null)
-                return defaultMagicCritFrequency;
+            {
+                // Wandless casters = MONSTERS only (players cannot cast without a wielded caster).
+                // FIXED 2026-08-21 (owner ruling): the target's Crit Resist now applies on this
+                // branch too - it was silently skipped, making mob-caster crits un-resistable
+                // while the same mob's MELEE crits were reduced. Zone-authored crit chance still
+                // replaces the default first, same as the with-wand path below.
+                var wandlessRate = GetZoneCritChanceOverride(wielder) ?? defaultMagicCritFrequency;
+                return wandlessRate * Creature.GetNegativeRatingMod(target.GetCritResistRating());
+            }
 
-            var critRate = (float)(weapon.GetProperty(PropertyFloat.CriticalFrequency) ?? defaultMagicCritFrequency);
+            // zone lock: outside authored areas a ZC weapon's Biting Strike stamp reads as absent
+            var critRate = ZcPowerSuppressed(weapon, wielder)
+                ? defaultMagicCritFrequency
+                : (float)(weapon.GetProperty(PropertyFloat.CriticalFrequency) ?? defaultMagicCritFrequency);
 
-            if (weapon.HasImbuedEffect(ImbuedEffectType.CriticalStrike))
+            if (weapon.HasImbuedEffect(ImbuedEffectType.CriticalStrike)
+                && !CritImbuesSuppressed(wielder))   // same ruling on the magic path
             {
                 var isPvP = wielder is Player && target is Player;
 
@@ -403,6 +495,11 @@ namespace ACE.Server.WorldObjects
             }
 
             critRate += wielder.GetCritRating() * 0.01f;
+
+            // Zone Control: authored crit_rating REPLACES the governed monster's crit chance (see melee path)
+            var zoneCrit = GetZoneCritChanceOverride(wielder);
+            if (zoneCrit.HasValue)
+                critRate = zoneCrit.Value;
 
             // mitigation
             var critResistRatingMod = Creature.GetNegativeRatingMod(target.GetCritResistRating());
@@ -418,14 +515,35 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public static float GetWeaponCritDamageMod(WorldObject weapon, Creature wielder, CreatureSkill skill, Creature target)
         {
-            var critDamageMod = (float)(weapon?.GetProperty(PropertyFloat.CriticalMultiplier) ?? defaultCritDamageMultiplier);
+            // zone lock: outside authored areas a ZC weapon's Crushing Blow stamp AND its
+            // aug-scaling crit term both read as absent
+            var zcSuppressed = ZcPowerSuppressed(weapon, wielder);
 
-            if (weapon != null && weapon.HasImbuedEffect(ImbuedEffectType.CripplingBlow))
+            var critDamageMod = zcSuppressed
+                ? defaultCritDamageMultiplier
+                : (float)(weapon?.GetProperty(PropertyFloat.CriticalMultiplier) ?? defaultCritDamageMultiplier);
+
+            if (weapon != null && weapon.HasImbuedEffect(ImbuedEffectType.CripplingBlow)
+                && !CritImbuesSuppressed(wielder))   // owner 2026-08-25: Crushing Blow is the only crit-damage source on a player weapon
             {
                 var cripplingBlowMod = GetCripplingBlowMod(skill);
 
-                critDamageMod = Math.Max(critDamageMod, cripplingBlowMod); 
+                critDamageMod = Math.Max(critDamageMod, cripplingBlowMod);
             }
+
+            // Weapon aug-scaling crit term (T11 weapon relevance): kc(quality) x per-aug crit
+            // modifier x min(matching combat augs, tier cap) — the aug-pegged floor. Math.Max so
+            // a Crushing Blow card / big CriticalMultiplier stays the jackpot above it (§7.10).
+            if (!zcSuppressed)
+                critDamageMod = Math.Max(critDamageMod,
+                    ACE.Server.Managers.WeaponScaling.WeaponScalingCombat.GetCritDamageBonus(weapon, wielder));
+
+            // Zone Control: authored crit_damage_rating IS the final multiplier; engine computes 1 + mod,
+            // so store value - 1 (e.g. authored 4 -> crits deal exactly 4x)
+            var zoneCritDmg = GetZoneCritDamageOverride(wielder);
+            if (zoneCritDmg.HasValue)
+                critDamageMod = Math.Max(0f, zoneCritDmg.Value - 1.0f);
+
             return critDamageMod;
         }
 
@@ -442,15 +560,34 @@ namespace ACE.Server.WorldObjects
             if (wielder == null || !(weapon is Caster) || weapon.W_DamageType != damageType)
                 return 1.0f;
 
-            var elementalDamageMod = weapon.ElementalDamageMod ?? 1.0f;
-
-            // additive to base multiplier
             var wielderEnchantments = wielder.EnchantmentManager.GetElementalDamageMod();
             var weaponEnchantments = weapon.EnchantmentManager.GetElementalDamageMod();
 
             var enchantments = wielderEnchantments + weaponEnchantments;
 
-            var modifier = (float)(elementalDamageMod + enchantments);
+            // Weapon aug-scaling: a stamped T11+ caster's quality roll GRADES its elemental
+            // modifier and the weapon's TIER scales it — the launcher mechanism on a different
+            // property (owner 2026-08-06: "keep bow and caster weapons scaling identical").
+            //
+            // COMPOSITION (owner GO 2026-08-06, CasterDamageShare_Plan): the resolved mod
+            // MULTIPLIES the enchantment sum, the way the bow's DamageMod multiplies Blood
+            // Drinker. Stock math added them, which made Spirit Drinker (+17.50 at 3,500 augs)
+            // an additive peer ~11x the wand — the wand was ~8 pct of its own multiplier and a
+            // T11 vs T14 wand measured ~1 pct apart. The rescale anchors S grade to the old
+            // totals exactly (r = 1/kMax); see CasterAuraRescale in WeaponScalingManager.
+            //
+            // Replace semantics: the STOCK ADDITIVE path is the fallback whenever the system is
+            // off or the caster is unstamped legacy — bit-for-bit pre-system behavior, so the
+            // kill switch has a clean prediction.
+            // zone lock: outside authored areas the graded caster mod is suppressed - the stock
+            // additive fallback below IS the base-stats behaviour the lock lands on
+            float modifier;
+            if (!ZcPowerSuppressed(weapon, wielder)
+                && ACE.Server.Managers.WeaponScaling.WeaponScalingCombat.TryGetCasterElementalMod(weapon, wielder as Player, out var gradedMod))
+                modifier = ACE.Server.Managers.WeaponScaling.WeaponScalingCombat.ComposeCasterModifier(
+                    gradedMod, enchantments, ACE.Server.Managers.WeaponScaling.WeaponScalingManager.Current.CasterAuraRescale);
+            else
+                modifier = (float)((weapon.ElementalDamageMod ?? 1.0f) + enchantments);
 
             if (modifier > 1.0f && target is Player)
                 modifier = 1.0f + (modifier - 1.0f) * ElementalDamageBonusPvPReduction;
@@ -491,8 +628,15 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public static float GetWeaponCreatureSlayerModifier(WorldObject weapon, Creature wielder, Creature target)
         {
-            if (weapon != null && weapon.SlayerCreatureType != null && weapon.SlayerDamageBonus != null &&
-                target != null && weapon.SlayerCreatureType == target.CreatureType)
+            // zone lock: outside authored areas a ZC weapon's Slayer stamp reads as absent
+            if (ZcPowerSuppressed(weapon, wielder))
+                return defaultModifier;
+
+            if (weapon != null && weapon.SlayerDamageBonus != null && target != null
+                && ((weapon.SlayerCreatureType != null && weapon.SlayerCreatureType == target.CreatureType)
+                    // forge-only "slayer of all creatures" (PropertyBool 50052; /wsforge cards:premade or
+                    // slayertype=all): the bonus applies to every target. Drops never carry it.
+                    || weapon.GetProperty(PropertyBool.SlayerAllCreatures) == true))
             {
                 // TODO: scale with base weapon skill?
                 return (float)weapon.SlayerDamageBonus;
@@ -573,9 +717,22 @@ namespace ACE.Server.WorldObjects
                 hasRending = true;
             }
 
+            // zone lock: outside authored areas a ZC weapon's Rend (and its rolled power) reads
+            // as absent - suppressed here, after eligibility, so retail/pet rends stay untouched
+            if (hasRending && ZcPowerSuppressed(weapon, wielder))
+                hasRending = false;
+
             if (hasRending && skill != null)
             {
                 var rendingMod = GetRendingMod(skill);
+
+                // Zone Control loot: per-weapon rend power override (ZoneLootMutator stamp) is a DIRECT
+                // vuln bonus (wire 1.5..10.0 = +150%..+1000%). rendingMod = 1 + override, REPLACING the
+                // skill-scaled formula and its 2.5 cap, so the drop's rolled strength is exactly 1000% max.
+                var rendOverride = weapon?.GetProperty((PropertyFloat)ACE.Server.Managers.ZoneControl.ZoneLootMutator.RendingModOverridePropId);
+                if (rendOverride.HasValue && rendOverride.Value > 0)
+                    rendingMod = 1.0f + (float)rendOverride.Value;
+
                 resistMod = Math.Max(resistMod, rendingMod);
             }
 
@@ -901,7 +1058,11 @@ namespace ACE.Server.WorldObjects
         public float GetIgnoreShieldMod(WorldObject weapon)
         {
             var creatureMod = IgnoreShield ?? 0.0f;
-            var weaponMod = weapon?.IgnoreShield ?? 0.0f;
+            // zone lock: outside authored areas a ZC weapon's Shield Cleaving stamp reads as
+            // absent (the attacker's own creature-side IgnoreShield is never gated)
+            var weaponMod = ZcPowerSuppressed(weapon, this as Creature)
+                ? 0.0
+                : weapon?.IgnoreShield ?? 0.0f;
 
             return 1.0f - (float)Math.Max(creatureMod, weaponMod);
         }
@@ -1109,7 +1270,10 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Returns TRUE if this item has a proc / 'cast on strike' spell
         /// </summary>
-        public bool HasProc => ProcSpell != null;
+        /// <summary>True when EITHER Cast on Strike slot is filled. This has to include slot 2: every
+        /// caller in WorldObject_Combat gates on HasProc before calling TryProcItem, so a weapon that
+        /// rolled only a ring would otherwise never fire it.</summary>
+        public bool HasProc => ProcSpell != null || ProcSpell2 != null;
 
         /// <summary>
         /// Returns TRUE if this item has a proc spell
@@ -1120,60 +1284,36 @@ namespace ACE.Server.WorldObjects
             return HasProc && ProcSpell == spellID;
         }
 
+        /// <summary>Cast on Strike slot 2 - the RING. Slot 1 (the arc) is the engine's own ProcSpell,
+        /// so nothing outside this file needs to know a second slot exists: TryProcItem rolls both.</summary>
+        public uint? ProcSpell2
+        {
+            get => GetProperty((PropertyDataId)ACE.Server.Managers.ZoneControl.ZoneLootMutator.ProcSpell2PropId);
+            set { if (!value.HasValue) RemoveProperty((PropertyDataId)ACE.Server.Managers.ZoneControl.ZoneLootMutator.ProcSpell2PropId); else SetProperty((PropertyDataId)ACE.Server.Managers.ZoneControl.ZoneLootMutator.ProcSpell2PropId, value.Value); }
+        }
+
+        /// <summary>Slot 2's own per-hit rate. Independent of slot 1's (owner 2026-08-27).</summary>
+        public double? ProcSpellRate2
+        {
+            get => GetProperty((PropertyFloat)ACE.Server.Managers.ZoneControl.ZoneLootMutator.ProcRate2PropId);
+            set { if (!value.HasValue) RemoveProperty((PropertyFloat)ACE.Server.Managers.ZoneControl.ZoneLootMutator.ProcRate2PropId); else SetProperty((PropertyFloat)ACE.Server.Managers.ZoneControl.ZoneLootMutator.ProcRate2PropId, value.Value); }
+        }
+
+        public bool HasProc2 => ProcSpell2 != null;
+
+        /// <summary>
+        /// Rolls BOTH Cast on Strike slots. Two independent rolls, not one roll that picks a spell
+        /// (owner 2026-08-27: the arc and the ring are separate entities) - so a weapon carrying both
+        /// procs more often than one carrying either, which is the only version where the second slot
+        /// is actually worth rolling.
+        ///
+        /// Kept as a single public entry point on purpose: every caller in WorldObject_Combat and the
+        /// cleave paths already calls TryProcItem, so folding slot 2 in here means the second slot
+        /// needs no call-site changes anywhere and cannot be forgotten at one of them.
+        /// </summary>
         public void TryProcItem(WorldObject attacker, Creature target, bool selfTarget)
         {
-            // roll for a chance of casting spell
-            var chance = ProcSpellRate ?? 0.0f;
-
-            // special handling for aetheria
-            if (Aetheria.IsAetheria(WeenieClassId) && attacker is Creature wielder)
-                chance = Aetheria.CalcProcRate(this, wielder);
-
-            var rng = ThreadSafeRandom.Next(0.0f, 1.0f);
-            if (rng >= chance)
-                return;
-
-            var spell = new Spell(ProcSpell.Value);
-
-            if (spell.NotFound)
-            {
-                if (attacker is Player player)
-                {
-                    if (spell._spellBase == null)
-                        player.Session.Network.EnqueueSend(new GameMessageSystemChat($"SpellId {ProcSpell.Value} Invalid.", ChatMessageType.System));
-                    else
-                        player.Session.Network.EnqueueSend(new GameMessageSystemChat($"{spell.Name} spell not implemented, yet!", ChatMessageType.System));
-                }
-                return;
-            }
-
-            // not sure if this should go before or after the resist check
-            // after would match Player_Magic, but would require changing the signature of TryCastSpell yet again
-            // starting with the simpler check here
-            if (!selfTarget && target != null && target.NonProjectileMagicImmune && !spell.IsProjectile)
-            {
-                if (attacker is Player player)
-                    player.Session.Network.EnqueueSend(new GameMessageSystemChat($"You fail to affect {target.Name} with {spell.Name}", ChatMessageType.Magic));
-
-                return;
-            }
-
-            var itemCaster = this is Creature ? null : this;
-
-            // For self-targeted spells, use the attacker as the target
-            var spellTarget = selfTarget ? attacker : target;
-
-            if (spell.NonComponentTargetType == ItemType.None)
-                attacker.TryCastSpell(spell, null, itemCaster, itemCaster, true, true);
-            else if (spell.NonComponentTargetType == ItemType.Vestements)
-            {
-                // TODO: spell.NonComponentTargetType should probably always go through TryCastSpell_WithItemRedirects,
-                // however i don't feel like testing every possible known type of item procspell in the current db to ensure there are no regressions
-                // current test case: 33990 Composite Bow casting Tattercoat
-                attacker.TryCastSpell_WithRedirects(spell, spellTarget, itemCaster, itemCaster, true, true);
-            }
-            else
-                attacker.TryCastSpell(spell, spellTarget, itemCaster, itemCaster, true, true);
+            TryProcItemWithChanceMod(attacker, target, selfTarget, 1.0f);
         }
 
         /// <summary>
@@ -1181,25 +1321,58 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public void TryProcItemWithChanceMod(WorldObject attacker, Creature target, bool selfTarget, float chanceMultiplier)
         {
-            var baseChance = ProcSpellRate ?? 0.0f;
+            // zone lock: outside authored areas a ZC weapon's Cast on Strike slots (arc AND ring)
+            // never fire. `this` is the proccing item, so cloaks/aetheria/player Ring Glyph
+            // crafts are untouched - they never carry ZcTier.
+            if (ZcPowerSuppressed(this, attacker as Creature))
+                return;
 
-            if (Aetheria.IsAetheria(WeenieClassId) && attacker is Creature wielder)
-                baseChance = Aetheria.CalcProcRate(this, wielder);
+            // Slot 1 - the arc, and every pre-existing proc on the shard (cloaks, aetheria, the ~11,700
+            // player Ring Glyph crafts). Aetheria's own rate curve applies here and only here.
+            if (ProcSpell != null)
+            {
+                var baseChance = ProcSpellRate ?? 0.0f;
 
-            var chance = Math.Clamp(baseChance * Math.Max(0f, chanceMultiplier), 0f, 1f);
+                if (Aetheria.IsAetheria(WeenieClassId) && attacker is Creature wielder)
+                    baseChance = Aetheria.CalcProcRate(this, wielder);
+
+                TryProcOneSpell(attacker, target, selfTarget, ProcSpell.Value, baseChance, chanceMultiplier);
+            }
+
+            // Slot 2 - the ring. Rolled separately against its own rate.
+            if (ProcSpell2 != null)
+                TryProcOneSpell(attacker, target, selfTarget, ProcSpell2.Value, ProcSpellRate2 ?? 0.0, chanceMultiplier);
+        }
+
+        /// <summary>The body that was TryProcItem before the card gained a second slot - one roll, one
+        /// spell. Unchanged in behaviour; it just takes the spell and rate as arguments now.</summary>
+        /// <summary>Fires this item's primary proc spell with a 100 pct chance - the owner's /buff leg
+        /// (2026-09-01) uses it to pre-cast the self-targeted surge of each worn aetheria, through the
+        /// exact cast path a real proc takes (item caster, no creature-aug bake), so a test character
+        /// starts a fight with the surges a real fight would have produced.</summary>
+        public void ForceProcSpell(WorldObject attacker, Creature target, bool selfTarget)
+        {
+            if (ProcSpell == null)
+                return;
+            TryProcOneSpell(attacker, target, selfTarget, ProcSpell.Value, 1.0, 1.0f);
+        }
+
+        private void TryProcOneSpell(WorldObject attacker, Creature target, bool selfTarget, uint procSpellId, double baseChance, float chanceMultiplier)
+        {
+            var chance = Math.Clamp(baseChance * Math.Max(0f, chanceMultiplier), 0.0, 1.0);
 
             var rng = ThreadSafeRandom.Next(0.0f, 1.0f);
             if (rng >= chance)
                 return;
 
-            var spell = new Spell(ProcSpell.Value);
+            var spell = new Spell(procSpellId);
 
             if (spell.NotFound)
             {
                 if (attacker is Player player)
                 {
                     if (spell._spellBase == null)
-                        player.Session.Network.EnqueueSend(new GameMessageSystemChat($"SpellId {ProcSpell.Value} Invalid.", ChatMessageType.System));
+                        player.Session.Network.EnqueueSend(new GameMessageSystemChat($"SpellId {procSpellId} Invalid.", ChatMessageType.System));
                     else
                         player.Session.Network.EnqueueSend(new GameMessageSystemChat($"{spell.Name} spell not implemented, yet!", ChatMessageType.System));
                 }


### PR DESCRIPTION
## T11 part 3 of 4: the Zone Control core (managers, commands, loot factories, WorldObjects wiring, tests)

Third of four sub-100-file PRs delivering the Zone Control / T11 (Tou Tou) branch. 98 files. Depends on parts 1 (#510, `TierTable` and the T11 loot rows) and 2 (#511, property enums, server properties, `VariationManager`): **this PR does not compile on master alone; master + parts 1 + 2 + 3 builds clean with 0 errors (verified)**. Any "X does not exist / does not contain a definition" note on this PR is a symbol from part 1 or 2. Merge after both.

### New managers (`Managers/ZoneControl`, `ZoneScaling`, `WeaponScaling`, `Rifts`, `BossGroupManager`)
- `ZoneControlManager` (store load/save, lock-free snapshot rebuilt copy-on-write, zones, per-WCID overrides, rank layers Default/Regular/Leader/Boss, master switches), `ZoneControlModels`, `ZoneStatResolver` (live stat resolution on spawn and on equip: vitals, attributes, skills, ratings, armor, elemental weakness, spell damage, regen, kill XP by rank), `ZoneModifiers` (modifier pool / bands / slot specials, MAX-wins per slot), `ZoneLootMutator` (weapon cards: Cast on Strike two-slot proc with banded damage and per-slot aug cap, Suppression, rends, all-creatures slayer, gear caps), `ZoneCraftGate` + `ZoneCraftGateStore` (T11+ crafting gate, three layers), `TierHitGate` (T11+ hit gate reporting every unmet requirement), `ZoneAppearance` (model / palette / body-part overrides), `ZoneSpawnScaler`, `ZoneEffectManager` (empowered casters, auras), `ZoneFallback` (T10 fallback set when Zone Control is off or the store is empty), `ZoneScalingModels`.
- `WeaponScalingManager` + `WeaponScalingCombat`: tier-scaled weapon relevance, 16-rung grade ladder, launcher and caster wire-in, per-school luminance aug caps, unified crit model. Code default OFF; the store row in part 4 turns it on.
- `RiftManager`, `RiftModels`, `RiftScaling`: instanced rift runs with a guardian. `BossGroupManager`.
- Wiring in `LandblockManager`, `WorldManager`, `PlayerManager`, `RecipeManager` (craft gate hook).

### Commands
New: `ZoneControlCommands` (73 verbs, Developer) with `ZoneControlCommandHelp` (the authoritative verb registry), `WeaponScalingCommands` (`/weaponscale`, `/wsforge`), `RiftCommands` (`/rift`, Player level). Extended: `AdminCommands` (`/nolog`, `/createinst`, `/removeinst`, `/spreadinst`, `/fixinstz`, `/fixvariation`), `DeveloperCommands` (`/zcvitals`, `/asforge`, `/bossgroup`, `/findwcid`, `/findnpc`), `PlayerCommands`, `TestCharacterCommands`.

### Loot factories
`LootGenerationFactory_ZoneSet` (new: tier-11+ structured per-slot drops, lane-first weapon draw, zone loot floor, drop budget, the augmentation-count wield gate replacing level requirements at T11+, gear caps) and the per-family factories (`LootGenerationFactory`, `_Melee`, `_Missile`, `_Caster`, `_Weapon`, `_Clothing`, `_Jewelry`, `_Gem`, `_Magic`, `_Spells`, `_Aetheria`, `_Rare`, `_Chance`) routed through `TierTable` and the zone set. `WorldObjectFactory`.

### Entities
`DamageEvent` (rating chain, unified crit, percent-HP hooks), `BaseDamageMod`, `AddEnchantmentResult`, `Landblock` (void-landblock self-healing init, unload re-home over a copied cell list, spawn diagnostics), `GeneratorProfile` (boss groups, scatter). `Network/Structure/AppraiseInfo` + `WeaponProfile` (Property Details via LongDesc, Modifiers section, Cast on Strike display).

### WorldObjects (the wiring)
- New: `Creature_PercentHpDamage.cs` (v11+ percent-of-max-HP damage model with relief curves, vulnerability compression, mob damage-taken mitigation), `Creature_Aura.cs`, `Player_ZoneBoundary.cs` (zone boundaries replace the prestige allowlist).
- Creature: `Creature.cs` (rank / exempt bool caches, lock-free for the resolver, invalidated on property writes), `Creature_Combat` / `_Melee` / `_Missile` / `_Magic` (zone-authored attack and spell damage replace the rolled base pre-mitigation, retail semantics; unified crit; hit gate), `Creature_Death` (kill XP by rank, zone loot, bonus currency, no-log areas, carried inventory kept in governed zones), `Creature_Equipment` (slot-special MAX cache on equip / dequip), `Creature_Rating`, `Creature_Vitals` (fixed HP snapshot, regen special), `Creature_BodyPart`, `Creature_Properties`, `CreatureAttribute` / `CreatureSkill` / `CreatureVital`, `Monster_Combat` / `_Melee` / `_Magic` / `_Tick`.
- Player: `Player.cs`, `Player_Combat` (cheat death / battle mend, Critical Strike and Crippling Blow suppressed for players, Shield Cleaving melee/missile only), `Player_Magic` (smart-ring parity with `SpellProjectile.CalculateDamage`, Cast on Strike ring slot, overpower on resisted ring hits), `Player_Inventory` (aug-count wield checks), `Player_Move`, `Player_Tick`, `Player_Use` (craft gate, portal bypass state).
- WorldObject: `WorldObject.cs`, `WorldObject_Combat`, `WorldObject_Magic` (ring proc band carried into `ApplyRingSpellAreaDamage`), `WorldObject_Properties` (cache invalidation on the 50047-50050 bools), `WorldObject_Weapon` (weapon scaling wire-in, proc no longer rolled twice per hit), `WorldObject_Teleport`, `SpellProjectile`, `EnchantmentManager`, `Hotspot`.

### Tests (5)
`EndgameVariationTests`, `ZoneDefaultLayerTests`, `ZoneSpawnResolutionTests`, `ZoneStoreCompatTests`, `WeaponScalingConfigTests`.

### Behaviour on live once merged
With `zonecontrol_enabled` on and an EMPTY store, every zone-aware path falls back to today's behaviour (`ZoneFallback`); weapon scaling is off by code default. The content that switches T11 on is part 4. Engine fixes that apply everywhere: proc double-roll, 0-point periodic heal messages suppressed, stat values never sent in scientific notation, spell damage retail semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Greater Rifts with timed, tier-scaled dungeon runs, guardians, rewards, and `/rift` commands.
  - Added Zone Control systems for layered stats, appearances, loot, crafting rules, boundary enforcement, effects, and terrain overrides.
  - Added configurable T11+ weapon scaling, forging tools, gear upgrades, and enhanced weapon appraisal details.
  - Added boss-group coordination, developer diagnostics, spawn tools, and administrative configuration commands.
- **Bug Fixes**
  - Improved spawn recovery, teleport and variation handling, landblock stability, loot scaling, and combat consistency.
  - Added clearer crafting refusal messages and safeguards against duplicate effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->