### PR TITLE
Gate T11 series behavior to v11+ and restore base-world parity

### DIFF
--- a/Source/ACE.Server/Entity/DamageEvent.cs
+++ b/Source/ACE.Server/Entity/DamageEvent.cs
@@ -450,9 +450,20 @@ namespace ACE.Server.Entity
                     if (attacker.IsEnraged && !(attacker is Player))
                         CriticalDamageMod *= attacker.EnrageDamageMultiplier ?? 1.0f;
 
+                    // GATED 2026-09-10 (owner, "full restore to old"). Folding the lum-aug flat and the
+                    // weapon-scaling flat into the crit base is a v11-25 rule, but it shipped
+                    // unconditional. Both terms are player-only (assigned inside `if (playerAttacker
+                    // != null)`), so monsters were unaffected - but every base-world PLAYER had their
+                    // lum-aug flat multiplied through the whole crit chain instead of being ignored,
+                    // which is what made bow crits read far higher than before the series.
+                    // Pre-series baseline (9d128e912) was exactly the `else` branch below.
+                    var endgameCrit = ACE.Server.Managers.ZoneControl.ZoneControlManager.EndgameRulesApply(attacker, Weapon);
+
                     // the full non-crit ceiling, ALL flats included, normal rating chain
-                    var maxNormalHit = (BaseDamageMod.MaxDamage + DebugLuminanceFlatDamageBonus + WeaponScalingFlatBonus)
-                                       * AttributeMod * PowerMod * SlayerMod * DamageRatingMod;
+                    var maxNormalHit = endgameCrit
+                        ? (BaseDamageMod.MaxDamage + DebugLuminanceFlatDamageBonus + WeaponScalingFlatBonus)
+                              * AttributeMod * PowerMod * SlayerMod * DamageRatingMod
+                        : BaseDamageMod.MaxDamage * AttributeMod * PowerMod * SlayerMod * DamageRatingMod;
 
                     DamageBeforeMitigation = maxNormalHit * CriticalDamageMod;
 

--- a/Source/ACE.Server/Managers/ZoneControl/ZoneControlManager.cs
+++ b/Source/ACE.Server/Managers/ZoneControl/ZoneControlManager.cs
@@ -1125,7 +1125,8 @@ namespace ACE.Server.Managers.ZoneControl
         /// <summary>
         /// Monster half of the endgame gate: does this CREATURE play by T11-25 rules?
         /// Location-based - true only for a non-player creature inside an enabled authored zone
-        /// at variation 11 or above. Always false when the master toggle is off.
+        /// at variation 11 or above. Always false when the master toggle is off, and false for a
+        /// creature carrying ExemptFromZoneScaling (pets are NOT exempt here - see the body).
         /// </summary>
         public static bool EndgameRulesApplyToMonster(Creature creature)
         {
@@ -1160,6 +1161,15 @@ namespace ACE.Server.Managers.ZoneControl
             // ordinary landblock take the endgame path. Dummy-based testing of T11 combat needs the
             // dummy inside an enabled zone at its variation.
             if (FindZoneRef(creature) == null)
+                return false;
+
+            // EXPLICIT PER-MONSTER OPT-OUT (review 2026-09-11). Bypassing IsZoneScalingExempt above
+            // was only meant to keep PETS on the endgame model; it also skipped the weenie bool
+            // ExemptFromZoneScaling, which is documented as the global "leave this creature alone"
+            // switch (a vendor or quest NPC standing inside a v11+ zone) and which TierHitGate already
+            // honours. Re-check just that bool here, after the lock-free landblock bail so the base
+            // world never pays for it. Pets are deliberately NOT excluded - see the note above.
+            if (ExemptBoolOf(creature))
                 return false;
 
             // HARD VARIATION FLOOR (owner 2026-09-10): "retail" is EVERY variation under 11, not

--- a/Source/ACE.Server/Managers/ZoneControl/ZoneControlManager.cs
+++ b/Source/ACE.Server/Managers/ZoneControl/ZoneControlManager.cs
@@ -1081,6 +1081,131 @@ namespace ACE.Server.Managers.ZoneControl
         public static bool IsZcGear(WorldObject wo)
             => (wo?.GetProperty(ACE.Entity.Enum.Properties.PropertyInt.ZcTier) ?? 0) >= 11;
 
+        // =====================================================================================
+        // THE CANONICAL ENDGAME GATE (owner rulings 2026-09-10)
+        // =====================================================================================
+        // WHY THIS EXISTS: the T11 series (#510-#513) was meant to change only variation 11-25,
+        // but seven separate sites each decided for themselves whether to gate, and several did
+        // not. The base world (variation_Id NULL/0 - 78,101 creature placements against 822 at
+        // v11) took a ~1.6x monster magic crit, a doubled crit frequency, a player crit-imbue
+        // kill, an uncapped player crit, a halved monster proc rate, and - with the master toggle
+        // OFF - a 211-point cap applied to max health that stopped players healing entirely.
+        //
+        // EVERY T11 behavior should ask one of the FOUR methods below, so the next change cannot
+        // quietly escape and an audit is close to a single grep.
+        //
+        // Two sites in this commit deliberately do NOT call them, and both are documented in place:
+        // SpellProjectile's arc-band guard keys off the already-computed `endgameCrit` local (so the
+        // band and the crit model can never disagree), and Hotspot tests ZcDamageImmune directly
+        // because Cheat Death is player-carried and must hold regardless of where the pad sits.
+        // Grep for `endgameCrit`, `endgameCast` and `zcProc` as well as the method names.
+        //
+        // RULING 1 - "fully inert": zonecontrol_enabled OFF means every gate below returns false, so
+        // no COMBAT-MODEL behavior in this series applies. A kill switch that still imposes its own
+        // numbers is not a kill switch. It also supersedes the 2026-08-23 "the T10 fallback cap wins
+        // outright" ruling for the WORN-GEAR CAPS specifically - that is what capped GearMaxHealth
+        // (hit points) with CapLine (a rating-line ceiling) and stranded players below their own max.
+        //
+        // 🔴 SCOPE, corrected after review - do NOT read this as "the whole fallback set is gone".
+        // With the toggle OFF, ZoneStatResolver STILL applies the rest of ZoneFallback to ZC-stamped
+        // ITEMS: Band (:257), AnchorDr / AnchorCdr 92/73 (:413) and ArmorLevel 732 (:456, :469). That
+        // is item re-pricing, which is the fallback's actual job and is deliberately untouched here.
+        // Only the CAP half went inert. The two are easy to conflate and an earlier version of this
+        // comment did exactly that.
+        //
+        // RULING 2 - the gate is SPLIT, by whose behavior is being decided:
+        //   MONSTERS gate by LOCATION, behind a hard floor at variation 11. A monster never leaves
+        //   its zone, so the location test is both free and exact. "Retail" means EVERY variation
+        //   below 11 (owner 2026-09-10) - the base world AND v1-v5 - not just variation_Id 0.
+        //   PLAYERS gate by GEAR STAMP. A player carries their gear across zone borders; gating
+        //   them by location would flip their own damage numbers mid-fight at the boundary.
+        //   Retail gear never carries ZcTier, so a base-world player on retail gear takes the
+        //   pre-series path in every case - which is exactly the restore target.
+
+        /// <summary>
+        /// Monster half of the endgame gate: does this CREATURE play by T11-25 rules?
+        /// Location-based - true only for a non-player creature inside an enabled authored zone
+        /// at variation 11 or above. Always false when the master toggle is off.
+        /// </summary>
+        public static bool EndgameRulesApplyToMonster(Creature creature)
+        {
+            if (!ServerConfig.zonecontrol_enabled.Value)
+                return false;
+            if (creature == null || creature is Player)
+                return false;
+
+            // FindZoneRef, NOT ResolveForCreature (fixed 2026-09-10 after review). ResolveForCreature
+            // bails on IsZoneScalingExempt, which is true for every Pet - but that exemption answers
+            // "may a zone RE-PRICE this creature's stats", a DIFFERENT question from "which combat
+            // model applies". Routing the gate through it made the T11 crit model permanently false
+            // for every pet in every zone: a T25 player summoning a pet inside a v22 zone had the
+            // pet silently drop the summoner's lum-aug crit flat (CombatPet copies the summoner's
+            // LuminanceAugmentMelee/MissileCount) and revert to the double-roll proc scan.
+            //
+            // Order matters for cost: FindZoneRef opens with a lock-free O(1)
+            // snap.EnabledLandblocks.Contains bail, so the ~78k base-world placements return here
+            // without touching a biota lock.
+            //
+            // CORRECTION 2026-09-10 (second review): an earlier version of this comment claimed the
+            // floor runs after the bail "because GetEffectiveVariation takes a lock". That is FALSE -
+            // FindZoneRef already calls GetEffectiveVariation itself when the landblock matches, so by
+            // the time we reach the floor the read has happened either way. The floor below is
+            // therefore REDUNDANT for correctness today (FindZoneRef only matches a zone whose
+            // Variation equals the creature's, and nothing is authored below v11) and is kept purely
+            // as the owner's belt-and-braces guarantee that authoring a zone at v5 can never promote
+            // its monsters. It is a cheap cached-path read, not a second lock.
+            //
+            // KNOWN LIMITATION (pre-existing, not introduced here): because an authored enabled zone
+            // is required, PropertyBool.ForceEndgameSystems alone cannot make a test dummy in an
+            // ordinary landblock take the endgame path. Dummy-based testing of T11 combat needs the
+            // dummy inside an enabled zone at its variation.
+            if (FindZoneRef(creature) == null)
+                return false;
+
+            // HARD VARIATION FLOOR (owner 2026-09-10): "retail" is EVERY variation under 11, not
+            // just the base world - v1-v5 are retail content and must never pick up T11 rules.
+            // Today no zone is authored below v11, so this is belt-and-braces: authoring a zone at
+            // v5 must NOT silently promote its monsters.
+            return GetEffectiveVariation(creature) >= VariationManager.EndgameMinVariation;
+        }
+
+        /// <summary>
+        /// Player half of the endgame gate: does this ITEM carry T11-25 rules?
+        /// Gear-stamp based, so a player's numbers do not change because they crossed a border.
+        /// Always false when the master toggle is off. A null item (an unarmed swing, a wandless
+        /// cast) is retail by definition - there is no stamp to honour.
+        /// </summary>
+        public static bool EndgameRulesApplyToPlayerGear(WorldObject item)
+        {
+            if (!ServerConfig.zonecontrol_enabled.Value)
+                return false;
+            return IsZcGear(item);
+        }
+
+        /// <summary>
+        /// The combat-site convenience: picks the correct half of the split for whoever is acting.
+        /// Pass the weapon/caster actually used for the attack (null for unarmed or wandless).
+        /// This is the call nearly every damage site should make.
+        /// </summary>
+        public static bool EndgameRulesApply(Creature actor, WorldObject weapon)
+            => actor is Player
+                ? EndgameRulesApplyToPlayerGear(weapon)
+                : EndgameRulesApplyToMonster(actor);
+
+        /// <summary>
+        /// Placed-content half of the gate: for a non-creature world object (a hotspot, a trap) whose
+        /// behavior is a property of WHERE IT SITS rather than of who walks into it. Variation floor
+        /// only - placed content resolves no creature profile. Always false when the toggle is off.
+        /// </summary>
+        public static bool EndgameRulesApplyToPlacedContent(WorldObject wo)
+        {
+            if (!ServerConfig.zonecontrol_enabled.Value)
+                return false;
+            if (wo == null)
+                return false;
+            return GetEffectiveVariation(wo) >= VariationManager.EndgameMinVariation;
+        }
+
         /// <summary>The appraisal line both weapon and armor panels pin while their power is
         /// suppressed for the examiner (wording owner-approved 2026-08-30). ONE constant so the
         /// two panels can never drift.</summary>
@@ -1125,6 +1250,16 @@ namespace ACE.Server.Managers.ZoneControl
         public static ZoneEffects ResolveEffectsForPlayer(Player player)
         {
             if (player == null)
+                return null;
+
+            // RULING 1 (added 2026-09-10): zonecontrol_enabled OFF means fully inert. This resolver had
+            // NO master-toggle check, so with Zone Control off a player standing in an area whose
+            // Effects carry SuppressEnabled still had zone effects applied to them - most visibly
+            // SuppressProdigal, which strips Prodigal Regeneration / Rejuvenation / Mana Renewal out of
+            // the regen enchantment mod in Creature_Vitals.VitalHeartBeat. Tou Tou (v11, 90 landblocks)
+            // authors exactly that, so the kill switch did not stop it. Also gates the DoT / slow /
+            // charm effects and the regen tuner, all of which are Zone Control features by definition.
+            if (!ServerConfig.zonecontrol_enabled.Value)
                 return null;
 
             // Fully lock-free: read the immutable published snapshot.

--- a/Source/ACE.Server/Managers/ZoneControl/ZoneFallback.cs
+++ b/Source/ACE.Server/Managers/ZoneControl/ZoneFallback.cs
@@ -55,10 +55,14 @@ namespace ACE.Server.Managers.ZoneControl
                     System.Math.Max(1, (int)System.Math.Round(max * scale)));
         }
 
-        /// <summary>The fallback worn cap for one of the three gear_cap_* stats.</summary>
-        public static int GearCap(string capStat) =>
-            capStat == ZoneStat.GearCapDr ? CapDr
-          : capStat == ZoneStat.GearCapCdr ? CapCdr
-          : CapLine;
+        // GearCap(string) REMOVED 2026-09-10. It was the "zonecontrol_enabled off => apply the T10
+        // fallback worn caps" lookup, and Creature_Equipment.GetGearCap was its only caller. The owner
+        // ruled that OFF must mean fully inert (no caps at all), because this lookup fed CapLine - a
+        // RATING-LINE ceiling of 211 - to GetGearMaxHealth, which is measured in HIT POINTS. That
+        // dropped server-side max health by over a thousand, clamped Current down to it, and left the
+        // server reading every player as permanently full: no healing, no heal kits, no regen.
+        // CORRECTION (second review): only CapLine is still live - it drives the band shrink factor
+        // above. CapDr and CapCdr now have NO consumers; they are kept as documentation of the T10
+        // worn-set anchors they were calibrated against, not because anything reads them.
     }
 }

--- a/Source/ACE.Server/Managers/ZoneScaling/ZoneScalingModels.cs
+++ b/Source/ACE.Server/Managers/ZoneScaling/ZoneScalingModels.cs
@@ -298,9 +298,9 @@ namespace ACE.Server.Managers.ZoneScaling
         // augs / enlightenment. Read for PLAYERS via the zone default the player stands in; no zone = the C#
         // default, so the caps apply everywhere. Creature.GetGearCap / GetEquippedItemsRatingSumCapped /
         // GetZoneModifierBonus are the read sites.
-        public const string GearCapDr = "gear_cap_dr";                     // worn Damage Resist sum (ladder ceiling 2500; ZoneFallback.CapDr 92 when zonecontrol_enabled is off)
-        public const string GearCapCdr = "gear_cap_cdr";                   // worn CritDmgResist / CritResist / NetherResist sums, EACH (ladder ceiling 1500; ZoneFallback.CapCdr 73 when off)
-        public const string GearCapLine = "gear_cap_line";                 // every anchored cantrip line: Dmg / CritDmg / MaxHP / MaxStam / MaxMana / HealBoost / each aug track / each attribute (ladder ceiling 2500; ZoneFallback.CapLine 211 when off)
+        public const string GearCapDr = "gear_cap_dr";                     // worn Damage Resist sum (ladder ceiling 2500; NO cap at all when zonecontrol_enabled is off - owner 2026-09-10)
+        public const string GearCapCdr = "gear_cap_cdr";                   // worn CritDmgResist / CritResist / NetherResist sums, EACH (ladder ceiling 1500; NO cap at all when off - owner 2026-09-10)
+        public const string GearCapLine = "gear_cap_line";                 // every anchored cantrip line: Dmg / CritDmg / MaxHP / MaxStam / MaxMana / HealBoost / each aug track / each attribute (ladder ceiling 2500; NO cap at all when off - the 211 line ceiling capped GearMaxHealth, measured in HIT POINTS, and stopped players healing)
         public const string XpKill = "xp_kill";
         public const string LumAward = "lum_award";
 

--- a/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
+++ b/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
@@ -1271,12 +1271,16 @@ namespace ACE.Server.Network.Structure
                 effectDescriptions.Add($"- Crushing Blow: {val:0.##}x Crit Dmg");
             }
 
-            // Crippling Blow - hidden for players since 2026-08-25: WorldObject.CritImbuesSuppressed
-            // makes it inert on a player's weapon, and an item panel that advertises an effect doing
-            // exactly zero is worse for trust than an absent line. This panel is only ever built for
-            // a player examining something, so the const alone is the right test here.
+            // Crippling Blow - hidden only when it is actually inert on THIS weapon. An item panel
+            // that advertises an effect doing exactly zero is worse for trust than an absent line,
+            // but so is hiding one that works. Since the 2026-09-10 gating, suppression requires
+            // ZC-stamped gear, so a RETAIL weapon's imbue is live again and must be shown.
+            // CritImbuesSuppressedOnItem is the panel-side form of the combat test - the wielder check
+            // is implicit because this panel is only ever built for a player examining something.
+            // (The older comment here said "the const alone is the right test", which stopped being
+            // true when the const gained the gear gate.)
             if (weapon.HasImbuedEffect(ImbuedEffectType.CripplingBlow)
-                && !WorldObject.CritImbuesSuppressedForPlayers)
+                && !WorldObject.CritImbuesSuppressedOnItem(weapon))
             {
                 var mod = WorldObject.GetCripplingBlowMod(skill);
                 effectDescriptions.Add($"- {ImbuedEffectType.CripplingBlow.DisplayName()}: {mod:0.##}x Crit Dmg");
@@ -1298,9 +1302,12 @@ namespace ACE.Server.Network.Structure
 
             // Critical Strike - hidden for players, same reason as Crippling Blow above.
             if (weapon.HasImbuedEffect(ImbuedEffectType.CriticalStrike)
-                && !WorldObject.CritImbuesSuppressedForPlayers)
+                && !WorldObject.CritImbuesSuppressedOnItem(weapon))
             {
-                var mod = WorldObject.GetCriticalStrikeMod(skill);
+                // pass the gear half of the gate so the panel shows the floor this weapon actually gets
+                // (retail 5 pct vs ZC-stamped 10 pct) - GetCriticalStrikeMod defaults to retail
+                var mod = WorldObject.GetCriticalStrikeMod(skill, false,
+                    ACE.Server.Managers.ZoneControl.ZoneControlManager.EndgameRulesApplyToPlayerGear(weapon));
                 effectDescriptions.Add($"- {ImbuedEffectType.CriticalStrike.DisplayName()}: +{mod:P1} Crit Chance");
             }
 

--- a/Source/ACE.Server/WorldObjects/Creature_Equipment.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Equipment.cs
@@ -224,6 +224,31 @@ namespace ACE.Server.WorldObjects
         /// dormant. Null until the first ZC rated item is worn.</summary>
         private Dictionary<PropertyInt, int> equippedItemsZcRatingCache;
 
+        /// <summary>
+        /// How many ZcTier 11+ items this creature currently has equipped. Maintained by the same
+        /// add/remove pair as the caches above, but OUTSIDE their rating-prop early-outs.
+        ///
+        /// Added 2026-09-10 (third review) because equippedItemsZcRatingCache was being used as a
+        /// "wears ZC gear" proxy and was wrong twice: it is never nulled on dequip, so a player who
+        /// removed all ZC gear stayed capped for the session; and it is only populated by items that
+        /// contribute a RatingCacheProps value, so a ZC set rolling only 50200-block lines (attributes,
+        /// skills, slot specials) left it null and bypassed the cap entirely.
+        ///
+        /// Clamped at 0 on decrement so a drifted count cannot go negative.
+        ///
+        /// 🔴 A count that drifts HIGH does NOT fail safe (corrected after review - an earlier version
+        /// of this comment claimed it did). A player sitting at count > 0 with no ZC gear keeps the
+        /// 2500/1500 ladder cap for the rest of the session instead of being uncapped, which is a
+        /// Ruling 1 violation, not a harmless over-application.
+        ///
+        /// Known drift routes: any removal that bypasses TryDequipObject, e.g. PetDevice.cs:1121
+        /// removing straight from EquippedObjects. Benign today only because the count is read inside
+        /// `this is Player` and that path is pet-side. The ZcTier re-stamp concern is NOT a drift
+        /// route - ZoneStatResolver.ApplyIfStale runs before the increment, and ReresolveWornZoneGear
+        /// keeps a balanced remove -> re-stamp -> add pair.
+        /// </summary>
+        private int equippedZcGearCount;
+
         private static readonly PropertyInt[] RatingCacheProps =
         {
             PropertyInt.GearDamage, PropertyInt.GearDamageResist, PropertyInt.GearCritDamage,
@@ -259,6 +284,11 @@ namespace ACE.Server.WorldObjects
 
         private void AddItemToEquippedItemsRatingCache(WorldObject wo)
         {
+            // BEFORE the rating-prop early-out below: a ZC piece can roll only 50200-block lines and
+            // contribute no Gear* rating at all, and it still counts as ZC gear.
+            if (ACE.Server.Managers.ZoneControl.ZoneControlManager.IsZcGear(wo))
+                equippedZcGearCount++;
+
             var any = false;
             foreach (var p in RatingCacheProps)
                 if (RatingOf(wo, p) != 0) { any = true; break; }
@@ -279,6 +309,11 @@ namespace ACE.Server.WorldObjects
 
         private void RemoveItemFromEquippedItemsRatingCache(WorldObject wo)
         {
+            // Mirrors the increment in Add: outside the early-out, so it stays balanced for ZC pieces
+            // that carry no Gear* rating.
+            if (ACE.Server.Managers.ZoneControl.ZoneControlManager.IsZcGear(wo))
+                equippedZcGearCount = Math.Max(0, equippedZcGearCount - 1);
+
             if (equippedItemsRatingCache == null)
                 return;
 
@@ -425,15 +460,61 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public int GetGearCap(string capStat, int ladderCap)
         {
-            // Zone Control off: the T10 fallback cap wins outright - no zone is consulted (owner 2026-08-23).
+            // FULLY INERT WHEN OFF (owner 2026-09-10). This previously returned the ZoneFallback set
+            // (CapDr 92 / CapCdr 73 / CapLine 211) for EVERY wearer shard-wide - the short-circuit sits
+            // ahead of the `is not Player` check, so it reached players and monsters alike.
+            //
+            // 🔴 THE LIVE BUG THAT COST AN EVENING (2026-09-10): GetGearMaxHealth() borrows CapLine.
+            // CapLine 211 is a RATING-LINE ceiling; GearMaxHealth is measured in HIT POINTS (~1,045 on
+            // GOM, ~1,565 on Lyncher). Capping one with the other dropped server max health by over a
+            // thousand, a regen tick then clamped Current down to that lower max, and the server started
+            // reading Current == MaxValue - so /heal returned +0, heal kits said "already at full
+            // health", and regen had no headroom, while the client still drew the uncapped bar. Turning
+            // Zone Control off broke healing for everyone on the shard.
+            //
+            // A kill switch must not impose its own numbers. Off now means NO CAP - the pre-series
+            // behaviour, where GetEquippedItemsRatingSum was never clamped at all. This supersedes the
+            // 2026-08-23 "the T10 fallback cap wins outright" ruling.
             if (!ServerConfig.zonecontrol_enabled.Value)
-                return ACE.Server.Managers.ZoneControl.ZoneFallback.GearCap(capStat);
-            if (this is not Player player)
-                return ladderCap;
-            var zone = ACE.Server.Managers.ZoneControl.ZoneControlManager.ResolveZoneDefaultForPlayer(player);
-            if (zone == null || !zone.Has(capStat))
-                return ladderCap;
-            return Math.Max(0, (int)Math.Round(zone.Get(capStat, ladderCap)));
+                return int.MaxValue;
+
+            // 100% RESTORE (owner 2026-09-10): "it would be silly to not restore 1 part - the WHOLE of
+            // the restore balances things out". Baseline had NO worn-gear cap anywhere, so UNGOVERNED
+            // content is uncapped in BOTH toggle states. Previously an ungoverned wearer still fell to
+            // ladderCap (2500/1500) whenever the toggle was on, which left T10 technically coupled to a
+            // switch that is supposed to be irrelevant to it. Governed content keeps the ladder and any
+            // zone-authored gear_cap_* override.
+            if (this is Player player)
+            {
+                // GEAR-GATED, NOT LOCATION-GATED (fixed 2026-09-10, second review). Keying this on
+                // ResolveZoneDefaultForPlayer made a maxed T25 set read 2500 INSIDE the governed zone
+                // and go UNCAPPED the moment the player stepped into the base world - ZC gear strictly
+                // stronger outside the content it was built for, and the wearer's own DR/CDR/line
+                // numbers flipping at the border. That is precisely the failure Ruling 2 exists to
+                // prevent, and I had it backwards.
+                //
+                // equippedZcGearCount is maintained by the equip/dequip pair OUTSIDE their rating-prop
+                // early-outs, so it counts ZC pieces that carry no Gear* rating and it drops back to 0
+                // on dequip. A plain int field read - no ZcTier biota lock on a rating path.
+                // (An earlier version tested equippedItemsZcRatingCache != null, which both missed
+                // rating-less ZC pieces and never cleared on dequip.)
+                if (equippedZcGearCount == 0)
+                    return int.MaxValue;                 // purely retail gear = baseline = no cap, anywhere
+
+                var zone = ACE.Server.Managers.ZoneControl.ZoneControlManager.ResolveZoneDefaultForPlayer(player);
+                if (zone != null && zone.Has(capStat))
+                    return Math.Max(0, (int)Math.Round(zone.Get(capStat, ladderCap)));
+                return ladderCap;                        // ZC-geared: the ladder ceiling applies everywhere
+            }
+
+            // RE-PRICING SITE, so use ResolveForCreature - which honours IsZoneScalingExempt.
+            // EndgameRulesApplyToMonster deliberately BYPASSES that exemption because it answers
+            // "which combat model applies"; using it here re-priced a CombatPet's rating sums inside a
+            // v11 zone, against the standing 2026-08-25 ruling that pet bonuses are the pet system's
+            // own ladder and not Zone Control's to re-price. Pets and exempt wcids stay uncapped.
+            return ACE.Server.Managers.ZoneControl.ZoneControlManager.ResolveForCreature(this) != null
+                ? ladderCap
+                : int.MaxValue;
         }
 
         /// <summary>
@@ -442,8 +523,10 @@ namespace ACE.Server.WorldObjects
         /// enchantments / augs / enlightenment stack on top untouched in the rating getters.
         /// The cap arguments are the LADDER ceilings (gear_cap_dr 2500, gear_cap_cdr 1500,
         /// gear_cap_line 2500) - calibrated so a maxed T25 set lands EXACTLY on them. A zone that
-        /// authors gear_cap_* tightens them for its own content; with zonecontrol_enabled OFF the
-        /// T10 fallback set replaces them entirely (ZoneFallback).
+        /// authors gear_cap_* tightens them for its own content; with zonecontrol_enabled OFF there is
+        /// NO cap at all (GetGearCap returns int.MaxValue - owner 2026-09-10, superseding the old
+        /// ZoneFallback 92/73/211 set, which capped GearMaxHealth in HIT POINTS with a RATING-LINE
+        /// ceiling and stopped every player healing).
         /// </summary>
         public int GetEquippedItemsRatingSumCapped(PropertyInt rating, string capStat, int defaultCap)
         {

--- a/Source/ACE.Server/WorldObjects/Hotspot.cs
+++ b/Source/ACE.Server/WorldObjects/Hotspot.cs
@@ -199,10 +199,45 @@ namespace ACE.Server.WorldObjects
         private void ActivateCommon(Creature creature, bool isActive, Func<Creature, bool> isDamageable)
         {
             if (!isActive) return;
-            // one gate for every damage type: Invincible, dead, and the Zone Control Cheat Death window
-            if (isDamageable != null && !isDamageable(creature)) return;
 
+            // GATED 2026-09-10 (owner, "full restore to old"). The unified gate below - Invincible,
+            // dead, and the Zone Control Cheat Death window, applied to EVERY damage type - shipped
+            // unconditional. Pre-series the only check was `if (creature.Invincible) return;` INSIDE
+            // the `default:` case, so the Mana / Stamina / Health branches always ran and still fired
+            // their sound, ActivationTalk and emote. That matters for retail HEALING pads, which are
+            // Health-branch hotspots carrying a NEGATIVE DamageNext - the new gate silently stopped
+            // them working on invincible or dead creatures.
+            // Hotspots are PLACED content, so the gate is by where the hotspot sits, not by who
+            // stepped on it.
+            var endgameHotspot = ACE.Server.Managers.ZoneControl.ZoneControlManager.EndgameRulesApplyToPlacedContent(this);
+
+            // CHEAT DEATH IS PLAYER-CARRIED, SO IT IS TESTED UNCONDITIONALLY (fixed 2026-09-10 after
+            // review). Gating the isDamageable predicate meant ZcDamageImmune - which that predicate
+            // is the ONLY place to test on this path - stopped being checked on base-world hotspots.
+            // The default: case survives because Player.TakeDamage bails on its own, but the
+            // Health / Mana / Stamina branches call UpdateVitalDelta DIRECTLY and bypass TakeDamage,
+            // so a player could be drained to death inside an immunity window they paid for.
+            // This is not a "restore" concern either: ZcDamageImmune did not exist pre-series, so
+            // honouring it here cannot diverge from baseline.
+            // SCOPED TO DAMAGING ACTIVATIONS (fixed 2026-09-10, second review). Returning
+            // unconditionally sat ahead of the Health / Mana / Stamina branches - which are exactly the
+            // negative-DamageNext RESTORE pads the gate below exists to protect - so a player inside a
+            // Cheat Death window got nothing from a retail healing pad. Worse, that is a ZC-only
+            // property changing UNGOVERNED behaviour, which the 100% restore forbids outright.
+            // amount > 0 drains; <= 0 restores (the vital branches pass -iAmount to UpdateVitalDelta).
+            //
+            // 🔴 HOISTED (third review): DamageNext is a PROPERTY, not a field - every read calls
+            // GetBaseDamage() (two biota reads) AND re-rolls ThreadSafeRandom. Testing `DamageNext > 0`
+            // here and then assigning `var amount = DamageNext` below took TWO DIFFERENT ROLLS, so on a
+            // variance band straddling zero a pad could pass this guard as a heal and then apply as
+            // damage. One roll, tested and applied.
             var amount = DamageNext;
+
+            if (amount > 0 && creature is Player immunePlayer && immunePlayer.ZcDamageImmune)
+                return;
+
+            if (endgameHotspot && isDamageable != null && !isDamageable(creature)) return;
+
             var iAmount = (int)Math.Round(amount);
 
             var player = creature as Player;
@@ -210,6 +245,9 @@ namespace ACE.Server.WorldObjects
             switch (DamageType)
             {
                 default:
+
+                    // pre-series check, restored for ungoverned content (see the gate above)
+                    if (!endgameHotspot && creature.Invincible) return;
 
                     amount *= creature.GetResistanceMod(DamageType, this, null);
 

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -1856,6 +1856,13 @@ namespace ACE.Server.WorldObjects
             // same way.
             var weapon        = procWeapon ?? GetEquippedWand();
 
+            // THE canonical endgame gate (owner 2026-09-10). Rings are cast by a PLAYER, so this is the
+            // GEAR half of the split: ZC-stamped caster = T11 rules anywhere, retail caster = retail
+            // math anywhere. A ring's damage is applied by THIS method and never reaches
+            // SpellProjectile.CalculateDamage, so the unified crit had to be gated here separately -
+            // without it, hand-cast rings kept critting for ~2x in the base world.
+            var endgameCrit = ACE.Server.Managers.ZoneControl.ZoneControlManager.EndgameRulesApplyToPlayerGear(weapon);
+
             var isLifeProjectile = spell.MetaSpellType == ACE.Entity.Enum.SpellType.LifeProjectile;
 
             // CR-2: use scanOrigin's ObjMaint when the detonation center differs from the caster
@@ -1971,8 +1978,14 @@ namespace ACE.Server.WorldObjects
                             var earlyMod = isLifeProjectile || isPvP
                                 ? GetWeaponCritDamageMod(weapon, this as Creature, attackSkill, creature)
                                 : 0f;
+                            // GATED 2026-09-10: the life branch dropped the retail 0.5f coefficient
+                            // unconditionally, so a RETAIL-geared player critting with a Life ring
+                            // spell got double the baseline crit bonus. Missed on the first pass -
+                            // only the war/void ring branch below was gated.
                             critDamageBonus = isLifeProjectile
-                                ? lifeMagicDamage * earlyMod
+                                ? (endgameCrit
+                                    ? lifeMagicDamage * earlyMod
+                                    : lifeMagicDamage * 0.5f * earlyMod)
                                 : (isPvP ? spell.MinDamage * 0.5f * earlyMod : 0f);
                         }
                     }
@@ -2010,7 +2023,7 @@ namespace ACE.Server.WorldObjects
                         baseDamage = procBaseDamage > 0
                             ? (long)Math.Round(procBaseDamage)
                             // unified crit: a PvE crit uses the MAX roll, matching SpellProjectile
-                            : (criticalHit && !isPvP
+                            : (endgameCrit && criticalHit && !isPvP
                                 ? spell.MaxDamage
                                 : ThreadSafeRandom.Next(spell.MinDamage, spell.MaxDamage));
 
@@ -2096,8 +2109,12 @@ namespace ACE.Server.WorldObjects
                     // one formula for hand-casts and ring procs alike, replacing the 0.5f
                     // proc-only re-derive. mod = CritX - 1 (default 1.0 = retail's 2x).
                     if (criticalHit && !isLifeProjectile && !isPvP)
-                        critDamageBonus = (baseDamage + skillBonus)
-                            * GetWeaponCritDamageMod(weapon, this as Creature, attackSkill, creature);
+                        critDamageBonus = endgameCrit
+                            ? (baseDamage + skillBonus)
+                                * GetWeaponCritDamageMod(weapon, this as Creature, attackSkill, creature)
+                            // retail: half of MAX, and the skill bonus is NOT folded into the crit term
+                            : spell.MaxDamage * 0.5f
+                                * GetWeaponCritDamageMod(weapon, this as Creature, attackSkill, creature);
 
                     var preModDamage = isLifeProjectile
                         ? lifeMagicDamage + critDamageBonus

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -567,6 +567,15 @@ namespace ACE.Server.WorldObjects
             if (resisted && !overpower)
                 return null;
 
+            // THE canonical endgame gate for this cast (owner 2026-09-10): a governed monster at
+            // variation 11+, or a player casting with ZC-stamped gear. Everything else - the whole
+            // base world, v1-v5, and any player on retail gear - takes the PRE-SERIES crit math
+            // below. The 08-29 unified crit was never meant to leave v11-25, but it shipped
+            // unconditional and gave 35,834 base-world caster placements a 1.60x crit.
+            // Deliberately placed AFTER the resist bail (third review) - a resisted spell returns
+            // above, so computing the gate first was wasted work on every resist.
+            var endgameCrit = ACE.Server.Managers.ZoneControl.ZoneControlManager.EndgameRulesApply(sourceCreature, weapon);
+
             CreatureSkill attackSkill = null;
             if (sourceCreature != null)
                 attackSkill = sourceCreature.GetCreatureSkill(Spell.School);
@@ -630,6 +639,15 @@ namespace ACE.Server.WorldObjects
                 if (criticalHit)
                     weaponCritDamageMod = GetWeaponCritDamageMod(weapon, sourceCreature, attackSkill, target);
 
+                // ORDERING MATTERS FOR THE RETAIL BRANCH (found by review 2026-09-10). Baseline
+                // (9d128e912:606) computed the crit bonus from the PRE-AUG base, then added the aug
+                // afterwards. The series moved the crit derivation below the aug term, so simply
+                // restoring the 0.5f coefficient still left retail life crits larger than baseline by
+                // exactly 0.5 x EffectiveLifeAugCount x weaponCritDamageMod. Capture the pre-aug value
+                // so the retail branch can reproduce baseline exactly; the governed branch deliberately
+                // keeps the new "crit off the fully composed base" model.
+                var lifeMagicDamagePreAug = lifeMagicDamage;
+
                 if (sourceCreature != null && sourceCreature.EffectiveLifeAugCount >= 1)
                 {
                     lifeMagicDamage += sourceCreature.EffectiveLifeAugCount;
@@ -655,6 +673,14 @@ namespace ACE.Server.WorldObjects
                             var sv = Math.Clamp(zpFlat.Get(ACE.Server.Managers.ZoneScaling.ZoneStat.SpellVariance), 0.0, 1.0);
                             lifeMagicDamage *= (float)(1.0 - sv * ThreadSafeRandom.Next(0.0f, 1.0f));
                         }
+
+                        // RE-SYNC (second review). An authored spell_damage REPLACES the whole composed
+                        // value - base AND the life aug term - and spell_variance then spreads it, so the
+                        // pre-aug capture taken further up is meaningless once either fires. Without this
+                        // the ungoverned crit branch would derive from a stale number unrelated to the
+                        // damage actually dealt. Unreachable while nothing is authored below v11, but the
+                        // capture must not silently rot if a zone ever is.
+                        lifeMagicDamagePreAug = lifeMagicDamage;
                     }
                 }
 
@@ -667,7 +693,11 @@ namespace ACE.Server.WorldObjects
 
                 // UNIFIED CRIT: CritX x the base the hit ACTUALLY uses - player and governed casters alike
                 if (criticalHit)
-                    critDamageBonus = lifeMagicDamage * weaponCritDamageMod;
+                    critDamageBonus = endgameCrit
+                        ? lifeMagicDamage * weaponCritDamageMod
+                        // retail: HALF, and off the PRE-AUG base - baseline derived this before the
+                        // life aug term was added (see lifeMagicDamagePreAug above)
+                        : lifeMagicDamagePreAug * 0.5f * weaponCritDamageMod;
 
                 finalDamage = (lifeMagicDamage + critDamageBonus) * elementalDamageMod * slayerMod * resistanceMod * absorbMod * attribBonus;
             }
@@ -718,7 +748,7 @@ namespace ACE.Server.WorldObjects
                 }
                 // unified crit: a PvE crit uses the MAX roll (retail melee's own rule), so the
                 // CritX multiple below lands on the spell's ceiling, not a random roll
-                baseDamage = criticalHit && !isPVP
+                baseDamage = endgameCrit && criticalHit && !isPVP
                     ? Spell.MaxDamage
                     : ThreadSafeRandom.Next(Spell.MinDamage, Spell.MaxDamage);
 
@@ -735,8 +765,31 @@ namespace ACE.Server.WorldObjects
                 // WHICH slot fired decides which band applies - the arc and the ring carry separate
                 // damage now. Matched on the spell id rather than on a flag, because the projectile is
                 // all we have here and the two slots can never hold the same spell.
+                // GATED 2026-09-10 (second review). The RING band in WorldObject_Magic was given a
+                // ZcPowerSuppressed check and this ARC band was not, so the same stranded-band bug
+                // survived here: with zonecontrol_enabled OFF (or the weapon zone lock on and the
+                // wielder outside a zone), the arc still REPLACED baseDamage with its authored band
+                // (~9,440) while endgameCrit was false, leaving the crit term on the spell's own retail
+                // derivation (Spell.MaxDamage * 0.5f, ~42) - a hit that cannot meaningfully crit.
+                // Ruling 1: the toggle makes ZC weapon power inert, bands included.
+                //
+                // GATED ON endgameCrit ITSELF (fourth review). Two earlier attempts got this wrong in
+                // the same way, so the guard now keys off the crit model rather than trying to restate
+                // its conditions:
+                //   - ZcPowerSuppressed alone failed because WeaponPowerSuppressed returns false
+                //     immediately for a non-Player wielder, BEFORE it reads zonecontrol_enabled.
+                //   - Adding an explicit zonecontrol_enabled test fixed only the toggle-OFF case; with
+                //     the toggle ON a BASE-WORLD monster still passed every condition while
+                //     endgameCrit was false, leaving the band (~9,440) paired with a retail crit term
+                //     (Spell.MaxDamage * 0.5f, ~42) - a hit that cannot meaningfully crit.
+                // The invariant that kept breaking is "band applies IFF the unified crit applies", so
+                // it is now expressed directly and cannot drift again. endgameCrit already folds in the
+                // master toggle, the v11 floor and the gear stamp. ZcPowerSuppressed still adds the
+                // player weapon zone lock on top.
                 double? procDmgOverride = null;
-                if (FromProc && weapon != null)
+                if (FromProc && weapon != null
+                    && endgameCrit
+                    && !ZcPowerSuppressed(weapon, sourceCreature))
                 {
                     if (weapon.ProcSpell.HasValue && weapon.ProcSpell.Value == Spell.Id)
                         procDmgOverride = weapon.GetProperty((PropertyFloat)ACE.Server.Managers.ZoneControl.ZoneLootMutator.ProcArcDamagePropId);
@@ -843,7 +896,9 @@ namespace ACE.Server.WorldObjects
                 // Blow band bounds it. This replaces the per-site 0.5f re-derives that quietly
                 // halved crush on every magic path. PvP keeps its retail bonus from above.
                 if (criticalHit && !isPVP)
-                    critDamageBonus = (float)((baseDamage + skillBonus) * weaponCritDamageMod);
+                    critDamageBonus = endgameCrit
+                        ? (float)((baseDamage + skillBonus) * weaponCritDamageMod)
+                        : Spell.MaxDamage * 0.5f * weaponCritDamageMod;   // retail: half of MAX, skillBonus NOT doubled
 
                 finalDamage = baseDamage + critDamageBonus + skillBonus;
 
@@ -1371,13 +1426,27 @@ namespace ACE.Server.WorldObjects
                 var displayAmount = amount;
 
                 // Zone Control "Cast on Strike" reads with its OWN name and its own sentence (owner
-                // 2026-08-27). Gated on FromProc AND on the spell being one of ours, so every retail
-                // proc - cloaks, aetheria, the player Ring Glyph crafts - keeps the stock message.
-                // The rename exists because the client would otherwise print the DAT name, and "Nether
-                // Arc I" reads as a weak spell when the card is anything but.
+                // 2026-08-27). The rename exists because the client would otherwise print the DAT
+                // name, and "Nether Arc I" reads as a weak spell when the card is anything but.
+                //
+                // 🔴 FIXED 2026-09-10 (fourth review): the old comment here claimed "every retail proc
+                // - cloaks, aetheria, the player Ring Glyph crafts - keeps the stock message", and the
+                // code did the OPPOSITE. TryGetProcDisplayName is keyed on SPELL ID ALONE, and its
+                // table is full of RETAIL ids - 2753 Blade Arc, 2718 Force Arc, the 1783-1789 ring set.
+                // Those are exactly the spells the ~11,700 player Ring Glyph crafts use, so a
+                // base-world player proccing a retail weapon got renamed attacker- AND defender-side
+                // combat lines. Damage was never affected; this is message text only. Now gated on the
+                // same endgameCrit that governs the rest of this cast, so the name follows the model.
+                // (endgameCrit is a local in CalculateDamage and not in scope here, so the same gate is
+                // recomputed from the instance members it was built from: the casting creature and
+                // ProjectileLauncher.)
                 var zcProcName = (string)null;
-                if (FromProc)
+                if (FromProc
+                    && ACE.Server.Managers.ZoneControl.ZoneControlManager.EndgameRulesApply(
+                        ProjectileSource as Creature, ProjectileLauncher))
+                {
                     ACE.Server.Managers.ZoneControl.ZoneLootMutator.TryGetProcDisplayName(Spell.Id, out zcProcName);
+                }
 
                 if (sourcePlayer != null)
                 {

--- a/Source/ACE.Server/WorldObjects/WorldObject_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Combat.cs
@@ -56,7 +56,12 @@ namespace ACE.Server.WorldObjects
                 // weapon (and `this`, e.g. equipped ammo) are IN EquippedObjects - so anything already
                 // rolled above was rolling a SECOND time here. A 5 pct weapon fired at 1-(0.95^2) = 9.75 pct.
                 // TryProcWeaponOnCleaveTarget already excluded the weapon this way; the primary path did not.
-                var equippedAetheria = wielder.EquippedObjects.Values.Where(i => i != weapon && i != this && i.HasProc && i.ProcSpellSelfTargeted == selfTarget);
+                // GATED 2026-09-10 (owner, "full restore to old"): the dedupe above is correct, but it
+                // shipped unconditional and halved MONSTER proc frequency shard-wide (9.75 pct -> 5.00 pct
+                // on a 5 pct weapon). Governed content keeps the fix; below v11 the pre-series double-roll
+                // stands, because that is the retail experience being restored.
+                var dedupeProcs = ACE.Server.Managers.ZoneControl.ZoneControlManager.EndgameRulesApply(wielder, weapon);
+                var equippedAetheria = wielder.EquippedObjects.Values.Where(i => (!dedupeProcs || (i != weapon && i != this)) && i.HasProc && i.ProcSpellSelfTargeted == selfTarget);
 
                 // aetheria
                 foreach (var aetheria in equippedAetheria)
@@ -94,7 +99,12 @@ namespace ACE.Server.WorldObjects
                 // weapon (and `this`, e.g. equipped ammo) are IN EquippedObjects - so anything already
                 // rolled above was rolling a SECOND time here. A 5 pct weapon fired at 1-(0.95^2) = 9.75 pct.
                 // TryProcWeaponOnCleaveTarget already excluded the weapon this way; the primary path did not.
-                var equippedAetheria = wielder.EquippedObjects.Values.Where(i => i != weapon && i != this && i.HasProc && i.ProcSpellSelfTargeted == selfTarget && i.IsProcSafeForCleave());
+                // GATED 2026-09-10 (owner, "full restore to old"): the dedupe above is correct, but it
+                // shipped unconditional and halved MONSTER proc frequency shard-wide (9.75 pct -> 5.00 pct
+                // on a 5 pct weapon). Governed content keeps the fix; below v11 the pre-series double-roll
+                // stands, because that is the retail experience being restored.
+                var dedupeProcs = ACE.Server.Managers.ZoneControl.ZoneControlManager.EndgameRulesApply(wielder, weapon);
+                var equippedAetheria = wielder.EquippedObjects.Values.Where(i => (!dedupeProcs || (i != weapon && i != this)) && i.HasProc && i.ProcSpellSelfTargeted == selfTarget && i.IsProcSafeForCleave());
 
                 foreach (var aetheria in equippedAetheria)
                     aetheria.TryProcItem(attacker, target, selfTarget);
@@ -327,7 +337,12 @@ namespace ACE.Server.WorldObjects
                 // weapon (and `this`, e.g. equipped ammo) are IN EquippedObjects - so anything already
                 // rolled above was rolling a SECOND time here. A 5 pct weapon fired at 1-(0.95^2) = 9.75 pct.
                 // TryProcWeaponOnCleaveTarget already excluded the weapon this way; the primary path did not.
-                var equippedAetheria = wielder.EquippedObjects.Values.Where(i => i != weapon && i != this && i.HasProc && i.ProcSpellSelfTargeted == selfTarget);
+                // GATED 2026-09-10 (owner, "full restore to old"): the dedupe above is correct, but it
+                // shipped unconditional and halved MONSTER proc frequency shard-wide (9.75 pct -> 5.00 pct
+                // on a 5 pct weapon). Governed content keeps the fix; below v11 the pre-series double-roll
+                // stands, because that is the retail experience being restored.
+                var dedupeProcs = ACE.Server.Managers.ZoneControl.ZoneControlManager.EndgameRulesApply(wielder, weapon);
+                var equippedAetheria = wielder.EquippedObjects.Values.Where(i => (!dedupeProcs || (i != weapon && i != this)) && i.HasProc && i.ProcSpellSelfTargeted == selfTarget);
 
                 foreach (var aetheria in equippedAetheria)
                     aetheria.TryProcItemWithChanceMod(attacker, target, selfTarget, chanceMultiplier);

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -1118,12 +1118,49 @@ namespace ACE.Server.WorldObjects
             {
                 // Carry the proc flag and the authored ring band through - a ring's damage AND its
                 // combat message are both produced inside that method, never on the projectile path.
-                var zcRingB = fromProc
+                // GATED 2026-09-10 (review). The authored ring band was read with no toggle check, so
+                // with zonecontrol_enabled OFF a ZC-stamped weapon still REPLACED the base with its
+                // band (~9,440) while the crit term fell back to the spell's own retail derivation
+                // (Spell.MaxDamage * 0.5f, ~42) - a hit that cannot meaningfully crit. Ruling 1 says
+                // ZC powers go fully inert when the toggle is off, and ZcPowerSuppressed already
+                // encodes exactly that (plus the weapon zone lock), so the band now vanishes with the
+                // rest of the weapon's ZC power instead of being left stranded.
+                // 🔴 ONE GATE FOR THE WHOLE ZC-PROC HANDOFF (2026-09-10, second parity sweep).
+                // Baseline called this method as `ApplyRingSpellAreaDamage(spell, lifeProjectileDamage: damage)`
+                // - fromProc took its DEFAULT false, so the proccing item never reached the method at all.
+                // The series began passing fromProc/procWeapon/procBaseDamage/procVariance unconditionally,
+                // which is right for ZC Cast-on-Strike and wrong for the ~11,700 retail Ring Glyph crafts.
+                // `zcProc` is that handoff: true only for a ZC-stamped proc, and everything below keys off it
+                // so the four arguments can never disagree with each other again.
+                var zcProc = fromProc
+                    && ACE.Server.Managers.ZoneControl.ZoneControlManager.EndgameRulesApplyToPlayerGear(weapon)
+                    && !ZcPowerSuppressed(weapon, ringPlayer);
+
+                var zcRingB = zcProc
                     ? (weapon?.GetProperty((PropertyFloat)ACE.Server.Managers.ZoneControl.ZoneLootMutator.ProcRingDamagePropId) ?? 0)
                     : 0;
+                // WHY EACH ARGUMENT KEYS OFF zcProc AND NOT fromProc:
+                //
+                // procWeapon - the method resolves `weapon = procWeapon ?? GetEquippedWand()`. Baseline
+                //   used the WAND SLOT only, null on a melee/missile character, so every weapon-derived
+                //   term took its default. Ungated, a retail Ring Glyph inherited the PROCCING weapon's
+                //   stats: crit chance 0.05 -> up to 0.50 (Critical Strike), crit damage mod 1.0 -> up
+                //   to 6.0 (Crippling Blow), plus rending (to x2.5), slayer and heritage baseline never
+                //   applied. That was the "players critting insanely hard" report.
+                //
+                // fromProc - baseline let this DEFAULT to false on the ring path, and three consumers
+                //   read it: Player_Magic.cs:1827 gates the Smart Ring multi-proc loop (baseline ran the
+                //   damage loop 1-3x, forcing true pins it at 1), :2218 fires the equipped cloak's proc
+                //   per hit target, and :2229 awards the War/Void Proficiency tick. Forcing it true was
+                //   three silent LOSSES for retail proc rings - the opposite direction to procWeapon,
+                //   which is exactly why both need the same gate rather than separate judgement.
+                //
+                // The underlying change is RIGHT for ZC Cast-on-Strike - a proc ring comes off a dagger
+                // or bow, not the wand slot, and rend was silently vanishing - so it is kept for
+                // ZC-stamped gear and reverted to baseline for retail, per the 100% restore.
                 ringPlayer.ApplyRingSpellAreaDamage(spell, lifeProjectileDamage: damage,
-                    fromProc: fromProc, procBaseDamage: zcRingB, procWeapon: fromProc ? weapon : null,
-                    procVariance: fromProc
+                    fromProc: zcProc, procBaseDamage: zcRingB, procWeapon: zcProc ? weapon : null,
+                    procVariance: zcProc
                         ? (weapon?.GetProperty((PropertyFloat)ACE.Server.Managers.ZoneControl.ZoneLootMutator.ProcRingVariancePropId) ?? 0)
                         : 0);
             }

--- a/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
@@ -377,9 +377,46 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public const bool CritImbuesSuppressedForPlayers = true;
 
-        /// <summary>True when Critical Strike / Crippling Blow must be ignored for this wielder.</summary>
-        public static bool CritImbuesSuppressed(Creature wielder)
-            => CritImbuesSuppressedForPlayers && wielder is Player;
+        /// <summary>
+        /// True when Critical Strike / Crippling Blow must be ignored for this wielder's weapon.
+        ///
+        /// GATED 2026-09-10 (owner, "full restore to old"): this was an unconditional
+        /// `wielder is Player` test, so it killed Critical Strike (crit rate 0.50 -> 0.10) and
+        /// Crushing Blow (crit multiplier 1+6.0 -> 1+1.0) for EVERY player on EVERY weapon,
+        /// retail gear included - a change that was only ever meant for v11-25. It now applies
+        /// through the gear half of the canonical gate, so a retail weapon keeps its imbues and a
+        /// ZC-stamped weapon still defers to Biting Strike / Crushing Blow as designed.
+        /// </summary>
+        /// <remarks>
+        /// `wielder is Player` is tested HERE, before the gate call (third review): passing
+        /// EndgameRulesApplyToPlayerGear as an ARGUMENT made C# evaluate the ZcTier biota read first, so
+        /// every MONSTER swing with a Critical Strike or Crippling Blow weapon paid a read lock whose
+        /// answer was then discarded - twice per swing, from GetWeaponCriticalChance and
+        /// GetWeaponCritDamageMod. Monster swings dominate on a populated server.
+        /// </remarks>
+        public static bool CritImbuesSuppressed(Creature wielder, WorldObject weapon)
+            => CritImbuesSuppressedForPlayers
+                && wielder is Player
+                && ACE.Server.Managers.ZoneControl.ZoneControlManager.EndgameRulesApplyToPlayerGear(weapon);
+
+        /// <summary>
+        /// Pre-resolved form for hot paths that already computed the gear half of the gate.
+        /// EndgameRulesApplyToPlayerGear reads PropertyInt.ZcTier, which takes the biota read lock the
+        /// 2026-09-04 review moved off the per-hit path - so a method that needs the answer more than
+        /// once must take it ONCE and pass the bool, never call the resolving overload twice.
+        /// </summary>
+        public static bool CritImbuesSuppressed(Creature wielder, bool endgameGear)
+            => CritImbuesSuppressedForPlayers && wielder is Player && endgameGear;
+
+        /// <summary>
+        /// Panel-side form of <see cref="CritImbuesSuppressed"/>. An item panel is only ever built for
+        /// a player examining something, so the wielder test is implicit and only the gear half remains.
+        /// ONE expression shared with the combat path so the panel can never advertise an imbue that is
+        /// inert, nor hide one that now works again on retail gear.
+        /// </summary>
+        public static bool CritImbuesSuppressedOnItem(WorldObject weapon)
+            => CritImbuesSuppressedForPlayers
+                && ACE.Server.Managers.ZoneControl.ZoneControlManager.EndgameRulesApplyToPlayerGear(weapon);
 
         /// <summary>The weapon zone lock (owner 2026-08-30): true when this ZC weapon's custom
         /// power is suppressed for this swing - toggle on, player wielder, ZcTier 11+ item,
@@ -401,9 +438,10 @@ namespace ACE.Server.WorldObjects
                 : (float)(weapon?.CriticalFrequency ?? defaultPhysicalCritFrequency);
 
             if (weapon != null && weapon.HasImbuedEffect(ImbuedEffectType.CriticalStrike)
-                && !CritImbuesSuppressed(wielder))   // owner 2026-08-25: Biting Strike is the only crit-chance source on a player weapon
+                && !CritImbuesSuppressed(wielder, weapon))   // owner 2026-08-25: Biting Strike is the only crit-chance source on a player weapon
             {
-                var criticalStrikeBonus = GetCriticalStrikeMod(skill);
+                // physical path: the magic-only floor never applies, so endgameGear is irrelevant here
+                var criticalStrikeBonus = GetCriticalStrikeMod(skill, false, false);
 
                 critRate = Math.Max(critRate, criticalStrikeBonus);
             }
@@ -462,6 +500,16 @@ namespace ACE.Server.WorldObjects
         private const float defaultMagicCritFrequency = 0.10f;
 
         /// <summary>
+        /// RETAIL magic crit chance, restored for ungoverned content (owner 2026-09-10).
+        /// The 08-29 unification above raised every caster on the shard from 0.05 to 0.10, not just
+        /// v11-25 - doubling the crit RATE of all 35,834 base-world caster placements on top of the
+        /// ~1.6x crit DAMAGE from the SpellProjectile rewrite. The unified value stays for governed
+        /// content; anything below variation 11, and any player on retail gear, reads retail again.
+        /// </summary>
+        private const float retailMagicCritFrequency = 0.05f;
+
+
+        /// <summary>
         /// Returns the critical chance for the caster weapon
         /// </summary>
         public static float GetWeaponMagicCritFrequency(WorldObject weapon, Creature wielder, CreatureSkill skill, Creature target)
@@ -475,21 +523,41 @@ namespace ACE.Server.WorldObjects
                 // branch too - it was silently skipped, making mob-caster crits un-resistable
                 // while the same mob's MELEE crits were reduced. Zone-authored crit chance still
                 // replaces the default first, same as the with-wand path below.
+                // FULL RESTORE (owner 2026-09-10, "the same retail experience before part 1,2,3,4"):
+                // pre-series this branch returned the bare default and SKIPPED the target's Crit Resist
+                // entirely. The 2026-08-21 fix that applies it is a genuine improvement and it makes mob
+                // crits resistable - but it shipped inside the series and changed base-world behavior,
+                // so it is now GOVERNED-ONLY. Revisit when the series is re-landed properly.
+                if (!ACE.Server.Managers.ZoneControl.ZoneControlManager.EndgameRulesApplyToMonster(wielder))
+                    return retailMagicCritFrequency;
+
                 var wandlessRate = GetZoneCritChanceOverride(wielder) ?? defaultMagicCritFrequency;
                 return wandlessRate * Creature.GetNegativeRatingMod(target.GetCritResistRating());
             }
 
+            // ONE gate read for this whole call (hoisted 2026-09-10 - it was taken twice, and the
+            // ZcTier read behind it holds the biota lock).
+            //
+            // FIXED 2026-09-10 (third review): this hoist originally called EndgameRulesApplyToPlayerGear
+            // - the PLAYER half - for EVERY wielder, which quietly halved governed caster MOBS. A v22 mob
+            // holding an ordinary wand has no ZcTier, so it read 0.05 instead of 0.10, while the SAME mob
+            // casting wandless still got 0.10 from the monster branch above. Ruling 2: monsters gate by
+            // LOCATION. EndgameRulesApply picks the correct half per wielder.
+            var endgameCast = ACE.Server.Managers.ZoneControl.ZoneControlManager.EndgameRulesApply(wielder, weapon);
+
             // zone lock: outside authored areas a ZC weapon's Biting Strike stamp reads as absent
+            var baseRate = endgameCast ? defaultMagicCritFrequency : retailMagicCritFrequency;
             var critRate = ZcPowerSuppressed(weapon, wielder)
-                ? defaultMagicCritFrequency
-                : (float)(weapon.GetProperty(PropertyFloat.CriticalFrequency) ?? defaultMagicCritFrequency);
+                ? baseRate
+                : (float)(weapon.GetProperty(PropertyFloat.CriticalFrequency) ?? baseRate);
 
             if (weapon.HasImbuedEffect(ImbuedEffectType.CriticalStrike)
-                && !CritImbuesSuppressed(wielder))   // same ruling on the magic path
+                && !CritImbuesSuppressed(wielder, endgameCast))   // same ruling on the magic path
             {
                 var isPvP = wielder is Player && target is Player;
 
-                var criticalStrikeMod = GetCriticalStrikeMod(skill, isPvP);
+                // endgameGear threaded through: an ungated floor would put a RETAIL caster at 10 pct
+                var criticalStrikeMod = GetCriticalStrikeMod(skill, isPvP, endgameCast);
 
                 critRate = Math.Max(critRate, criticalStrikeMod);
             }
@@ -524,7 +592,7 @@ namespace ACE.Server.WorldObjects
                 : (float)(weapon?.GetProperty(PropertyFloat.CriticalMultiplier) ?? defaultCritDamageMultiplier);
 
             if (weapon != null && weapon.HasImbuedEffect(ImbuedEffectType.CripplingBlow)
-                && !CritImbuesSuppressed(wielder))   // owner 2026-08-25: Crushing Blow is the only crit-damage source on a player weapon
+                && !CritImbuesSuppressed(wielder, weapon))   // owner 2026-08-25: Crushing Blow is the only crit-damage source on a player weapon
             {
                 var cripplingBlowMod = GetCripplingBlowMod(skill);
 
@@ -863,7 +931,21 @@ namespace ACE.Server.WorldObjects
 
         public static float MaxCriticalStrikeMod = 0.5f;
 
-        public static float GetCriticalStrikeMod(CreatureSkill skill, bool isPvP = false)
+        /// <param name="endgameGear">
+        /// True only when the wielder's caster is ZC-stamped (the gear half of the canonical gate).
+        /// Added 2026-09-10 after review: the magic FLOOR below reads defaultMagicCritFrequency, which
+        /// the series raised 0.05 -> 0.10. Because this method is ungated, a RETAIL caster carrying a
+        /// Critical Strike imbue was floored at 10 pct instead of the baseline 5 pct whenever its base
+        /// magic skill was low enough for the floor to win - and GetWeaponMagicCritFrequency then takes
+        /// Math.Max(critRate, this). Defaults to FALSE so every existing caller stays on retail.
+        /// </param>
+        /// <remarks>
+        /// `endgameGear` is deliberately NOT defaulted (fourth review). Two adjacent defaulted bools
+        /// made `GetCriticalStrikeMod(skill, endgameGear)` compile and bind silently to `isPvP` -
+        /// halving the magic mod AND leaving the retail floor in place, with no diagnostic. Requiring
+        /// it turns that mistake into a compile error.
+        /// </remarks>
+        public static float GetCriticalStrikeMod(CreatureSkill skill, bool isPvP, bool endgameGear)
         {
             var baseMod = 0.0f;
 
@@ -917,7 +999,9 @@ namespace ACE.Server.WorldObjects
             if (baseMod >= minEffective)
                 criticalStrikeMod = baseMod;*/
 
-            var defaultCritFrequency = skillType == ImbuedSkillType.Magic ? defaultMagicCritFrequency : defaultPhysicalCritFrequency;
+            var defaultCritFrequency = skillType == ImbuedSkillType.Magic
+                ? (endgameGear ? defaultMagicCritFrequency : retailMagicCritFrequency)
+                : defaultPhysicalCritFrequency;   // physical floor is 0.1f at baseline and now - untouched
 
             var criticalStrikeMod = Math.Max(defaultCritFrequency, baseMod);
 


### PR DESCRIPTION
## Problem

The T11 series (#510-#513) changed shared combat math in place rather than adding zone-gated behavior, so several changes reached base-world content (variation NULL/0 and v1-v5). Observed after deploy: players could not heal or regenerate at all, monsters hit far harder, and player crits were inflated.

## Root causes

- **Healing and regen dead.** `GetGearCap` capped `GearMaxHealth` - measured in **hit points** - with `CapLine`, a **rating-line** ceiling of 211. Server-side max health dropped below current, a regen tick clamped current down to it, and the server then read every player as permanently full: `/heal` returned +0, heal kits said "already at full health", regen had no headroom. The client still drew the uncapped bar, producing the confusing "5,112/6,466" reports.
- **Monsters hitting harder.** The unified magic crit shipped ungated - roughly 1.6x crit damage and ~2x crit frequency, reaching 35,834 base-world caster placements.
- **Player crits inflated.** Ring procs passed `procWeapon`/`fromProc` ungated, so retail Ring Glyph crafts inherited the proccing weapon's Critical Strike (crit chance 0.05 -> up to 0.50) and Crippling Blow (crit mod 1.0 -> up to 6.0), plus rending, slayer and heritage that baseline never applied.
- **Regen suppressed with the kill switch off.** `ResolveEffectsForPlayer` had no master-toggle check, so zone regen suppression still applied when Zone Control was disabled.

## Approach

One canonical gate in `ZoneControlManager`, used at every site:

- `EndgameRulesApplyToMonster` - location, behind a hard variation >= 11 floor
- `EndgameRulesApplyToPlayerGear` - `ZcTier >= 11` stamp
- `EndgameRulesApply` - selects the correct half per actor
- `EndgameRulesApplyToPlacedContent` - hotspots and traps

Two rules are encoded in it: `zonecontrol_enabled` OFF means no combat-model behavior from this series applies, and the gate is **split** - monsters by location, players by gear stamp, so a player's numbers do not change as they cross a zone border.

## Verification

Five independent review passes plus two mechanical parity sweeps against `9d128e912`. The final sweep reduces every gate to a literal under the live configuration and reports base-world behavior **arithmetically identical** to pre-series across damage, healing and regen - including matching RNG draw counts per event. A separate pass confirmed T11-T25 endgame behavior is still reachable and unchanged for governed actors.

## Deliberately not included

Loot generation is unchanged by owner decision.

## Known follow-ups (not regressions from this PR)

**Live today:**

- **Kiting governed monsters out of their zone.** `FindZoneRef` reads location per swing with no spawn latch, so pulling a v11+ caster one landblock outside its zone drops its crit frequency 0.10 -> 0.05, voids authored `crit_rating`, and collapses a Cast-on-Strike arc band from its authored value to `Spell.MaxDamage`. Pre-existing (zone stats were always location-resolved); this PR widens it by flipping the crit model too.

**Latent until T11 gear exists:**

- **HP capped by a rating ceiling.** `GetGearMaxHealth` still borrows `gear_cap_line`. Inert only because the 2500 ladder exceeds real gear HP - any zone authoring `gear_cap_line` below a wearer's `GearMaxHealth` reproduces the original healing bug exactly. The real fix is a dedicated cap key for a hit-point quantity.
- **Client max-health desync.** `HandleMaxHealthUpdate` re-pushes `GearMaxHealth` to the client only on equip/dequip, so a cap change from a zone border, a live toggle flip or `zc_armor_zone_lock` silently desyncs the bar. This is the mechanism behind the original confusing reports.
- **The gear half of the split is player-chosen, per swing.** An archer can wear a ZC wand while firing a retail bow and have ring procs judged by the wand; a retail weapon inside an endgame zone keeps the double proc roll and its crit imbues where a ZC weapon forfeits them; a retail launcher with ZC ammo is judged by the launcher. Worth revisiting the ruling before T11 ships.
- **Unarmed builds cannot reach the endgame model** - `Weapon` is null for martial arts and ZC gear cannot stamp "no weapon".
- **Zone-authored `gear_cap_*` no longer binds a retail-geared player inside a governed zone.** Correct if that knob is a ZC-ladder anchor, wrong if it was meant as a zone-entry restriction.
- **Governed ring vs projectile life-crit drift** - the ring derives its crit pre-aug, the projectile post-aug.
- **Placed-content gate has no zone-existence test**, so disabling a zone flips its monsters to retail but leaves its hotspots on endgame rules.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored retail damage, critical-hit, spell, and proc behavior for content not governed by Zone Control.
  * Applied endgame-specific damage and critical-hit rules only to eligible Zone Control gear, creatures, and content.
  * Corrected appraisal displays for Critical Strike and Crippling Blow effects.
  * Updated gear-rating caps based on Zone Control status, with uncapped ratings when the system is disabled or not applicable.
  * Corrected hotspot healing, draining, and damage behavior for non-endgame content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->