### PR TITLE
Fix TryReadClothingTable bypassing mods for custom JSON clothing bases

### DIFF
--- a/Source/ACE.DatLoader.Tests/TryReadClothingTableTests.cs
+++ b/Source/ACE.DatLoader.Tests/TryReadClothingTableTests.cs
@@ -1,0 +1,89 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ACE.DatLoader.Entity;
+using ACE.DatLoader.FileTypes;
+
+namespace ACE.DatLoader.Tests
+{
+    [TestClass]
+    public class TryReadClothingTableTests
+    {
+        private class TestDatDatabase : DatDatabase
+        {
+            public TestDatDatabase() : base() { }
+        }
+
+        [TestMethod]
+        public void TryReadClothingTable_InvalidClothingId_ReturnsFalse()
+        {
+            var db = new TestDatDatabase();
+            // Not in 0x10xxxxxx range
+            var result = db.TryReadClothingTable(0x01000001, out var clothingTable);
+
+            Assert.IsFalse(result);
+            Assert.IsNull(clothingTable);
+        }
+
+        [TestMethod]
+        public void TryReadClothingTable_CachedValidTable_ReturnsTrue()
+        {
+            var db = new TestDatDatabase();
+            uint customClothingId = 0x10000959;
+
+            var table = new ClothingTable();
+            table.ClothingBaseEffects.Add(0x02000001, new ClothingBaseEffect());
+
+            db.FileCache[customClothingId] = table;
+
+            var result = db.TryReadClothingTable(customClothingId, out var clothingTable);
+
+            Assert.IsTrue(result);
+            Assert.IsNotNull(clothingTable);
+            Assert.AreSame(table, clothingTable);
+        }
+
+        [TestMethod]
+        public void TryReadClothingTable_CachedWithSubPalEffects_ReturnsTrue()
+        {
+            var db = new TestDatDatabase();
+            uint customClothingId = 0x100009D5;
+
+            var table = new ClothingTable();
+            table.ClothingSubPalEffects.Add(1, new CloSubPalEffect());
+
+            db.FileCache[customClothingId] = table;
+
+            var result = db.TryReadClothingTable(customClothingId, out var clothingTable);
+
+            Assert.IsTrue(result);
+            Assert.IsNotNull(clothingTable);
+            Assert.AreSame(table, clothingTable);
+        }
+
+        [TestMethod]
+        public void TryReadClothingTable_CachedEmptyTable_ReturnsFalse()
+        {
+            var db = new TestDatDatabase();
+            uint customClothingId = 0x10000959;
+
+            var table = new ClothingTable(); // 0 effects
+            db.FileCache[customClothingId] = table;
+
+            var result = db.TryReadClothingTable(customClothingId, out var clothingTable);
+
+            Assert.IsFalse(result);
+            Assert.IsNull(clothingTable);
+        }
+
+        [TestMethod]
+        public void TryReadClothingTable_TrulyAbsent_ReturnsFalse()
+        {
+            var db = new TestDatDatabase();
+            uint absentId = 0x10000999;
+
+            var result = db.TryReadClothingTable(absentId, out var clothingTable);
+
+            Assert.IsFalse(result);
+            Assert.IsNull(clothingTable);
+        }
+    }
+}

--- a/Source/ACE.DatLoader/DatDatabase.cs
+++ b/Source/ACE.DatLoader/DatDatabase.cs
@@ -31,6 +31,13 @@ namespace ACE.DatLoader
 
         public ConcurrentDictionary<uint, FileType> FileCache { get; } = new ConcurrentDictionary<uint, FileType>();
 
+        /// <summary>
+        /// Protected constructor for derived test/mock implementations
+        /// </summary>
+        protected DatDatabase()
+        {
+        }
+
         public DatDatabase(string filePath, bool keepOpen = false)
         {
             if (!File.Exists(filePath))
@@ -76,25 +83,33 @@ namespace ACE.DatLoader
             if (!IsClothingBaseId(fileId))
                 return false;
 
-            if (FileCache.TryGetValue(fileId, out FileType cached) && cached is not ClothingTable)
-                return false;
-
-            // The dat must actually CONTAIN this id before we read it. ReadFromDat returns a new EMPTY
-            // ClothingTable when the file is absent - GetReaderForFile returns null, the datReader guard
-            // is skipped, nothing throws so the catch never runs - and then caches that empty object.
-            // Returning true in that case handed callers a table with no ClothingBaseEffects, which
-            // silently defeated their AddSetupAsClothingBase fallback and rendered the item with no
-            // model or texture at all. Returning false lets the fallback do its job.
-            if (!AllFiles.ContainsKey(fileId))
+            if (FileCache.TryGetValue(fileId, out FileType cached))
             {
-                if (missingClothingWarned.TryAdd(fileId, 0))
-                    log.Warn($"ClothingBase 0x{fileId:X8} is referenced by content but is not present in {Enum.GetName(typeof(DatDatabaseType), Header.DataSet)} - falling back to SetupId. Fix the content or update the dats.");
+                if (cached is ClothingTable cachedTable && (cachedTable.ClothingBaseEffects.Count > 0 || cachedTable.ClothingSubPalEffects.Count > 0))
+                {
+                    clothingTable = cachedTable;
+                    return true;
+                }
 
                 return false;
             }
 
+            // ReadFromDat allows Harmony mods (such as CustomClothingBase JSON loader) or DAT files
+            // to provide the ClothingTable.
             clothingTable = ReadFromDat<ClothingTable>(fileId);
-            return true;
+
+            if (clothingTable != null && (clothingTable.ClothingBaseEffects.Count > 0 || clothingTable.ClothingSubPalEffects.Count > 0))
+                return true;
+
+            clothingTable = null;
+
+            // The table is genuinely absent from both the dat and any mods/cache:
+            // ReadFromDat returned an empty ClothingTable with no effects. Returning false
+            // lets callers fall back to AddSetupAsClothingBase so the item can still render.
+            if (missingClothingWarned.TryAdd(fileId, 0))
+                log.Warn($"ClothingBase 0x{fileId:X8} is referenced by content but is not present in {Enum.GetName(typeof(DatDatabaseType), Header.DataSet)} - falling back to SetupId. Fix the content or update the dats.");
+
+            return false;
         }
 
         public T ReadFromDat<T>(uint fileId) where T : FileType, new()

--- a/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
@@ -256,6 +256,36 @@ namespace ACE.Server.Command.Handlers
             Console.WriteLine($"{string.Join("\n", compatibleCBs.ToArray())}");
         }
 
+        [CommandHandler("testcb", AccessLevel.Developer, CommandHandlerFlag.ConsoleInvoke, "Test TryReadClothingTable for a clothing base ID")]
+        public static void HandleTestClothingBase(Session session, params string[] parameters)
+        {
+            if (parameters.Length == 0)
+            {
+                Console.WriteLine("Usage: @testcb <hexClothingBaseId>");
+                return;
+            }
+
+            var arg = parameters[0].StartsWith("0x", StringComparison.OrdinalIgnoreCase) ? parameters[0].Substring(2) : parameters[0];
+            if (!uint.TryParse(arg, System.Globalization.NumberStyles.HexNumber, null, out var cbId))
+            {
+                Console.WriteLine($"Invalid hex ID: {parameters[0]}");
+                return;
+            }
+
+            bool success = DatManager.PortalDat.TryReadClothingTable(cbId, out var ct);
+            Console.WriteLine($"[TESTCB] TryReadClothingTable(0x{cbId:X8}) => {success}");
+            if (success && ct != null)
+            {
+                Console.WriteLine($"  ClothingBaseEffects count: {ct.ClothingBaseEffects.Count}");
+                Console.WriteLine($"  ClothingSubPalEffects count: {ct.ClothingSubPalEffects.Count}");
+                foreach (var kvp in ct.ClothingBaseEffects)
+                {
+                    Console.WriteLine($"    SetupId: 0x{kvp.Key:X8}, CloObjectEffects: {kvp.Value.CloObjectEffects.Count}");
+                }
+            }
+        }
+
+
 
         // ==================================
         // Client Testing


### PR DESCRIPTION
In PR #511, a check \if (!AllFiles.ContainsKey(fileId)) return false;\ was added to DatDatabase.TryReadClothingTable to detect absent clothing tables and fall back to AddSetupAsClothingBase.

However, custom clothing mods such as CustomClothingBase provide clothing table definitions via JSON files (intercepted via Harmony hooks on ReadFromDat/GetReaderForFile) rather than physical entries in the client_portal.dat B-Tree index. Because AllFiles only contains physical DAT entries, this check returned false and bypassed ReadFromDat entirely, logging fallback warnings and preventing custom clothing visuals from loading.

This fix:
1. Checks FileCache for valid tables with effects first.
2. Calls ReadFromDat<ClothingTable>(fileId) to allow Harmony hooks to supply custom/JSON clothing tables (or read from DAT).
3. If the resulting table has ClothingBaseEffects or ClothingSubPalEffects > 0, returns true.
4. If truly absent or empty (0 effects), returns false and logs the fallback warning once per ID.
5. Adds unit tests covering cache hits, subpalettes, empty tables, and absent IDs.
6. Adds a developer console command @testcb <hexId> for live inspection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a developer console command for testing clothing base data by ID, including effect and setup counts.
  * The command accepts hexadecimal IDs with or without a `0x` prefix and provides usage or validation feedback.

* **Bug Fixes**
  * Improved clothing table lookup to correctly handle cached, empty, missing, and invalid data.
  * Added warning feedback when clothing data cannot be found, allowing fallback behavior to proceed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->