### PR TITLE
Fix a UniqueQueue key collision in DeepSave

### DIFF
--- a/Source/ACE.Server.Tests/SaveOwnershipTokenTests.cs
+++ b/Source/ACE.Server.Tests/SaveOwnershipTokenTests.cs
@@ -1,0 +1,62 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using ACE.Server.WorldObjects;
+
+namespace ACE.Server.Tests
+{
+    /// <summary>
+    /// Regression cover for the DeepSave save-flag ownership rule (PR #514, 2026-09-09).
+    ///
+    /// DeepSave's callback clears SaveInProgress on objects it never raised the flag on, so it must not
+    /// clear a flag a NEWER save raised after DeepSave enqueued. The first cut compared DateTime.UtcNow
+    /// stamps; CodeRabbit pointed out UtcNow can repeat within its resolution (two stamps in the same
+    /// instant read as "not newer") and can step backwards under NTP. Ownership is now a monotonic
+    /// token from one process-wide counter, and this pins the comparison the callback relies on.
+    ///
+    /// The predicate is tested directly rather than through a live WorldObject: constructing one drags in
+    /// the biota/physics stack, and the rule under test is the comparison, not the plumbing around it.
+    /// </summary>
+    [TestClass]
+    public class SaveOwnershipTokenTests
+    {
+        [TestMethod]
+        public void FlagStampedBeforeCutoff_IsOursToClear()
+        {
+            // A save that raised its flag before the callback captured the cutoff is ahead of that
+            // callback in the single-threaded queue, or was orphaned - either way the callback clears it.
+            Assert.IsTrue(WorldObject.SaveFlagOwnedAtOrBefore(token: 41, cutoff: 42));
+        }
+
+        [TestMethod]
+        public void FlagStampedAtCutoff_IsOursToClear()
+        {
+            // The "same instant" case the timestamp version got wrong: a flag stamped by the very last
+            // save before the cutoff was read carries the cutoff value itself, and it is older, not newer.
+            Assert.IsTrue(WorldObject.SaveFlagOwnedAtOrBefore(token: 42, cutoff: 42));
+        }
+
+        [TestMethod]
+        public void FlagStampedAfterCutoff_BelongsToNewerSave()
+        {
+            // Raised after the enqueue: a newer save is in flight and its own callback clears it.
+            Assert.IsFalse(WorldObject.SaveFlagOwnedAtOrBefore(token: 43, cutoff: 42));
+        }
+
+        [TestMethod]
+        public void NeverStamped_IsOursToClear()
+        {
+            // An object that has never been through SaveBiotaToDatabase carries token 0 - the stranded
+            // flag rescue DeepSave exists for must still reach it.
+            Assert.IsTrue(WorldObject.SaveFlagOwnedAtOrBefore(token: 0, cutoff: 42));
+        }
+
+        [TestMethod]
+        public void CurrentSaveToken_IsMonotonic()
+        {
+            // The cutoff a callback captures can only move forward, whatever the wall clock does.
+            var a = WorldObject.CurrentSaveToken;
+            var b = WorldObject.CurrentSaveToken;
+            Assert.IsTrue(b >= a);
+        }
+    }
+}

--- a/Source/ACE.Server/Entity/Actions/IAction.cs
+++ b/Source/ACE.Server/Entity/Actions/IAction.cs
@@ -86,7 +86,6 @@ namespace ACE.Server.Entity.Actions
         Player_SetNonBusy,
         PlayerAllegiance_HandleLogin,
         PlayerDatabase_SaveBiotasInParallelCallback,
-        PlayerInventory_DeepSaveCallback,
         PlayerCombat_ChangeCombatMode,
         PlayerCombat_ChangeCombatModeCallback,
         PlayerCombat_SetActionType,
@@ -471,6 +470,7 @@ namespace ACE.Server.Entity.Actions
         BossGroupManager_KickSpawn,
         Player_ZcCheatDeathExpired,   // Zone Control Cheat Death window closed notice (2026-08-23)
         ZoneControl_LadderReresolve,   // live stat resolution: online worn-gear re-stamp after `ladder apply`
+        PlayerInventory_DeepSaveCallback,   // inventory DeepSave flag cleanup on the world action queue
     }
     public static class ActionTypeConverter
     {

--- a/Source/ACE.Server/Entity/Actions/IAction.cs
+++ b/Source/ACE.Server/Entity/Actions/IAction.cs
@@ -86,6 +86,7 @@ namespace ACE.Server.Entity.Actions
         Player_SetNonBusy,
         PlayerAllegiance_HandleLogin,
         PlayerDatabase_SaveBiotasInParallelCallback,
+        PlayerInventory_DeepSaveCallback,
         PlayerCombat_ChangeCombatMode,
         PlayerCombat_ChangeCombatModeCallback,
         PlayerCombat_SetActionType,

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -200,8 +200,16 @@ namespace ACE.Server.WorldObjects
             // because each side misses a case the other covers: a sub-item that leaves the container
             // in flight is only in the captured set, and a sub-item with no changes to write (so not
             // in biotas) that a player batch save left SaveInProgress is only found by walking the
-            // container. Setting a flag false twice is harmless.
+            // container.
             var savedObjects = new List<WorldObject> { item };
+
+            // Ownership: DeepSave never SETS SaveInProgress, so every flag it clears was set by some
+            // other save. A flag set BEFORE this enqueue belongs to a save that is already ahead of us
+            // in the single-threaded queue (or was orphaned by one) - safe to clear once ours completes.
+            // A flag set AFTER this enqueue belongs to a newer save still in flight; clearing it would
+            // hand the object to a third save early. SaveBiotaToDatabase stamps SaveStartTime together
+            // with SaveInProgress, so the timestamp is the ownership test.
+            var enqueuedAt = DateTime.UtcNow;
 
             if (item.ChangesDetected)
                 biotas.Add((item.Biota, item.BiotaDatabaseLock));
@@ -239,25 +247,24 @@ namespace ACE.Server.WorldObjects
                 var clearFlagsAction = new ActionChain();
                 clearFlagsAction.AddAction(WorldManager.ActionQueue, ActionType.PlayerInventory_DeepSaveCallback, () =>
                 {
-                    foreach (var wo in savedObjects)
+                    void ClearIfOurs(WorldObject wo)
                     {
-                        if (wo.IsDestroyed)
-                            continue;
+                        if (wo.IsDestroyed || !wo.SaveInProgress)
+                            return;
+                        if (wo.SaveStartTime > enqueuedAt)
+                            return;   // a newer save owns this flag; its own callback clears it
 
                         wo.SaveInProgress = false;
                         wo.SaveStartTime = DateTime.MinValue; // Reset for next save
                     }
 
+                    foreach (var wo in savedObjects)
+                        ClearIfOurs(wo);
+
                     if (item is Container savedContainer)
                     {
                         foreach (var subItem in savedContainer.Inventory.Values)
-                        {
-                            if (subItem.IsDestroyed)
-                                continue;
-
-                            subItem.SaveInProgress = false;
-                            subItem.SaveStartTime = DateTime.MinValue; // Reset for next save
-                        }
+                            ClearIfOurs(subItem);
                     }
 
                     // ChangesDetected is deliberately left alone here, so a failed write is picked up

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -207,9 +207,10 @@ namespace ACE.Server.WorldObjects
             // other save. A flag set BEFORE this enqueue belongs to a save that is already ahead of us
             // in the single-threaded queue (or was orphaned by one) - safe to clear once ours completes.
             // A flag set AFTER this enqueue belongs to a newer save still in flight; clearing it would
-            // hand the object to a third save early. SaveBiotaToDatabase stamps SaveStartTime together
-            // with SaveInProgress, so the timestamp is the ownership test.
-            var enqueuedAt = DateTime.UtcNow;
+            // hand the object to a third save early. SaveBiotaToDatabase stamps a monotonic SaveToken
+            // together with SaveInProgress; the counter's value now is the cutoff (see
+            // WorldObject_Database.cs for why a token and not a timestamp).
+            var enqueuedToken = CurrentSaveToken;
 
             if (item.ChangesDetected)
                 biotas.Add((item.Biota, item.BiotaDatabaseLock));
@@ -251,7 +252,7 @@ namespace ACE.Server.WorldObjects
                     {
                         if (wo.IsDestroyed || !wo.SaveInProgress)
                             return;
-                        if (wo.SaveStartTime > enqueuedAt)
+                        if (!SaveFlagOwnedAtOrBefore(wo.SaveToken, enqueuedToken))
                             return;   // a newer save owns this flag; its own callback clears it
 
                         wo.SaveInProgress = false;

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -195,6 +195,14 @@ namespace ACE.Server.WorldObjects
         {
             var biotas = new Collection<(Biota biota, ReaderWriterLockSlim rwLock)>();
 
+            // Every object whose flags this save is responsible for, captured NOW. The callback
+            // clears flags on this set AND on whatever the container holds when the save completes,
+            // because each side misses a case the other covers: a sub-item that leaves the container
+            // in flight is only in the captured set, and a sub-item with no changes to write (so not
+            // in biotas) that a player batch save left SaveInProgress is only found by walking the
+            // container. Setting a flag false twice is harmless.
+            var savedObjects = new List<WorldObject> { item };
+
             if (item.ChangesDetected)
                 biotas.Add((item.Biota, item.BiotaDatabaseLock));
 
@@ -204,6 +212,8 @@ namespace ACE.Server.WorldObjects
             {
                 foreach (var subItem in container.Inventory.Values)
                 {
+                    savedObjects.Add(subItem);
+
                     if (subItem.ChangesDetected)
                         biotas.Add((subItem.Biota, subItem.BiotaDatabaseLock));
                 }
@@ -229,10 +239,13 @@ namespace ACE.Server.WorldObjects
                 var clearFlagsAction = new ActionChain();
                 clearFlagsAction.AddAction(WorldManager.ActionQueue, ActionType.PlayerInventory_DeepSaveCallback, () =>
                 {
-                    if (!item.IsDestroyed)
+                    foreach (var wo in savedObjects)
                     {
-                        item.SaveInProgress = false;
-                        item.SaveStartTime = DateTime.MinValue; // Reset for next save
+                        if (wo.IsDestroyed)
+                            continue;
+
+                        wo.SaveInProgress = false;
+                        wo.SaveStartTime = DateTime.MinValue; // Reset for next save
                     }
 
                     if (item is Container savedContainer)

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -196,10 +196,7 @@ namespace ACE.Server.WorldObjects
             var biotas = new Collection<(Biota biota, ReaderWriterLockSlim rwLock)>();
 
             if (item.ChangesDetected)
-            {
-                // REMOVE THIS LINE: item.SaveBiotaToDatabase(false);
                 biotas.Add((item.Biota, item.BiotaDatabaseLock));
-            }
 
             // if the player is dropping a container to the landblock,
             // we must ensure any items within the container also have the correct properties
@@ -208,27 +205,55 @@ namespace ACE.Server.WorldObjects
                 foreach (var subItem in container.Inventory.Values)
                 {
                     if (subItem.ChangesDetected)
-                    {
-                        // REMOVE THIS LINE: subItem.SaveBiotaToDatabase(false);
                         biotas.Add((subItem.Biota, subItem.BiotaDatabaseLock));
-                    }
                 }
             }
 
+            // Always enqueue, even with nothing to write: the callback below is the only thing that
+            // clears a SaveInProgress a player batch save may have left on an item that has since
+            // left the player's inventory - the batch callback only touches current possessions.
+
+            // The sourceTrace becomes the UniqueQueue key ("SaveBiotasInParallel " + trace), and
+            // UniqueQueue REPLACES a pending entry that shares a key - the earlier task and its
+            // callback never run. A bare player guid was the same key SavePlayerToDatabase uses, so:
+            //   - a DeepSave replacing a pending batch save dropped every batched write, and left
+            //     SaveInProgress stranded true on the player (which blocks login) and its possessions;
+            //   - a later enqueue replacing a pending DeepSave meant the dropped item's new ContainerId
+            //     was never written - log out and back in before the landblock saved and the item
+            //     loaded back into the player's inventory.
+            // Keyed per player AND per item so neither can happen. Player_Trade.cs already uses a
+            // composite key for the same reason.
             DatabaseManager.Shard.SaveBiotasInParallel(biotas, result =>
             {
-                // Clear save flags
-                item.SaveInProgress = false;
-                item.SaveStartTime = DateTime.MinValue; // Reset for next save
-                if (item is Container container)
+                // Clear the flags on the world thread, matching the other SaveBiotasInParallel callers.
+                var clearFlagsAction = new ActionChain();
+                clearFlagsAction.AddAction(WorldManager.ActionQueue, ActionType.PlayerInventory_DeepSaveCallback, () =>
                 {
-                    foreach (var subItem in container.Inventory.Values)
+                    if (!item.IsDestroyed)
                     {
-                        subItem.SaveInProgress = false;
-                        subItem.SaveStartTime = DateTime.MinValue; // Reset for next save
+                        item.SaveInProgress = false;
+                        item.SaveStartTime = DateTime.MinValue; // Reset for next save
                     }
-                }
-            }, this.Guid.ToString());
+
+                    if (item is Container savedContainer)
+                    {
+                        foreach (var subItem in savedContainer.Inventory.Values)
+                        {
+                            if (subItem.IsDestroyed)
+                                continue;
+
+                            subItem.SaveInProgress = false;
+                            subItem.SaveStartTime = DateTime.MinValue; // Reset for next save
+                        }
+                    }
+
+                    // ChangesDetected is deliberately left alone here, so a failed write is picked up
+                    // by the next landblock or player batch save rather than lost.
+                    if (!result)
+                        log.Warn($"[SAVE] DeepSave failed for {Name} - {item.Name} (0x{item.Guid}), {biotas.Count} biota(s) will be retried by the next batch save");
+                });
+                clearFlagsAction.EnqueueChain();
+            }, this.Guid.ToString() + " : DeepSave : " + item.Guid.ToString());
         }
 
         public enum RemoveFromInventoryAction

--- a/Source/ACE.Server/WorldObjects/WorldObject_Database.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Database.cs
@@ -38,6 +38,27 @@ namespace ACE.Server.WorldObjects
         internal DateTime SaveStartTime { get; set; }
         private int? LastSavedStackSize { get; set; }  // Track last saved value to detect corruption
 
+        // Save ownership (2026-09-09). Every SaveBiotaToDatabase that raises SaveInProgress also stamps a
+        // token from one process-wide monotonic counter. A callback that wants to clear the flag captures
+        // the counter at ITS enqueue and clears only flags whose token is not newer - so a save that
+        // started after the enqueue keeps its flag until its own callback runs. Tokens, not timestamps:
+        // DateTime.UtcNow can repeat within its resolution and can step backwards under NTP, and either
+        // would let an older callback wipe a newer save's flag.
+        private static long _saveTokenSequence;
+
+        /// <summary>The token stamped by the SaveBiotaToDatabase that last raised SaveInProgress here.</summary>
+        internal long SaveToken { get; private set; }
+
+        /// <summary>The counter's current value - capture this at enqueue as the ownership cutoff.</summary>
+        public static long CurrentSaveToken => System.Threading.Interlocked.Read(ref _saveTokenSequence);
+
+        private void StampSaveToken() => SaveToken = System.Threading.Interlocked.Increment(ref _saveTokenSequence);
+
+        /// <summary>True when a flag stamped with <paramref name="token"/> belongs to a save that was
+        /// already in flight when a callback captured <paramref name="cutoff"/> - i.e. that callback may
+        /// clear it. A token newer than the cutoff is a later save's, and is left alone.</summary>
+        public static bool SaveFlagOwnedAtOrBefore(long token, long cutoff) => token <= cutoff;
+
         /// <summary>
         /// This variable is set to true when a change is made, and set to false before a save is requested.<para />
         /// The primary use for this is to trigger save on add/modify/remove of properties.
@@ -259,6 +280,7 @@ namespace ACE.Server.WorldObjects
             LastRequestedDatabaseSave = DateTime.UtcNow;
             SaveInProgress = true;
             SaveStartTime = DateTime.UtcNow;
+            StampSaveToken();
             LastSavedStackSize = StackSize;
             
             // For batch saves (enqueueSave=false), don't clear ChangesDetected here
@@ -425,6 +447,7 @@ namespace ACE.Server.WorldObjects
             LastRequestedDatabaseSave = DateTime.UtcNow;
             SaveInProgress = true;
             SaveStartTime = DateTime.UtcNow;
+            StampSaveToken();
             LastSavedStackSize = StackSize;
             ChangesDetected = false;
 


### PR DESCRIPTION
## Summary

`DeepSave` was silently dropping saves because of a `UniqueQueue` key collision.

`DeepSave` passed the bare player GUID as its `sourceTrace`, which becomes the `UniqueQueue` key. `UniqueQueue` **replaces** a pending entry with a matching key, so the earlier task and its callback never run. Both `SavePlayerToDatabase` branches use the same bare-GUID key, so the two could silently cancel each other:

- **A DeepSave replaces a pending batch save.** The batch had already set `SaveInProgress` on the player and every batched possession and cleared their `ChangesDetected`. None of it is written, none of it is retried, and the player's `SaveInProgress` is never cleared. It carries to the `OfflinePlayer` and blocks login (`[LOGIN BLOCK]`). If it was the logout save, the player is never switched offline.
- **A later enqueue replaces a pending DeepSave.** The dropped or given item's new `ContainerId` is never written. If the player logs out and back in before the landblock saves, the DB still says they own it and it loads back into their inventory.

## Fix

Key per player **and** per item: `Guid + " : DeepSave : " + item.Guid`, matching the composite-key pattern `Player_Trade.cs` already uses. The queue is single-threaded, so de-colliding the keys makes both saves run in order; it introduces no concurrency.

The same commit also brings the callback in line with the other `SaveBiotasInParallel` callers:

- flags are cleared on `WorldManager.ActionQueue` under a new `ActionType.PlayerInventory_DeepSaveCallback` instead of from the DB worker thread
- the item and its contents are guarded with `IsDestroyed`
- a failed write logs a warning; `ChangesDetected` is left untouched on failure so the next batch save retries it
- the enqueue is kept even when there is nothing to write, because this callback is the only thing that clears a `SaveInProgress` a player batch save left on an item that has since left the inventory
- stale `// REMOVE THIS LINE:` comments removed

No gameplay-visible change.

## Verification

- Read `UniqueQueue`, `SerializedShardDatabase`, both `SavePlayerToDatabase` branches, all three `DeepSave` call sites, `SaveBiotaToDatabase` and the offline-player login path; every claim above is against the current code
- All six `SaveBiotasInParallel` producers checked; `DeepSave` was the only one sharing a key with another producer
- Release build clean, deployed to a test shard


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved inventory save reliability during concurrent player and item saves.
  - Inventory changes remain available for retry when a save attempt fails.
  - Items and contained subitems are processed more consistently during saves.
  - Destroyed items are excluded from save-status updates.
  - Save status is reset reliably after processing, reducing stuck or missed inventory updates.
  - Pending player and item saves remain separate, preventing one save from replacing another.
  - Prevented newer save operations from being incorrectly cleared by earlier operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->